### PR TITLE
perf(ai): add Semaphore to limit concurrent inference on 4-core CPUs

### DIFF
--- a/src/infrastructure/ai/semantic_cleaner_impl.rs
+++ b/src/infrastructure/ai/semantic_cleaner_impl.rs
@@ -55,6 +55,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use futures::future::try_join_all;
+use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
 
 use crate::domain::semantic_cleaner::{private, SemanticCleaner};
@@ -212,6 +213,9 @@ pub struct SemanticCleanerImpl {
     // Config
     /// Model and pipeline configuration
     config: ModelConfig,
+
+    /// Semaphore to limit concurrent inference blocking tasks (avoids thread thrashing on 4-core CPUs)
+    semaphore: Arc<Semaphore>,
 }
 
 impl SemanticCleanerImpl {
@@ -362,6 +366,7 @@ impl SemanticCleanerImpl {
             chunker,
             scorer,
             config,
+            semaphore: Arc::new(Semaphore::new(num_cpus::get().max(1))),
         })
     }
 
@@ -458,11 +463,15 @@ impl SemanticCleaner for SemanticCleanerImpl {
         // Following `async-join-parallel`: use try_join_all for concurrent independent operations
         // Following `async-spawn-blocking`: InferenceEngine already uses spawn_blocking internally
         // Following `anti-lock-across-await`: No locks held across await points
-        let embeddings = try_join_all(
-            token_buffers
-                .iter()
-                .map(|input| self.inference_engine.run_inference(input)),
-        )
+        let semaphore = Arc::clone(&self.semaphore);
+        let embeddings = try_join_all(token_buffers.iter().map(|input| {
+            let sem = Arc::clone(&semaphore);
+            let engine = &self.inference_engine;
+            async move {
+                let _permit = sem.acquire_owned().await.expect("semaphore no fue cerrado");
+                engine.run_inference(input).await
+            }
+        }))
         .await
         .map_err(|e| {
             SemanticError::Inference(format!("Concurrent embedding generation failed: {}", e))


### PR DESCRIPTION
## PR #2 — Mark 2026

Adds concurrency throttling to AI inference pipeline to prevent thread pool thrashing on 4-core CPUs.

### Problem
`try_join_all` in `clean()` launches ALL chunk inference tasks simultaneously. Each uses `spawn_blocking`. With 10+ chunks on 4 physical cores (i5-4590) = thread thrashing, context switching overhead, memory pressure.

### Solution
`Arc<tokio::sync::Semaphore>` with `num_cpus::get()` permits (4 on target hardware). Each `run_inference` acquires a permit before execution, released automatically via `Drop`.

### Changes
- Added `semaphore: Arc<Semaphore>` field to `SemanticCleanerImpl`
- Wrapped inference calls with `acquire_owned().await`
- Zero API change — transparent internal throttle

### Verification
- ✅ 669/669 tests passed (0 failed)
- ✅ 0 clippy warnings
- ✅ Only `semantic_cleaner_impl.rs` changed (+14/-5 lines)
- ✅ GitNexus: LOW risk, 0 affected processes