### PR TITLE
feat(v1.3): SPA detection warning + JsRenderer trait stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [Usage](#-usage)
 - [Testing](#-testing)
 - [Architecture](#-architecture)
+- [Known Limitations](#-known-limitations-spajs-rendered-sites)
 - [Documentation](#-documentation)
 - [Development](#-development)
 - [Bug Fixes](#-bug-fixes)
@@ -499,6 +500,33 @@ strip = true
 
 ---
 
+## ⚠️ Known Limitations: SPA/JS-rendered Sites
+
+### Single Page Applications (SPAs)
+
+**Problem:** Sites that render content client-side via JavaScript (React, Vue, Angular, etc.) return empty or minimal HTML when fetched without a browser engine. The scraper's HTTP client receives only the initial shell HTML — the actual content is injected by JavaScript after page load.
+
+**Symptoms:**
+- Extracted content is below 50 characters after readability/fallback extraction
+- Page titles are empty or generic
+- HTML contains only `<div id="root">` or `<div id="app">` mount points
+
+**Current Behavior (Phase 1):**
+- A warning is emitted via `tracing::warn!` when minimal content is detected
+- Warning format: `{domain} returned minimal content ({N} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16`
+- The `--force-js-render` CLI flag is reserved for future use (currently no-op)
+- The `JsRenderer` trait is defined in the domain layer as a forward-compatible stub
+
+**Planned Solution (v1.4 — Phase 2):**
+- Full JavaScript rendering via headless browser (Chromium-based)
+- `JsRenderer` trait implementations in the Infrastructure layer
+- Automatic SPA detection with fallback to JS rendering
+- No new crates will be added until Phase 2 implementation
+
+**Workaround:** For SPA sites, consider using the site's API directly if available, or wait for v1.4 JS rendering support.
+
+---
+
 ## 🤝 Contributing
 
 ### Getting Started
@@ -661,7 +689,8 @@ By contributing to this project, you agree that your contributions will be licen
 
 - [ ] **v1.1.0** — TLS fingerprint impersonation via `wreq` + BoringSSL ([Issue #14](https://github.com/XaviCode1000/rust-scraper/issues/14))
 - [ ] **v1.2.0** — Vector DB integration (LanceDB or Qdrant for RAG export)
-- [ ] **v1.3.0** — JavaScript rendering (headless browser) — for SPA sites
+- [ ] **v1.3.0** — SPA content detection & warnings (Phase 1 of JS rendering)
+- [ ] **v1.4.0** — JavaScript rendering (headless browser) — for SPA sites
 - [ ] **v2.0.0** — Distributed scraping
 
 ---

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -13,6 +13,7 @@ pub use crawler_service::{
 };
 pub use http_client::create_http_client;
 pub use scraper_service::{
-    scrape_multiple_with_limit, scrape_with_config, scrape_with_readability,
+    detect_spa_content, scrape_multiple_with_limit, scrape_with_config, scrape_with_readability,
+    SpaDetectionResult,
 };
 pub use url_filter::{extract_domain, is_allowed, is_excluded, is_internal_link, matches_pattern};

--- a/src/application/scraper_service.rs
+++ b/src/application/scraper_service.rs
@@ -19,6 +19,83 @@ use futures::stream::{self, StreamExt};
 use tracing::{debug, info, warn};
 use wreq::Client;
 
+/// Minimum character threshold for considering content "substantial".
+/// Pages below this threshold after extraction likely require JS rendering.
+const MIN_CONTENT_CHARS: usize = 50;
+
+/// Result of SPA content detection analysis.
+///
+/// Contains diagnostic information about why a page was flagged
+/// as potentially requiring JavaScript rendering.
+#[derive(Debug, Clone)]
+pub struct SpaDetectionResult {
+    /// The URL that was analyzed
+    pub url: String,
+    /// Character count of the extracted content
+    pub char_count: usize,
+    /// Whether the page title looks like a default/empty title
+    pub has_empty_title: bool,
+    /// Whether the HTML contains common SPA indicators
+    pub has_spa_markers: bool,
+}
+
+/// Detect whether a page likely requires JavaScript rendering (SPA detection).
+///
+/// Analyzes extracted content to identify pages that returned minimal content
+/// after readability/fallback extraction, which is a common symptom of
+/// Single Page Applications that render client-side.
+///
+/// # Arguments
+///
+/// * `url` - The URL that was scraped
+/// * `content` - The extracted text content
+///
+/// # Returns
+///
+/// * `Some(SpaDetectionResult)` if the page appears to be an SPA
+/// * `None` if the content appears substantial enough
+///
+/// # Detection Heuristics
+///
+/// A page is flagged as potentially SPA-dependent when:
+/// - Extracted content is below `MIN_CONTENT_CHARS` (50 chars)
+///
+/// This is a conservative first-pass detection. Future versions will also
+/// check for:
+/// - Empty or generic titles
+/// - `<div id="root">` or similar SPA mount points
+/// - Absence of meaningful semantic HTML
+pub fn detect_spa_content(url: &str, content: &str) -> Option<SpaDetectionResult> {
+    let char_count = content.chars().count();
+
+    if char_count >= MIN_CONTENT_CHARS {
+        return None;
+    }
+
+    // Check for common SPA title patterns
+    let has_empty_title = url
+        .split('/')
+        .nth(2)
+        .map(|host| {
+            let title = host.to_lowercase();
+            title.is_empty() || title == "localhost" || title.starts_with("www.")
+        })
+        .unwrap_or(false);
+
+    // Check for common SPA mount point markers in content
+    let has_spa_markers = content.is_empty()
+        || content.trim().is_empty()
+        || content.contains("<div id=\"root\">")
+        || content.contains("<div id=\"app\">");
+
+    Some(SpaDetectionResult {
+        url: url.to_string(),
+        char_count,
+        has_empty_title,
+        has_spa_markers,
+    })
+}
+
 /// Scrape a URL using Readability algorithm for clean content extraction
 ///
 /// This is the 2026 best practice approach — uses the same algorithm as
@@ -96,6 +173,14 @@ pub async fn scrape_with_config(
         Ok(article) => {
             let assets = download_assets_if_enabled(&html, url, config).await?;
 
+            // SPA detection: check if extracted content is minimal
+            if let Some(spa_info) = detect_spa_content(url.as_str(), &article.text_content) {
+                warn!(
+                    "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                    spa_info.url, spa_info.char_count
+                );
+            }
+
             results.push(ScrapedContent {
                 title: article.title,
                 content: article.text_content,
@@ -111,6 +196,14 @@ pub async fn scrape_with_config(
             warn!("⚠️  Readability failed for {}: {}", url, e);
             let fallback_content = crate::infrastructure::scraper::fallback::extract_text(&html);
             let assets = download_assets_if_enabled(&html, url, config).await?;
+
+            // SPA detection: check if fallback content is minimal
+            if let Some(spa_info) = detect_spa_content(url.as_str(), &fallback_content) {
+                warn!(
+                    "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                    spa_info.url, spa_info.char_count
+                );
+            }
 
             results.push(ScrapedContent {
                 title: url
@@ -253,5 +346,45 @@ mod tests {
     fn test_scraper_config_concurrency_custom() {
         let config = ScraperConfig::default().with_scraper_concurrency(5);
         assert_eq!(config.scraper_concurrency, 5);
+    }
+
+    #[test]
+    fn test_detect_spa_content_below_threshold() {
+        let result = detect_spa_content("https://example.com", "");
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.char_count, 0);
+        assert_eq!(result.url, "https://example.com");
+    }
+
+    #[test]
+    fn test_detect_spa_content_above_threshold() {
+        let result = detect_spa_content("https://example.com", "This is a substantial content that exceeds the minimum threshold of 50 characters easily.");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_spa_content_spa_markers() {
+        let result = detect_spa_content("https://spa.example.com", "<div id=\"root\"></div>");
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.has_spa_markers);
+    }
+
+    #[test]
+    fn test_detect_spa_content_just_below_threshold() {
+        // 49 chars - just below threshold
+        let content = "a".repeat(49);
+        let result = detect_spa_content("https://example.com", &content);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().char_count, 49);
+    }
+
+    #[test]
+    fn test_detect_spa_content_at_threshold() {
+        // Exactly 50 chars - at threshold, should NOT trigger
+        let content = "a".repeat(50);
+        let result = detect_spa_content("https://example.com", &content);
+        assert!(result.is_none());
     }
 }

--- a/src/domain/js_renderer.rs
+++ b/src/domain/js_renderer.rs
@@ -1,0 +1,92 @@
+//! JavaScript renderer trait — Forward-compatible stub for SPA support
+//!
+//! This trait defines the interface for JavaScript rendering of web pages.
+//! Currently no implementation exists — this is a forward-compatible stub
+//! for Phase 2 (full JS rendering with headless browser).
+//!
+//! # Architecture
+//!
+//! Following Clean Architecture: this trait lives in the Domain layer because
+//! it defines a business capability (rendering JS-dependent pages), not a
+//! specific implementation. Infrastructure will provide the actual renderer
+//! (e.g., headless Chrome via `headless_chrome` or `fantoccini`).
+//!
+//! # Planned Implementation (v1.4)
+//!
+//! ```text
+//! Domain:       JsRenderer trait (this file)
+//! Infrastructure: HeadlessChromeRenderer (future)
+//! Application:  ScraperService selects renderer based on content detection
+//! ```
+//!
+//! See: <https://github.com/XaviCode1000/rust-scraper/issues/16>
+
+use thiserror::Error;
+
+/// Error type for JavaScript rendering failures.
+///
+/// Covers all expected failure modes for headless browser rendering:
+/// - Browser launch/communication failures
+/// - Page load timeouts
+/// - Navigation errors
+#[derive(Error, Debug)]
+pub enum JsRenderError {
+    /// Browser failed to launch or communicate
+    #[error("browser error: {0}")]
+    Browser(String),
+
+    /// Page load timed out
+    #[error("timeout loading {url} after {timeout_ms}ms")]
+    Timeout {
+        /// URL that timed out
+        url: String,
+        /// Timeout duration in milliseconds
+        timeout_ms: u64,
+    },
+
+    /// Navigation to URL failed
+    #[error("navigation failed: {0}")]
+    Navigation(String),
+
+    /// Content extraction after rendering failed
+    #[error("content extraction failed: {0}")]
+    Extraction(String),
+}
+
+/// Trait for JavaScript rendering of web pages.
+///
+/// Implementations use a headless browser to execute JavaScript and return
+/// the fully rendered HTML. This is needed for Single Page Applications (SPAs)
+/// that render content client-side.
+///
+/// Uses native async fn in trait (Rust 1.88+), no `async-trait` crate needed.
+///
+/// # Example (future implementation)
+///
+/// ```ignore
+/// use rust_scraper::domain::JsRenderer;
+/// use url::Url;
+///
+/// // Future: HeadlessChromeRenderer implements JsRenderer
+/// let renderer = HeadlessChromeRenderer::new().await?;
+/// let html = renderer.render(&Url::parse("https://example.com/spa")?).await?;
+/// ```
+pub trait JsRenderer: Send + Sync {
+    /// Render a URL by executing JavaScript in a headless browser.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL to render
+    ///
+    /// # Returns
+    ///
+    /// The fully rendered HTML content as a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns `JsRenderError` if rendering fails for any reason.
+    fn render(
+        &self,
+        url: &url::Url,
+    ) -> impl std::future::Future<Output = Result<String, JsRenderError>> + Send;
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -6,6 +6,7 @@
 pub mod crawler_entities;
 pub mod entities;
 pub mod exporter;
+pub mod js_renderer;
 pub mod value_objects;
 
 #[cfg(feature = "ai")]
@@ -17,4 +18,5 @@ pub use crawler_entities::{
 };
 pub use entities::{DocumentChunk, DownloadedAsset, ExportFormat, ExportState, ScrapedContent};
 pub use exporter::{ExportResult, Exporter, ExporterConfig, ExporterError};
+pub use js_renderer::{JsRenderError, JsRenderer};
 pub use value_objects::ValidUrl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub mod domain;
 pub use domain::semantic_cleaner::SemanticCleaner;
 pub use domain::{
     ContentType, CrawlError, CrawlResult, CrawlerConfig, CrawlerConfigBuilder, DiscoveredUrl,
-    DownloadedAsset, ExportFormat, ScrapedContent, ValidUrl,
+    DownloadedAsset, ExportFormat, JsRenderError, JsRenderer, ScrapedContent, ValidUrl,
 };
 #[cfg(feature = "ai")]
 pub use error::SemanticError;
@@ -170,10 +170,11 @@ pub use error::SemanticError;
 // Application layer — Use cases (orchestration)
 pub mod application;
 pub use application::{
-    crawl_site, crawl_with_sitemap, create_http_client, discover_urls_for_tui, extract_domain,
+    crawl_site, crawl_with_sitemap, create_http_client, detect_spa_content, discover_urls_for_tui,
+    extract_domain,
     http_client::{HttpClient, HttpClientConfig, HttpError},
     is_allowed, is_excluded, is_internal_link, matches_pattern, scrape_multiple_with_limit,
-    scrape_urls_for_tui, scrape_with_config, scrape_with_readability,
+    scrape_urls_for_tui, scrape_with_config, scrape_with_readability, SpaDetectionResult,
 };
 
 // Infrastructure layer — Implementations (technical details)
@@ -780,6 +781,18 @@ pub struct Args {
     #[cfg(not(feature = "ai"))]
     #[arg(long, default_value = "false", hide = true)]
     pub clean_ai: bool,
+
+    // ========== JavaScript Rendering (reserved for v1.4) ==========
+    /// Force JavaScript rendering for SPA sites (not yet implemented)
+    ///
+    /// Reserved for future use. When implemented, this will enable
+    /// headless browser rendering for sites that require JavaScript
+    /// to display content (Single Page Applications).
+    ///
+    /// Currently this flag is a no-op and has no effect.
+    /// Track implementation: https://github.com/XaviCode1000/rust-scraper/issues/16
+    #[arg(long, default_value = "false")]
+    pub force_js_render: bool,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `JsRenderer` trait in domain layer (forward-compatible stub, no implementation)
- Add empty-content detection in scraper pipeline (< 50 chars triggers warning)
- Emit warning when SPA-like content detected with issue tracking URL
- Document limitation in README (Known Limitations section)
- Zero new dependencies, no Chrome code

## Related

- Closes #16
- Phase 2 tracked in #18