### PR TITLE
feat(storage): implement CrawlResultRepository with append-only log

### DIFF
--- a/src/application/container.rs
+++ b/src/application/container.rs
@@ -76,3 +76,25 @@ impl Container {
         self.crawl_result_repo.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::CrawlerConfig;
+    use crate::infrastructure::config::ScraperConfig;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_container_wires_crawl_result_repository() {
+        let tmp = TempDir::new().unwrap();
+        let crawler_config = CrawlerConfig::new(url::Url::parse("https://example.com").unwrap());
+        let scraper_config = ScraperConfig {
+            output_dir: tmp.path().to_path_buf(),
+            ..Default::default()
+        };
+
+        let container = Container::new(crawler_config, scraper_config).await.unwrap();
+        let repo = container.crawl_result_repository();
+        assert!(repo.is_some(), "crawl_result_repository() debe retornar Some");
+    }
+}

--- a/src/application/container.rs
+++ b/src/application/container.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use crate::application::crawl_result_repository::CrawlResultRepositoryImpl;
 use crate::application::http_client::{HttpClient, HttpClientConfig};
 use crate::domain::{repositories::CrawlResultRepository, CrawlerConfig};
 use crate::infrastructure::config::ScraperConfig;
@@ -21,6 +22,7 @@ pub struct Container {
     pub scraper_config: ScraperConfig,
     pub http_client: Arc<HttpClient>,
     pub state_store: Option<Arc<StateStore>>,
+    pub crawl_result_repo: Option<Arc<dyn CrawlResultRepository>>,
 }
 
 impl Container {
@@ -44,11 +46,22 @@ impl Container {
         // State store is optional (for resume mode)
         let state_store = None;
 
+        // Crawl result repository using append-only log
+        let log_path = scraper_config.output_dir.join("crawl_results.bin");
+        let crawl_result_repo = match CrawlResultRepositoryImpl::new(log_path, 1024) {
+            Ok(repo) => Some(Arc::new(repo) as Arc<dyn CrawlResultRepository>),
+            Err(e) => {
+                tracing::warn!("no se pudo inicializar el repositorio: {e}");
+                None
+            }
+        };
+
         Ok(Self {
             crawler_config,
             scraper_config,
             http_client,
             state_store,
+            crawl_result_repo,
         })
     }
 
@@ -58,9 +71,8 @@ impl Container {
         self
     }
 
-    /// Get a repository for crawl results (backed by state store if available).
+    /// Get a repository for crawl results (backed by append-only log).
     pub fn crawl_result_repository(&self) -> Option<Arc<dyn CrawlResultRepository>> {
-        // TODO: Implement CrawlResultRepository for StateStore
-        None
+        self.crawl_result_repo.clone()
     }
 }

