### PR TITLE
telemetry(bench): add Criterion micro-benchmarks for WAF and SIMD cosine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +531,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +601,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -853,6 +892,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2327,6 +2402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,6 +3064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,6 +3357,34 @@ dependencies = [
  "quick-xml 0.38.4",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -3988,6 +4108,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "console-subscriber",
+ "criterion",
  "crossterm 0.28.1",
  "dashmap 6.1.0",
  "dirs 5.0.1",
@@ -4913,6 +5034,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,11 +228,21 @@ static_assertions = "1.1"
 assert_cmd = "2"
 predicates = "3"
 
+criterion = { version = "0.5", features = ["html_reports"] }
 
 tempfile = "3"
 walkdir = "2"
 wiremock = "0.6"
 proptest = "1.6"
+
+[[bench]]
+name = "waf_detection"
+harness = false
+
+[[bench]]
+name = "cosine_similarity"
+harness = false
+required-features = ["ai"]
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2", "chrono"] }

--- a/benches/cosine_similarity.rs
+++ b/benches/cosine_similarity.rs
@@ -1,0 +1,32 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+// Only compile with ai feature
+#[cfg(feature = "ai")]
+use rust_scraper::infrastructure::ai::embedding_ops::cosine_similarity;
+
+#[cfg(feature = "ai")]
+fn bench_cosine_similarity(c: &mut Criterion) {
+    let dims = 384;
+    // Deterministic data — no rand crate needed
+    let a: Vec<f32> = (0..dims).map(|i| (i as f32 * 0.01).sin()).collect();
+    let b: Vec<f32> = (0..dims).map(|i| (i as f32 * 0.01 + 1.0).cos()).collect();
+
+    let mut group = c.benchmark_group("cosine_similarity");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("simd_384d", |bencher| {
+        bencher.iter(|| black_box(cosine_similarity(black_box(&a), black_box(&b))))
+    });
+    group.finish();
+}
+
+#[cfg(feature = "ai")]
+criterion_group!(benches, bench_cosine_similarity);
+
+#[cfg(feature = "ai")]
+criterion_main!(benches);
+
+// Placeholder when ai feature is disabled
+#[cfg(not(feature = "ai"))]
+fn main() {
+    println!("Benchmarks require --features ai");
+}

--- a/benches/waf_detection.rs
+++ b/benches/waf_detection.rs
@@ -1,0 +1,57 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use rust_scraper::infrastructure::http::waf_engine::WafInspector;
+use wreq::header::HeaderMap;
+
+fn bench_waf_verify_integrity(c: &mut Criterion) {
+    // Generate ~500KB HTML body with some WAF signatures embedded
+    let body = generate_html_body();
+
+    let mut group = c.benchmark_group("waf_detection");
+    group.throughput(Throughput::Bytes(body.len() as u64));
+    group.bench_function("verify_integrity_500kb", |b| {
+        b.iter(|| {
+            black_box(WafInspector::verify_integrity(
+                black_box(&HeaderMap::new()),
+                black_box(&body),
+            ))
+        })
+    });
+    group.finish();
+}
+
+fn generate_html_body() -> String {
+    let template = r#"<html><head><title>Page</title></head><body>
+<div class="content">
+<h1>Article Title</h1>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
+<div class="article-content">
+<p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>
+</div>
+</body></html>"#;
+
+    // Include some WAF signatures for realistic detection
+    let signatures = [
+        "cf-turnstile",
+        "Just a moment...",
+        "g-recaptcha",
+        "datadome",
+        "challenge-platform",
+    ];
+
+    let mut body = String::new();
+    // Repeat until ~500KB
+    while body.len() < 500_000 {
+        body.push_str(template);
+        // Insert a signature every 10 templates for realism
+        if body.len() % (template.len() * 10) < template.len() {
+            if let Some(sig) = signatures.get((body.len() / template.len()) % signatures.len()) {
+                body.push_str(&format!("<div class=\"waf-marker\">{}</div>", sig));
+            }
+        }
+    }
+    body
+}
+
+criterion_group!(benches, bench_waf_verify_integrity);
+criterion_main!(benches);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,11 +6,10 @@
 //! Run with features: cargo test --test integration --features images,documents
 
 use rust_scraper::{
-    create_http_client, save_results, scrape_with_config, scrape_with_readability, DownloadedAsset,
+    create_http_client, save_results, scrape_with_readability, DownloadedAsset,
     ScrapedContent, ValidUrl,
 };
 use tempfile::TempDir;
-use walkdir::WalkDir;
 
 // ============================================================================
 // Integration Tests: Full scraping pipeline
@@ -306,6 +305,8 @@ fn test_save_results_markdown_with_markdown_syntax() {
 #[cfg(feature = "images")]
 #[tokio::test]
 async fn test_download_images_from_website() {
+    use rust_scraper::scrape_with_config;
+
     // Arrange - Use webscraper.io test site (free, no auth required)
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let output_dir = temp_dir.path().to_path_buf();
@@ -372,6 +373,8 @@ async fn test_download_images_from_website() {
 #[cfg(feature = "documents")]
 #[tokio::test]
 async fn test_download_documents_from_website() {
+    use rust_scraper::scrape_with_config;
+
     // Arrange - Use a test site with documents if available
     // Note: Most test sites don't have documents, so this tests the extraction logic
     let temp_dir = TempDir::new().expect("Failed to create temp dir");


### PR DESCRIPTION
## PR #4 — Mark 2026

Adds Criterion micro-benchmarks to measure performance of the two critical hot paths optimized in Mark 2026.

### Benchmarks

| Benchmark | Target | Metric |
|-----------|--------|--------|
| `waf_detection` | `WafInspector::verify_integrity()` with 500KB HTML | MiB/s throughput |
| `cosine_similarity` | SIMD `f32x8` cosine_similarity() with 384D vectors | vectors/sec |

### Changes
- `criterion 0.5` added to dev-dependencies with `html_reports` feature
- `benches/waf_detection.rs` — realistic 500KB HTML body with WAF signatures
- `benches/cosine_similarity.rs` — deterministic 384D vectors, feature-gated behind `ai`

### Usage
```bash
cargo bench --bench waf_detection
cargo bench --bench cosine_similarity --features ai
```

### Verification
- ✅ `cargo check --benches` compiles
- ✅ `cargo clippy --benches -- -D warnings` clean
- ✅ 669/669 tests unaffected