### PR TITLE
refactor(concurrency): replace blocking locks + String dedup with lock-free u64 + async locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,6 +3987,7 @@ dependencies = [
 name = "rust_scraper"
 version = "1.1.0"
 dependencies = [
+ "ahash",
  "aho-corasick",
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,11 @@ redis = { version = "0.27", features = ["tokio-comp", "connection-manager", "rus
 # governor pulls in dashmap 5.x. Both are needed. Do NOT remove either.
 dashmap = "6"
 
+# Hasher for u64-keyed URL deduplication (DashSet<u64, ahash::RandomState>).
+# Per-process randomized seed (FR-3 HashDoS resistance). Direct dep — previously
+# only transitive under the `ai` feature. Default `std` feature for hash_one().
+ahash = { version = "0.8", features = ["std"] }
+
 # TUI (preparar para Fase 2) - FASE 1 Web Crawler
 ratatui = "0.29"
 catppuccin = "2"

--- a/src/application/crawler_service.rs
+++ b/src/application/crawler_service.rs
@@ -21,13 +21,13 @@
 //! use rust_scraper::application::crawler::engine;
 //! ```
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::Result;
-use tokio::sync::Mutex;
 use tracing::{debug, error, info, instrument, span, warn, Level};
 use url::Url;
+
+use super::deduplicator::UrlDeduplicator;
 
 pub use crate::domain::{
     CorrelationId, CrawlError, CrawlResult, CrawlerConfig, DiscoveredUrl, ScrapedContent, ValidUrl,
@@ -538,10 +538,11 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
         0,
         config_clone.seed_url.clone(),
     );
-    queue.push(seed_discovered);
+    queue.push(seed_discovered).await;
 
-    // Track visited URLs
-    let visited = Arc::new(Mutex::new(HashSet::<String>::new()));
+    // Track visited URLs — lock-free DashSet<u64, ahash::RandomState> (8 B/key).
+    // try_insert is synchronous/atomic; no Mutex/.await in the hot loop (D5).
+    let visited = Arc::new(UrlDeduplicator::new());
 
     // Results collector - usa mpsc channel para lock-free collection
     // Capacidad basada en max_pages para evitar reallocs
@@ -576,7 +577,7 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
         // Fix Bug 5: discovered links were pushed to queue (Arc<UrlQueue>)
         // but never transferred to url_queue (VecDeque), so sub-paths
         // were never crawled.
-        url_queue.append(&mut queue.drain_all());
+        url_queue.append(&mut queue.drain_all().await);
 
         // Spawn new tasks up to concurrency limit
         while let Some(discovered_url) = url_queue.pop_front() {
@@ -587,13 +588,10 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
                 break;
             }
 
-            // Check if already visited
-            {
-                let visited_guard = visited.lock().await;
-                if visited_guard.contains(discovered_url.url.as_str()) {
-                    drop(visited_guard);
-                    continue;
-                }
+            // Check if already visited — atomic, lock-free (no .await on the
+            // dedup call; try_insert is synchronous per design D5).
+            if !visited.try_insert(discovered_url.url.as_str()) {
+                continue;
             }
 
             // Clone data for task (async-clone-before-await)
@@ -643,19 +641,16 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
                                                 if is_internal_link(&normalized, seed_domain) {
                                                     // Check if allowed by filters
                                                     if is_allowed(&normalized, &config_task) {
-                                                        // Check if not visited
-                                                        let visited_guard =
-                                                            visited_task.lock().await;
-                                                        if !visited_guard.contains(&normalized) {
-                                                            drop(visited_guard);
-
+                                                        // Check if not visited — atomic,
+                                                        // lock-free (no .await on try_insert).
+                                                        if visited_task.try_insert(&normalized) {
                                                             let new_discovered =
                                                                 DiscoveredUrl::html(
                                                                     parsed_url,
                                                                     url_depth + 1,
                                                                     parent_url.clone(),
                                                                 );
-                                                            queue_task.push(new_discovered);
+                                                            queue_task.push(new_discovered).await;
                                                         }
                                                     }
                                                 }

--- a/src/application/deduplicator.rs
+++ b/src/application/deduplicator.rs
@@ -1,111 +1,101 @@
-//! Deduplicator module — URL deduplication logic
+//! URL deduplication module.
 //!
-//! Extracts the deduplication logic from crawler_service.rs to allow
-//! for independent testing and potential future swapping (e.g., Redis-backed).
+//! Lock-free, memory-efficient URL deduplication built on
+//! `DashSet<u64, ahash::RandomState>`. Stores an 8-byte hash per URL instead of
+//! the full normalized `String`, collapsing per-URL residency from ~150 B to
+//! ~8 B (FR-2: <100 MB for 10 M URLs).
 //!
 //! # Design Decisions
 //!
-//! - Uses `tokio::sync::Mutex` for async-safe interior mutability
-//! - Implements trait-based design for testability
-//! - Stores URLs as strings (normalized) for memory efficiency
-//! - Provides both sync and async interfaces
+//! - `DashSet<u64, ahash::RandomState>` — lock-free concurrent check-and-insert
+//! - Per-process randomized seed via `ahash::RandomState::new()` (FR-3 HashDoS
+//!   resistance); deliberately NOT `RandomState::default()` (frozen keys)
+//! - `try_insert` is synchronous and atomic — no `Mutex`, no `.await` in the
+//!   hot loop (FR-8: no data races, no lost updates)
+//! - Deterministic within a single process (FR-5): the seed is fixed for the
+//!   process lifetime, so identical URLs hash to identical `u64` keys
 
-use std::collections::HashSet;
-use std::sync::Arc;
-
-use tokio::sync::Mutex;
+use dashmap::DashSet;
 use url::Url;
 
-/// Trait for URL deduplication - allows different implementations
-pub trait UrlDeduplicator: Send + Sync {
-    /// Check if URL was already visited
-    fn is_visited(&self, url: &str) -> impl std::future::Future<Output = bool> + Send;
-
-    /// Mark URL as visited
-    fn mark_visited(&self, url: String) -> impl std::future::Future<Output = ()> + Send;
-
-    /// Get current count of visited URLs
-    fn visited_count(&self) -> impl std::future::Future<Output = usize> + Send;
-
-    /// Check and mark in one operation (atomic)
-    fn check_and_mark(&self, url: String) -> impl std::future::Future<Output = bool> + Send;
-}
-
-/// In-memory URL deduplicator using HashSet
+/// Lock-free URL deduplicator.
+///
+/// Stores a `u64` hash (8 bytes) per seen URL rather than the full string.
+/// Dedup is atomic: `try_insert` performs a single `DashSet::insert`
+/// (check-and-insert in one step), so concurrent callers cannot race past each
+/// other.
+///
+/// The hash seed is randomized per process startup (`RandomState::new()`,
+/// satisfying FR-3) yet stable for the deduplicator's lifetime, so the same URL
+/// always maps to the same `u64` within one process (FR-5).
 ///
 /// # Example
 ///
 /// ```rust
-/// use rust_scraper::application::deduplicator::{UrlDeduplicator, InMemoryDeduplicator};
+/// use rust_scraper::application::deduplicator::UrlDeduplicator;
 ///
-/// #[tokio::main]
-/// async fn main() {
-///     let dedup = InMemoryDeduplicator::new();
-///
-///     // First time - returns false (not visited)
-///     let is_new = dedup.check_and_mark("https://example.com".into()).await;
-///     assert!(!is_new);
-///
-///     // Second time - returns true (already visited)
-///     let is_new = dedup.check_and_mark("https://example.com".into()).await;
-///     assert!(is_new);
-/// }
+/// let dedup = UrlDeduplicator::new();
+/// assert!(dedup.try_insert("https://example.com"));   // newly inserted
+/// assert!(!dedup.try_insert("https://example.com"));  // already seen
+/// assert_eq!(dedup.len(), 1);
 /// ```
-#[derive(Clone)]
-pub struct InMemoryDeduplicator {
-    visited: Arc<Mutex<HashSet<String>>>,
+pub struct UrlDeduplicator {
+    seen: DashSet<u64, ahash::RandomState>,
+    rs: ahash::RandomState,
 }
 
-impl InMemoryDeduplicator {
-    /// Create a new in-memory deduplicator
+impl UrlDeduplicator {
+    /// Create a new deduplicator with a fresh per-process randomized seed.
+    ///
+    /// Pre-allocates capacity for ~100 URLs (mem-with-capacity).
+    #[must_use]
     pub fn new() -> Self {
+        let rs = ahash::RandomState::new();
         Self {
-            visited: Arc::new(Mutex::new(HashSet::new())),
+            seen: DashSet::with_capacity_and_hasher(100, rs.clone()),
+            rs,
         }
     }
 
-    /// Create with pre-allocated capacity
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            visited: Arc::new(Mutex::new(HashSet::with_capacity(capacity))),
-        }
+    /// Atomically check-and-insert a URL.
+    ///
+    /// Returns `true` if the URL was newly inserted, `false` if it was already
+    /// present. This is a single lock-free `DashSet::insert` — no `Mutex`, no
+    /// `.await` — so it is safe to call from many Tokio tasks concurrently
+    /// (FR-8) without data races or lost updates.
+    #[must_use]
+    pub fn try_insert(&self, url: &str) -> bool {
+        self.seen.insert(self.rs.hash_one(url))
+    }
+
+    /// Number of unique URLs currently tracked.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    /// Whether no URLs have been tracked yet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
     }
 }
 
-impl Default for InMemoryDeduplicator {
+impl Default for UrlDeduplicator {
     fn default() -> Self {
+        // Delegate to `new()` so the seed is randomized (RandomState::new()).
+        // Do NOT replace with `#[derive(Default)]`: the derived impl would use
+        // `RandomState::default()` (frozen compile-time keys), violating FR-3.
         Self::new()
     }
 }
 
-impl UrlDeduplicator for InMemoryDeduplicator {
-    async fn is_visited(&self, url: &str) -> bool {
-        let visited = self.visited.lock().await;
-        visited.contains(url)
-    }
-
-    async fn mark_visited(&self, url: String) {
-        let mut visited = self.visited.lock().await;
-        visited.insert(url);
-    }
-
-    async fn visited_count(&self) -> usize {
-        let visited = self.visited.lock().await;
-        visited.len()
-    }
-
-    async fn check_and_mark(&self, url: String) -> bool {
-        let mut visited = self.visited.lock().await;
-        !visited.insert(url) // Return true if already existed, false if newly inserted
-    }
-}
-
-/// Normalize URL for consistent deduplication
+/// Normalize a URL for consistent deduplication and filtering.
 ///
 /// - Removes trailing slashes
-/// - Removes www prefix
-/// - Converts to lowercase (for domain)
-/// - Removes default ports (80, 443)
+/// - Removes `www.` prefix
+/// - Drops default ports (80, 443)
+/// - Lowercases the host (via `Url` parsing)
 pub fn normalize_url(url: &Url) -> String {
     let scheme = url.scheme();
     let host = url.host_str().unwrap_or("");
@@ -150,106 +140,109 @@ pub fn normalize_url(url: &Url) -> String {
     result
 }
 
-/// Results collector - collects crawl results without Mutex per item
-///
-/// Instead of `Arc<Mutex<Vec<T>>>`, uses channels for better performance
-/// in high-concurrency scenarios.
-#[derive(Clone)]
-pub struct ResultsCollector<T: Clone + Send> {
-    results: Arc<Mutex<Vec<T>>>,
-}
-
-impl<T: Clone + Send> ResultsCollector<T> {
-    /// Create a new results collector
-    pub fn new() -> Self {
-        Self {
-            results: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    /// Create with pre-allocated capacity
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            results: Arc::new(Mutex::new(Vec::with_capacity(capacity))),
-        }
-    }
-
-    /// Add a result
-    pub async fn add(&self, result: T) {
-        let mut results = self.results.lock().await;
-        results.push(result);
-    }
-
-    /// Get all results
-    pub async fn get_all(&self) -> Vec<T> {
-        let results = self.results.lock().await;
-        results.clone()
-    }
-
-    /// Get count
-    pub async fn len(&self) -> usize {
-        let results = self.results.lock().await;
-        results.len()
-    }
-
-    /// Check if empty
-    pub async fn is_empty(&self) -> bool {
-        let results = self.results.lock().await;
-        results.is_empty()
-    }
-
-    /// Clear all results
-    pub async fn clear(&self) {
-        let mut results = self.results.lock().await;
-        results.clear();
-    }
-}
-
-impl<T: Clone + Send> Default for ResultsCollector<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
-    #[tokio::test]
-    async fn test_deduplicator_check_and_mark() {
-        let dedup = InMemoryDeduplicator::new();
-
-        // First time should return false (was inserted)
-        let result = dedup
-            .check_and_mark("https://example.com".to_string())
-            .await;
-        assert!(!result, "First insert should return false (URL was added)");
-
-        // Second time should return true (already exists)
-        let result = dedup
-            .check_and_mark("https://example.com".to_string())
-            .await;
-        assert!(
-            result,
-            "Second check should return true (URL already visited)"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_deduplicator_count() {
-        let dedup = InMemoryDeduplicator::new();
-
-        assert_eq!(dedup.visited_count().await, 0);
-
-        dedup.mark_visited("https://a.com".to_string()).await;
-        assert_eq!(dedup.visited_count().await, 1);
-
-        dedup.mark_visited("https://b.com".to_string()).await;
-        assert_eq!(dedup.visited_count().await, 2);
+    #[test]
+    fn test_new_deduplicator_is_empty() {
+        // empty: fresh deduplicator holds nothing, first insert succeeds
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.is_empty());
+        assert_eq!(dedup.len(), 0);
+        assert!(dedup.try_insert("https://example.com"));
+        assert!(!dedup.is_empty());
+        assert_eq!(dedup.len(), 1);
     }
 
     #[test]
-    fn test_normalize_url() {
+    fn test_whitespace_url_does_not_panic() {
+        // whitespace: a whitespace-only string is hashed as-is (no trimming
+        // here); it must not panic and must dedup like any other key.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("   "));
+        assert!(!dedup.try_insert("   "));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_valid_url_insert_and_dedup() {
+        // valid + Scenario: Basic dedup — same URL rejected twice
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com/page")); // newly inserted
+        assert!(!dedup.try_insert("https://example.com/page")); // already seen
+        assert_eq!(dedup.len(), 1);
+        // A different URL is accepted (Scenario: Different URLs accepted)
+        assert!(dedup.try_insert("https://example.com/other"));
+        assert_eq!(dedup.len(), 2);
+    }
+
+    #[test]
+    fn test_no_host_url_handled() {
+        // no-host: a URL without a host is hashed as a plain string — no panic,
+        // normal dedup semantics.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("/relative/path"));
+        assert!(!dedup.try_insert("/relative/path"));
+        assert!(dedup.try_insert("javascript:void(0)"));
+        assert_eq!(dedup.len(), 2);
+    }
+
+    #[test]
+    fn test_deterministic_within_process() {
+        // deterministic + FR-5: same URL -> same u64 within one process ->
+        // consistent dedup. 100 inserts of the same URL; only the first wins.
+        let dedup = UrlDeduplicator::new();
+        let url = "https://example.com/deterministic";
+        let mut newly_inserted = 0;
+        for _ in 0..100 {
+            if dedup.try_insert(url) {
+                newly_inserted += 1;
+            }
+        }
+        assert_eq!(newly_inserted, 1);
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_padded_urls_are_distinct() {
+        // padded: try_insert does NOT trim/normalize; surrounding whitespace
+        // yields a distinct hash from the bare URL. Normalization is
+        // normalize_url's job, applied by callers before inserting.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com"));
+        assert!(dedup.try_insert(" https://example.com "));
+        assert!(dedup.try_insert("https://example.com\n"));
+        assert_eq!(dedup.len(), 3);
+        // Re-inserting the bare URL is still a duplicate of itself
+        assert!(!dedup.try_insert("https://example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_inserts_unique() {
+        // concurrent + Scenario: Concurrent access correctness (FR-8)
+        // 1000 Tokio tasks each insert a unique URL; the set must end up with
+        // exactly 1000 entries — no panics, no lost updates.
+        let dedup = Arc::new(UrlDeduplicator::new());
+        let mut handles = Vec::with_capacity(1000);
+        for i in 0..1000u32 {
+            let dedup = Arc::clone(&dedup);
+            handles.push(tokio::spawn(async move {
+                let url = format!("https://example.com/page/{i}");
+                assert!(dedup.try_insert(&url), "unique URL must be newly inserted");
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+        assert_eq!(dedup.len(), 1000);
+    }
+
+    #[test]
+    fn test_normalize_url_preserved() {
+        // normalize_url is kept (DC-3 only deletes the legacy ResultsCollector,
+        // not this helper). Verify it still behaves as documented.
         let url = Url::parse("https://www.example.com/").unwrap();
         assert_eq!(normalize_url(&url), "https://example.com");
 
@@ -258,19 +251,5 @@ mod tests {
 
         let url = Url::parse("https://example.com:80/page").unwrap();
         assert_eq!(normalize_url(&url), "https://example.com/page");
-    }
-
-    #[tokio::test]
-    async fn test_results_collector() {
-        let collector: ResultsCollector<String> = ResultsCollector::new();
-
-        collector.add("result1".to_string()).await;
-        collector.add("result2".to_string()).await;
-
-        assert_eq!(collector.len().await, 2);
-        assert!(!collector.is_empty().await);
-
-        let all = collector.get_all().await;
-        assert_eq!(all, vec!["result1", "result2"]);
     }
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -20,7 +20,7 @@ pub use crawler_service::{
     crawl_site, crawl_with_sitemap, discover_urls_for_tui, scrape_single_url_for_tui,
     scrape_urls_for_tui,
 };
-pub use deduplicator::{normalize_url, ResultsCollector as InMemoryDeduplicator, UrlDeduplicator};
+pub use deduplicator::{normalize_url, UrlDeduplicator};
 pub use http_client::create_http_client;
 pub use rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 pub use results_channel::{CrawlMessage, ResultsAdapter, ResultsCollector};

--- a/src/infrastructure/crawler/url_queue.rs
+++ b/src/infrastructure/crawler/url_queue.rs
@@ -4,9 +4,13 @@
 //!
 //! # Rules Applied
 //!
-//! - **async-no-lock-across-await**: Uses DashSet for lock-free concurrent access
-//! - **mem-with-capacity**: Pre-allocates internal structures
-//! - **own-borrow-over-clone**: Efficient borrowing where possible
+//! - **async-no-lock-across-await**: The pending-URL `Vec` is guarded by a
+//!   `tokio::sync::Mutex` acquired via `.lock().await` (never
+//!   `blocking_lock()`). Each guard is held for nanoseconds across no `.await`
+//!   point. The dedup `seen` set is a lock-free `DashSet`.
+//! - **mem-with-capacity**: Pre-allocates internal structures.
+//! - **mem-u64-dedup**: `seen` stores `u64` hashes (8 B) instead of `String`s
+//!   (~150 B), keyed by a per-process `ahash::RandomState` seed.
 
 use dashmap::DashSet;
 use tokio::sync::Mutex;
@@ -16,25 +20,33 @@ use crate::domain::DiscoveredUrl;
 
 /// Thread-safe URL queue with deduplication
 ///
-/// Following **async-no-lock-across-await**: Uses DashSet for concurrent access
-/// without holding locks across .await points.
-/// Following **mem-with-capacity**: Pre-allocates internal storage.
+/// Following **async-no-lock-across-await**: uses `tokio::sync::Mutex` with
+/// `.lock().await` for the pending-URL buffer (held across no `.await`), and a
+/// lock-free `DashSet<u64, ahash::RandomState>` for the seen set.
+/// Following **mem-with-capacity**: pre-allocates internal storage.
 pub struct UrlQueue {
-    /// Pending URLs to crawl
+    /// Pending URLs to crawl — the only `tokio::sync::Mutex`, held briefly.
     queue: Mutex<Vec<DiscoveredUrl>>,
-    /// Set of URLs already in queue or visited (for deduplication)
-    seen: DashSet<String>,
+    /// Set of URL hashes already enqueued or visited (for deduplication).
+    /// `u64` keys (8 B) instead of `String` (~150 B).
+    seen: DashSet<u64, ahash::RandomState>,
+    /// Per-process randomized hash seed (FR-3). Cloned into `seen` at
+    /// construction so both use identical keys.
+    rs: ahash::RandomState,
 }
 
 impl UrlQueue {
     /// Create a new URL queue
     ///
-    /// Following **mem-with-capacity**: Pre-allocates internal structures.
+    /// Following **mem-with-capacity**: pre-allocates internal structures and
+    /// a per-process randomized hash seed (FR-3 HashDoS resistance).
     #[must_use]
     pub fn new() -> Self {
+        let rs = ahash::RandomState::new();
         Self {
             queue: Mutex::new(Vec::with_capacity(100)),
-            seen: DashSet::with_capacity(100),
+            seen: DashSet::with_capacity_and_hasher(100, rs.clone()),
+            rs,
         }
     }
 
@@ -49,21 +61,19 @@ impl UrlQueue {
     /// # Returns
     ///
     /// `true` if added, `false` if duplicate
-    pub fn push(&self, url: DiscoveredUrl) -> bool {
-        let url_str = url.url.as_str().to_string();
-
-        // Fix Bug 2: Use atomic insert() instead of separate contains() + insert()
-        // DashSet::insert() returns false if the value already exists,
-        // making this a single atomic check-and-insert operation.
-        // Prevents race condition where two threads both see contains()=false
-        // then both insert().
-        if !self.seen.insert(url_str) {
+    pub async fn push(&self, url: DiscoveredUrl) -> bool {
+        // Lock-free, atomic check-and-insert via DashSet::insert (no Mutex, no
+        // .await). Prevents the race where two tasks both pass contains() and
+        // both insert. The hash uses the per-process randomized seed (FR-3/FR-5).
+        let hash = self.rs.hash_one(url.url.as_str());
+        if !self.seen.insert(hash) {
             debug!("Duplicate URL in queue: {}", url.url);
             return false;
         }
 
-        // Add to queue
-        let mut queue = self.queue.blocking_lock();
+        // Pending-URL Vec is the only tokio::sync::Mutex; the guard is held
+        // across no .await (AL-2) — acquired, pushed, dropped.
+        let mut queue = self.queue.lock().await;
         queue.push(url);
 
         true
@@ -74,21 +84,21 @@ impl UrlQueue {
     /// # Returns
     ///
     /// `Some(DiscoveredUrl)` if queue has URLs, `None` if empty
-    pub fn pop(&self) -> Option<DiscoveredUrl> {
-        let mut queue = self.queue.blocking_lock();
+    pub async fn pop(&self) -> Option<DiscoveredUrl> {
+        let mut queue = self.queue.lock().await;
         queue.pop()
     }
 
     /// Drain all pending URLs from the internal queue into a VecDeque.
     ///
-    /// Used to transfer discovered links from the deduplicated UrlQueue
-    /// to the main crawl loop's VecDeque work queue.
+    /// Used to transfer discovered links from the deduplicated `UrlQueue` to
+    /// the main crawl loop's `VecDeque` work queue.
     ///
     /// # Returns
     ///
     /// VecDeque of all pending URLs (queue is emptied)
-    pub fn drain_all(&self) -> std::collections::VecDeque<DiscoveredUrl> {
-        let mut queue = self.queue.blocking_lock();
+    pub async fn drain_all(&self) -> std::collections::VecDeque<DiscoveredUrl> {
+        let mut queue = self.queue.lock().await;
         std::collections::VecDeque::from(std::mem::take(&mut *queue))
     }
 
@@ -97,8 +107,8 @@ impl UrlQueue {
     /// # Returns
     ///
     /// Number of URLs in the queue
-    pub fn len(&self) -> usize {
-        self.queue.blocking_lock().len()
+    pub async fn len(&self) -> usize {
+        self.queue.lock().await.len()
     }
 
     /// Check if the queue is empty
@@ -107,22 +117,26 @@ impl UrlQueue {
     ///
     /// `true` if queue is empty
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.queue.blocking_lock().is_empty()
+    pub async fn is_empty(&self) -> bool {
+        self.queue.lock().await.is_empty()
     }
 
     /// Get the number of seen URLs
     ///
+    /// Reads the lock-free `DashSet` directly — no mutex acquisition, so this
+    /// stays synchronous (AL-3 applies only to methods that acquire the lock).
+    ///
     /// # Returns
     ///
     /// Number of URLs that have been seen (added or visited)
+    #[must_use]
     pub fn seen_count(&self) -> usize {
         self.seen.len()
     }
 
     /// Clear the queue (but not the seen set)
-    pub fn clear(&self) {
-        self.queue.blocking_lock().clear();
+    pub async fn clear(&self) {
+        self.queue.lock().await.clear();
     }
 
     /// Get all URLs from the queue (for debugging)
@@ -131,8 +145,8 @@ impl UrlQueue {
     ///
     /// Vec of all URLs currently in the queue
     #[cfg(test)]
-    pub fn get_all(&self) -> Vec<DiscoveredUrl> {
-        self.queue.blocking_lock().clone()
+    pub async fn get_all(&self) -> Vec<DiscoveredUrl> {
+        self.queue.lock().await.clone()
     }
 }
 
@@ -153,107 +167,107 @@ mod tests {
         DiscoveredUrl::html(url, 0, parent)
     }
 
-    #[test]
-    fn test_url_queue_new() {
+    #[tokio::test]
+    async fn test_url_queue_new() {
         let queue = UrlQueue::new();
-        assert!(queue.is_empty());
-        assert_eq!(queue.len(), 0);
+        assert!(queue.is_empty().await);
+        assert_eq!(queue.len().await, 0);
         assert_eq!(queue.seen_count(), 0);
     }
 
-    #[test]
-    fn test_url_queue_push_pop() {
+    #[tokio::test]
+    async fn test_url_queue_push_pop() {
         let queue = UrlQueue::new();
 
         let url1 = create_test_url("/page1");
         let url2 = create_test_url("/page2");
 
-        assert!(queue.push(url1));
-        assert!(queue.push(url2));
+        assert!(queue.push(url1).await);
+        assert!(queue.push(url2).await);
 
-        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.len().await, 2);
         assert_eq!(queue.seen_count(), 2);
 
-        let popped = queue.pop();
+        let popped = queue.pop().await;
         assert!(popped.is_some());
         assert_eq!(popped.unwrap().url.path(), "/page2"); // LIFO
 
-        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.len().await, 1);
     }
 
-    #[test]
-    fn test_url_queue_duplicate_detection() {
+    #[tokio::test]
+    async fn test_url_queue_duplicate_detection() {
         let queue = UrlQueue::new();
 
         let url1 = create_test_url("/page1");
         let url2 = create_test_url("/page1"); // Same URL
 
-        assert!(queue.push(url1));
-        assert!(!queue.push(url2)); // Duplicate
+        assert!(queue.push(url1).await);
+        assert!(!queue.push(url2).await); // Duplicate
 
-        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.len().await, 1);
         assert_eq!(queue.seen_count(), 1);
     }
 
-    #[test]
-    fn test_url_queue_empty_pop() {
+    #[tokio::test]
+    async fn test_url_queue_empty_pop() {
         let queue = UrlQueue::new();
-        assert!(queue.pop().is_none());
+        assert!(queue.pop().await.is_none());
     }
 
-    #[test]
-    fn test_url_queue_clear() {
+    #[tokio::test]
+    async fn test_url_queue_clear() {
         let queue = UrlQueue::new();
 
-        queue.push(create_test_url("/page1"));
-        queue.push(create_test_url("/page2"));
+        queue.push(create_test_url("/page1")).await;
+        queue.push(create_test_url("/page2")).await;
 
-        assert_eq!(queue.len(), 2);
+        assert_eq!(queue.len().await, 2);
 
-        queue.clear();
+        queue.clear().await;
 
-        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.len().await, 0);
         assert_eq!(queue.seen_count(), 2); // Seen set not cleared
     }
 
-    #[test]
-    fn test_url_queue_multiple_urls() {
+    #[tokio::test]
+    async fn test_url_queue_multiple_urls() {
         let queue = UrlQueue::new();
 
         for i in 0..10 {
             let url = create_test_url(&format!("/page{}", i));
-            assert!(queue.push(url));
+            assert!(queue.push(url).await);
         }
 
-        assert_eq!(queue.len(), 10);
+        assert_eq!(queue.len().await, 10);
         assert_eq!(queue.seen_count(), 10);
 
         // Pop all
         for _ in 0..10 {
-            assert!(queue.pop().is_some());
+            assert!(queue.pop().await.is_some());
         }
 
-        assert!(queue.is_empty());
+        assert!(queue.is_empty().await);
     }
 
-    #[test]
-    fn test_url_queue_drain_all() {
+    #[tokio::test]
+    async fn test_url_queue_drain_all() {
         let queue = UrlQueue::new();
 
-        queue.push(create_test_url("/page1"));
-        queue.push(create_test_url("/page2"));
-        queue.push(create_test_url("/page3"));
+        queue.push(create_test_url("/page1")).await;
+        queue.push(create_test_url("/page2")).await;
+        queue.push(create_test_url("/page3")).await;
 
-        assert_eq!(queue.len(), 3);
+        assert_eq!(queue.len().await, 3);
 
-        let drained = queue.drain_all();
+        let drained = queue.drain_all().await;
 
         assert_eq!(drained.len(), 3);
-        assert!(queue.is_empty());
+        assert!(queue.is_empty().await);
 
         // Re-pushing same URLs should fail (dedup via seen set)
-        assert!(!queue.push(create_test_url("/page1")));
-        assert!(!queue.push(create_test_url("/page2")));
-        assert!(!queue.push(create_test_url("/page3")));
+        assert!(!queue.push(create_test_url("/page1")).await);
+        assert!(!queue.push(create_test_url("/page2")).await);
+        assert!(!queue.push(create_test_url("/page3")).await);
     }
 }

--- a/tests/crawler_integration.rs
+++ b/tests/crawler_integration.rs
@@ -98,7 +98,7 @@ fn test_is_internal_link() {
 /// This test is ignored by default to avoid network calls.
 /// Run with: `cargo test --test crawler_integration -- --ignored`
 #[tokio::test]
-#[ignore = "requires network - url_queue uses blocking_lock() which panics inside tokio runtime"]
+#[ignore = "requires network"]
 async fn test_crawl_site_small() {
     let seed = Url::parse("https://example.com").unwrap();
     let config = CrawlerConfig::builder(seed)
@@ -118,7 +118,7 @@ async fn test_crawl_site_small() {
 ///
 /// This test is ignored by default to avoid network calls.
 #[tokio::test]
-#[ignore = "requires network - url_queue uses blocking_lock() which panics inside tokio runtime"]
+#[ignore = "requires network"]
 async fn test_discover_urls() {
     let seed = Url::parse("https://example.com").unwrap();
     let config = CrawlerConfig::new(seed);
@@ -138,7 +138,7 @@ async fn test_discover_urls() {
 ///
 /// This test is ignored by default to avoid network calls.
 #[tokio::test]
-#[ignore = "requires network - url_queue uses blocking_lock() which panics inside tokio runtime"]
+#[ignore = "requires network"]
 async fn test_crawl_with_sitemap() {
     use rust_scraper::crawl_with_sitemap;
 


### PR DESCRIPTION
## Summary
- Replace 7 blocking_lock() calls with tokio::sync::Mutex + .lock().await
- Replace String-based deduplication with lock-free DashSet<u64, ahash::RandomState>
- Add ahash direct dependency for per-process randomized seed (HashDoS resistance)
- Migrate crawler_service.rs visited set to lock-free UrlDeduplicator
- Migrate url_queue.seen from DashSet<String> to DashSet<u64, ahash::RandomState>
- Delete dead InMemoryDeduplicator + UrlDeduplicator trait + fix mod.rs alias bug
- Add ahash direct dependency

## Changes
| File | Change |
|------|--------|
| Cargo.toml | Adds ahash direct dependency |
| Cargo.lock | Updated |
| src/application/crawler_service.rs | Replaces inline DashSet<String> + tokio::Mutex with lock-free UrlDeduplicator |
| src/application/deduplicator.rs | Replaces dead trait + InMemoryDeduplicator with lock-free UrlDeduplicator struct + 8 unit tests |
| src/application/mod.rs | Fixes alias bug, exports new UrlDeduplicator |
| src/infrastructure/crawler/url_queue.rs | Replaces 7 blocking_lock() with tokio::sync::Mutex + .lock().await; migrates seen to DashSet<u, ahash::RandomState> |
| tests/crawler_integration.rs | Minor test fix |

## Test Plan
- [x] cargo fmt --check
- [x] cargo check --all-targets
- [x] cargo test --lib application::deduplicator (8/8 pass)
- [x] cargo test --lib application::crawler_service (5/5 pass)
- [x] cargo test --lib infrastructure::crawler::url_queue (7/7 pass)
- [x] cargo test --test crawler_integration (8/8 pass)
- [x] cargo nextest run --all-features (864/864 pass)
- [x] git diff --check

Part of #38.

Maintainer-approved PR for concurrency refactor PR1.