### PR TITLE
feat(infra): elastic ingestion foundation — autotuning, SQLite, error variants (PR 1/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,29 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sqlite"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9cc6210316f8b7ced394e2a5d2833ce7097fb28afb5881299c61bc18e8e0e9"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "rusqlite",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
 
 [[package]]
 name = "deranged"
@@ -1461,6 +1484,18 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1870,6 +1905,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2508,6 +2552,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3984,6 +4039,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "uuid",
+]
+
+[[package]]
 name = "rust_scraper"
 version = "1.1.0"
 dependencies = [
@@ -4003,6 +4074,7 @@ dependencies = [
  "criterion",
  "crossterm 0.28.1",
  "dashmap 6.2.1",
+ "deadpool-sqlite",
  "dirs 5.0.1",
  "fs2",
  "futures",
@@ -4026,9 +4098,11 @@ dependencies = [
  "rand 0.9.4",
  "ratatui",
  "ratatui-form",
+ "rayon",
  "redis",
  "regex",
  "rmcp",
+ "rusqlite",
  "rustls-webpki",
  "schemars",
  "scraper",
@@ -4040,6 +4114,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "syntect",
+ "sys-info",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -4733,6 +4808,16 @@ dependencies = [
  "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,23 @@ quick-xml = "0.37"
 # CPU detection for hardware-aware concurrency
 num_cpus = "1"
 
+# ============================================================================
+# Elastic Ingestion (Issue #51) — autotuning + SQLite persistence + CPU pool
+# ============================================================================
+# SQLite embedded persistence (bundled libsqlite3; chrono/uuid feature gates)
+rusqlite = { version = "0.31", features = ["bundled", "chrono", "uuid"] }
+# Async SQLite connection pool (WAL-friendly, pooled blocking calls off Tokio)
+# NOTE: task pinned "0.15" (nonexistent); 0.13 needs rusqlite 0.38 (conflicts
+# with proposal-pinned rusqlite 0.31). Frozen design.md pins no version.
+# Resolver-selected max version compatible with rusqlite 0.31 is 0.8.1.
+deadpool-sqlite = "0.8"
+# Total RAM detection for hardware autotuning (CPU uses num_cpus above)
+# NOTE: task pinned "0.10" but that version does not exist on crates.io
+# (candidates: 0.9.1, 0.9.0). proposal.md specifies "0.9" — using that.
+sys-info = "0.9"
+# Promoted from transitive to direct: explicit isolated Rayon thread pool (PR3)
+rayon = "1.10"
+
 # Progress bars
 indicatif = { version = "0.17", features = ["improved_unicode"] }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@
 //! This provides type-safe, structured error handling instead of anyhow.
 
 use thiserror::Error;
+use wreq::Error as WreqError;
 
 /// Main error type for the scraper library.
 ///
@@ -99,6 +100,38 @@ pub enum ScraperError {
     /// Batch export failed (partial success)
     #[error("Error de exportación en batch: {0}")]
     ExportBatch(String),
+
+    /// Global download timeout (30s)
+    #[error("descarga superó tiempo global de 30 segundos")]
+    GlobalTimeout,
+
+    /// Slowloris attack detected (per-chunk timeout)
+    #[error("descarga superó timeout de inactividad de 5 segundos por chunk")]
+    SlowlorisTimeout,
+
+    /// Payload exceeded 25MB limit
+    #[error("recurso superó límite de 25 MB")]
+    PayloadTooLarge,
+
+    /// Network error (connection failed, timeout, etc.)
+    #[error("error de red: {0}")]
+    NetworkFailure(#[from] WreqError),
+
+    /// Semaphore exhausted (backpressure)
+    #[error("semáforo agotado: no hay permisos disponibles")]
+    SemaphoreInanition,
+
+    /// Persistence error (SQLite storage layer — resources/chunks CRUD, pool).
+    ///
+    /// Holds the underlying error rendered to a string so it uniformly covers
+    /// both `rusqlite::Error` and `deadpool_sqlite` pool errors (which are
+    /// different types) without forcing two `#[from]` variants.
+    #[error("Error de persistencia: {0}")]
+    Persistence(String),
+
+    /// Elastic ingestion pipeline error (orchestration / dispatch failures).
+    #[error("Error de ingestión: {0}")]
+    Ingestion(String),
 
     /// Semantic cleaning error (AI-powered content processing)
     #[cfg(feature = "ai")]
@@ -288,6 +321,21 @@ impl ScraperError {
     pub fn export_batch(msg: impl Into<String>) -> Self {
         Self::ExportBatch(msg.into())
     }
+
+    /// Create a Persistence error from anything displayable.
+    ///
+    /// Used to uniformly convert `rusqlite::Error` and `deadpool_sqlite` pool
+    /// errors into `ScraperError::Persistence` without `#[from]` ambiguity.
+    #[must_use]
+    pub fn persistence(err: impl std::fmt::Display) -> Self {
+        Self::Persistence(err.to_string())
+    }
+
+    /// Create an Ingestion error from anything displayable.
+    #[must_use]
+    pub fn ingestion(err: impl std::fmt::Display) -> Self {
+        Self::Ingestion(err.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -321,6 +369,38 @@ mod tests {
         let std_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let err: ScraperError = std_err.into();
         assert!(err.to_string().contains("file not found"));
+    }
+
+    #[test]
+    fn test_persistence_error_message() {
+        let err = ScraperError::persistence("disco lleno");
+        assert_eq!(err.to_string(), "Error de persistencia: disco lleno");
+    }
+
+    #[test]
+    fn test_ingestion_error_message() {
+        let err = ScraperError::ingestion("pipeline abortó");
+        assert_eq!(err.to_string(), "Error de ingestión: pipeline abortó");
+    }
+
+    #[test]
+    fn test_persistence_error_from_rusqlite() {
+        // Triangulation: the Display-based helper must carry the real rusqlite
+        // error text (proves it converts a genuine DB error, not a hardcoded value).
+        let db = rusqlite::Connection::open_in_memory().expect("open in-memory sqlite");
+        let rusqlite_err = db
+            .prepare("SELECT * FROM tabla_inexistente")
+            .expect_err("expected error for missing table");
+        let scraper_err = ScraperError::persistence(&rusqlite_err);
+        let msg = scraper_err.to_string();
+        assert!(
+            msg.contains("persistencia"),
+            "missing Spanish prefix: {msg}"
+        );
+        assert!(
+            msg.contains("no such table"),
+            "missing rusqlite detail: {msg}"
+        );
     }
 
     #[cfg(feature = "ai")]

--- a/src/infrastructure/autotuning.rs
+++ b/src/infrastructure/autotuning.rs
@@ -1,0 +1,421 @@
+//! Hardware autotuning for the elastic ingestion pipeline (Issue #51).
+//!
+//! Derives pipeline sizing defaults from the host hardware:
+//! - CPU cores via [`num_cpus::get()`] (Rayon pool / DB pool fan-out).
+//! - RAM budget via [`sys_info::mem_info()`] × 0.7 (byte-weighted semaphore).
+//!
+//! Configuration resolution priority (frozen design decision #12):
+//! **CLI flag > `RUST_SCRAPER_*` env var > auto-detected default**.
+//!
+//! All resolution logic is exposed as pure functions taking `(cli_override, env_value)`
+//! so the priority order is unit-testable without mutating the process environment
+//! (which would be racy under parallel test execution).
+
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+// ============================================================================
+// Constants (frozen design decisions #6, #11; spec hardware-autotuning §Fallback)
+// ============================================================================
+
+/// Fallback CPU core count when detection fails or returns 0.
+pub const FALLBACK_CPU_CORES: usize = 4;
+
+/// Fallback RAM budget (2 GiB in bytes) when `sys_info` fails.
+///
+/// Frozen: the user's task and the hardware-autotuning spec agree on 2 GiB
+/// (2_147_483_648 bytes) — NOT `8 GiB × 0.7`.
+pub const FALLBACK_RAM_BUDGET_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Default per-resource byte ceiling (25 MiB) for the download semaphore.
+pub const DEFAULT_MAX_RESOURCE_BYTES: u64 = 25 * 1024 * 1024;
+
+/// Minimum DB connection pool size (frozen design decision #6: floor 4).
+pub const MIN_DB_POOL_SIZE: usize = 4;
+
+/// Default SQLite database path: `~/.rust_scraper/crawl.db`.
+pub const DEFAULT_DB_DIR: &str = ".rust_scraper";
+pub const DEFAULT_DB_FILE: &str = "crawl.db";
+
+// ============================================================================
+// Environment variable names (frozen design decision #12 — snake-upper)
+// ============================================================================
+
+pub const ENV_CPU_CORES: &str = "RUST_SCRAPER_CPU_CORES";
+pub const ENV_RAM_BUDGET: &str = "RUST_SCRAPER_RAM_BUDGET";
+pub const ENV_MAX_RESOURCE_MB: &str = "RUST_SCRAPER_MAX_RESOURCE_MB";
+pub const ENV_DB_PATH: &str = "RUST_SCRAPER_DB_PATH";
+
+// ============================================================================
+// Hardware detection primitives
+// ============================================================================
+
+/// Detect the number of available CPU cores via [`num_cpus::get()`].
+///
+/// Falls back to [`FALLBACK_CPU_CORES`] when the platform reports 0.
+#[must_use]
+pub fn detect_cpu_cores() -> usize {
+    let n = num_cpus::get();
+    if n == 0 {
+        FALLBACK_CPU_CORES
+    } else {
+        n
+    }
+}
+
+/// Compute the RAM budget (bytes) from an optional total-RAM value in KiB.
+///
+/// - `Some(total_kib)` → `total_kib * 1024 * 0.7` (70% of total RAM, truncated).
+/// - `None` (detection failed) → [`FALLBACK_RAM_BUDGET_BYTES`] + a `tracing::warn!`.
+///
+/// Exposed as a pure function (taking the detected value, not calling `sys_info`
+/// directly) so the fallback path is unit-testable without mocking the OS.
+#[must_use]
+pub fn ram_budget_from(total_kib: Option<u64>) -> u64 {
+    match total_kib {
+        Some(kib) => kib.saturating_mul(1024).saturating_mul(7) / 10,
+        None => {
+            warn!(
+                error = "sys_info::mem_info falló",
+                fallback_bytes = FALLBACK_RAM_BUDGET_BYTES,
+                "Usando 2 GiB como presupuesto de RAM"
+            );
+            FALLBACK_RAM_BUDGET_BYTES
+        },
+    }
+}
+
+/// Detect the RAM budget via [`sys_info::mem_info()`], falling back to 2 GiB.
+#[must_use]
+pub fn detect_ram_budget() -> u64 {
+    ram_budget_from(sys_info::mem_info().ok().map(|m| m.total))
+}
+
+/// Default SQLite database path: `~/.rust_scraper/crawl.db`.
+///
+/// Falls back to `./crawl.db` when the home directory cannot be determined.
+#[must_use]
+pub fn default_db_path() -> PathBuf {
+    match dirs::home_dir() {
+        Some(home) => home.join(DEFAULT_DB_DIR).join(DEFAULT_DB_FILE),
+        None => PathBuf::from(DEFAULT_DB_FILE),
+    }
+}
+
+// ============================================================================
+// Pure resolution (priority: CLI > env > autodetect) — fully unit-testable
+// ============================================================================
+
+/// Resolve CPU cores: `cli` wins, then `env`, then auto-detect.
+#[must_use]
+pub fn resolve_cpu_cores(cli: Option<usize>, env: Option<usize>) -> usize {
+    cli.or(env).unwrap_or_else(detect_cpu_cores)
+}
+
+/// Resolve RAM budget (bytes): `cli` wins, then `env`, then auto-detect.
+#[must_use]
+pub fn resolve_ram_budget(cli: Option<u64>, env: Option<u64>) -> u64 {
+    cli.or(env).unwrap_or_else(detect_ram_budget)
+}
+
+/// Resolve the per-resource byte ceiling: `cli` wins, then `env`, then default.
+#[must_use]
+pub fn resolve_max_resource_bytes(cli: Option<u64>, env: Option<u64>) -> u64 {
+    cli.or(env).unwrap_or(DEFAULT_MAX_RESOURCE_BYTES)
+}
+
+/// Resolve the DB path: `cli` wins, then `env`, then [`default_db_path`].
+#[must_use]
+pub fn resolve_db_path(cli: Option<&Path>, env: Option<PathBuf>) -> PathBuf {
+    cli.map(PathBuf::from)
+        .or(env)
+        .unwrap_or_else(default_db_path)
+}
+
+// ============================================================================
+// Env readers (used by AutotuningConfig/ElasticConfig wiring)
+// ============================================================================
+
+/// Read `RUST_SCRAPER_CPU_CORES` override (parsed as `usize`).
+#[must_use]
+pub fn env_cpu_cores() -> Option<usize> {
+    std::env::var(ENV_CPU_CORES)
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+}
+
+/// Read `RUST_SCRAPER_RAM_BUDGET` override (bytes, or suffixed e.g. `8GB`).
+#[must_use]
+pub fn env_ram_budget() -> Option<u64> {
+    std::env::var(ENV_RAM_BUDGET)
+        .ok()
+        .and_then(|v| parse_ram_bytes(&v))
+}
+
+/// Read `RUST_SCRAPER_MAX_RESOURCE_MB` override (interpreted as MiB → bytes).
+#[must_use]
+pub fn env_max_resource_bytes() -> Option<u64> {
+    std::env::var(ENV_MAX_RESOURCE_MB)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(|mb| mb.saturating_mul(1024).saturating_mul(1024))
+}
+
+/// Read `RUST_SCRAPER_DB_PATH` override.
+#[must_use]
+pub fn env_db_path() -> Option<PathBuf> {
+    std::env::var(ENV_DB_PATH).ok().map(PathBuf::from)
+}
+
+/// Parse a RAM budget string: plain bytes, or a number with a binary suffix
+/// (`B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB`).
+///
+/// Per the hardware-autotuning spec scenario (`--ram-budget 8GB` → `8 * 1024^3`),
+/// all suffixes are treated as binary (powers of 1024).
+#[must_use]
+pub fn parse_ram_bytes(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let mut split = 0;
+    for (i, c) in s.char_indices() {
+        if c.is_ascii_digit() || c == '.' {
+            split = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    let (num_str, unit) = s.split_at(split);
+    let num: f64 = num_str.parse().ok()?;
+    let power: u32 = match unit.trim().to_ascii_uppercase().as_str() {
+        "" | "B" => 0,
+        "KB" | "KIB" => 1,
+        "MB" | "MIB" => 2,
+        "GB" | "GIB" => 3,
+        "TB" | "TIB" => 4,
+        _ => return None,
+    };
+    let mult: u64 = 1024u64.pow(power);
+    if num < 0.0 {
+        return None;
+    }
+    Some((num * mult as f64) as u64)
+}
+
+// ============================================================================
+// ElasticConfig — full elastic ingestion config (frozen design §Interfaces)
+// ============================================================================
+
+/// Overrides supplied by CLI flags (PR5). `None` means "not set → fall back".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ElasticOverrides {
+    /// `--cpu-cores` override.
+    pub cpu_cores: Option<usize>,
+    /// `--ram-budget` override (bytes).
+    pub ram_budget_bytes: Option<u64>,
+    /// `--max-resource-mb` override (bytes).
+    pub max_resource_bytes: Option<u64>,
+    /// `--db-path` override.
+    pub db_path: Option<PathBuf>,
+}
+
+/// Resolved elastic ingestion configuration.
+///
+/// Combines auto-detected hardware sizing with the full pipeline parameters.
+/// `db_pool_size` is derived as `cpu_cores` with a floor of 4 (frozen decision #6).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ElasticConfig {
+    /// Detected/overridden CPU core count (Rayon pool size).
+    pub cpu_cores: usize,
+    /// Detected/overridden RAM budget in bytes (semaphore permits).
+    pub ram_budget_bytes: u64,
+    /// Per-resource byte ceiling (default 25 MiB).
+    pub max_resource_bytes: u64,
+    /// DB connection pool size (`cpu_cores`, floor 4).
+    pub db_pool_size: usize,
+    /// SQLite database file path.
+    pub db_path: PathBuf,
+}
+
+impl ElasticConfig {
+    /// Resolve the full config from CLI overrides, falling back to env vars and
+    /// then auto-detected defaults (priority: CLI > env > autodetect).
+    #[must_use]
+    pub fn resolve(overrides: &ElasticOverrides) -> Self {
+        let cpu_cores = resolve_cpu_cores(overrides.cpu_cores, env_cpu_cores());
+        let ram_budget_bytes = resolve_ram_budget(overrides.ram_budget_bytes, env_ram_budget());
+        let max_resource_bytes =
+            resolve_max_resource_bytes(overrides.max_resource_bytes, env_max_resource_bytes());
+        let db_path = resolve_db_path(overrides.db_path.as_deref(), env_db_path());
+        let db_pool_size = cpu_cores.max(MIN_DB_POOL_SIZE);
+        Self {
+            cpu_cores,
+            ram_budget_bytes,
+            max_resource_bytes,
+            db_pool_size,
+            db_path,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+
+    // ---- detection primitives ----
+
+    #[test]
+    fn test_detect_cpu_cores_matches_num_cpus() {
+        let detected = detect_cpu_cores();
+        let n = num_cpus::get();
+        let expected = if n == 0 { FALLBACK_CPU_CORES } else { n };
+        assert_eq!(detected, expected);
+    }
+
+    #[test]
+    fn test_ram_budget_from_none_falls_back_to_2gib() {
+        assert_eq!(ram_budget_from(None), FALLBACK_RAM_BUDGET_BYTES);
+        assert_eq!(FALLBACK_RAM_BUDGET_BYTES, 2 * GIB);
+    }
+
+    #[test]
+    fn test_ram_budget_from_32gib_machine() {
+        // 32 GiB total RAM = 33_554_432 KiB → 70% in bytes (truncated).
+        let total_kib: u64 = 32 * 1024 * 1024;
+        let expected = total_kib * 1024 * 7 / 10;
+        assert_eq!(ram_budget_from(Some(total_kib)), expected);
+        // Sanity: 70% of 32 GiB is ~22.4 GiB (> 15 GiB, < 24 GiB).
+        let result = ram_budget_from(Some(total_kib));
+        assert!(result > 15 * GIB && result < 24 * GIB);
+    }
+
+    #[test]
+    fn test_detect_ram_budget_is_nonzero_and_sane() {
+        let budget = detect_ram_budget();
+        assert!(budget > 0, "RAM budget must be positive");
+        // Either autodetected (> a few MiB) or the 2 GiB fallback.
+        assert!(budget >= FALLBACK_RAM_BUDGET_BYTES || budget > 100 * MIB);
+    }
+
+    #[test]
+    fn test_default_db_path_under_home() {
+        let p = default_db_path();
+        assert!(p.ends_with(DEFAULT_DB_FILE));
+        assert!(p.to_string_lossy().contains(DEFAULT_DB_DIR));
+    }
+
+    // ---- pure resolution priority (CLI > env > autodetect) ----
+
+    #[test]
+    fn test_resolve_cpu_cores_cli_wins() {
+        assert_eq!(resolve_cpu_cores(Some(4), Some(8)), 4);
+    }
+
+    #[test]
+    fn test_resolve_cpu_cores_env_beats_autodetect() {
+        assert_eq!(resolve_cpu_cores(None, Some(8)), 8);
+    }
+
+    #[test]
+    fn test_resolve_cpu_cores_autodetect_when_no_overrides() {
+        assert_eq!(resolve_cpu_cores(None, None), detect_cpu_cores());
+    }
+
+    #[test]
+    fn test_resolve_ram_budget_priority() {
+        assert_eq!(resolve_ram_budget(Some(8 * GIB), Some(4 * GIB)), 8 * GIB);
+        assert_eq!(resolve_ram_budget(None, Some(4 * GIB)), 4 * GIB);
+        assert_eq!(resolve_ram_budget(None, None), detect_ram_budget());
+    }
+
+    #[test]
+    fn test_resolve_max_resource_bytes_default_and_overrides() {
+        assert_eq!(
+            resolve_max_resource_bytes(Some(50 * MIB), Some(10 * MIB)),
+            50 * MIB
+        );
+        assert_eq!(resolve_max_resource_bytes(None, Some(10 * MIB)), 10 * MIB);
+        assert_eq!(
+            resolve_max_resource_bytes(None, None),
+            DEFAULT_MAX_RESOURCE_BYTES
+        );
+        assert_eq!(DEFAULT_MAX_RESOURCE_BYTES, 25 * MIB);
+    }
+
+    #[test]
+    fn test_resolve_db_path_priority() {
+        let cli = Path::new("/tmp/x.db");
+        assert_eq!(resolve_db_path(Some(cli), None), PathBuf::from("/tmp/x.db"));
+        assert_eq!(
+            resolve_db_path(None, Some(PathBuf::from("/c/d.db"))),
+            PathBuf::from("/c/d.db")
+        );
+        assert_eq!(resolve_db_path(None, None), default_db_path());
+    }
+
+    // ---- ElasticConfig.resolve ----
+
+    #[test]
+    fn test_elastic_config_resolve_with_full_overrides() {
+        let overrides = ElasticOverrides {
+            cpu_cores: Some(4),
+            ram_budget_bytes: Some(8 * GIB),
+            max_resource_bytes: Some(50 * MIB),
+            db_path: Some(PathBuf::from("/tmp/elastic.db")),
+        };
+        let cfg = ElasticConfig::resolve(&overrides);
+        assert_eq!(cfg.cpu_cores, 4);
+        assert_eq!(cfg.ram_budget_bytes, 8 * GIB);
+        assert_eq!(cfg.max_resource_bytes, 50 * MIB);
+        assert_eq!(cfg.db_pool_size, 4); // max(4, 4)
+        assert_eq!(cfg.db_path, PathBuf::from("/tmp/elastic.db"));
+    }
+
+    #[test]
+    fn test_elastic_config_db_pool_floor_when_cpu_below_4() {
+        // cpu override 2 → db_pool_size must floor at 4 (frozen decision #6).
+        let overrides = ElasticOverrides {
+            cpu_cores: Some(2),
+            ..Default::default()
+        };
+        let cfg = ElasticConfig::resolve(&overrides);
+        assert_eq!(cfg.cpu_cores, 2);
+        assert_eq!(cfg.db_pool_size, MIN_DB_POOL_SIZE);
+        assert_eq!(MIN_DB_POOL_SIZE, 4);
+    }
+
+    #[test]
+    fn test_elastic_config_db_pool_matches_cpu_when_above_floor() {
+        let overrides = ElasticOverrides {
+            cpu_cores: Some(8),
+            ..Default::default()
+        };
+        let cfg = ElasticConfig::resolve(&overrides);
+        assert_eq!(cfg.db_pool_size, 8);
+    }
+
+    // ---- parse_ram_bytes (env/CLI suffix parsing) ----
+
+    #[test]
+    fn test_parse_ram_bytes_plain_and_suffixed() {
+        assert_eq!(parse_ram_bytes("8589934592"), Some(8 * GIB));
+        assert_eq!(parse_ram_bytes("8GB"), Some(8 * GIB));
+        assert_eq!(parse_ram_bytes("8GiB"), Some(8 * GIB));
+        assert_eq!(parse_ram_bytes("8MB"), Some(8 * MIB));
+        assert_eq!(parse_ram_bytes("8"), Some(8));
+        assert_eq!(parse_ram_bytes("  4 gb "), Some(4 * GIB)); // trimmed + lowercase
+    }
+
+    #[test]
+    fn test_parse_ram_bytes_rejects_garbage() {
+        assert_eq!(parse_ram_bytes(""), None);
+        assert_eq!(parse_ram_bytes("garbage"), None);
+        assert_eq!(parse_ram_bytes("8XB"), None); // unknown unit
+        assert_eq!(parse_ram_bytes("-8GB"), None); // negative
+    }
+}

--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -343,6 +343,65 @@ impl clap::builder::TypedValueParser for ConcurrencyValueParser {
 }
 
 // ============================================================================
+// Elastic Ingestion Autotuning Config (Issue #51)
+// ============================================================================
+
+/// Hardware-autotuning configuration snapshot for the elastic ingestion
+/// pipeline (Issue #51).
+///
+/// Serializable so it can be written to / read from a config file. Holds the
+/// two core auto-detected sizing values; the fuller
+/// [`crate::infrastructure::autotuning::ElasticConfig`] adds DB/pool parameters.
+///
+/// Resolution priority (frozen design decision #12): explicit override >
+/// `RUST_SCRAPER_*` env var > auto-detected default.
+///
+/// # Examples
+///
+/// ```
+/// use rust_scraper::AutotuningConfig;
+///
+/// // Explicit overrides win.
+/// let cfg = AutotuningConfig::resolve(Some(4), Some(8 * 1024 * 1024 * 1024));
+/// assert_eq!(cfg.cpu_cores, 4);
+/// assert_eq!(cfg.ram_budget_bytes, 8 * 1024 * 1024 * 1024);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AutotuningConfig {
+    /// Detected/overridden CPU core count.
+    pub cpu_cores: usize,
+    /// Detected/overridden RAM budget in bytes.
+    pub ram_budget_bytes: u64,
+}
+
+impl AutotuningConfig {
+    /// Resolve the autotuning snapshot.
+    ///
+    /// Priority: `cpu_override`/`ram_override` > `RUST_SCRAPER_CPU_CORES` /
+    /// `RUST_SCRAPER_RAM_BUDGET` env > auto-detected defaults.
+    #[must_use]
+    pub fn resolve(cpu_override: Option<usize>, ram_override: Option<u64>) -> Self {
+        use crate::infrastructure::autotuning;
+        Self {
+            cpu_cores: autotuning::resolve_cpu_cores(cpu_override, autotuning::env_cpu_cores()),
+            ram_budget_bytes: autotuning::resolve_ram_budget(
+                ram_override,
+                autotuning::env_ram_budget(),
+            ),
+        }
+    }
+
+    /// Build a snapshot from a resolved [`ElasticConfig`].
+    #[must_use]
+    pub fn from_elastic(elastic: &crate::infrastructure::autotuning::ElasticConfig) -> Self {
+        Self {
+            cpu_cores: elastic.cpu_cores,
+            ram_budget_bytes: elastic.ram_budget_bytes,
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -423,5 +482,50 @@ mod tests {
     fn test_concurrency_config_from_str_invalid() {
         let config = ConcurrencyConfig::from("not-a-number");
         assert!(config.is_auto());
+    }
+
+    #[test]
+    fn test_autotuning_config_resolve_with_overrides() {
+        let cfg = AutotuningConfig::resolve(Some(4), Some(8 * 1024 * 1024 * 1024));
+        assert_eq!(cfg.cpu_cores, 4);
+        assert_eq!(cfg.ram_budget_bytes, 8 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_autotuning_config_resolve_without_overrides_is_sane() {
+        // No overrides → falls through env (likely unset) → auto-detected defaults.
+        let cfg = AutotuningConfig::resolve(None, None);
+        assert!(cfg.cpu_cores > 0, "cpu_cores must be positive");
+        assert!(
+            cfg.ram_budget_bytes > 0,
+            "ram_budget_bytes must be positive"
+        );
+    }
+
+    #[test]
+    fn test_autotuning_config_serializes_roundtrip() {
+        let cfg = AutotuningConfig {
+            cpu_cores: 8,
+            ram_budget_bytes: 16 * 1024 * 1024 * 1024,
+        };
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        assert!(json.contains("\"cpu_cores\":8"), "json: {json}");
+        assert!(json.contains("\"ram_budget_bytes\":"));
+        let back: AutotuningConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, cfg);
+    }
+
+    #[test]
+    fn test_autotuning_config_from_elastic() {
+        let elastic = crate::infrastructure::autotuning::ElasticConfig {
+            cpu_cores: 6,
+            ram_budget_bytes: 12 * 1024 * 1024 * 1024,
+            max_resource_bytes: 25 * 1024 * 1024,
+            db_pool_size: 6,
+            db_path: std::path::PathBuf::from("/tmp/elastic.db"),
+        };
+        let snap = AutotuningConfig::from_elastic(&elastic);
+        assert_eq!(snap.cpu_cores, 6);
+        assert_eq!(snap.ram_budget_bytes, 12 * 1024 * 1024 * 1024);
     }
 }

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -23,5 +23,9 @@ pub mod output;
 pub mod scraper;
 pub mod user_agent;
 
+// Elastic ingestion (Issue #51) — hardware autotuning + SQLite persistence.
+pub mod autotuning;
+pub mod persistence;
+
 #[cfg(feature = "ai")]
 pub mod ai;

--- a/src/infrastructure/persistence/mod.rs
+++ b/src/infrastructure/persistence/mod.rs
@@ -1,0 +1,11 @@
+//! SQLite persistence layer for the elastic ingestion pipeline (Issue #51).
+//!
+//! Provides a WAL-mode [`deadpool_sqlite`] connection pool and explicit schema
+//! initialization for the `resources` and `chunks` tables. Per-connection
+//! pragmas (`journal_mode=WAL`, `synchronous=NORMAL`, `cache_size=-4000`) are
+//! applied via a `post_create` pool hook so **every** pooled connection honours
+//! the spec's "each connection MUST use WAL-mode pragmas" requirement.
+
+pub mod sqlite;
+
+pub use sqlite::{create_pool, setup_schema, SqliteVectorRepository};

--- a/src/infrastructure/persistence/sqlite.rs
+++ b/src/infrastructure/persistence/sqlite.rs
@@ -1,0 +1,291 @@
+//! SQLite schema, WAL pragmas, and connection pool for elastic ingestion.
+//!
+//! Schema is frozen per `design.md` (the authoritative frozen artifact). The
+//! task-list DDL transcription differed in three places; this implementation
+//! follows the frozen design:
+//! - `chunks.id` is `TEXT` (required by `VectorRepository::save_vector(id: &str)`
+//!   in PR4 — the task's `INTEGER` would force a destructive migration).
+//! - `created_at` is `TEXT` (SQLite stores timestamps as TEXT regardless; the
+//!   task's `TIMESTAMP` is cosmetic but diverges from design).
+//! - the `content_hash` index lives on `resources` (which has the column); the
+//!   task's `idx_chunks_hash ON chunks(content_hash)` referenced a non-existent
+//!   column and would fail `setup_schema`.
+
+use std::path::Path;
+
+use deadpool_sqlite::{Config, Hook, HookError, Manager, Pool, Runtime};
+
+use crate::error::ScraperError;
+
+// ============================================================================
+// Schema (frozen design.md §schema)
+// ============================================================================
+
+/// WAL + per-connection pragmas, applied on every new pooled connection via the
+/// `post_create` hook. `journal_mode=WAL` is persistent (DB header); the other
+/// two are per-connection and therefore MUST be set on each connection.
+const INIT_PRAGMAS: &str = "\
+PRAGMA journal_mode = WAL;\
+PRAGMA synchronous = NORMAL;\
+PRAGMA cache_size = -4000;";
+
+/// Forward-only schema (`CREATE ... IF NOT EXISTS`). Run once by
+/// [`SqliteVectorRepository::setup_schema`]. No destructive migration in v1.
+const SCHEMA_DDL: &str = "\
+CREATE TABLE IF NOT EXISTS resources (\
+    url TEXT PRIMARY KEY,\
+    title TEXT,\
+    content_hash TEXT,\
+    size_bytes INTEGER,\
+    status TEXT,\
+    created_at TEXT,\
+    updated_at TEXT,\
+    metadata_json TEXT\
+);\
+CREATE TABLE IF NOT EXISTS chunks (\
+    id TEXT PRIMARY KEY,\
+    resource_url TEXT NOT NULL REFERENCES resources(url),\
+    chunk_index INTEGER,\
+    content TEXT,\
+    embedding_vector BLOB,\
+    created_at TEXT\
+);\
+CREATE INDEX IF NOT EXISTS idx_chunks_resource ON chunks(resource_url);\
+CREATE INDEX IF NOT EXISTS idx_resources_content_hash ON resources(content_hash);";
+
+// ============================================================================
+// Pool construction
+// ============================================================================
+
+/// Build a WAL-mode SQLite connection pool backed by [`deadpool_sqlite`].
+///
+/// `pool_size` is clamped to at least 1 (the caller — `ElasticConfig` — already
+/// applies the frozen `cpu_cores`/floor-4 sizing). The parent directory of
+/// `db_path` is created if missing. Per-connection pragmas are applied via a
+/// `post_create` hook so every connection honours the WAL-mode contract.
+///
+/// The pool is created lazily — the database file is only materialized on the
+/// first [`Pool::get`] (i.e. inside [`SqliteVectorRepository::setup_schema`]),
+/// which is the explicit fail-fast point if the path is not writable.
+pub fn create_pool(db_path: &Path, pool_size: usize) -> Result<Pool, ScraperError> {
+    // Fail-fast: ensure the parent directory exists before opening the DB.
+    if let Some(parent) = db_path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ScraperError::persistence(format!("crear directorio {parent:?}: {e}"))
+            })?;
+        }
+    }
+
+    let cfg = Config::new(db_path.to_path_buf());
+    let manager = Manager::from_config(&cfg, Runtime::Tokio1);
+    let pool = Pool::builder(manager)
+        .max_size(pool_size.max(1))
+        .runtime(Runtime::Tokio1)
+        .post_create(pragma_hook())
+        .build()
+        .map_err(|e| ScraperError::persistence(format!("construir pool SQLite: {e}")))?;
+    Ok(pool)
+}
+
+/// `post_create` hook applying the WAL-mode pragmas to each new connection.
+fn pragma_hook() -> Hook {
+    Hook::async_fn(|obj, _metrics| {
+        Box::pin(async move {
+            obj.interact(|conn| conn.execute_batch(INIT_PRAGMAS))
+                .await
+                .map_err(|e| HookError::message(format!("init pragmas (interact): {e}")))?
+                .map_err(|e| HookError::message(format!("init pragmas: {e}")))?;
+            Ok(())
+        })
+    })
+}
+
+// ============================================================================
+// SqliteVectorRepository (PR1: schema init; PR4 adds CRUD + dedup)
+// ============================================================================
+
+/// SQLite-backed vector repository for the elastic ingestion pipeline.
+///
+/// PR1 provides explicit schema initialization only; the `VectorRepository`
+/// trait CRUD (`save_vector`, `get_vector`) and content-hash deduplication land
+/// in PR4. Per frozen design decision #1, schema creation is **explicit** —
+/// [`SqliteVectorRepository::setup_schema`] MUST be called at startup. There is
+/// no implicit schema creation on first connection.
+#[derive(Debug, Clone)]
+pub struct SqliteVectorRepository {
+    pool: Pool,
+}
+
+impl SqliteVectorRepository {
+    /// Wrap an existing pool. The pool should already have had
+    /// [`setup_schema`] run against it.
+    #[must_use]
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Borrow the underlying pool (used by PR2+ wiring and tests).
+    #[must_use]
+    pub fn pool(&self) -> &Pool {
+        &self.pool
+    }
+
+    /// Explicitly initialize the database schema (tables + indexes).
+    ///
+    /// **MUST** be called once at startup (frozen design decision #1). Acquires
+    /// a pooled connection — which also materializes the database file and runs
+    /// the per-connection pragmas via the `post_create` hook — making this the
+    /// fail-fast point if the configured `db_path` is not writable.
+    ///
+    /// The DDL is idempotent (`CREATE ... IF NOT EXISTS`), so calling it on an
+    /// already-initialized database is a safe no-op.
+    pub async fn setup_schema(pool: &Pool) -> Result<(), ScraperError> {
+        let conn = pool
+            .get()
+            .await
+            .map_err(|e| ScraperError::persistence(format!("obtener conexión del pool: {e}")))?;
+        conn.interact(|c| c.execute_batch(SCHEMA_DDL))
+            .await
+            .map_err(|e| ScraperError::persistence(format!("ddl (interact): {e}")))?
+            .map_err(|e| ScraperError::persistence(format!("ddl schema: {e}")))?;
+        Ok(())
+    }
+}
+
+/// Free-function alias for [`SqliteVectorRepository::setup_schema`] so callers
+/// that only hold a `&Pool` (without constructing the repository) can init the
+/// schema at startup.
+pub async fn setup_schema(pool: &Pool) -> Result<(), ScraperError> {
+    SqliteVectorRepository::setup_schema(pool).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a fresh pool over a temp-file DB and run the schema.
+    async fn fresh_pool(size: usize) -> (TempDir, Pool) {
+        let dir = TempDir::new().expect("tempdir");
+        let db_path = dir.path().join("crawl.db");
+        let pool = create_pool(&db_path, size).expect("create_pool");
+        SqliteVectorRepository::setup_schema(&pool)
+            .await
+            .expect("setup_schema");
+        (dir, pool)
+    }
+
+    /// Count rows in `sqlite_master` matching `type` and `name`.
+    async fn master_count(pool: &Pool, kind: &str, name: &str) -> i64 {
+        // Own the strings: the `interact` closure must be `Send + 'static`, so it
+        // cannot capture borrowed `&str` from this function's frame.
+        let kind = kind.to_string();
+        let name = name.to_string();
+        let conn = pool.get().await.expect("get");
+        conn.interact(move |c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
+                rusqlite::params![kind, name],
+                |row| row.get::<_, i64>(0),
+            )
+        })
+        .await
+        .expect("interact")
+        .expect("count")
+    }
+
+    async fn pragma_string(pool: &Pool, pragma: &str) -> String {
+        let sql = format!("PRAGMA {pragma}");
+        let conn = pool.get().await.expect("get");
+        conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, String>(0)))
+            .await
+            .expect("interact")
+            .expect("pragma row")
+    }
+
+    async fn pragma_int(pool: &Pool, pragma: &str) -> i64 {
+        let sql = format!("PRAGMA {pragma}");
+        let conn = pool.get().await.expect("get");
+        conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, i64>(0)))
+            .await
+            .expect("interact")
+            .expect("pragma row")
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_creates_resources_table() {
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(master_count(&pool, "table", "resources").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_creates_chunks_table() {
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(master_count(&pool, "table", "chunks").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_creates_indexes() {
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(
+            master_count(&pool, "index", "idx_chunks_resource").await,
+            1,
+            "idx_chunks_resource missing"
+        );
+        assert_eq!(
+            master_count(&pool, "index", "idx_resources_content_hash").await,
+            1,
+            "idx_resources_content_hash missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wal_pragmas_applied_to_connection() {
+        // A freshly-created pooled connection must carry all three pragmas
+        // (proves the post_create hook runs on each connection).
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(pragma_string(&pool, "journal_mode").await, "wal");
+        // synchronous: 0=OFF,1=NORMAL,2=FULL,3=EXTRA — NORMAL must be 1.
+        assert_eq!(pragma_int(&pool, "synchronous").await, 1);
+        assert_eq!(pragma_int(&pool, "cache_size").await, -4000);
+    }
+
+    #[tokio::test]
+    async fn test_db_file_created_when_absent() {
+        let dir = TempDir::new().expect("tempdir");
+        let db_path = dir.path().join("nested").join("crawl.db");
+        assert!(!db_path.exists());
+        let pool = create_pool(&db_path, 4).expect("create_pool");
+        SqliteVectorRepository::setup_schema(&pool)
+            .await
+            .expect("setup_schema");
+        // setup_schema materializes the DB file (parent dir created by create_pool).
+        assert!(db_path.exists(), "DB file should exist after setup_schema");
+    }
+
+    #[tokio::test]
+    async fn test_pool_size_is_configurable() {
+        let (_dir, pool) = fresh_pool(8).await;
+        let status = pool.status();
+        assert_eq!(status.max_size, 8, "pool max_size must honor configuration");
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_is_idempotent() {
+        let (_dir, pool) = fresh_pool(4).await;
+        // Running setup_schema twice must not error (CREATE ... IF NOT EXISTS).
+        SqliteVectorRepository::setup_schema(&pool)
+            .await
+            .expect("second setup_schema should be a no-op");
+        assert_eq!(master_count(&pool, "table", "resources").await, 1);
+        assert_eq!(master_count(&pool, "table", "chunks").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_repository_wraps_pool() {
+        let (_dir, pool) = fresh_pool(4).await;
+        let repo = SqliteVectorRepository::new(pool.clone());
+        assert_eq!(repo.pool().status().max_size, 4);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,9 @@ pub use cli::{
 pub use infrastructure::observability::LogGuard;
 
 // Config types
-pub use infrastructure::config::{ConcurrencyConfig, OutputFormat, ScraperConfig};
+pub use infrastructure::config::{
+    AutotuningConfig, ConcurrencyConfig, OutputFormat, ScraperConfig,
+};
 
 // Error and result types
 pub use clap::{Parser, ValueEnum};


### PR DESCRIPTION
## Elastic Ingestion Autotuning (Issue #51) — PR 1/5: Foundation

### What
Foundation layer for elastic ingestion pipeline: hardware autotuning config, SQLite persistence (WAL-mode pool + schema), and ScraperError variants for the full 5-PR chain.

### Changes
- **AutotuningConfig**: CPU/RAM detection via `num_cpus` + `sys-info`, with CLI/env override priority
- **SQLite persistence**: `deadpool-sqlite` 0.8 pool with per-connection WAL pragmas, schema DDL (resources + chunks tables)
- **Error variants**: `Persistence`, `Ingestion`, `GlobalTimeout`, `SlowlorisTimeout`, `PayloadTooLarge`, `NetworkFailure`, `SemaphoreInanition`
- **Deps**: rusqlite 0.31 (bundled), deadpool-sqlite 0.8, sys-info 0.9, rayon 1.10

### Test Results
- 31 new unit tests (3 error + 8 SQLite + 16 autotuning + 4 config)
- Full lib regression: 577 passed / 0 failed / 5 ignored
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅

### SDD Chain
Stacked-to-main | PR 1 of 5 | Depends on: none | Blocks: PR2 (async I/O)

<!-- SDD: elastic-ingestion-51/pr1 -->