### PR TITLE
feat(cli): add --single-page flag to scrape only seed URL without discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,17 @@
 Production-ready web scraper. Clean Architecture, TUI selector, AI semantic cleaning.
 
 **Stack:** Rust 1.88 · Tokio · wreq (TLS fingerprint) · ratatui · tract-onnx (feature-gated)
-**Hardware:** Intel i5-4590 (4C), 8GB DDR3, HDD — cloud CI for heavy work
+**Hardware:** Ryzen 7 5700X (8C/16T), 32GB DDR4, NVMe — local dev for most tasks
+
+### Build dependencies (required)
+
+`cmake` is mandatory — `wreq` → `boring2` → `boring-sys2` needs it to compile BoringSSL.
+Without it, nothing compiles. Install before first build:
+
+```bash
+# Fedora
+sudo dnf install cmake
+```
 
 ---
 
@@ -14,9 +24,11 @@ Production-ready web scraper. Clean Architecture, TUI selector, AI semantic clea
 ```
 gitnexus analyze                    # Refresh index (re-run after branch switch)
 gitnexus analyze --skills           # Regenerate skill files if communities changed
+codedb_status                       # Verify CodeDB index is fresh
 ```
 
 If you see "Index is stale" from any gitnexus tool → stop and run `gitnexus analyze` first.
+If `codedb_status` shows stale index → run `codedb_index` to rebuild.
 
 If `gitnexus analyze` crashes with `Napi::Error` or hangs → clean first:
 ```bash
@@ -35,7 +47,7 @@ gitnexus_impact({target: "symbolName", direction: "upstream"})
 - **HIGH risk** → stop, warn user, get approval
 - **CRITICAL risk** → stop, require user sign-off
 
-Consult `gitnexus-master` skill for full impact analysis protocol (depth groups, confidence scores).
+Consult `gitnexus-impact-analysis` skill for full impact analysis protocol (depth groups, confidence scores).
 
 ### 3. Before Writing Rust
 
@@ -52,15 +64,7 @@ gitnexus_detect_changes()      # Verify only expected symbols changed
 
 If `gitnexus_detect_changes()` shows unexpected affected symbols → review before committing.
 
-### 5. Before Finishing (self-check)
-
-1. `cargo check` passes
-2. No clippy warnings
-3. `gitnexus_impact` was run for modified symbols
-4. No HIGH/CRITICAL risk ignored
-5. `gitnexus_detect_changes()` confirms expected scope
-
-### 6. Cloud Verification (after commit)
+### 5. Cloud Verification (after commit)
 
 ```bash
 gh workflow run ci.yml --ref $(git branch --show-current)
@@ -73,7 +77,7 @@ Only push after CI shows ✅. If CI fails → fix locally, re-commit, re-trigger
 
 ## Commands
 
-### Local (safe, <30s total)
+### Local (safe, <5s total)
 
 ```bash
 cargo check                    # Verify compilation
@@ -83,21 +87,24 @@ cargo fmt --check              # Format check
 cargo fmt                      # Format
 ```
 
-### Forbidden on this machine (HDD + 8GB RAM — WILL freeze system)
+### Local (moderate, <5 min)
 
-| Command | Why | Alternative |
-|---------|-----|-------------|
-| `cargo nextest run` | 680 tests, 5-10 min, 100% CPU | `gh workflow run ci.yml` |
-| `cargo nextest run --all-features` | AI model (90MB) loads | CI |
-| `cargo build --release` | 10+ min optimization | CI |
-| `cargo build` | Slower than `cargo check` | `cargo check` |
-| `just test-ci` | Full gate, 10+ min | `gh workflow run ci.yml` |
-| `cargo llvm-cov` | Instrument + test, 15+ min | CI |
-| `cargo miri test` | Interprets instructions, 30+ min | CI |
-
-**Exception:** single test for debugging is allowed:
 ```bash
-cargo nextest run --test-threads 2 -E 'test(specific_test_name)'
+cargo nextest run              # Full suite, ~1-2 min
+cargo nextest run --all-features  # With AI, ~2-3 min
+just test-ci                   # Full gate (fmt+clippy+tests), ~3-5 min
+cargo build --release          # ~3-5 min (LTO fat)
+```
+
+> **Note:** `cargo build --release` uses LTO fat + codegen-units=1 (see `Cargo.toml:257`).
+> First clean build compiles BoringSSL from C++ source — expect longer times.
+> Incremental builds with sccache are significantly faster.
+
+### Prefer CI (slow, >5 min)
+
+```bash
+cargo llvm-cov                 # Coverage instrumentation (~5-8 min)
+cargo miri test                # Memory safety interpretation (~10-15 min)
 ```
 
 ---
@@ -106,38 +113,40 @@ cargo nextest run --test-threads 2 -E 'test(specific_test_name)'
 
 Sub-agents get a fresh context with no memory. The orchestrator controls context access.
 
-### MANDATORY: Sub-agents MUST use GitNexus
+### MANDATORY: Sub-agents MUST use GitNexus + CodeDB
 
-**Every sub-agent that reads, writes, or reviews code MUST use GitNexus tools for code investigation.** The orchestrator enforces this by:
+**Every sub-agent that reads, writes, or reviews code MUST use GitNexus and CodeDB tools for code investigation.** The orchestrator enforces this by:
 
-1. Always passing `gitnexus-master/SKILL.md` in the skill paths
-2. Including in the sub-agent prompt: `"You MUST use gitnexus_query to find code, gitnexus_impact before editing, and gitnexus_detect_changes before returning. Do NOT grep the project codebase."`
-3. Sub-agents that grep instead of using GitNexus are discipline failures
+1. Always passing the relevant skill names in the sub-agent prompt
+2. Including in the sub-agent prompt: `"You MUST use codedb_search/codedb_symbol to find code, gitnexus_impact before editing, and gitnexus_detect_changes before returning. Do NOT grep the project codebase."`
+3. Sub-agents that grep instead of using GitNexus/CodeDB are discipline failures
 
 **Delegate when:**
-- Reading 4+ files to understand codebase → exploration sub-agent (with gitnexus-master)
-- Writing code across 2+ files → writer sub-agent (with gitnexus-master + rust-skills)
+- Reading 4+ files to understand codebase → exploration sub-agent (with gitnexus-exploring + codedb)
+- Writing code across 2+ files → writer sub-agent (with gitnexus-exploring + codedb + rust-skills)
 - Running tests or CI → sub-agent
-- Multi-step refactoring → sub-agent (with gitnexus-master + rust-skills)
+- Multi-step refactoring → sub-agent (with gitnexus-refactoring + codedb + rust-skills)
 
 **Do inline when:**
 - Reading 1-3 files for decision/verification
 - Single-file mechanical edits
 - Git/gh state checks (status, log, diff)
 
-**When delegating, pass skill paths explicitly:**
+**When delegating, reference skills by name (OpenCode auto-discovers them):**
 ```
 ## Skills to load before work
-- /path/to/gitnexus-master/SKILL.md
-- /path/to/rust-skills/SKILL.md
+- gitnexus-exploring
+- codedb
+- rust-skills
 ```
 
 Every sub-agent prompt that involves code MUST include:
 ```
-MANDATORY: Load gitnexus-master skill. Use MCP tools (gitnexus_query,
-gitnexus_impact, gitnexus_detect_changes) — NEVER shell out to `gitnexus`
-CLI for analysis. MCP tools are instant. CLI is only for analyze/clean/wiki.
-NEVER grep the project codebase when gitnexus_query works.
+MANDATORY: Load gitnexus-exploring and codedb skills. Use MCP tools
+(codedb_search, codedb_symbol, gitnexus_query, gitnexus_impact,
+gitnexus_detect_changes) — NEVER shell out to CLI for analysis.
+MCP tools are instant. CLI is only for analyze/clean/wiki.
+NEVER grep the project codebase when codedb_search works.
 ```
 
 ---
@@ -146,7 +155,6 @@ NEVER grep the project codebase when gitnexus_query works.
 
 - Error messages in **Spanish** (not English)
 - HTTP client is **`wreq`** (not `reqwest`) — TLS fingerprint emulation for WAF evasion
-- Never use `.unwrap()` in production — use `?` or `match`
 
 ---
 
