### PR TITLE
feat(scraper): add title_resolver.rs and wire host fallback for empty titles

### DIFF
--- a/src/application/crawler_service.rs
+++ b/src/application/crawler_service.rs
@@ -373,7 +373,7 @@ pub async fn scrape_single_url_for_tui(
             let assets = download_assets_if_enabled(&html, url, config).await?;
 
             Ok(ScrapedContent {
-                title: article.title,
+                title: crate::application::resolve_title(&article.title, url),
                 content: article.text_content,
                 url: ValidUrl::new(url.clone()),
                 excerpt: article.excerpt,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -13,6 +13,7 @@ pub mod http_client;
 pub mod rate_limiter;
 pub mod results_channel;
 pub mod scraper_service;
+pub mod title_resolver;
 pub mod url_filter;
 
 pub use crawler_service::{
@@ -27,4 +28,5 @@ pub use scraper_service::{
     detect_spa_content, scrape_multiple_with_limit, scrape_with_config, scrape_with_readability,
     SpaDetectionResult,
 };
+pub use title_resolver::resolve_title;
 pub use url_filter::{extract_domain, is_allowed, is_excluded, is_internal_link, matches_pattern};

--- a/src/application/scraper_service.rs
+++ b/src/application/scraper_service.rs
@@ -213,7 +213,7 @@ pub async fn scrape_with_config(
             }
 
             results.push(ScrapedContent {
-                title: article.title,
+                title: crate::application::resolve_title(&article.title, url),
                 content: article.text_content,
                 url: ValidUrl::new(url.clone()),
                 excerpt: article.excerpt,

--- a/src/application/title_resolver.rs
+++ b/src/application/title_resolver.rs
@@ -1,0 +1,92 @@
+use tracing::debug;
+use url::Url;
+
+/// Resolve a possibly-empty extracted title to a guaranteed-non-empty string.
+///
+/// - Empty/whitespace-only input → `Document: [<host>]` (or `Document: [unknown_host]`).
+/// - Non-empty input → returned unchanged (trim-for-check only; `validate()` trims downstream).
+pub fn resolve_title(extracted_title: &str, url: &Url) -> String {
+    if extracted_title.trim().is_empty() {
+        let host = url.host_str().unwrap_or("unknown_host");
+        let resolved = format!("Document: [{host}]");
+        debug!(
+            target: "application::title_resolver",
+            url = %url,
+            fallback = %resolved,
+            "extracted title empty; applied host-based fallback"
+        );
+        resolved
+    } else {
+        extracted_title.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_title;
+    use url::Url;
+
+    fn parse(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn test_resolve_title_empty_returns_host_fallback() {
+        assert_eq!(
+            resolve_title("", &parse("https://example.com/page")),
+            "Document: [example.com]"
+        );
+    }
+
+    #[test]
+    fn test_resolve_title_whitespace_returns_host_fallback() {
+        assert_eq!(
+            resolve_title("   ", &parse("https://blog.example.com/post")),
+            "Document: [blog.example.com]"
+        );
+    }
+
+    #[test]
+    fn test_resolve_title_mixed_whitespace_returns_host_fallback() {
+        assert_eq!(
+            resolve_title("  \n  ", &parse("https://example.com")),
+            "Document: [example.com]"
+        );
+    }
+
+    #[test]
+    fn test_resolve_title_valid_passes_through_unchanged() {
+        assert_eq!(
+            resolve_title("My Article Title", &parse("https://example.com")),
+            "My Article Title"
+        );
+    }
+
+    #[test]
+    fn test_resolve_title_no_host_returns_unknown_host() {
+        assert_eq!(
+            resolve_title("", &parse("file:///path")),
+            "Document: [unknown_host]"
+        );
+    }
+
+    #[test]
+    fn test_resolve_title_is_deterministic() {
+        let url = parse("https://example.com/page");
+        let first = resolve_title("", &url);
+        let second = resolve_title("", &url);
+        assert_eq!(first, second);
+        assert_eq!(first, "Document: [example.com]");
+    }
+
+    #[test]
+    fn test_resolve_title_padded_nonempty_is_not_fallback() {
+        // Trim-for-check only: a padded-but-nonempty title is returned as-is,
+        // NOT trimmed and NOT replaced with the fallback. This documents the
+        // behaviour-preserving semantics (validate() trims downstream).
+        assert_eq!(
+            resolve_title("  Padded  ", &parse("https://example.com")),
+            "  Padded  "
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add title_resolver.rs module to guarantee non-empty titles for ScrapedContent.
- Wire the module into both Readability success branches.
- Fallback format: Document: [host] for empty titles.

## Changes
| File | Change |
|------|--------|
| src/application/title_resolver.rs | New module with resolve_title() + 7 unit tests |
| src/application/mod.rs | Register title_resolver module |
| src/application/crawler_service.rs | Wire resolve_title() in Readability success branch |
| src/application/scraper_service.rs | Wire resolve_title() in Readability success branch |

## Test Plan
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo clippy -- -D warnings
- [x] cargo test title_resolver
- [x] cargo test --lib application::crawler_service::tests
- [x] cargo test --lib application::scraper_service::tests
- [x] git diff --check
- [x] gitnexus_detect_changes

Part of #49.

Maintainer-approved PR for empty-title-fallback fix.