--- a/src/application/crawl_result_repository.rs
+++ b/src/application/crawl_result_repository.rs
@@ -15,6 +15,7 @@
 //! - Sequential append → HDD-friendly sequential write (~120MB/s)
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -35,6 +36,10 @@ pub struct CrawlResultRepositoryImpl {
     tx: mpsc::Sender<WriteCommand>,
     index: Arc<DashMap<String, u64>>,
     log_path: PathBuf,
+    /// Set to true if the background writer encounters an I/O error.
+    /// Subsequent save() calls will fail explicitly instead of silently
+    /// accepting writes that will never be persisted.
+    write_error: Arc<AtomicBool>,
 }
 
 impl CrawlResultRepositoryImpl {
@@ -50,6 +55,7 @@ impl CrawlResultRepositoryImpl {
     pub fn new(log_path: PathBuf, buffer_capacity: usize) -> Result<Self, CrawlError> {
         let (tx, rx) = mpsc::channel(buffer_capacity);
         let index = Arc::new(DashMap::new());
+        let write_error = Arc::new(AtomicBool::new(false));
 
         // Recovery: scan existing log if present
         if log_path.exists() {
@@ -57,10 +63,16 @@ impl CrawlResultRepositoryImpl {
         }
 
         // Spawn background writer
-        let writer = BackgroundWriter::new(log_path.clone(), rx, Arc::clone(&index));
+        let writer =
+            BackgroundWriter::new(log_path.clone(), rx, Arc::clone(&index), Arc::clone(&write_error));
         tokio::spawn(writer.run());
 
-        Ok(Self { tx, index, log_path })
+        Ok(Self {
+            tx,
+            index,
+            log_path,
+            write_error,
+        })
     }
 
     /// Rebuild the DashMap index by scanning the log file sequentially.
@@ -113,16 +125,29 @@ impl CrawlResultRepositoryImpl {
 
 impl CrawlResultRepository for CrawlResultRepositoryImpl {
     fn save(&self, content: &ScrapedContent) -> Result<(), CrawlError> {
+        // Guard: if the background writer is dead, fail explicitly
+        if self.write_error.load(Ordering::Relaxed) {
+            return Err(CrawlError::Storage(
+                "writer caído, datos no persistidos".to_string(),
+            ));
+        }
+
         let payload = serde_json::to_vec(content)
             .map_err(|e| CrawlError::Storage(format!("serialización fallida: {}", e)))?;
 
         let url = content.url.as_str().to_string();
         self.tx
-            .try_send(WriteCommand::Append {
-                url: url.clone(),
-                payload,
-            })
-            .map_err(|_| CrawlError::Storage("canal lleno, backpressure".to_string()))?;
+            .try_send(WriteCommand::Append { url, payload })
+            .map_err(|e| match e {
+                mpsc::error::TrySendError::Full(_) => {
+                    CrawlError::Storage("canal lleno, backpressure".to_string())
+                }
+                mpsc::error::TrySendError::Closed(_) => {
+                    // Writer task dropped the receiver — mark as dead
+                    self.write_error.store(true, Ordering::Relaxed);
+                    CrawlError::Storage("writer caído, canal cerrado".to_string())
+                }
+            })?;
 
         Ok(())
     }
@@ -166,6 +191,7 @@ struct BackgroundWriter {
     rx: mpsc::Receiver<WriteCommand>,
     index: Arc<DashMap<String, u64>>,
     log_path: PathBuf,
+    write_error: Arc<AtomicBool>,
 }
 
 impl BackgroundWriter {
@@ -173,8 +199,14 @@ impl BackgroundWriter {
         log_path: PathBuf,
         rx: mpsc::Receiver<WriteCommand>,
         index: Arc<DashMap<String, u64>>,
+        write_error: Arc<AtomicBool>,
     ) -> Self {
-        Self { rx, index, log_path }
+        Self {
+            rx,
+            index,
+            log_path,
+            write_error,
+        }
     }
 
     async fn run(mut self) {
@@ -188,6 +220,7 @@ impl BackgroundWriter {
             Ok(f) => f,
             Err(e) => {
                 tracing::error!("no se pudo abrir log para escritura: {e}");
+                self.write_error.store(true, Ordering::Relaxed);
                 return;
             }
         };
@@ -197,18 +230,22 @@ impl BackgroundWriter {
                 WriteCommand::Append { url, payload } => {
                     let len = payload.len() as u32;
                     let len_bytes = len.to_le_bytes();
+
                     let offset = file.metadata().map(|m| m.len()).unwrap_or(0);
 
                     if file.write_all(&len_bytes).is_err() {
                         tracing::error!("error escribiendo longitud al log");
+                        self.write_error.store(true, Ordering::Relaxed);
                         continue;
                     }
                     if file.write_all(&payload).is_err() {
                         tracing::error!("error escribiendo payload al log");
+                        self.write_error.store(true, Ordering::Relaxed);
                         continue;
                     }
                     if file.write_all(b"\n").is_err() {
                         tracing::error!("error escribiendo newline al log");
+                        self.write_error.store(true, Ordering::Relaxed);
                         continue;
                     }
                     let _ = file.flush();

--- a/src/application/crawl_result_repository.rs
+++ b/src/application/crawl_result_repository.rs
@@ -1,0 +1,419 @@
+//! Append-only storage for crawl results
+//!
+//! Implements [`CrawlResultRepository`] using a binary append-only log file
+//! with a [`DashMap`] in-memory index (URL → byte offset). A single background
+//! writer task receives writes via [`mpsc::channel`] — no locks on the hot path.
+//!
+//! ## Storage Format
+//!
+//! ```text
+//! [4 bytes: u32 LE payload_length][N bytes: JSON ScrapedContent][1 byte: \n]
+//! ```
+//!
+//! - `\n` terminator enables corruption detection and manual inspection
+//! - Size prefix enables O(1) random access via index offset
+//! - Sequential append → HDD-friendly sequential write (~120MB/s)
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::mpsc;
+
+use crate::domain::repositories::CrawlResultRepository;
+use crate::domain::{CrawlError, ScrapedContent};
+
+enum WriteCommand {
+    Append { url: String, payload: Vec<u8> },
+}
+
+/// Append-only storage for crawl results
+///
+/// Writes are sent to a background writer task via an mpsc channel.
+/// Reads use the in-memory DashMap index for O(1) lookups.
+pub struct CrawlResultRepositoryImpl {
+    tx: mpsc::Sender<WriteCommand>,
+    index: Arc<DashMap<String, u64>>,
+    log_path: PathBuf,
+}
+
+impl CrawlResultRepositoryImpl {
+    /// Create a new append-only repository.
+    ///
+    /// Spawns a background writer task and, if the log file exists, rebuilds
+    /// the index by scanning existing records.
+    ///
+    /// # Arguments
+    ///
+    /// * `log_path` - Path to the append-only log file
+    /// * `buffer_capacity` - Capacity of the mpsc channel (backpressure limit)
+    pub fn new(log_path: PathBuf, buffer_capacity: usize) -> Result<Self, CrawlError> {
+        let (tx, rx) = mpsc::channel(buffer_capacity);
+        let index = Arc::new(DashMap::new());
+
+        // Recovery: scan existing log if present
+        if log_path.exists() {
+            Self::recover_index(&log_path, &index)?;
+        }
+
+        // Spawn background writer
+        let writer = BackgroundWriter::new(log_path.clone(), rx, Arc::clone(&index));
+        tokio::spawn(writer.run());
+
+        Ok(Self { tx, index, log_path })
+    }
+
+    /// Rebuild the DashMap index by scanning the log file sequentially.
+    fn recover_index(path: &PathBuf, index: &DashMap<String, u64>) -> Result<(), CrawlError> {
+        use std::io::Read;
+
+        let file = std::fs::File::open(path)
+            .map_err(|e| CrawlError::Storage(format!("no se pudo abrir log: {}", e)))?;
+        let mut reader = std::io::BufReader::new(file);
+        let mut offset: u64 = 0;
+
+        loop {
+            let mut len_buf = [0u8; 4];
+            match reader.read_exact(&mut len_buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => {
+                    return Err(CrawlError::Storage(format!(
+                        "lectura corrupta en offset {offset}: {e}"
+                    )))
+                }
+            }
+
+            let len = u32::from_le_bytes(len_buf) as usize;
+
+            // If remaining file is too short, discard incomplete trailing record
+            let mut payload = vec![0u8; len];
+            if reader.read_exact(&mut payload).is_err() {
+                // Partial trailing record — crash-safe: skip silently
+                break;
+            }
+
+            // Skip newline
+            let mut newline = [0u8; 1];
+            let _ = reader.read_exact(&mut newline);
+
+            // Extract URL from JSON to populate index
+            if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&payload) {
+                if let Some(url) = json.get("url").and_then(|u| u.as_str()) {
+                    index.insert(url.to_string(), offset);
+                }
+            }
+
+            offset += 4 + len as u64 + 1;
+        }
+
+        Ok(())
+    }
+}
+
+impl CrawlResultRepository for CrawlResultRepositoryImpl {
+    fn save(&self, content: &ScrapedContent) -> Result<(), CrawlError> {
+        let payload = serde_json::to_vec(content)
+            .map_err(|e| CrawlError::Storage(format!("serialización fallida: {}", e)))?;
+
+        let url = content.url.as_str().to_string();
+        self.tx
+            .try_send(WriteCommand::Append {
+                url: url.clone(),
+                payload,
+            })
+            .map_err(|_| CrawlError::Storage("canal lleno, backpressure".to_string()))?;
+
+        Ok(())
+    }
+
+    fn find_by_url(&self, url: &str) -> Result<Option<ScrapedContent>, CrawlError> {
+        use std::io::{Read, Seek, SeekFrom};
+
+        let offset = match self.index.get(url) {
+            Some(entry) => *entry,
+            None => return Ok(None),
+        };
+
+        let mut file = std::fs::File::open(&self.log_path)
+            .map_err(|e| CrawlError::Storage(format!("no se pudo abrir log: {}", e)))?;
+
+        file.seek(SeekFrom::Start(offset))
+            .map_err(|e| CrawlError::Storage(format!("seek fallido: {}", e)))?;
+
+        let mut len_buf = [0u8; 4];
+        file.read_exact(&mut len_buf)
+            .map_err(|e| CrawlError::Storage(format!("lectura de longitud fallida: {}", e)))?;
+        let len = u32::from_le_bytes(len_buf) as usize;
+
+        let mut payload = vec![0u8; len];
+        file.read_exact(&mut payload)
+            .map_err(|e| CrawlError::Storage(format!("lectura de payload fallida: {}", e)))?;
+
+        let result: ScrapedContent = serde_json::from_slice(&payload)
+            .map_err(|e| CrawlError::Storage(format!("deserialización fallida: {}", e)))?;
+
+        Ok(Some(result))
+    }
+
+    fn get_all_urls(&self) -> Result<Vec<String>, CrawlError> {
+        Ok(self.index.iter().map(|entry| entry.key().clone()).collect())
+    }
+}
+
+/// Background writer task that processes write commands sequentially.
+struct BackgroundWriter {
+    rx: mpsc::Receiver<WriteCommand>,
+    index: Arc<DashMap<String, u64>>,
+    log_path: PathBuf,
+}
+
+impl BackgroundWriter {
+    fn new(
+        log_path: PathBuf,
+        rx: mpsc::Receiver<WriteCommand>,
+        index: Arc<DashMap<String, u64>>,
+    ) -> Self {
+        Self { rx, index, log_path }
+    }
+
+    async fn run(mut self) {
+        use std::io::Write;
+
+        let mut file = match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.log_path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::error!("no se pudo abrir log para escritura: {e}");
+                return;
+            }
+        };
+
+        while let Some(cmd) = self.rx.recv().await {
+            match cmd {
+                WriteCommand::Append { url, payload } => {
+                    let len = payload.len() as u32;
+                    let len_bytes = len.to_le_bytes();
+                    let offset = file.metadata().map(|m| m.len()).unwrap_or(0);
+
+                    if file.write_all(&len_bytes).is_err() {
+                        tracing::error!("error escribiendo longitud al log");
+                        continue;
+                    }
+                    if file.write_all(&payload).is_err() {
+                        tracing::error!("error escribiendo payload al log");
+                        continue;
+                    }
+                    if file.write_all(b"\n").is_err() {
+                        tracing::error!("error escribiendo newline al log");
+                        continue;
+                    }
+                    let _ = file.flush();
+
+                    self.index.insert(url, offset);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+    use url::Url;
+
+    use crate::domain::value_objects::ValidUrl;
+
+    /// Helper: URL with trailing slash removed for consistent assertions.
+    /// Url::parse normalizes "https://a.com" to "https://a.com/"
+    fn make_content(url_str: &str, title: &str) -> ScrapedContent {
+        let url = Url::parse(url_str).unwrap();
+        ScrapedContent {
+            url: ValidUrl::new(url),
+            title: title.to_string(),
+            content: format!("Content for {title}"),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: vec![],
+        }
+    }
+
+    /// Poll until the background writer has processed a write for the given URL.
+    async fn wait_for_index(repo: &CrawlResultRepositoryImpl, url: &str) {
+        for _ in 0..40 {
+            if repo.find_by_url(url).unwrap().is_some() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_save_and_find_by_url() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+
+        let content = make_content("https://example.com", "Example");
+        repo.save(&content).unwrap();
+
+        // Poll until the background writer has updated the index
+        wait_for_index(&repo, "https://example.com/").await;
+
+        let found = repo.find_by_url("https://example.com/").unwrap();
+        assert!(found.is_some(), "expected to find saved content");
+        let found = found.unwrap();
+        assert_eq!(found.title, "Example");
+        assert_eq!(found.content, "Content for Example");
+        // Normalized URL from url::Url includes trailing slash
+        assert_eq!(found.url.as_str(), "https://example.com/");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_url_unknown_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+
+        let found = repo.find_by_url("https://unknown.com").unwrap();
+        assert!(found.is_none(), "expected None for unknown URL");
+    }
+
+    #[tokio::test]
+    async fn test_get_all_urls_returns_all_saved() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+
+        repo.save(&make_content("https://a.com", "A")).unwrap();
+        repo.save(&make_content("https://b.com", "B")).unwrap();
+        repo.save(&make_content("https://c.com", "C")).unwrap();
+
+        // Wait for all three writes
+        wait_for_index(&repo, "https://a.com/").await;
+        wait_for_index(&repo, "https://b.com/").await;
+        wait_for_index(&repo, "https://c.com/").await;
+
+        let mut urls = repo.get_all_urls().unwrap();
+        urls.sort();
+        // url::Url normalizes bare domains with trailing slash
+        assert_eq!(
+            urls,
+            vec!["https://a.com/", "https://b.com/", "https://c.com/"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recovery_rebuilds_index() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+
+        // First session: save entries
+        {
+            let repo = CrawlResultRepositoryImpl::new(log_path.clone(), 64).unwrap();
+            repo.save(&make_content("https://first.com", "First")).unwrap();
+            repo.save(&make_content("https://second.com", "Second")).unwrap();
+            wait_for_index(&repo, "https://first.com/").await;
+            wait_for_index(&repo, "https://second.com/").await;
+        } // repo drops — writer task stops
+
+        // Second session: recover from existing log
+        {
+            let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+            let mut urls = repo.get_all_urls().unwrap();
+            urls.sort();
+            assert_eq!(
+                urls,
+                vec!["https://first.com/", "https://second.com/"]
+            );
+
+            let found = repo.find_by_url("https://first.com/").unwrap();
+            assert!(found.is_some());
+            assert_eq!(found.unwrap().title, "First");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_empty_repository_returns_empty_urls() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+
+        let urls = repo.get_all_urls().unwrap();
+        assert!(urls.is_empty(), "expected empty URL list for fresh repo");
+    }
+
+    #[tokio::test]
+    async fn test_save_multiple_and_read_each() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+
+        let contents = vec![
+            make_content("https://alpha.com/page1", "Alpha One"),
+            make_content("https://beta.com/page2", "Beta Two"),
+            make_content("https://gamma.com/page3", "Gamma Three"),
+        ];
+
+        for c in &contents {
+            repo.save(c).unwrap();
+        }
+
+        // Wait for all writes
+        wait_for_index(&repo, "https://alpha.com/page1").await;
+        wait_for_index(&repo, "https://beta.com/page2").await;
+        wait_for_index(&repo, "https://gamma.com/page3").await;
+
+        let found = repo.find_by_url("https://alpha.com/page1").unwrap().unwrap();
+        assert_eq!(found.title, "Alpha One");
+        assert_eq!(found.content, "Content for Alpha One");
+
+        let found = repo.find_by_url("https://gamma.com/page3").unwrap().unwrap();
+        assert_eq!(found.title, "Gamma Three");
+        assert_eq!(found.content, "Content for Gamma Three");
+    }
+
+    #[tokio::test]
+    async fn test_crash_safe_partial_record() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+
+        // Write a valid record followed by a partial (truncated) record
+        {
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path)
+                .unwrap();
+
+            // Valid record
+            let content = make_content("https://valid.com", "Valid");
+            let payload = serde_json::to_vec(&content).unwrap();
+            let len = (payload.len() as u32).to_le_bytes();
+            file.write_all(&len).unwrap();
+            file.write_all(&payload).unwrap();
+            file.write_all(b"\n").unwrap();
+
+            // Partial record: write only 2 bytes of a 4-byte length prefix
+            file.write_all(&[0xFF, 0xFF]).unwrap();
+            file.flush().unwrap();
+        }
+
+        // Recovery should succeed and only contain valid.com
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+        let urls = repo.get_all_urls().unwrap();
+        assert_eq!(urls, vec!["https://valid.com/"]);
+
+        // And we can retrieve the valid record
+        let found = repo.find_by_url("https://valid.com/").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().title, "Valid");
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,6 +4,7 @@
 //! using infrastructure services. It depends on both domain and infrastructure.
 
 pub mod container;
+pub mod crawl_result_repository;
 pub mod crawler_service;
 pub mod deduplicator;
 pub mod export_factory;

--- a/src/domain/entities.rs
+++ b/src/domain/entities.rs
@@ -165,7 +165,7 @@ pub struct ScrapedContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub html: Option<String>,
     /// Downloaded assets (images, documents)
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub assets: Vec<DownloadedAsset>,
 }
 

--- a/src/domain/error/crawl_error.rs
+++ b/src/domain/error/crawl_error.rs
@@ -83,6 +83,10 @@ pub enum CrawlError {
     /// Sitemap not found during auto-discovery
     #[error("sitemap not found for {0}")]
     SitemapNotFound(String),
+
+    /// Storage error (append-only log corruption, backpressure, serialization)
+    #[error("error de almacenamiento: {0}")]
+    Storage(String),
 }
 
 #[cfg(test)]
@@ -127,6 +131,23 @@ mod tests {
     fn test_crawl_error_internal() {
         let error = CrawlError::Internal("something went wrong".to_string());
         assert!(error.to_string().contains("something went wrong"));
+    }
+
+    #[test]
+    fn test_crawl_error_storage_display() {
+        let error = CrawlError::Storage("archivo corrupto".to_string());
+        assert!(
+            error.to_string().contains("error de almacenamiento"),
+            "expected Storage display to contain 'error de almacenamiento', got: {}",
+            error
+        );
+        assert!(error.to_string().contains("archivo corrupto"));
+    }
+
+    #[test]
+    fn test_crawl_error_storage_empty_message() {
+        let error = CrawlError::Storage(String::new());
+        assert!(error.to_string().contains("error de almacenamiento"));
     }
 
     #[test]

--- a/src/domain/repositories.rs
+++ b/src/domain/repositories.rs
@@ -3,24 +3,24 @@
 //! Defines contracts for storing and retrieving domain entities.
 //! Infrastructure layer implements these traits.
 
-use crate::domain::{CrawlError, CrawlResult, ScrapedContent};
+use crate::domain::{CrawlError, ScrapedContent};
 
 /// Repository interface for crawl results
 ///
 /// Defines the contract for persisting and retrieving crawl data.
 /// Implementations can use files, databases, or other storage backends.
 pub trait CrawlResultRepository {
-    /// Save a crawl result
+    /// Save scraped content
     ///
     /// # Arguments
     ///
-    /// * `result` - The crawl result to persist
+    /// * `content` - The scraped content to persist
     ///
     /// # Returns
     ///
     /// * `Ok(())` - Success
     /// * `Err(CrawlError)` - Persistence error
-    fn save(&self, result: &CrawlResult) -> Result<(), CrawlError>;
+    fn save(&self, content: &ScrapedContent) -> Result<(), CrawlError>;
 
     /// Find scraped content by URL
     ///
@@ -42,4 +42,49 @@ pub trait CrawlResultRepository {
     /// * `Ok(Vec<String>)` - List of crawled URLs
     /// * `Err(CrawlError)` - Query error
     fn get_all_urls(&self) -> Result<Vec<String>, CrawlError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::ScrapedContent;
+    use crate::domain::value_objects::ValidUrl;
+    use url::Url;
+
+    /// Minimal mock that implements the new save(&ScrapedContent) signature.
+    /// This test verifies the trait accepts ScrapedContent, NOT CrawlResult.
+    struct MockRepo;
+
+    impl CrawlResultRepository for MockRepo {
+        fn save(&self, _content: &ScrapedContent) -> Result<(), CrawlError> {
+            Ok(())
+        }
+
+        fn find_by_url(&self, _url: &str) -> Result<Option<ScrapedContent>, CrawlError> {
+            Ok(None)
+        }
+
+        fn get_all_urls(&self) -> Result<Vec<String>, CrawlError> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn test_repository_trait_save_accepts_scraped_content() {
+        let repo = MockRepo;
+        let url = Url::parse("https://example.com").unwrap();
+        let valid_url = ValidUrl::new(url);
+        let content = ScrapedContent {
+            url: valid_url,
+            title: "Test".to_string(),
+            content: "Hello".to_string(),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: vec![],
+        };
+        let result = repo.save(&content);
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
## PR #3 — Mark 2026

Replaces the null stub with a real append-only log implementation optimized for HDD sequential writes.

### Architecture
- **Binary log**: `[4-byte LE len][JSON payload][\n]` — sequential append, O(1) seek by offset
- **Background writer**: `tokio::spawn` with `mpsc` channel, non-blocking `try_send` for backpressure
- **DashMap index**: `URL → byte offset` for O(1) lookups, thread-safe
- **Recovery**: linear scan on startup rebuilds index (HDD sequential, efficient)

### Changes
- New `CrawlResultRepositoryImpl` + `BackgroundWriter` (419 lines)
- `CrawlError::Storage(String)` variant (Spanish error messages)
- Trait updated: `save(&ScrapedContent)` instead of `save(&CrawlResult)`
- Container wired, returns `Some` instead of `None`
- `#[serde(default)]` on `assets` for JSON roundtrip compat

### Verification
- ✅ 679/679 tests passed (0 failed)
- ✅ 0 clippy warnings
- ✅ 6/6 spec requirements compliant
- ✅ 6/6 scenarios validated
- ✅ GitNexus: LOW risk, 6 files changed

### Known Limitation
Save-and-forget: `save()` returns `Ok(())` on queue success. If the background writer fails (disk full), error is logged but caller is not notified. This is a deliberate design trade-off for speed over guaranteed delivery.