### PR TITLE
fix(deps): migrate rand to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,7 @@ dependencies = [
  "proptest",
  "pulldown-cmark",
  "quick-xml 0.37.5",
- "rand 0.8.6",
+ "rand 0.9.4",
  "ratatui",
  "ratatui-form",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ sha2 = "0.10"
 thiserror = "2"
 
 # Random for user agent rotation (TASK-05)
-rand = "0.8"
+rand = "0.9"
 
 # Cache directory management (TASK-001: User-Agent lazy update)
 dirs = "5"

--- a/src/application/http_client/client.rs
+++ b/src/application/http_client/client.rs
@@ -251,8 +251,9 @@ impl HttpClient {
 
                         // Fallback strategy 3: Add random delay (1-3 seconds)
                         if ua_index == 4 {
+                            use rand::Rng;
                             ua_index += 1;
-                            let delay_ms = 1000 + (rand::random::<u64>() % 2000);
+                            let delay_ms = 1000 + (rand::rng().random::<u64>() % 2000);
                             warn!("Adding random delay {}ms for WAF bypass", delay_ms);
                             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                             continue;
@@ -417,8 +418,8 @@ pub fn create_http_client() -> Result<Client, ScraperError> {
 /// Get random user agent from pool (legacy function)
 pub fn get_random_user_agent_from_pool(pool: &[String]) -> String {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
-    let index = rng.gen_range(0..pool.len());
+    let mut rng = rand::rng();
+    let index = rng.random_range(0..pool.len());
     pool[index].clone()
 }
 

--- a/src/domain/value_objects.rs
+++ b/src/domain/value_objects.rs
@@ -49,9 +49,11 @@ impl CorrelationId {
     /// assert!(traceparent.starts_with("00-"));
     /// ```
     pub fn new() -> Self {
+        use rand::Rng;
+        let mut rng = rand::rng();
         Self {
             trace_id: Uuid::now_v7(),
-            span_id: rand::random(),
+            span_id: rng.random(),
         }
     }
 

--- a/src/infrastructure/user_agent.rs
+++ b/src/infrastructure/user_agent.rs
@@ -211,8 +211,9 @@ impl UserAgentCache {
 /// ```
 #[must_use]
 pub fn get_random_user_agent_from_pool(pool: &[String]) -> String {
-    let rand_idx = rand::random::<usize>() % pool.len();
-    pool[rand_idx].clone()
+    use rand::Rng;
+    let index = rand::rng().random_range(0..pool.len());
+    pool[index].clone()
 }
 
 /// Legacy function for backward compatibility (DEPRECATED)

--- a/tests/security_integration.rs
+++ b/tests/security_integration.rs
@@ -110,13 +110,12 @@ async fn test_datadome_silent_challenge_detection() {
 #[tokio::test]
 async fn test_datadome_high_entropy_detection() {
     // RED: Test that DataDome high-entropy challenge is detected
-    // Create a high-entropy string (>100KB) with uniform byte distribution
-    // to trigger the entropy-based detection. Repeating a random Base64-like
-    // string ensures high Shannon entropy (>6.5).
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    let high_entropy_chunk: String = (0..256).map(|_| rng.gen::<u8>() as char).collect();
-    let obfuscated_js = high_entropy_chunk.repeat(400); // ~100KB of high-entropy data
+    // Create deterministic high-entropy content (>100KB) so CI does not depend on randomness.
+    let obfuscated_js: String = (32u8..=126)
+        .cycle()
+        .take(95 * 1100)
+        .map(char::from)
+        .collect();
 
     // With threshold lowered to 5.5, high-entropy content should be detected
     // UTF-8 encoding of code points 128-255 produces non-uniform bytes (~5.5-6.0 bits)


### PR DESCRIPTION
## Summary
- Migrate the direct rand dependency from 0.8 to 0.9.
- Update direct rand API usage to rand::rng().random() / random_range().
- Make the DataDome entropy fixture deterministic so the security test does not depend on RNG.

## Changes
| File | Change |
|------|--------|
| Cargo.toml | Updates direct rand dependency to 0.9 |
| Cargo.lock | Retargets rust_scraper direct rand dependency to 0.9.4 |
| src/application/http_client/client.rs | Migrates HTTP client random delay and legacy UA picker to rand 0.9 APIs |
| src/domain/value_objects.rs | Migrates CorrelationId span ID generation to rand 0.9 API |
| src/infrastructure/user_agent.rs | Migrates UA random selection to unbiased random_range |
| tests/security_integration.rs | Replaces random high-entropy fixture with deterministic content |

## Test Plan
- [x] cargo fmt --check
- [x] cargo check --all-targets
- [x] cargo clippy -- -D warnings
- [x] cargo test --test security_integration test_datadome_high_entropy_detection
- [x] cargo test --test security_integration
- [x] cargo test --lib infrastructure::user_agent::tests
- [x] cargo test --lib test_correlation_id*
- [x] git diff --check

Part of #33.

Maintainer-approved maintenance PR for audit-rust-2026 PR2.