### PR TITLE
refactor(ai): desugar async-trait to boxed future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3991,7 +3991,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-compression",
- "async-trait",
  "axum 0.8.9",
  "built",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ full = ["images", "documents"]
 # AI-powered semantic cleaning (Module 3 + 4 + 5 + 7)
 ai = [
     "dep:tokenizers",
-    "dep:async-trait",
     "dep:unicode-segmentation",
     "dep:smallvec",
     "dep:wide",
@@ -191,8 +190,6 @@ tokenizers = { version = "0.21", optional = true }
 # CRITICAL: Use rustls-tls to avoid OpenSSL native linking
 # Also disable default-tls to prevent pulling native-tls
 hf-hub = { version = "0.5", default-features = false, features = ["tokio", "rustls-tls"], optional = true }
-# Async trait support for dyn-compatible traits
-async-trait = { version = "0.1", optional = true }
 
 # ============================================================================
 # Semantic Chunking Dependencies (feature-gated: --features ai)

--- a/src/domain/semantic_cleaner.rs
+++ b/src/domain/semantic_cleaner.rs
@@ -8,11 +8,16 @@
 //!
 //! - **Sealed trait pattern** (`api-sealed-trait`): Prevents external implementations
 //!   that could violate invariants. Only infrastructure/ai module can implement.
-//! - **Async interface** (`async-trait`): All cleaning operations are async for non-blocking I/O
+//! - **Async interface** (boxed futures): Async methods are manually desugared to
+//!   `Pin<Box<dyn Future<Output = T> + Send>>` to preserve dyn-compatibility
+//!   (`Box<dyn SemanticCleaner>`) without depending on the `async-trait` macro.
 //! - **Explicit error types**: Uses `SemanticError` for type-safe error handling
 //!   (`err-thiserror-lib`, `err-context-chain`)
 //! - **Borrowed input**: Accepts `&str` not `&String` (`own-borrow-over-clone`)
 //! - **Owned output**: Returns `Vec<DocumentChunk>` for ownership transfer
+
+use std::future::Future;
+use std::pin::Pin;
 
 use crate::domain::DocumentChunk;
 use crate::error::SemanticError;
@@ -61,7 +66,6 @@ pub(crate) mod private {
 /// - Implementations MUST be thread-safe (`Send + Sync`)
 /// - Implementations MUST cache models to avoid reloading
 /// - Implementations MUST use memory-mapped files for large models (`mem-zero-copy`)
-#[async_trait::async_trait]
 pub trait SemanticCleaner: private::Sealed + Send + Sync {
     /// Clean HTML content and split into semantic chunks
     ///
@@ -108,7 +112,17 @@ pub trait SemanticCleaner: private::Sealed + Send + Sync {
     /// - **First call**: May trigger model download (~90MB) + load (~100-500ms)
     /// - **Subsequent calls**: Cache hit, ~10-50ms per page
     /// - **Memory**: Uses memory-mapped files, ~90MB virtual memory (not RSS)
-    async fn clean(&self, html: &str) -> Result<Vec<DocumentChunk>, SemanticError>;
+    ///
+    /// # Note
+    ///
+    /// Desugared to a boxed future (`Pin<Box<dyn Future + Send>>`) instead of
+    /// `async fn` so the trait stays dyn-compatible (`Box<dyn SemanticCleaner>`).
+    /// The single lifetime `'a` ties `&self` and `html` to the returned future,
+    /// matching the `async-trait` macro's default desugaring.
+    fn clean<'a>(
+        &'a self,
+        html: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>>;
 
     /// Get the model's maximum token limit
     ///

--- a/src/infrastructure/ai/semantic_cleaner_impl.rs
+++ b/src/infrastructure/ai/semantic_cleaner_impl.rs
@@ -51,7 +51,9 @@
 //! # }
 //! ```
 
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::future::try_join_all;
@@ -412,92 +414,96 @@ impl SemanticCleanerImpl {
 // This is required by the sealed trait pattern
 impl private::Sealed for SemanticCleanerImpl {}
 
-#[async_trait::async_trait]
 impl SemanticCleaner for SemanticCleanerImpl {
-    async fn clean(&self, html: &str) -> Result<Vec<DocumentChunk>, SemanticError> {
-        debug!(
-            html_length = html.len(),
-            "Starting full RAG pipeline: chunk → tokenize → embed → score"
-        );
+    fn clean<'a>(
+        &'a self,
+        html: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>> {
+        Box::pin(async move {
+            debug!(
+                html_length = html.len(),
+                "Starting full RAG pipeline: chunk → tokenize → embed → score"
+            );
 
-        // Step 1: Semantic chunking (uses arena internally)
-        // Following `own-borrow-over-clone`: borrow html, don't clone
-        let chunks = self
-            .chunker
-            .chunk(html)
-            .map_err(|e| SemanticError::Tokenize(format!("Chunking failed: {}", e)))?;
+            // Step 1: Semantic chunking (uses arena internally)
+            // Following `own-borrow-over-clone`: borrow html, don't clone
+            let chunks = self
+                .chunker
+                .chunk(html)
+                .map_err(|e| SemanticError::Tokenize(format!("Chunking failed: {}", e)))?;
 
-        if chunks.is_empty() {
-            debug!("No chunks produced from HTML");
-            return Ok(Vec::new());
-        }
+            if chunks.is_empty() {
+                debug!("No chunks produced from HTML");
+                return Ok(Vec::new());
+            }
 
-        debug!(chunks_count = chunks.len(), "Step 1: Chunking complete");
+            debug!(chunks_count = chunks.len(), "Step 1: Chunking complete");
 
-        // Step 2: Tokenize all chunks (mem-reuse-collections: reuse buffer)
-        // Pre-allocate with capacity following `mem-with-capacity`
-        let mut token_buffers = Vec::with_capacity(chunks.len());
-        for chunk in &chunks {
-            let input = self.tokenizer.tokenize(&chunk.content).map_err(|e| {
-                SemanticError::Tokenize(format!("Tokenization failed for chunk: {}", e))
+            // Step 2: Tokenize all chunks (mem-reuse-collections: reuse buffer)
+            // Pre-allocate with capacity following `mem-with-capacity`
+            let mut token_buffers = Vec::with_capacity(chunks.len());
+            for chunk in &chunks {
+                let input = self.tokenizer.tokenize(&chunk.content).map_err(|e| {
+                    SemanticError::Tokenize(format!("Tokenization failed for chunk: {}", e))
+                })?;
+
+                // Validate token count
+                if input.seq_len() > self.config.max_tokens {
+                    return Err(SemanticError::ChunkTooLarge {
+                        chunk_id: format!("chunk-{}", token_buffers.len()),
+                        tokens: input.seq_len(),
+                        max: self.config.max_tokens,
+                    });
+                }
+
+                token_buffers.push(input);
+            }
+
+            debug!(
+                tokens_generated = token_buffers.len(),
+                "Step 2: Tokenization complete"
+            );
+
+            // Step 3: Generate embeddings CONCURRENTLY (async-join-parallel)
+            // Following `async-join-parallel`: use try_join_all for concurrent independent operations
+            // Following `async-spawn-blocking`: InferenceEngine already uses spawn_blocking internally
+            // Following `anti-lock-across-await`: No locks held across await points
+            let semaphore = Arc::clone(&self.semaphore);
+            let embeddings = try_join_all(token_buffers.iter().map(|input| {
+                let sem = Arc::clone(&semaphore);
+                let engine = &self.inference_engine;
+                async move {
+                    let _permit = sem.acquire_owned().await.expect("semaphore no fue cerrado");
+                    engine.run_inference(input).await
+                }
+            }))
+            .await
+            .map_err(|e| {
+                SemanticError::Inference(format!("Concurrent embedding generation failed: {}", e))
             })?;
 
-            // Validate token count
-            if input.seq_len() > self.config.max_tokens {
-                return Err(SemanticError::ChunkTooLarge {
-                    chunk_id: format!("chunk-{}", token_buffers.len()),
-                    tokens: input.seq_len(),
-                    max: self.config.max_tokens,
-                });
-            }
+            debug!(
+                embeddings_generated = embeddings.len(),
+                embedding_dim = embeddings.first().map(|e| e.len()).unwrap_or(0),
+                "Step 3: Embedding generation complete"
+            );
 
-            token_buffers.push(input);
-        }
+            // Step 4: Score and filter (own-borrow-over-clone: borrow embeddings)
+            // Following `own-borrow-over-clone`: borrow &chunks and &embeddings, don't clone
+            // Following `opt-simd-portable`: RelevanceScorer uses SIMD cosine similarity
+            let filtered = self.filter_by_relevance(&chunks, &embeddings)?;
 
-        debug!(
-            tokens_generated = token_buffers.len(),
-            "Step 2: Tokenization complete"
-        );
+            debug!(
+                chunks_before = chunks.len(),
+                chunks_after = filtered.len(),
+                filtered_out = chunks.len() - filtered.len(),
+                "Step 4: Relevance filtering complete"
+            );
 
-        // Step 3: Generate embeddings CONCURRENTLY (async-join-parallel)
-        // Following `async-join-parallel`: use try_join_all for concurrent independent operations
-        // Following `async-spawn-blocking`: InferenceEngine already uses spawn_blocking internally
-        // Following `anti-lock-across-await`: No locks held across await points
-        let semaphore = Arc::clone(&self.semaphore);
-        let embeddings = try_join_all(token_buffers.iter().map(|input| {
-            let sem = Arc::clone(&semaphore);
-            let engine = &self.inference_engine;
-            async move {
-                let _permit = sem.acquire_owned().await.expect("semaphore no fue cerrado");
-                engine.run_inference(input).await
-            }
-        }))
-        .await
-        .map_err(|e| {
-            SemanticError::Inference(format!("Concurrent embedding generation failed: {}", e))
-        })?;
+            info!(total_chunks = filtered.len(), "Full RAG pipeline complete");
 
-        debug!(
-            embeddings_generated = embeddings.len(),
-            embedding_dim = embeddings.first().map(|e| e.len()).unwrap_or(0),
-            "Step 3: Embedding generation complete"
-        );
-
-        // Step 4: Score and filter (own-borrow-over-clone: borrow embeddings)
-        // Following `own-borrow-over-clone`: borrow &chunks and &embeddings, don't clone
-        // Following `opt-simd-portable`: RelevanceScorer uses SIMD cosine similarity
-        let filtered = self.filter_by_relevance(&chunks, &embeddings)?;
-
-        debug!(
-            chunks_before = chunks.len(),
-            chunks_after = filtered.len(),
-            filtered_out = chunks.len() - filtered.len(),
-            "Step 4: Relevance filtering complete"
-        );
-
-        info!(total_chunks = filtered.len(), "Full RAG pipeline complete");
-
-        Ok(filtered)
+            Ok(filtered)
+        })
     }
 
     fn max_tokens(&self) -> usize {


### PR DESCRIPTION
## Summary
- Remove the direct async-trait dependency from the ai feature.
- Desugar SemanticCleaner::clean to an object-safe boxed future.
- Preserve Box<dyn SemanticCleaner> compatibility without changing runtime behavior.

## Changes
| File | Change |
|------|--------|
| Cargo.toml | Removes dep:async-trait from the ai feature and drops the direct optional dependency |
| Cargo.lock | Removes async-trait from rust_scraper direct dependencies; it remains transitive via redis/rmcp |
| src/domain/semantic_cleaner.rs | Replaces #[async_trait] with an explicit Pin<Box<dyn Future + Send + 'a>> signature |
| src/infrastructure/ai/semantic_cleaner_impl.rs | Wraps the existing async body in Box::pin(async move { ... }) |

## Test Plan
- [x] cargo fmt --check
- [x] cargo check --features ai
- [x] cargo check --all-targets --features ai
- [x] cargo test --features ai --lib semantic_cleaner
- [x] cargo tree --features ai -i async-trait
- [x] git diff --check

Part of #33.

Maintainer-approved maintenance PR for audit-rust-2026 PR3.