@@ -172,12 +180,6 @@ Responses scanned for WAF signatures (Cloudflare, reCAPTCHA, hCaptcha, DataDome,
 
 ## Boundaries
 
-### Always
-
-- `cargo check` before marking tasks complete
-- `cargo clippy -- -D warnings` before committing
-- Run `cargo fmt` before committing
-
 ### Ask first
 
 - Adding or removing dependencies
@@ -187,10 +189,9 @@ Responses scanned for WAF signatures (Cloudflare, reCAPTCHA, hCaptcha, DataDome,
 ### Never
 
 - Commit secrets, `.env`, or credentials
-- Use `.unwrap()` in production code
+- Use `.unwrap()` in production code — use `?` or `match`
 - Force push to main
 - Modify `target/`, `dist/`, `build/` directories
-- Run any command from the forbidden table above
 
 ---
 
@@ -198,41 +199,40 @@ Responses scanned for WAF signatures (Cloudflare, reCAPTCHA, hCaptcha, DataDome,
 
 | Purpose | Skill | Load when |
 |---------|-------|-----------|
-| Code intelligence | `gitnexus-master` | Any code work — has full MCP tools, CLI commands, impact protocol |
-| Rust quality | `rust-skills` | Writing Rust — ownership, error handling, async, testing |
+| Code exploration | `gitnexus-exploring` | Understanding architecture, tracing flows |
+| Impact analysis | `gitnexus-impact-analysis` | Before editing any symbol |
+| Debugging | `gitnexus-debugging` | Tracing bugs, error investigation |
+| Refactoring | `gitnexus-refactoring` | Rename, extract, split, move |
+| PR review | `gitnexus-pr-review` | Reviewing pull requests |
+| GitNexus reference | `gitnexus-guide` | Tool/resource/schema questions |
+| GitNexus CLI | `gitnexus-cli` | Index, status, clean, wiki commands |
+| **Code search** | **`codedb`** | **Structural search, symbols, callers, outlines, file tree** |
+| Rust quality | `rust-skills` | Writing Rust — ownership, error handling, async |
 | SDD workflow | `sdd-*` skills | Planning/verifying changes |
 
-Skills contain tool details (parameters, flags, schemas). This file contains workflow (when, sequence).
-
----
-
-## Resources
-
-- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — Architecture details
-- [justfile](justfile) — Task recipes
-- [docs/wiki/](docs/wiki/) — GitNexus auto-generated documentation
+Skills are auto-discovered by OpenCode from `~/.config/opencode/skills/`. Reference by name only — no paths needed.
 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **rust_scraper** (4319 symbols, 7915 relationships, 161 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **rust_scraper** (4460 symbols, 9232 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `gitnexus analyze` from the project root.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 
@@ -243,15 +243,65 @@ This project is indexed by GitNexus as **rust_scraper** (4319 symbols, 7915 rela
 | `gitnexus://repo/rust_scraper/processes` | All execution flows |
 | `gitnexus://repo/rust_scraper/process/{name}` | Step-by-step execution trace |
 
-## CLI
+## Skills
 
-| Task | Read this skill file |
-|------|---------------------|
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
-| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
-| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
-| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
-| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+| Task | Skill |
+|------|-------|
+| Understand architecture / "How does X work?" | `gitnexus-exploring` |
+| Blast radius / "What breaks if I change X?" | `gitnexus-impact-analysis` |
+| Trace bugs / "Why is X failing?" | `gitnexus-debugging` |
+| Rename / extract / split / refactor | `gitnexus-refactoring` |
+| Review pull requests | `gitnexus-pr-review` |
+| Tools, resources, schema reference | `gitnexus-guide` |
+| Index, status, clean, wiki CLI commands | `gitnexus-cli` |
 
 <!-- gitnexus:end -->
+
+<!-- codedb:start -->
+# CodeDB — Structural Code Search
+
+CodeDB is a fast structural search engine. Use it for quick code lookups, file trees, outlines, and dependency graphs. GitNexus handles deep graph analysis and execution flows.
+
+> Index stale? Run `codedb_index` from the project root.
+
+## When to Use CodeDB
+
+- **Quick file tree** — `codedb_tree` for project orientation
+- **Find symbol definitions** — `codedb_symbol` (exact, sub-ms)
+- **Full-text search** — `codedb_search` (trigram-accelerated, supports regex)
+- **Find all callers** — `codedb_callers` before refactoring
+- **File outline** — `codedb_outline` for functions/structs/imports in a file
+- **Dependency graph** — `codedb_deps` for import analysis
+- **Task context** — `codedb_context` replaces 3–5 sequential calls
+
+## CodeDB vs GitNexus
+
+| Use CodeDB for | Use GitNexus for |
+|----------------|------------------|
+| Fast structural search (sub-ms) | Deep execution flow analysis |
+| File trees, outlines, symbol lookup | Impact analysis (blast radius) |
+| Full-text search (trigram) | Process tracing, call chains |
+| Dependency graph (import analysis) | Community detection, clusters |
+
+**Use both:** CodeDB for quick lookups, GitNexus for deep analysis.
+
+## Key Tools
+
+| Tool | Use for |
+|------|---------|
+| `codedb_tree` | Project orientation — file tree with symbol counts |
+| `codedb_symbol` | Find where a symbol is defined |
+| `codedb_search` | Full-text search (supports regex) |
+| `codedb_callers` | Every call site of a symbol |
+| `codedb_outline` | Functions/structs/imports in a file |
+| `codedb_deps` | Dependency graph (imported_by / depends_on) |
+| `codedb_context` | Task-shaped context (replaces 3-5 calls) |
+| `codedb_hot` | Recently modified files |
+
+## Never Do
+
+- NEVER use `codedb_edit` when native edit tools work — it's a fallback only
+- NEVER use CodeDB for impact analysis — use GitNexus `impact` instead
+- NEVER use CodeDB for execution flow tracing — use GitNexus `query`/`context` instead
+
+<!-- codedb:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,20 +22,23 @@ sudo dnf install cmake
 ### 1. Session Start
 
 ```
-gitnexus analyze                    # Refresh index (re-run after branch switch)
-gitnexus analyze --skills           # Regenerate skill files if communities changed
+gitnexus analyze --index-only --skip-agents-md    # Refresh index on a clean tree without touching AGENTS.md
+gitnexus analyze --skills --index-only --skip-agents-md  # Regenerate skill files if communities changed
 codedb_status                       # Verify CodeDB index is fresh
 ```
 
 If you see "Index is stale" from any gitnexus tool → stop and run `gitnexus analyze` first.
 If `codedb_status` shows stale index → run `codedb_index` to rebuild.
 
+Before reindexing, make sure the worktree is clean. If you still need `gitnexus_detect_changes()` later in the session, do not rerun `gitnexus analyze` after editing files.
+
 If `gitnexus analyze` crashes with `Napi::Error` or hangs → clean first:
 ```bash
-gitnexus clean -f && gitnexus analyze
+gitnexus clean -f && gitnexus analyze --index-only --skip-agents-md
 ```
 
-**Never** run `gitnexus analyze --skip-agents-md` or add `--no-stats` — we want AGENTS.md to stay in sync.
+**Use** `--skip-agents-md` whenever you want to refresh the index without modifying `AGENTS.md`. Use `--index-only` for pure index mode when you do not want file injection at all.
+**Do not** rerun `gitnexus analyze` in a dirty worktree if you still need `gitnexus_detect_changes()` to report your current edits.
 
 ### 2. Before Editing Code
 
@@ -215,9 +218,9 @@ Skills are auto-discovered by OpenCode from `~/.config/opencode/skills/`. Refere
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **rust_scraper** (4460 symbols, 9232 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **rust_scraper** (4465 symbols, 9237 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `gitnexus analyze` from the project root.
+> Index stale? Run `gitnexus analyze --index-only --skip-agents-md` from the project root. Use `gitnexus analyze --skills --index-only --skip-agents-md` only when regenerating skill files.
 
 ## Always Do
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,47 @@
+[tools]
+# === Core ===
+rust = "1.88"                          # MSRV — keep in sync with Cargo.toml rust-version
+
+# === Build acceleration ===
+sccache = "latest"                     # compiler cache
+mold = "latest"                        # fast linker
+
+# === Task runner ===
+just = "latest"                        # command recipes
+
+# === Dev tools (aqua — prebuilt binaries, no compilation) ===
+cargo-binstall = "latest"              # bootstraps cargo tools from prebuilt binaries
+typos = "1.42.3"                       # spell checker (aqua shorthand, pinned for MSRV compat)
+
+# === Dev tools (cargo backend — prebuilt via binstall when available) ===
+"cargo:cargo-nextest" = "0.9.114"      # test runner (pinned — latest requires Rust >1.88)
+"cargo:cargo-deny" = "latest"          # license/advisory/ban audit
+"cargo:cargo-audit" = "latest"         # security advisory check
+"cargo:cargo-machete" = "latest"       # unused dependency detection
+"cargo:cargo-edit" = "latest"          # cargo add/rm/upgrade
+
+# === Optional (uncomment when needed) ===
+# rust-analyzer = "latest"             # LSP — global install preferred
+# "cargo:cargo-outdated" = "latest"    # no aqua, no binstall — compiles
+# "cargo:cargo-expand" = "latest"      # no aqua, no binstall — compiles
+# "cargo:cargo-watch" = "latest"       # no aqua, no binstall — compiles
+# "cargo:cargo-llvm-cov" = "latest"    # no aqua, no binstall — compiles
+# "cargo:cargo-mutants" = "latest"     # no aqua, no binstall — compiles
+
+[env]
+RUSTC_WRAPPER = "sccache"
+
+[tasks.setup]
+description = "Install and verify local development tools"
+run = [
+  "mise install",
+  "just setup",
+]
+
+[tasks.check]
+description = "Run the fast local compile check"
+run = "cargo check"
+
+[tasks.analyze]
+description = "Refresh the GitNexus index"
+run = "gitnexus analyze"

--- a/src/adapters/downloader/mod.rs
+++ b/src/adapters/downloader/mod.rs
@@ -93,15 +93,13 @@ impl Downloader {
 
         std::fs::create_dir_all(&images_path).map_err(|e| {
             ScraperError::Io(std::io::Error::other(format!(
-                "Failed to create images directory: {}",
-                e
+                "Failed to create images directory: {e}"
             )))
         })?;
 
         std::fs::create_dir_all(&documents_path).map_err(|e| {
             ScraperError::Io(std::io::Error::other(format!(
-                "Failed to create documents directory: {}",
-                e
+                "Failed to create documents directory: {e}"
             )))
         })?;
 
@@ -110,7 +108,7 @@ impl Downloader {
             .timeout(std::time::Duration::from_secs(config.timeout_secs))
             .user_agent(&config.user_agent)
             .build()
-            .map_err(|e| ScraperError::Config(format!("failed to build http client: {}", e)))?;
+            .map_err(|e| ScraperError::Config(format!("failed to build http client: {e}")))?;
 
         Ok(Self { client, config })
     }

--- a/src/adapters/tui/action.rs
+++ b/src/adapters/tui/action.rs
@@ -64,19 +64,19 @@ impl fmt::Display for Action {
         match self {
             Self::Tick => write!(f, "Tick"),
             Self::Render => write!(f, "Render"),
-            Self::Resize(w, h) => write!(f, "Resize({}, {})", w, h),
+            Self::Resize(w, h) => write!(f, "Resize({w}, {h})"),
             Self::Suspend => write!(f, "Suspend"),
             Self::Resume => write!(f, "Resume"),
             Self::Quit => write!(f, "Quit"),
             Self::ClearScreen => write!(f, "ClearScreen"),
-            Self::Error(e) => write!(f, "Error({})", e),
+            Self::Error(e) => write!(f, "Error({e})"),
             Self::ToggleHelp => write!(f, "ToggleHelp"),
             Self::CloseModal => write!(f, "CloseModal"),
             Self::UrlConfirmed(urls) => write!(f, "UrlConfirmed({} urls)", urls.len()),
             Self::UrlCancelled => write!(f, "UrlCancelled"),
             Self::ConfigDone(_) => write!(f, "ConfigDone"),
             Self::ConfigCancelled => write!(f, "ConfigCancelled"),
-            Self::Progress(p) => write!(f, "Progress({:?})", p),
+            Self::Progress(p) => write!(f, "Progress({p:?})"),
         }
     }
 }

--- a/src/adapters/tui/app.rs
+++ b/src/adapters/tui/app.rs
@@ -366,7 +366,7 @@ impl App {
         tui.draw(|frame| {
             for component in self.components.iter_mut() {
                 if let Err(e) = component.draw(frame, frame.area()) {
-                    let _ = action_tx.send(Action::Error(format!("Error al dibujar: {}", e)));
+                    let _ = action_tx.send(Action::Error(format!("Error al dibujar: {e}")));
                 }
             }
 
@@ -381,7 +381,7 @@ impl App {
 
                     if let Err(e) = modal.draw(frame, modal_rect) {
                         let _ =
-                            action_tx.send(Action::Error(format!("Error al dibujar modal: {}", e)));
+                            action_tx.send(Action::Error(format!("Error al dibujar modal: {e}")));
                     }
                 }
             }

--- a/src/adapters/tui/component.rs
+++ b/src/adapters/tui/component.rs
@@ -212,7 +212,7 @@ impl Component for StatusBar {
             if i > 0 {
                 spans.push(Span::styled(" │ ", Theme::text_subtle()));
             }
-            spans.push(Span::styled(format!("{}: ", key), Theme::accent()));
+            spans.push(Span::styled(format!("{key}: "), Theme::accent()));
             spans.push(Span::styled(desc.as_str(), Theme::text_muted()));
         }
 

--- a/src/adapters/tui/error_log_widget.rs
+++ b/src/adapters/tui/error_log_widget.rs
@@ -175,7 +175,7 @@ impl ErrorLogWidget {
         let title = if error_count > self.max_errors {
             format!("Errors ({}/{}) (j/k scroll)", self.max_errors, error_count)
         } else {
-            format!("Errors ({})", error_count)
+            format!("Errors ({error_count})")
         };
 
         let block = Block::default().borders(Borders::ALL).title(title.as_str());

--- a/src/adapters/tui/progress_types.rs
+++ b/src/adapters/tui/progress_types.rs
@@ -143,12 +143,12 @@ impl ScrapeError {
     /// Get user-friendly message
     pub fn message(&self) -> String {
         match self {
-            ScrapeError::Network(s) => format!("Network error: {}", s),
-            ScrapeError::Http(status, msg) => format!("HTTP {}: {}", status, msg),
-            ScrapeError::WafBlocked(provider) => format!("WAF blocked ({})", provider),
-            ScrapeError::Parse(s) => format!("Parse error: {}", s),
-            ScrapeError::Timeout(s) => format!("Timeout: {}", s),
-            ScrapeError::Connection(s) => format!("Connection error: {}", s),
+            ScrapeError::Network(s) => format!("Network error: {s}"),
+            ScrapeError::Http(status, msg) => format!("HTTP {status}: {msg}"),
+            ScrapeError::WafBlocked(provider) => format!("WAF blocked ({provider})"),
+            ScrapeError::Parse(s) => format!("Parse error: {s}"),
+            ScrapeError::Timeout(s) => format!("Timeout: {s}"),
+            ScrapeError::Connection(s) => format!("Connection error: {s}"),
             ScrapeError::Other(s) => s.clone(),
         }
     }

--- a/src/adapters/tui/progress_view.rs
+++ b/src/adapters/tui/progress_view.rs
@@ -74,7 +74,7 @@ pub async fn run_progress_view(
     ];
 
     let mut app = App::new(AppMode::Progress)
-        .map_err(|e| io::Error::other(format!("Error al crear app: {}", e)))?
+        .map_err(|e| io::Error::other(format!("Error al crear app: {e}")))?
         .with_component(Header::new(AppMode::Progress))
         .with_component(ProgressWidget::new(urls))
         .with_component(ErrorLogWidget::new())

--- a/src/adapters/tui/progress_widget.rs
+++ b/src/adapters/tui/progress_widget.rs
@@ -274,8 +274,8 @@ impl ProgressWidget {
         let total = self.state.total;
 
         // Format label: "40% (2/5)  Est: 12s"
-        let percentage_str = format!("{:3.0}%", percent);
-        let count_str = format!("({}/{})", processed, total);
+        let percentage_str = format!("{percent:3.0}%");
+        let count_str = format!("({processed}/{total})");
         let eta_str = match self.state.eta_seconds {
             Some(secs) => {
                 if secs == 0 && processed < total {
@@ -283,11 +283,11 @@ impl ProgressWidget {
                 } else if secs == 0 {
                     "Est: done".to_string()
                 } else if secs < 60 {
-                    format!("Est: {}s", secs)
+                    format!("Est: {secs}s")
                 } else {
                     let mins = secs / 60;
                     let secs_rem = secs % 60;
-                    format!("Est: {}m {}s", mins, secs_rem)
+                    format!("Est: {mins}m {secs_rem}s")
                 }
             },
             None => "Est: --".to_string(),
@@ -295,9 +295,9 @@ impl ProgressWidget {
 
         // Build label with spinner if still processing
         let label = if processed < total {
-            format!("{} {} {}", percentage_str, count_str, eta_str)
+            format!("{percentage_str} {count_str} {eta_str}")
         } else {
-            format!("{} {} ✅", percentage_str, count_str)
+            format!("{percentage_str} {count_str} ✅")
         };
 
         // Choose color based on state
@@ -339,7 +339,7 @@ impl ProgressWidget {
                 let status_text = match url_state.status {
                     ScrapeStatus::Completed => {
                         if let Some(chars) = url_state.chars {
-                            format!("Completed  {} chars", chars)
+                            format!("Completed  {chars} chars")
                         } else {
                             "Completed".to_string()
                         }
@@ -409,7 +409,7 @@ impl ProgressWidget {
         use ratatui::widgets::{List, ListItem, Paragraph};
 
         let error_count = self.state.errors.len();
-        let title = format!("Errors ({})", error_count);
+        let title = format!("Errors ({error_count})");
         let block = Block::default().borders(Borders::ALL).title(title.as_str());
 
         if error_count == 0 {
@@ -469,26 +469,24 @@ impl ProgressWidget {
             .saturating_sub(completed + self.state.failed);
         let failed = self.state.failed;
 
-        let status_line = format!(
-            "📊 {} completed | {} remaining | {} failed",
-            completed, remaining, failed
-        );
+        let status_line =
+            format!("📊 {completed} completed | {remaining} remaining | {failed} failed");
 
         // ETA on footer as well
         let eta_line = match self.state.eta_seconds {
             Some(secs) if secs > 0 && remaining > 0 => {
                 if secs < 60 {
-                    format!("⏱ {}s", secs)
+                    format!("⏱ {secs}s")
                 } else {
                     let mins = secs / 60;
                     let s = secs % 60;
-                    format!("⏱ {}m {}s", mins, s)
+                    format!("⏱ {mins}m {s}s")
                 }
             },
             _ => "⏱ done".to_string(),
         };
 
-        let combined = format!("{}    {}", status_line, eta_line);
+        let combined = format!("{status_line}    {eta_line}");
 
         let footer = Paragraph::new(combined)
             .style(Style::default().fg(Theme::text()))

--- a/src/adapters/tui/tui_terminal.rs
+++ b/src/adapters/tui/tui_terminal.rs
@@ -167,13 +167,17 @@ fn setup_panic_hook() {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{stderr, stdin, stdout, IsTerminal};
+
     use super::*;
 
-    /// Returns true if running outside CI.
-    /// CI runners (GitHub Actions, etc.) do not have a TTY, so crossterm
-    /// initialization will fail with "Resource temporarily unavailable".
+    /// Returns true only when terminal setup can run against real TTY streams.
+    /// Some local command runners are not CI, but still do not expose a TTY.
     fn has_terminal() -> bool {
         std::env::var("CI").is_err()
+            && stdin().is_terminal()
+            && stdout().is_terminal()
+            && stderr().is_terminal()
     }
 
     #[test]

--- a/src/adapters/url_path.rs
+++ b/src/adapters/url_path.rs
@@ -87,7 +87,7 @@ impl UrlPath {
         let clean = path.split('?').next().unwrap_or(path);
         let clean = clean.split('#').next().unwrap_or(clean);
         let normalized = if clean.is_empty() || !clean.starts_with('/') {
-            format!("/{}", clean)
+            format!("/{clean}")
         } else {
             clean.to_string()
         };
@@ -143,7 +143,7 @@ impl UrlPath {
         };
 
         if self.is_root {
-            return format!("index.{}", extension);
+            return format!("index.{extension}");
         }
         let path_trimmed = self.raw.trim_start_matches('/');
         // Convert /docs/api/v2/users/ → docs-api-v2-users
@@ -157,12 +157,12 @@ impl UrlPath {
         let upper = sanitized.to_uppercase();
         let is_reserved = WINDOWS_RESERVED.iter().any(|&r| r == upper);
         let final_name = if is_reserved {
-            format!("{}_safe", sanitized)
+            format!("{sanitized}_safe")
         } else {
             sanitized
         };
 
-        format!("{}.{}", final_name, extension)
+        format!("{final_name}.{extension}")
     }
 
     /// Get directory part (everything except last component)
@@ -255,7 +255,7 @@ impl OutputPath {
     pub fn to_full_path_with_format(&self, format: Option<OutputFormat>) -> String {
         let folder = self.to_folder_path();
         let filename = self.path.to_safe_filename_with_format(format);
-        format!("{}{}", folder, filename)
+        format!("{folder}{filename}")
     }
 
     pub fn to_pathbuf(&self) -> PathBuf {
@@ -275,7 +275,7 @@ impl OutputPath {
         if dir.is_empty() {
             "images/".to_string()
         } else {
-            format!("{}images/", dir)
+            format!("{dir}images/")
         }
     }
 }

--- a/src/application/crawl_result_repository.rs
+++ b/src/application/crawl_result_repository.rs
@@ -84,7 +84,7 @@ impl CrawlResultRepositoryImpl {
         use std::io::Read;
 
         let file = std::fs::File::open(path)
-            .map_err(|e| CrawlError::Storage(format!("no se pudo abrir log: {}", e)))?;
+            .map_err(|e| CrawlError::Storage(format!("no se pudo abrir log: {e}")))?;
         let mut reader = std::io::BufReader::new(file);
         let mut offset: u64 = 0;
 
@@ -137,7 +137,7 @@ impl CrawlResultRepository for CrawlResultRepositoryImpl {
         }
 
         let payload = serde_json::to_vec(content)
-            .map_err(|e| CrawlError::Storage(format!("serialización fallida: {}", e)))?;
+            .map_err(|e| CrawlError::Storage(format!("serialización fallida: {e}")))?;
 
         let url = content.url.as_str().to_string();
         self.tx
@@ -165,22 +165,22 @@ impl CrawlResultRepository for CrawlResultRepositoryImpl {
         };
 
         let mut file = std::fs::File::open(&self.log_path)
-            .map_err(|e| CrawlError::Storage(format!("no se pudo abrir log: {}", e)))?;
+            .map_err(|e| CrawlError::Storage(format!("no se pudo abrir log: {e}")))?;
 
         file.seek(SeekFrom::Start(offset))
-            .map_err(|e| CrawlError::Storage(format!("seek fallido: {}", e)))?;
+            .map_err(|e| CrawlError::Storage(format!("seek fallido: {e}")))?;
 
         let mut len_buf = [0u8; 4];
         file.read_exact(&mut len_buf)
-            .map_err(|e| CrawlError::Storage(format!("lectura de longitud fallida: {}", e)))?;
+            .map_err(|e| CrawlError::Storage(format!("lectura de longitud fallida: {e}")))?;
         let len = u32::from_le_bytes(len_buf) as usize;
 
         let mut payload = vec![0u8; len];
         file.read_exact(&mut payload)
-            .map_err(|e| CrawlError::Storage(format!("lectura de payload fallida: {}", e)))?;
+            .map_err(|e| CrawlError::Storage(format!("lectura de payload fallida: {e}")))?;
 
         let result: ScrapedContent = serde_json::from_slice(&payload)
-            .map_err(|e| CrawlError::Storage(format!("deserialización fallida: {}", e)))?;
+            .map_err(|e| CrawlError::Storage(format!("deserialización fallida: {e}")))?;
 
         Ok(Some(result))
     }

--- a/src/application/crawler_service.rs
+++ b/src/application/crawler_service.rs
@@ -190,7 +190,7 @@ pub async fn discover_urls_for_tui(
             .get(base_url)
             .send()
             .await
-            .map_err(|e| anyhow::anyhow!("HTTP error: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("HTTP error: {e}"))?;
 
         let status = response.status();
         let content_type = response
@@ -212,15 +212,15 @@ pub async fn discover_urls_for_tui(
         let html = response
             .text()
             .await
-            .map_err(|e| anyhow::anyhow!("Network error: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("Network error: {e}"))?;
 
         debug!("Received HTML: {} bytes", html.len());
 
-        let base = Url::parse(base_url).map_err(|e| anyhow::anyhow!("Invalid URL: {}", e))?;
+        let base = Url::parse(base_url).map_err(|e| anyhow::anyhow!("Invalid URL: {e}"))?;
 
         // Extract links
         let links =
-            extract_links(&html, base_url).map_err(|e| anyhow::anyhow!("Parse error: {}", e))?;
+            extract_links(&html, base_url).map_err(|e| anyhow::anyhow!("Parse error: {e}"))?;
 
         // Filter and normalize URLs
         let mut urls = Vec::new();
@@ -409,7 +409,7 @@ pub async fn scrape_single_url_for_tui(
             Ok(ScrapedContent {
                 title: url
                     .host_str()
-                    .ok_or_else(|| ScraperError::invalid_url(format!("URL missing host: {}", url)))?
+                    .ok_or_else(|| ScraperError::invalid_url(format!("URL missing host: {url}")))?
                     .to_string(),
                 content: fallback_content,
                 url: ValidUrl::new(url.clone()),
@@ -944,7 +944,7 @@ async fn crawl_with_subpath_sitemaps(
     for i in 1..=segments.len().min(3) {
         let sub_path = segments[..i].join("/");
         for sitemap_name in &["sitemap.xml", "sitemap_index.xml"] {
-            let candidate = format!("/{}/{}", sub_path, sitemap_name);
+            let candidate = format!("/{sub_path}/{sitemap_name}");
             if let Ok(sitemap_url) = base.join(&candidate) {
                 let sitemap_str = sitemap_url.as_str();
                 tracing::debug!("Trying sub-path sitemap: {}", sitemap_str);
@@ -1069,7 +1069,7 @@ async fn discover_sitemap_url(base_url: &str) -> Result<String, CrawlError> {
     for i in 1..=segments.len().min(3) {
         let sub_path = segments[..i].join("/");
         for sitemap_name in &["sitemap.xml", "sitemap_index.xml"] {
-            let candidate = format!("/{}/{}", sub_path, sitemap_name);
+            let candidate = format!("/{sub_path}/{sitemap_name}");
             if let Ok(sitemap_url) = base.join(&candidate) {
                 let sitemap_str = sitemap_url.as_str();
                 tracing::debug!("Trying sub-path sitemap: {}", sitemap_str);

--- a/src/application/deduplicator.rs
+++ b/src/application/deduplicator.rs
@@ -113,7 +113,7 @@ pub fn normalize_url(url: &Url) -> String {
     let path = url.path();
 
     // Build normalized string manually to avoid borrow issues
-    let mut result = format!("{}://", scheme);
+    let mut result = format!("{scheme}://");
 
     // Handle www prefix
     let host = host.strip_prefix("www.").unwrap_or(host);
@@ -123,7 +123,7 @@ pub fn normalize_url(url: &Url) -> String {
         (None, _) => "",
         (Some(80), _) => "", // Remove port 80 regardless of scheme
         (Some(443), "https") => "",
-        (Some(p), _) => &format!(":{}", p),
+        (Some(p), _) => &format!(":{p}"),
     };
 
     result.push_str(host);

--- a/src/application/export_factory.rs
+++ b/src/application/export_factory.rs
@@ -36,8 +36,8 @@ pub fn create_exporter(
             // Auto-detect: checks if export.jsonl or export.json exists
             info!("Auto-detecting format...");
 
-            let jsonl_path = output_dir.join(format!("{}.jsonl", filename));
-            let vector_path = output_dir.join(format!("{}.json", filename));
+            let jsonl_path = output_dir.join(format!("{filename}.jsonl"));
+            let vector_path = output_dir.join(format!("{filename}.json"));
 
             if vector_path.exists() {
                 info!("Detected Vector format - {:?} exists", vector_path);

--- a/src/application/http_client/client.rs
+++ b/src/application/http_client/client.rs
@@ -112,7 +112,7 @@ impl HttpClient {
 
         let client = builder
             .build()
-            .map_err(|e| ScraperError::Config(format!("failed to create http client: {}", e)))?;
+            .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))?;
 
         let user_agents = UserAgentCache::fallback_agents();
 
@@ -165,7 +165,7 @@ impl HttpClient {
     pub async fn get(&self, url: &str) -> HttpResult<String> {
         // Validate URL first
         let parsed_url =
-            Url::parse(url).map_err(|e| HttpError::Request(format!("Invalid URL: {}", e)))?;
+            Url::parse(url).map_err(|e| HttpError::Request(format!("Invalid URL: {e}")))?;
 
         // Ensure URL has http or https scheme
         if !matches!(parsed_url.scheme(), "http" | "https") {
@@ -409,7 +409,7 @@ pub fn create_http_client() -> Result<Client, ScraperError> {
         .cookie_store(true)
         .redirect(wreq::redirect::Policy::limited(10))
         .build()
-        .map_err(|e| ScraperError::Config(format!("failed to create http client: {}", e)))?;
+        .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))?;
 
     Ok(client)
 }

--- a/src/application/http_client/error.rs
+++ b/src/application/http_client/error.rs
@@ -39,15 +39,15 @@ impl std::fmt::Display for HttpError {
         match self {
             HttpError::Forbidden => write!(f, "403 Forbidden - site blocking"),
             HttpError::RateLimited(retry_after) => {
-                write!(f, "429 Rate Limited - retry after {} seconds", retry_after)
+                write!(f, "429 Rate Limited - retry after {retry_after} seconds")
             },
-            HttpError::ClientError(code) => write!(f, "Client Error {}", code),
-            HttpError::ServerError(code) => write!(f, "Server Error {}", code),
+            HttpError::ClientError(code) => write!(f, "Client Error {code}"),
+            HttpError::ServerError(code) => write!(f, "Server Error {code}"),
             HttpError::Timeout => write!(f, "Request Timeout"),
-            HttpError::Connection(msg) => write!(f, "Connection Error: {}", msg),
-            HttpError::Request(msg) => write!(f, "Request Error: {}", msg),
+            HttpError::Connection(msg) => write!(f, "Connection Error: {msg}"),
+            HttpError::Request(msg) => write!(f, "Request Error: {msg}"),
             HttpError::WafChallenge(provider) => {
-                write!(f, "WAF/CAPTCHA challenge detected ({})", provider)
+                write!(f, "WAF/CAPTCHA challenge detected ({provider})")
             },
         }
     }

--- a/src/application/scraper_service.rs
+++ b/src/application/scraper_service.rs
@@ -248,7 +248,7 @@ pub async fn scrape_with_config(
             results.push(ScrapedContent {
                 title: url
                     .host_str()
-                    .ok_or_else(|| ScraperError::invalid_url(format!("URL missing host: {}", url)))?
+                    .ok_or_else(|| ScraperError::invalid_url(format!("URL missing host: {url}")))?
                     .to_string(),
                 content: fallback_content,
                 url: ValidUrl::new(url.clone()),

--- a/src/application/url_filter.rs
+++ b/src/application/url_filter.rs
@@ -194,7 +194,7 @@ pub fn extract_domain(url: &str) -> Option<String> {
 #[must_use]
 pub fn is_internal_link(url: &str, seed_domain: &str) -> bool {
     extract_domain(url)
-        .map(|domain| domain == seed_domain || domain.ends_with(&format!(".{}", seed_domain)))
+        .map(|domain| domain == seed_domain || domain.ends_with(&format!(".{seed_domain}")))
         .unwrap_or(false)
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -144,6 +144,11 @@ pub struct Args {
     pub sitemap_url: Option<String>,
 
     // ========== Behavior ==========
+    /// Scrape only the seed URL without discovery or crawling
+    #[arg(long, default_value = "false", env = "RUST_SCRAPER_SINGLE_PAGE")]
+    #[clap(next_help_heading = "Behavior")]
+    pub single_page: bool,
+
     /// Resume mode - skip URLs already processed
     #[arg(long, env = "RUST_SCRAPER_RESUME")]
     #[clap(next_help_heading = "Behavior")]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -83,7 +83,7 @@ pub fn init_logging_dual(level: &str, quiet: bool, no_color: bool) {
     let filter = if quiet {
         EnvFilter::new("rust_scraper=warn,tokio=warn,reqwest=warn")
     } else {
-        EnvFilter::new(format!("rust_scraper={},tokio=warn,reqwest=warn", level))
+        EnvFilter::new(format!("rust_scraper={level},tokio=warn,reqwest=warn"))
     };
 
     let fmt_layer = fmt::layer()

--- a/src/cli/orchestrator.rs
+++ b/src/cli/orchestrator.rs
@@ -45,7 +45,7 @@ pub async fn run(args: Args) -> CliExit {
 
     let target_url = match url::Url::parse(target_url_str) {
         Ok(url) => url,
-        Err(e) => return CliExit::UsageError(format!("Invalid URL: {}", e)),
+        Err(e) => return CliExit::UsageError(format!("Invalid URL: {e}")),
     };
 
     // Create crawler config from args
@@ -86,7 +86,7 @@ pub async fn run(args: Args) -> CliExit {
 
     // Report failures
     for (url, error) in &failures {
-        eprintln!("Failed to scrape {}: {}", url, error);
+        eprintln!("Failed to scrape {url}: {error}");
     }
 
     if results.is_empty() {
@@ -147,7 +147,7 @@ pub async fn run(args: Args) -> CliExit {
             CliExit::Success
         },
         Err(e) => {
-            eprintln!("Export failed: {:?}", e);
+            eprintln!("Export failed: {e:?}");
             e
         },
     }

--- a/src/cli/orchestrator.rs
+++ b/src/cli/orchestrator.rs
@@ -56,14 +56,18 @@ pub async fn run(args: Args) -> CliExit {
         .exclude_patterns(args.exclude_patterns.clone())
         .build();
 
-    // URL discovery phase
-    let discovered_urls: Vec<url::Url> = discover_urls(&crawler_config, &args).await;
-    if discovered_urls.is_empty() {
-        info!("No URLs discovered");
-        return CliExit::Success;
-    }
+    let urls_to_scrape = if args.single_page {
+        plan_urls(true, target_url.clone(), Vec::new())
+    } else {
+        // URL discovery phase
+        let discovered_urls: Vec<url::Url> = discover_urls(&crawler_config, &args).await;
+        if discovered_urls.is_empty() {
+            info!("No URLs discovered");
+            return CliExit::Success;
+        }
 
-    let urls_to_scrape = discovered_urls;
+        plan_urls(false, target_url.clone(), discovered_urls)
+    };
 
     // Create scraper config
     let mut scraper_config = ScraperConfig::default()
@@ -150,5 +154,48 @@ pub async fn run(args: Args) -> CliExit {
             eprintln!("Export failed: {e:?}");
             e
         },
+    }
+}
+
+fn plan_urls(
+    single_page: bool,
+    seed_url: url::Url,
+    discovered_urls: Vec<url::Url>,
+) -> Vec<url::Url> {
+    if single_page {
+        vec![seed_url]
+    } else {
+        discovered_urls
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan_urls;
+
+    #[test]
+    fn plan_urls_returns_only_seed_url_for_single_page() {
+        let seed_url = url::Url::parse("https://example.com").expect("valid seed url");
+        let discovered_urls = vec![
+            url::Url::parse("https://example.com/about").expect("valid discovered url"),
+            url::Url::parse("https://example.com/blog").expect("valid discovered url"),
+        ];
+
+        let planned = plan_urls(true, seed_url.clone(), discovered_urls);
+
+        assert_eq!(planned, vec![seed_url]);
+    }
+
+    #[test]
+    fn plan_urls_keeps_discovered_urls_in_normal_mode() {
+        let seed_url = url::Url::parse("https://example.com").expect("valid seed url");
+        let discovered_urls = vec![
+            url::Url::parse("https://example.com/about").expect("valid discovered url"),
+            url::Url::parse("https://example.com/blog").expect("valid discovered url"),
+        ];
+
+        let planned = plan_urls(false, seed_url, discovered_urls.clone());
+
+        assert_eq!(planned, discovered_urls);
     }
 }

--- a/src/cli/preflight.rs
+++ b/src/cli/preflight.rs
@@ -227,7 +227,7 @@ pub enum PreflightResult {
 pub async fn preflight_check(url: &url::Url) -> PreflightResult {
     let client = match crate::create_http_client() {
         Ok(c) => c,
-        Err(e) => return PreflightResult::Failed(format!("failed to create HTTP client: {}", e)),
+        Err(e) => return PreflightResult::Failed(format!("failed to create HTTP client: {e}")),
     };
 
     match client
@@ -252,7 +252,7 @@ pub async fn preflight_check(url: &url::Url) -> PreflightResult {
                 warn!("HEAD request failed ({}), trying GET fallback...", e);
                 preflight_get_fallback(&client, url).await
             } else {
-                PreflightResult::Failed(format!("network error: {}", e))
+                PreflightResult::Failed(format!("network error: {e}"))
             }
         },
     }
@@ -269,7 +269,7 @@ async fn preflight_get_fallback(client: &wreq::Client, url: &url::Url) -> Prefli
     {
         Ok(resp) if resp.status().is_success() => PreflightResult::Ok,
         Ok(resp) => PreflightResult::Warning(resp.status().as_u16()),
-        Err(e) => PreflightResult::Failed(format!("HEAD y GET fallaron: {}", e)),
+        Err(e) => PreflightResult::Failed(format!("HEAD y GET fallaron: {e}")),
     }
 }
 

--- a/src/cli/scrape_flow.rs
+++ b/src/cli/scrape_flow.rs
@@ -187,7 +187,7 @@ pub async fn scrape_urls(
                         let _ = tx
                             .send(ScrapeProgress::Failed {
                                 url: url_str.clone(),
-                                error: ScrapeError::Other(format!("{}", e)),
+                                error: ScrapeError::Other(format!("{e}")),
                             })
                             .await;
                     }

--- a/src/cli/scrape_flow.rs
+++ b/src/cli/scrape_flow.rs
@@ -96,13 +96,7 @@ pub async fn scrape_urls(
     args: &Args,
     progress_tx: Option<mpsc::Sender<ScrapeProgress>>,
 ) -> (Vec<ScrapedContent>, Vec<(String, String)>) {
-    let http_config = HttpClientConfig {
-        max_retries: args.max_retries,
-        backoff_base_ms: args.backoff_base_ms,
-        backoff_max_ms: args.backoff_max_ms,
-        accept_language: args.accept_language.clone(),
-        ..HttpClientConfig::default()
-    };
+    let http_config = build_http_client_config(args);
     let http_client = match HttpClient::new(http_config) {
         Ok(c) => c,
         Err(e) => {
@@ -214,4 +208,49 @@ pub async fn scrape_urls(
     }
 
     (results, failures)
+}
+
+fn build_http_client_config(args: &Args) -> HttpClientConfig {
+    HttpClientConfig {
+        max_retries: args.max_retries,
+        backoff_base_ms: args.backoff_base_ms,
+        backoff_max_ms: args.backoff_max_ms,
+        accept_language: args.accept_language.clone(),
+        timeout_secs: args.timeout_secs,
+        ..HttpClientConfig::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_http_client_config;
+    use clap::Parser;
+
+    #[test]
+    fn build_http_client_config_uses_args_timeout_secs() {
+        let args = crate::Args::parse_from([
+            "rust_scraper",
+            "--url",
+            "https://example.com",
+            "--timeout-secs",
+            "7",
+        ]);
+
+        let config = build_http_client_config(&args);
+
+        assert_eq!(config.timeout_secs, 7);
+        assert_eq!(config.max_retries, args.max_retries);
+        assert_eq!(config.backoff_base_ms, args.backoff_base_ms);
+        assert_eq!(config.backoff_max_ms, args.backoff_max_ms);
+        assert_eq!(config.accept_language, args.accept_language);
+    }
+
+    #[test]
+    fn build_http_client_config_preserves_default_timeout_when_unset() {
+        let args = crate::Args::parse_from(["rust_scraper", "--url", "https://example.com"]);
+
+        let config = build_http_client_config(&args);
+
+        assert_eq!(config.timeout_secs, 30);
+    }
 }

--- a/src/domain/entities.rs
+++ b/src/domain/entities.rs
@@ -429,8 +429,7 @@ impl DocumentChunk<Draft> {
         for (key, value) in &self.metadata {
             if value.trim().is_empty() {
                 return Err(ValidationError::InvalidMetadata(format!(
-                    "metadata key '{}' has empty value",
-                    key
+                    "metadata key '{key}' has empty value"
                 )));
             }
         }

--- a/src/domain/exporter.rs
+++ b/src/domain/exporter.rs
@@ -109,7 +109,7 @@ impl ExporterConfig {
         let state_dir = self.output_dir.join("state");
         // Extract domain from filename if possible, otherwise use filename
         let domain = self.filename.clone();
-        state_dir.join(format!("{}.json", domain))
+        state_dir.join(format!("{domain}.json"))
     }
 }
 

--- a/src/domain/link_extractor.rs
+++ b/src/domain/link_extractor.rs
@@ -37,7 +37,7 @@ impl LinkProcessor {
     /// Pure function for domain checking logic.
     pub fn is_internal_link(url: &str, domain: &str) -> bool {
         Self::extract_domain(url)
-            .map(|url_domain| url_domain == domain || url_domain.ends_with(&format!(".{}", domain)))
+            .map(|url_domain| url_domain == domain || url_domain.ends_with(&format!(".{domain}")))
             .unwrap_or(false)
     }
 

--- a/src/domain/pattern_matching/mod.rs
+++ b/src/domain/pattern_matching/mod.rs
@@ -68,13 +68,13 @@ pub fn matches_pattern(url_str: &str, pattern: &str) -> bool {
             let domain = &p[2..p.len() - 1]; // "example.com/"
             let domain = domain.trim_end_matches('/');
             // Must be a subdomain, NOT the root domain itself
-            host.ends_with(&format!(".{}", domain))
+            host.ends_with(&format!(".{domain}"))
         },
         // *.example.com → match subdomain ONLY (not root domain)
         p if p.starts_with("*.") => {
             let domain = &p[2..];
             // Must be a subdomain, NOT the root domain itself
-            host.ends_with(&format!(".{}", domain))
+            host.ends_with(&format!(".{domain}"))
         },
         // Exact host match (no wildcard)
         p => host == p,

--- a/src/domain/url_validation.rs
+++ b/src/domain/url_validation.rs
@@ -62,14 +62,13 @@ pub fn validate_and_parse_url(url: &str) -> Result<url::Url> {
     }
 
     let parsed = url::Url::parse(url.trim())
-        .map_err(|e| ScraperError::invalid_url(format!("Failed to parse URL '{}': {}", url, e)))?;
+        .map_err(|e| ScraperError::invalid_url(format!("Failed to parse URL '{url}': {e}")))?;
 
     match parsed.scheme() {
         "http" | "https" => {},
         scheme => {
             return Err(ScraperError::invalid_url(format!(
-                "URL must use http or https scheme, got '{}'",
-                scheme
+                "URL must use http or https scheme, got '{scheme}'"
             )))
         },
     }

--- a/src/domain/url_validator.rs
+++ b/src/domain/url_validator.rs
@@ -33,8 +33,7 @@ impl UrlValidator {
                     if let Ok(major) = major_str.parse::<u32>() {
                         if major > 99 {
                             return ValidationResult::Invalid(format!(
-                                "Invalid Node.js version pattern: v{}",
-                                version
+                                "Invalid Node.js version pattern: v{version}"
                             ));
                         }
                     }
@@ -46,7 +45,7 @@ impl UrlValidator {
         match url.scheme() {
             "http" | "https" => {},
             scheme => {
-                return ValidationResult::Invalid(format!("Unsupported scheme: {}", scheme));
+                return ValidationResult::Invalid(format!("Unsupported scheme: {scheme}"));
             },
         }
 

--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -205,7 +205,7 @@ impl std::fmt::Display for ConcurrencyConfig {
         if self.is_auto() {
             write!(f, "auto")
         } else if let Some(value) = self.value {
-            write!(f, "{}", value)
+            write!(f, "{value}")
         } else {
             write!(f, "auto")
         }
@@ -278,7 +278,7 @@ impl From<&str> for ConcurrencyConfig {
             Self::default()
         } else {
             s.parse().map(ConcurrencyConfig::new).unwrap_or_else(|_| {
-                eprintln!("Warning: Invalid concurrency '{}', using auto-detect", s);
+                eprintln!("Warning: Invalid concurrency '{s}', using auto-detect");
                 Self::default()
             })
         }
@@ -335,8 +335,7 @@ impl clap::builder::TypedValueParser for ConcurrencyValueParser {
                 clap::Error::raw(
                     clap::error::ErrorKind::InvalidValue,
                     format!(
-                        "'{}' is not a valid concurrency value (expected number or 'auto')",
-                        value
+                        "'{value}' is not a valid concurrency value (expected number or 'auto')"
                     ),
                 )
             })

--- a/src/infrastructure/crawler/http_client.rs
+++ b/src/infrastructure/crawler/http_client.rs
@@ -77,7 +77,7 @@ pub async fn fetch_url(url: &str, config: &CrawlerConfig) -> Result<String, Craw
     debug!("Fetching URL: {}", url);
 
     let client = create_rate_limited_client(config.delay_ms)
-        .map_err(|e| CrawlError::Internal(format!("Failed to create HTTP client: {}", e)))?;
+        .map_err(|e| CrawlError::Internal(format!("Failed to create HTTP client: {e}")))?;
 
     let response = client
         .get(url)

--- a/src/infrastructure/crawler/link_extractor.rs
+++ b/src/infrastructure/crawler/link_extractor.rs
@@ -43,9 +43,8 @@ pub fn extract_links(html: &str, base_url: &str) -> Result<Vec<String>, crate::d
     debug!("Extracting links from HTML (base_url={})", base_url);
 
     let document = Html::parse_document(html);
-    let selector = Selector::parse("a[href]").map_err(|e| {
-        crate::domain::CrawlError::Parse(format!("Failed to parse selector: {}", e))
-    })?;
+    let selector = Selector::parse("a[href]")
+        .map_err(|e| crate::domain::CrawlError::Parse(format!("Failed to parse selector: {e}")))?;
 
     // Parse base URL once
     let base =
@@ -102,7 +101,7 @@ pub fn extract_links(html: &str, base_url: &str) -> Result<Vec<String>, crate::d
 #[must_use]
 pub fn is_internal_link(url: &str, domain: &str) -> bool {
     extract_domain(url)
-        .map(|url_domain| url_domain == domain || url_domain.ends_with(&format!(".{}", domain)))
+        .map(|url_domain| url_domain == domain || url_domain.ends_with(&format!(".{domain}")))
         .unwrap_or(false)
 }
 

--- a/src/infrastructure/crawler/memory_manager.rs
+++ b/src/infrastructure/crawler/memory_manager.rs
@@ -113,7 +113,7 @@ impl MemoryManager {
         // Write URLs to disk in chunks
         let chunk_size = 10_000;
         for (chunk_idx, chunk) in urls.chunks(chunk_size).enumerate() {
-            let file_path = temp_dir.join(format!("urls_chunk_{}.txt", chunk_idx));
+            let file_path = temp_dir.join(format!("urls_chunk_{chunk_idx}.txt"));
             let mut content = String::new();
             for url in chunk {
                 content.push_str(url.as_str());
@@ -121,7 +121,7 @@ impl MemoryManager {
             }
 
             std::fs::write(&file_path, content).map_err(|e| {
-                MemoryError::DiskSwapFailed(format!("failed to write chunk {}: {}", chunk_idx, e))
+                MemoryError::DiskSwapFailed(format!("failed to write chunk {chunk_idx}: {e}"))
             })?;
         }
 

--- a/src/infrastructure/crawler/url_validator.rs
+++ b/src/infrastructure/crawler/url_validator.rs
@@ -62,8 +62,7 @@ impl UrlValidator {
                     if let Ok(major) = major_str.parse::<u32>() {
                         if major > 99 {
                             return ValidationResult::Invalid(format!(
-                                "Invalid Node.js version pattern: v{}",
-                                version
+                                "Invalid Node.js version pattern: v{version}"
                             ));
                         }
                     }
@@ -75,7 +74,7 @@ impl UrlValidator {
         match url.scheme() {
             "http" | "https" => {},
             scheme => {
-                return ValidationResult::Invalid(format!("Unsupported scheme: {}", scheme));
+                return ValidationResult::Invalid(format!("Unsupported scheme: {scheme}"));
             },
         }
 
@@ -107,12 +106,10 @@ impl UrlValidator {
                 Ok(ValidationResult::Valid) // Treat redirect as valid if we can't follow
             },
             404 | 410 => Ok(ValidationResult::Invalid(format!(
-                "URL not found (status {})",
-                status
+                "URL not found (status {status})"
             ))),
             _ => Ok(ValidationResult::Invalid(format!(
-                "HTTP error (status {})",
-                status
+                "HTTP error (status {status})"
             ))),
         }
     }

--- a/src/infrastructure/export/file_exporter.rs
+++ b/src/infrastructure/export/file_exporter.rs
@@ -81,7 +81,7 @@ impl FileExporter {
         let metadata = doc
             .metadata
             .iter()
-            .map(|(k, v)| format!("{}: {}", k, v))
+            .map(|(k, v)| format!("{k}: {v}"))
             .collect::<Vec<_>>()
             .join("\n");
 
@@ -154,9 +154,9 @@ impl FileExporter {
             .replace(':', "_");
 
         let filename = if filename.is_empty() || filename.ends_with('-') {
-            format!("index.{}", ext)
+            format!("index.{ext}")
         } else {
-            format!("{}.{}", filename, ext)
+            format!("{filename}.{ext}")
         };
 
         output_dir.join(domain).join(filename)
@@ -188,7 +188,7 @@ impl Exporter for FileExporter {
                     .map_err(|e| ExporterError::WriteError(e.to_string()))?;
 
                 use std::io::Write;
-                writeln!(file, "{}", json).map_err(|e| ExporterError::WriteError(e.to_string()))?;
+                writeln!(file, "{json}").map_err(|e| ExporterError::WriteError(e.to_string()))?;
                 Ok(())
             },
             crate::domain::entities::ExportFormat::Vector => {

--- a/src/infrastructure/export/jsonl_exporter.rs
+++ b/src/infrastructure/export/jsonl_exporter.rs
@@ -53,9 +53,9 @@ impl JsonlExporter {
             .map_err(|e| ExporterError::WriteError(format!("{}: {}", lock_path.display(), e)))?;
         // allow: fs2::FileExt::lock_exclusive, clippy misidentifies as std::io::FileExt (1.89+)
         #[allow(clippy::incompatible_msrv)]
-        lock_file.lock_exclusive().map_err(|e| {
-            ExporterError::WriteError(format!("failed to acquire file lock: {}", e))
-        })?;
+        lock_file
+            .lock_exclusive()
+            .map_err(|e| ExporterError::WriteError(format!("failed to acquire file lock: {e}")))?;
 
         // Fix: Only truncate if file doesn't exist yet.
         // Prevents data loss when writer() is called multiple times

--- a/src/infrastructure/export/state_store.rs
+++ b/src/infrastructure/export/state_store.rs
@@ -129,12 +129,9 @@ impl StateStore {
         // Acquire shared lock to prevent reading during concurrent write
         let lock_path = path.with_extension("json.lock");
         let lock_file = fs::File::create(&lock_path).map_err(ScraperError::Io)?;
-        // allow: fs2::FileExt::lock_shared, clippy misidentifies as std::io::FileExt (1.89+)
-        #[allow(clippy::incompatible_msrv)]
-        lock_file.lock_shared().map_err(|e| {
+        fs2::FileExt::lock_shared(&lock_file).map_err(|e| {
             ScraperError::Io(std::io::Error::other(format!(
-                "failed to acquire state read lock: {}",
-                e
+                "failed to acquire state read lock: {e}"
             )))
         })?;
 
@@ -192,8 +189,7 @@ impl StateStore {
         let lock_file = fs::File::create(&lock_path).map_err(ScraperError::Io)?;
         lock_file.lock_exclusive().map_err(|e| {
             ScraperError::Io(std::io::Error::other(format!(
-                "failed to acquire state lock: {}",
-                e
+                "failed to acquire state lock: {e}"
             )))
         })?;
 

--- a/src/infrastructure/export/vector_exporter.rs
+++ b/src/infrastructure/export/vector_exporter.rs
@@ -160,11 +160,10 @@ impl VectorExporter {
                 .map(|d| d.to_string())
                 .unwrap_or_else(|| "null".to_string());
             let header = format!(
-                r#"{{"format_version": "1.0", "model_name": null, "dimensions": {}, "total_documents": 0, "created_at": "{}", "documents": ["#,
-                dimensions_json, timestamp
+                r#"{{"format_version": "1.0", "model_name": null, "dimensions": {dimensions_json}, "total_documents": 0, "created_at": "{timestamp}", "documents": ["#
             );
 
-            write!(writer, "{}", header)?;
+            write!(writer, "{header}")?;
         }
 
         Ok(())
@@ -232,12 +231,12 @@ impl Exporter for VectorExporter {
         if !is_first_doc {
             write!(writer, ",")?;
         }
-        writeln!(writer, "{}", serialized)?;
+        writeln!(writer, "{serialized}")?;
 
         self.close_json(&mut writer, 1)?;
 
         // Release lock
-        file.unlock()?;
+        fs2::FileExt::unlock(&file)?;
 
         Ok(())
     }
@@ -260,14 +259,14 @@ impl Exporter for VectorExporter {
             }
 
             let serialized = self.serialize_document(doc)?;
-            writeln!(writer, "{}", serialized)?;
+            writeln!(writer, "{serialized}")?;
             doc_count += 1;
         }
 
         self.close_json(&mut writer, doc_count)?;
 
         // Release lock
-        file.unlock()?;
+        fs2::FileExt::unlock(&file)?;
 
         Ok(())
     }

--- a/src/infrastructure/http/waf_engine.rs
+++ b/src/infrastructure/http/waf_engine.rs
@@ -210,7 +210,7 @@ impl WafInspector {
                 {
                     return Err(ScraperError::WafBlocked {
                         url: String::new(),
-                        provider: format!("{}: header detected", provider),
+                        provider: format!("{provider}: header detected"),
                     });
                 }
             }
@@ -233,7 +233,7 @@ impl WafInspector {
             let provider = WAF_BODY_SIGNATURES[mat.pattern()].1;
             return Err(ScraperError::WafBlocked {
                 url: String::new(),
-                provider: format!("Signature detected: {}", provider),
+                provider: format!("Signature detected: {provider}"),
             });
         }
 

--- a/src/infrastructure/mcp_server/mod.rs
+++ b/src/infrastructure/mcp_server/mod.rs
@@ -899,8 +899,7 @@ impl McpHandler {
         let output_dir = params.output_dir.as_deref().unwrap_or("./output");
         let filename = params.filename.as_deref().unwrap_or("export");
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "JSONL exporter ready at: {}/{}.jsonl",
-            output_dir, filename
+            "JSONL exporter ready at: {output_dir}/{filename}.jsonl"
         ))]))
     }
 
@@ -924,8 +923,7 @@ impl McpHandler {
         let output_dir = params.output_dir.as_deref().unwrap_or("./output");
         let filename = params.filename.as_deref().unwrap_or("export");
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "Vector exporter ready at: {}/{}.json",
-            output_dir, filename
+            "Vector exporter ready at: {output_dir}/{filename}.json"
         ))]))
     }
 
@@ -949,8 +947,7 @@ impl McpHandler {
         let url = params.url.as_deref().unwrap_or("");
         let format = params.format.as_deref().unwrap_or("jsonl");
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "Pipeline queued for: {} → [{}]",
-            url, format
+            "Pipeline queued for: {url} → [{format}]"
         ))]))
     }
 
@@ -1161,8 +1158,7 @@ impl McpHandler {
 
         match crate::infrastructure::http::waf_engine::WafInspector::detect_body(&params.html) {
             Some(provider) => Ok(CallToolResult::success(vec![Content::text(format!(
-                "WAF detected: {}",
-                provider
+                "WAF detected: {provider}"
             ))])),
             None => Ok(CallToolResult::success(vec![Content::text(
                 "no WAF detected",
@@ -1196,8 +1192,7 @@ impl McpHandler {
                 "WAF integrity check passed",
             )])),
             Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
-                "WAF blocked: {}",
-                e
+                "WAF blocked: {e}"
             ))])),
         }
     }
@@ -1328,8 +1323,7 @@ impl McpHandler {
         );
         match std::process::Command::new("open").arg(&uri).spawn() {
             Ok(_) => Ok(CallToolResult::success(vec![Content::text(format!(
-                "Opened in Obsidian: {}",
-                uri
+                "Opened in Obsidian: {uri}"
             ))])),
             Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
                 "failed to open Obsidian: {e}"
@@ -1396,8 +1390,7 @@ impl McpHandler {
 
         // TODO: Wire up actual asset downloading from scraper_service
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "Asset download queued: images={}, documents={}, base={}",
-            download_images, download_documents, base_url
+            "Asset download queued: images={download_images}, documents={download_documents}, base={base_url}"
         ))]))
     }
 }

--- a/src/infrastructure/observability/async_logging.rs
+++ b/src/infrastructure/observability/async_logging.rs
@@ -60,7 +60,7 @@ impl AsyncLogWriter {
         // Run writer task
         tokio::spawn(async move {
             if let Err(e) = run_writer_task(entries_rx, log_dir, app_name, config_clone).await {
-                eprintln!("Async logging error: {}", e);
+                eprintln!("Async logging error: {e}");
             }
         });
 
@@ -81,7 +81,7 @@ impl AsyncLogWriter {
                 eprintln!("WARN: Log buffer overflow - entry dropped");
                 Ok(()) // Don't block, just drop
             },
-            Err(e) => anyhow::bail!("Log write error: {}", e),
+            Err(e) => anyhow::bail!("Log write error: {e}"),
         }
     }
 

--- a/src/infrastructure/observability/logging.rs
+++ b/src/infrastructure/observability/logging.rs
@@ -50,7 +50,7 @@ impl std::str::FromStr for LogFormat {
         match s.to_lowercase().as_str() {
             "json" => Ok(Self::Json),
             "text" => Ok(Self::Text),
-            _ => Err(format!("Invalid log format: {}. Valid: text, json", s)),
+            _ => Err(format!("Invalid log format: {s}. Valid: text, json")),
         }
     }
 }
@@ -117,7 +117,7 @@ pub fn init_json_logging_dual(
     let filter = if quiet {
         EnvFilter::new("rust_scraper=warn,tokio=warn,reqwest=warn")
     } else {
-        EnvFilter::new(format!("rust_scraper={},tokio=warn,reqwest=warn", level))
+        EnvFilter::new(format!("rust_scraper={level},tokio=warn,reqwest=warn"))
     };
 
     // Build subscriber layers
@@ -136,7 +136,7 @@ pub fn init_json_logging_dual(
     if let Some(dir) = log_dir {
         // Create file appender with daily rotation
         let file_appender =
-            RollingFileAppender::new(Rotation::DAILY, dir, format!("{}.log", app_name));
+            RollingFileAppender::new(Rotation::DAILY, dir, format!("{app_name}.log"));
 
         // NON-BLOCKING: Worker thread handles file I/O, Tokio threads never block
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);

--- a/src/infrastructure/obsidian/uri.rs
+++ b/src/infrastructure/obsidian/uri.rs
@@ -29,7 +29,7 @@ fn encode_obsidian_param(input: &str) -> String {
                 // Non-ASCII: UTF-8 percent-encode each byte
                 let mut buf = [0u8; 4];
                 for &byte in c.encode_utf8(&mut buf).as_bytes() {
-                    out.push_str(&format!("%{:02X}", byte));
+                    out.push_str(&format!("%{byte:02X}"));
                 }
             },
         }
@@ -77,7 +77,7 @@ pub fn open_in_obsidian(uri: &str) -> Result<(), String> {
     std::process::Command::new(cmd)
         .args(&args)
         .spawn()
-        .map_err(|e| format!("failed to open URI: {}", e))?;
+        .map_err(|e| format!("failed to open URI: {e}"))?;
 
     Ok(())
 }

--- a/src/infrastructure/scraper/readability.rs
+++ b/src/infrastructure/scraper/readability.rs
@@ -46,7 +46,7 @@ pub struct Article {
 /// ```
 pub fn parse(html: &str, url: Option<&str>) -> Result<Article> {
     let article = legible::parse(html, url, None)
-        .map_err(|e| ScraperError::Extraction(format!("Readability failed: {}", e)))?;
+        .map_err(|e| ScraperError::Extraction(format!("Readability failed: {e}")))?;
 
     Ok(Article {
         title: article.title,

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -8,6 +8,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::time::Duration;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn cmd() -> Command {
     Command::cargo_bin("rust_scraper").expect("binary exists")
@@ -105,4 +109,92 @@ fn test_dry_run_flag_accepted() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("--url is required"));
+}
+
+// ============================================================================
+// Tests: Single-page scraping
+// ============================================================================
+
+#[tokio::test]
+async fn test_single_page_requests_only_seed_and_writes_output() {
+    let mock_server = MockServer::start().await;
+    let output_dir = TempDir::new().expect("create temp output dir");
+    let seed_html = r#"
+        <html>
+            <head><title>Single Page Test</title></head>
+            <body>
+                <main>
+                    <article>
+                        <h1>Single Page Test</h1>
+                        <p>This page has enough meaningful content for the fallback extractor to produce a usable document.</p>
+                        <p>The linked page must not be requested while --single-page is active, because discovery is skipped.</p>
+                        <a href="/linked">Linked page that should not be fetched</a>
+                    </article>
+                </main>
+            </body>
+        </html>
+    "#;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(seed_html))
+        .expect(1)
+        .named("single-page seed request")
+        .mount(&mock_server)
+        .await;
+
+    cmd()
+        .arg("--url")
+        .arg(mock_server.uri())
+        .arg("--single-page")
+        .arg("--output")
+        .arg(output_dir.path())
+        .arg("--quiet")
+        .assert()
+        .success();
+
+    let received_requests = mock_server
+        .received_requests()
+        .await
+        .expect("request recording should be enabled");
+    assert_eq!(received_requests.len(), 1);
+    assert_eq!(received_requests[0].url.path(), "/");
+
+    let output_entries = std::fs::read_dir(output_dir.path())
+        .expect("read output dir")
+        .count();
+    assert!(output_entries > 0, "single-page scrape should write output");
+}
+
+#[tokio::test]
+async fn test_single_page_custom_timeout_is_used_by_scrape_client() {
+    let mock_server = MockServer::start().await;
+    let output_dir = TempDir::new().expect("create temp output dir");
+
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("slow response content")
+                .set_delay(Duration::from_secs(2)),
+        )
+        .expect(1)
+        .named("single-page timeout request")
+        .mount(&mock_server)
+        .await;
+
+    cmd()
+        .arg("--url")
+        .arg(format!("{}/slow", mock_server.uri()))
+        .arg("--single-page")
+        .arg("--timeout-secs")
+        .arg("1")
+        .arg("--output")
+        .arg(output_dir.path())
+        .arg("--quiet")
+        .assert()
+        .code(69)
+        .stderr(predicate::str::contains(
+            "No pages were successfully scraped",
+        ));
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -6,6 +6,37 @@
 
 use clap::Parser;
 use rust_scraper::{Args, Commands, ExportFormat, OutputFormat, Shell};
+use std::sync::{Mutex, OnceLock};
+
+fn single_page_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("env lock poisoned")
+}
+
+fn parse_args_with_single_page_env<I, S>(args: I, value: Option<&str>) -> Args
+where
+    I: IntoIterator<Item = S>,
+    S: Into<std::ffi::OsString> + Clone,
+{
+    let _guard = single_page_env_lock();
+    let previous = std::env::var_os("RUST_SCRAPER_SINGLE_PAGE");
+
+    match value {
+        Some(value) => std::env::set_var("RUST_SCRAPER_SINGLE_PAGE", value),
+        None => std::env::remove_var("RUST_SCRAPER_SINGLE_PAGE"),
+    }
+
+    let parsed = Args::parse_from(args);
+
+    match previous {
+        Some(previous) => std::env::set_var("RUST_SCRAPER_SINGLE_PAGE", previous),
+        None => std::env::remove_var("RUST_SCRAPER_SINGLE_PAGE"),
+    }
+
+    parsed
+}
 
 // ============================================================================
 // Tests: Default values
@@ -26,6 +57,7 @@ fn test_args_defaults() {
     assert!(!args.download_documents);
     assert!(!args.use_sitemap);
     assert!(!args.interactive);
+    assert!(!args.single_page);
     assert!(!args.resume);
     assert!(!args.clean_ai);
     assert!(!args.force_js_render);
@@ -82,6 +114,57 @@ fn test_args_url_with_query_params() {
         args.url,
         Some("https://example.com/search?q=test&page=1".to_string())
     );
+}
+
+#[test]
+fn test_args_single_page_defaults_to_false() {
+    let args =
+        parse_args_with_single_page_env(["rust_scraper", "--url", "https://example.com"], None);
+    assert!(!args.single_page);
+}
+
+#[test]
+fn test_args_single_page_env_true_enables_flag() {
+    let args = parse_args_with_single_page_env(
+        ["rust_scraper", "--url", "https://example.com"],
+        Some("true"),
+    );
+    assert!(args.single_page);
+}
+
+#[test]
+fn test_args_single_page_flag_wins_over_env_false() {
+    let args = parse_args_with_single_page_env(
+        [
+            "rust_scraper",
+            "--url",
+            "https://example.com",
+            "--single-page",
+        ],
+        Some("false"),
+    );
+    assert!(args.single_page);
+}
+
+#[test]
+fn test_args_single_page_with_crawl_limits() {
+    let args = parse_args_with_single_page_env(
+        [
+            "rust_scraper",
+            "--url",
+            "https://example.com",
+            "--single-page",
+            "--max-depth",
+            "5",
+            "--max-pages",
+            "100",
+        ],
+        None,
+    );
+
+    assert!(args.single_page);
+    assert_eq!(args.max_depth, 5);
+    assert_eq!(args.max_pages, 100);
 }
 
 // ============================================================================

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -80,6 +80,7 @@ fn test_args_has_required_fields() {
         sitemap_url: None,
         interactive: false,
         config_tui: false,
+        single_page: false,
         resume: false,
         state_dir: None,
         clean_ai: false,


### PR DESCRIPTION
## Summary

Adds `--single-page` flag and `RUST_SCRAPER_SINGLE_PAGE` env var to force scraping exactly the seed URL, skipping URL discovery and crawling entirely.

Closes #48.

## Changes

### Work Unit 1 — Flag Parsing & URL Selection
- `src/cli/args.rs`: added `single_page: bool` with `RUST_SCRAPER_SINGLE_PAGE` env support
- `src/cli/orchestrator.rs`: branch on `single_page` to skip discovery and use only the seed URL via `plan_urls` helper
- `tests/cli_tests.rs`: 6 new tests covering default false, env true, flag wins over env=false, and precedence over `--max-depth`/`--max-pages`

### Work Unit 2 — Timeout Wiring & Integration Proof
- `src/cli/scrape_flow.rs`: extracted `build_http_client_config` helper that wires `args.timeout_secs` into `HttpClientConfig`
- `tests/cli_binary_test.rs`: 2 new wiremock integration tests proving single-page issues exactly one request and custom timeout is enforced

### Docs
- `AGENTS.md`: hardened GitNexus workflow (`--index-only --skip-agents-md`, removed legacy fallback, name-based skill refs)

## Behavior

```bash
# Scrape ONLY this URL, no discovery, no crawling
./rust_scraper --url "https://example.com" --single-page

# Respects --timeout-secs for this single page
./rust_scraper --url "https://example.com" --single-page --timeout-secs 90

# Also works via env var
RUST_SCRAPER_SINGLE_PAGE=true ./rust_scraper --url "https://example.com"
```

`--single-page` wins over `--max-depth` and `--max-pages` (ignored, not rejected).

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo nextest run --profile dev --lib` → 535 passed, 5 skipped ✅
- `cargo nextest run --profile dev --test cli_tests --test cli_binary_test` → 48 passed, 1 skipped ✅
- Real-world testing: 4 URLs verified (example.com, web-scraping.dev/products, practice.expandtesting.com, httpbin.org/html) ✅

## Known separate issue

`httpbin.org/html` exposed a pre-existing export bug (`invalid config: empty_title`) on pages without `<title>`. Filed as #49 — separate from this change.