### PR TITLE
feat(crawler): elastic async I/O with byte-weighted backpressure (PR 2/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,29 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sqlite"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9cc6210316f8b7ced394e2a5d2833ce7097fb28afb5881299c61bc18e8e0e9"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "rusqlite",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
 
 [[package]]
 name = "deranged"
@@ -1461,6 +1484,18 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1870,6 +1905,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2508,6 +2552,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3984,6 +4039,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "uuid",
+]
+
+[[package]]
 name = "rust_scraper"
 version = "1.1.0"
 dependencies = [
@@ -4003,6 +4074,7 @@ dependencies = [
  "criterion",
  "crossterm 0.28.1",
  "dashmap 6.2.1",
+ "deadpool-sqlite",
  "dirs 5.0.1",
  "fs2",
  "futures",
@@ -4026,9 +4098,11 @@ dependencies = [
  "rand 0.9.4",
  "ratatui",
  "ratatui-form",
+ "rayon",
  "redis",
  "regex",
  "rmcp",
+ "rusqlite",
  "rustls-webpki",
  "schemars",
  "scraper",
@@ -4040,6 +4114,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "syntect",
+ "sys-info",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -4733,6 +4808,16 @@ dependencies = [
  "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,23 @@ quick-xml = "0.37"
 # CPU detection for hardware-aware concurrency
 num_cpus = "1"
 
+# ============================================================================
+# Elastic Ingestion (Issue #51) — autotuning + SQLite persistence + CPU pool
+# ============================================================================
+# SQLite embedded persistence (bundled libsqlite3; chrono/uuid feature gates)
+rusqlite = { version = "0.31", features = ["bundled", "chrono", "uuid"] }
+# Async SQLite connection pool (WAL-friendly, pooled blocking calls off Tokio)
+# NOTE: task pinned "0.15" (nonexistent); 0.13 needs rusqlite 0.38 (conflicts
+# with proposal-pinned rusqlite 0.31). Frozen design.md pins no version.
+# Resolver-selected max version compatible with rusqlite 0.31 is 0.8.1.
+deadpool-sqlite = "0.8"
+# Total RAM detection for hardware autotuning (CPU uses num_cpus above)
+# NOTE: task pinned "0.10" but that version does not exist on crates.io
+# (candidates: 0.9.1, 0.9.0). proposal.md specifies "0.9" — using that.
+sys-info = "0.9"
+# Promoted from transitive to direct: explicit isolated Rayon thread pool (PR3)
+rayon = "1.10"
+
 # Progress bars
 indicatif = { version = "0.17", features = ["improved_unicode"] }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@
 //! This provides type-safe, structured error handling instead of anyhow.
 
 use thiserror::Error;
+use wreq::Error as WreqError;
 
 /// Main error type for the scraper library.
 ///
@@ -99,6 +100,38 @@ pub enum ScraperError {
     /// Batch export failed (partial success)
     #[error("Error de exportación en batch: {0}")]
     ExportBatch(String),
+
+    /// Global download timeout (30s)
+    #[error("descarga superó tiempo global de 30 segundos")]
+    GlobalTimeout,
+
+    /// Slowloris attack detected (per-chunk timeout)
+    #[error("descarga superó timeout de inactividad de 5 segundos por chunk")]
+    SlowlorisTimeout,
+
+    /// Payload exceeded 25MB limit
+    #[error("recurso superó límite de 25 MB")]
+    PayloadTooLarge,
+
+    /// Network error (connection failed, timeout, etc.)
+    #[error("error de red: {0}")]
+    NetworkFailure(#[from] WreqError),
+
+    /// Semaphore exhausted (backpressure)
+    #[error("semáforo agotado: no hay permisos disponibles")]
+    SemaphoreInanition,
+
+    /// Persistence error (SQLite storage layer — resources/chunks CRUD, pool).
+    ///
+    /// Holds the underlying error rendered to a string so it uniformly covers
+    /// both `rusqlite::Error` and `deadpool_sqlite` pool errors (which are
+    /// different types) without forcing two `#[from]` variants.
+    #[error("Error de persistencia: {0}")]
+    Persistence(String),
+
+    /// Elastic ingestion pipeline error (orchestration / dispatch failures).
+    #[error("Error de ingestión: {0}")]
+    Ingestion(String),
 
     /// Semantic cleaning error (AI-powered content processing)
     #[cfg(feature = "ai")]
@@ -288,6 +321,21 @@ impl ScraperError {
     pub fn export_batch(msg: impl Into<String>) -> Self {
         Self::ExportBatch(msg.into())
     }
+
+    /// Create a Persistence error from anything displayable.
+    ///
+    /// Used to uniformly convert `rusqlite::Error` and `deadpool_sqlite` pool
+    /// errors into `ScraperError::Persistence` without `#[from]` ambiguity.
+    #[must_use]
+    pub fn persistence(err: impl std::fmt::Display) -> Self {
+        Self::Persistence(err.to_string())
+    }
+
+    /// Create an Ingestion error from anything displayable.
+    #[must_use]
+    pub fn ingestion(err: impl std::fmt::Display) -> Self {
+        Self::Ingestion(err.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -321,6 +369,38 @@ mod tests {
         let std_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let err: ScraperError = std_err.into();
         assert!(err.to_string().contains("file not found"));
+    }
+
+    #[test]
+    fn test_persistence_error_message() {
+        let err = ScraperError::persistence("disco lleno");
+        assert_eq!(err.to_string(), "Error de persistencia: disco lleno");
+    }
+
+    #[test]
+    fn test_ingestion_error_message() {
+        let err = ScraperError::ingestion("pipeline abortó");
+        assert_eq!(err.to_string(), "Error de ingestión: pipeline abortó");
+    }
+
+    #[test]
+    fn test_persistence_error_from_rusqlite() {
+        // Triangulation: the Display-based helper must carry the real rusqlite
+        // error text (proves it converts a genuine DB error, not a hardcoded value).
+        let db = rusqlite::Connection::open_in_memory().expect("open in-memory sqlite");
+        let rusqlite_err = db
+            .prepare("SELECT * FROM tabla_inexistente")
+            .expect_err("expected error for missing table");
+        let scraper_err = ScraperError::persistence(&rusqlite_err);
+        let msg = scraper_err.to_string();
+        assert!(
+            msg.contains("persistencia"),
+            "missing Spanish prefix: {msg}"
+        );
+        assert!(
+            msg.contains("no such table"),
+            "missing rusqlite detail: {msg}"
+        );
     }
 
     #[cfg(feature = "ai")]

--- a/src/infrastructure/autotuning.rs
+++ b/src/infrastructure/autotuning.rs
@@ -1,0 +1,421 @@
+//! Hardware autotuning for the elastic ingestion pipeline (Issue #51).
+//!
+//! Derives pipeline sizing defaults from the host hardware:
+//! - CPU cores via [`num_cpus::get()`] (Rayon pool / DB pool fan-out).
+//! - RAM budget via [`sys_info::mem_info()`] × 0.7 (byte-weighted semaphore).
+//!
+//! Configuration resolution priority (frozen design decision #12):
+//! **CLI flag > `RUST_SCRAPER_*` env var > auto-detected default**.
+//!
+//! All resolution logic is exposed as pure functions taking `(cli_override, env_value)`
+//! so the priority order is unit-testable without mutating the process environment
+//! (which would be racy under parallel test execution).
+
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+// ============================================================================
+// Constants (frozen design decisions #6, #11; spec hardware-autotuning §Fallback)
+// ============================================================================
+
+/// Fallback CPU core count when detection fails or returns 0.
+pub const FALLBACK_CPU_CORES: usize = 4;
+
+/// Fallback RAM budget (2 GiB in bytes) when `sys_info` fails.
+///
+/// Frozen: the user's task and the hardware-autotuning spec agree on 2 GiB
+/// (2_147_483_648 bytes) — NOT `8 GiB × 0.7`.
+pub const FALLBACK_RAM_BUDGET_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Default per-resource byte ceiling (25 MiB) for the download semaphore.
+pub const DEFAULT_MAX_RESOURCE_BYTES: u64 = 25 * 1024 * 1024;
+
+/// Minimum DB connection pool size (frozen design decision #6: floor 4).
+pub const MIN_DB_POOL_SIZE: usize = 4;
+
+/// Default SQLite database path: `~/.rust_scraper/crawl.db`.
+pub const DEFAULT_DB_DIR: &str = ".rust_scraper";
+pub const DEFAULT_DB_FILE: &str = "crawl.db";
+
+// ============================================================================
+// Environment variable names (frozen design decision #12 — snake-upper)
+// ============================================================================
+
+pub const ENV_CPU_CORES: &str = "RUST_SCRAPER_CPU_CORES";
+pub const ENV_RAM_BUDGET: &str = "RUST_SCRAPER_RAM_BUDGET";
+pub const ENV_MAX_RESOURCE_MB: &str = "RUST_SCRAPER_MAX_RESOURCE_MB";
+pub const ENV_DB_PATH: &str = "RUST_SCRAPER_DB_PATH";
+
+// ============================================================================
+// Hardware detection primitives
+// ============================================================================
+
+/// Detect the number of available CPU cores via [`num_cpus::get()`].
+///
+/// Falls back to [`FALLBACK_CPU_CORES`] when the platform reports 0.
+#[must_use]
+pub fn detect_cpu_cores() -> usize {
+    let n = num_cpus::get();
+    if n == 0 {
+        FALLBACK_CPU_CORES
+    } else {
+        n
+    }
+}
+
+/// Compute the RAM budget (bytes) from an optional total-RAM value in KiB.
+///
+/// - `Some(total_kib)` → `total_kib * 1024 * 0.7` (70% of total RAM, truncated).
+/// - `None` (detection failed) → [`FALLBACK_RAM_BUDGET_BYTES`] + a `tracing::warn!`.
+///
+/// Exposed as a pure function (taking the detected value, not calling `sys_info`
+/// directly) so the fallback path is unit-testable without mocking the OS.
+#[must_use]
+pub fn ram_budget_from(total_kib: Option<u64>) -> u64 {
+    match total_kib {
+        Some(kib) => kib.saturating_mul(1024).saturating_mul(7) / 10,
+        None => {
+            warn!(
+                error = "sys_info::mem_info falló",
+                fallback_bytes = FALLBACK_RAM_BUDGET_BYTES,
+                "Usando 2 GiB como presupuesto de RAM"
+            );
+            FALLBACK_RAM_BUDGET_BYTES
+        },
+    }
+}
+
+/// Detect the RAM budget via [`sys_info::mem_info()`], falling back to 2 GiB.
+#[must_use]
+pub fn detect_ram_budget() -> u64 {
+    ram_budget_from(sys_info::mem_info().ok().map(|m| m.total))
+}
+
+/// Default SQLite database path: `~/.rust_scraper/crawl.db`.
+///
+/// Falls back to `./crawl.db` when the home directory cannot be determined.
+#[must_use]
+pub fn default_db_path() -> PathBuf {
+    match dirs::home_dir() {
+        Some(home) => home.join(DEFAULT_DB_DIR).join(DEFAULT_DB_FILE),
+        None => PathBuf::from(DEFAULT_DB_FILE),
+    }
+}
+
+// ============================================================================
+// Pure resolution (priority: CLI > env > autodetect) — fully unit-testable
+// ============================================================================
+
+/// Resolve CPU cores: `cli` wins, then `env`, then auto-detect.
+#[must_use]
+pub fn resolve_cpu_cores(cli: Option<usize>, env: Option<usize>) -> usize {
+    cli.or(env).unwrap_or_else(detect_cpu_cores)
+}
+
+/// Resolve RAM budget (bytes): `cli` wins, then `env`, then auto-detect.
+#[must_use]
+pub fn resolve_ram_budget(cli: Option<u64>, env: Option<u64>) -> u64 {
+    cli.or(env).unwrap_or_else(detect_ram_budget)
+}
+
+/// Resolve the per-resource byte ceiling: `cli` wins, then `env`, then default.
+#[must_use]
+pub fn resolve_max_resource_bytes(cli: Option<u64>, env: Option<u64>) -> u64 {
+    cli.or(env).unwrap_or(DEFAULT_MAX_RESOURCE_BYTES)
+}
+
+/// Resolve the DB path: `cli` wins, then `env`, then [`default_db_path`].
+#[must_use]
+pub fn resolve_db_path(cli: Option<&Path>, env: Option<PathBuf>) -> PathBuf {
+    cli.map(PathBuf::from)
+        .or(env)
+        .unwrap_or_else(default_db_path)
+}
+
+// ============================================================================
+// Env readers (used by AutotuningConfig/ElasticConfig wiring)
+// ============================================================================
+
+/// Read `RUST_SCRAPER_CPU_CORES` override (parsed as `usize`).
+#[must_use]
+pub fn env_cpu_cores() -> Option<usize> {
+    std::env::var(ENV_CPU_CORES)
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+}
+
+/// Read `RUST_SCRAPER_RAM_BUDGET` override (bytes, or suffixed e.g. `8GB`).
+#[must_use]
+pub fn env_ram_budget() -> Option<u64> {
+    std::env::var(ENV_RAM_BUDGET)
+        .ok()
+        .and_then(|v| parse_ram_bytes(&v))
+}
+
+/// Read `RUST_SCRAPER_MAX_RESOURCE_MB` override (interpreted as MiB → bytes).
+#[must_use]
+pub fn env_max_resource_bytes() -> Option<u64> {
+    std::env::var(ENV_MAX_RESOURCE_MB)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(|mb| mb.saturating_mul(1024).saturating_mul(1024))
+}
+
+/// Read `RUST_SCRAPER_DB_PATH` override.
+#[must_use]
+pub fn env_db_path() -> Option<PathBuf> {
+    std::env::var(ENV_DB_PATH).ok().map(PathBuf::from)
+}
+
+/// Parse a RAM budget string: plain bytes, or a number with a binary suffix
+/// (`B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB`).
+///
+/// Per the hardware-autotuning spec scenario (`--ram-budget 8GB` → `8 * 1024^3`),
+/// all suffixes are treated as binary (powers of 1024).
+#[must_use]
+pub fn parse_ram_bytes(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let mut split = 0;
+    for (i, c) in s.char_indices() {
+        if c.is_ascii_digit() || c == '.' {
+            split = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    let (num_str, unit) = s.split_at(split);
+    let num: f64 = num_str.parse().ok()?;
+    let power: u32 = match unit.trim().to_ascii_uppercase().as_str() {
+        "" | "B" => 0,
+        "KB" | "KIB" => 1,
+        "MB" | "MIB" => 2,
+        "GB" | "GIB" => 3,
+        "TB" | "TIB" => 4,
+        _ => return None,
+    };
+    let mult: u64 = 1024u64.pow(power);
+    if num < 0.0 {
+        return None;
+    }
+    Some((num * mult as f64) as u64)
+}
+
+// ============================================================================
+// ElasticConfig — full elastic ingestion config (frozen design §Interfaces)
+// ============================================================================
+
+/// Overrides supplied by CLI flags (PR5). `None` means "not set → fall back".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ElasticOverrides {
+    /// `--cpu-cores` override.
+    pub cpu_cores: Option<usize>,
+    /// `--ram-budget` override (bytes).
+    pub ram_budget_bytes: Option<u64>,
+    /// `--max-resource-mb` override (bytes).
+    pub max_resource_bytes: Option<u64>,
+    /// `--db-path` override.
+    pub db_path: Option<PathBuf>,
+}
+
+/// Resolved elastic ingestion configuration.
+///
+/// Combines auto-detected hardware sizing with the full pipeline parameters.
+/// `db_pool_size` is derived as `cpu_cores` with a floor of 4 (frozen decision #6).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ElasticConfig {
+    /// Detected/overridden CPU core count (Rayon pool size).
+    pub cpu_cores: usize,
+    /// Detected/overridden RAM budget in bytes (semaphore permits).
+    pub ram_budget_bytes: u64,
+    /// Per-resource byte ceiling (default 25 MiB).
+    pub max_resource_bytes: u64,
+    /// DB connection pool size (`cpu_cores`, floor 4).
+    pub db_pool_size: usize,
+    /// SQLite database file path.
+    pub db_path: PathBuf,
+}
+
+impl ElasticConfig {
+    /// Resolve the full config from CLI overrides, falling back to env vars and
+    /// then auto-detected defaults (priority: CLI > env > autodetect).
+    #[must_use]
+    pub fn resolve(overrides: &ElasticOverrides) -> Self {
+        let cpu_cores = resolve_cpu_cores(overrides.cpu_cores, env_cpu_cores());
+        let ram_budget_bytes = resolve_ram_budget(overrides.ram_budget_bytes, env_ram_budget());
+        let max_resource_bytes =
+            resolve_max_resource_bytes(overrides.max_resource_bytes, env_max_resource_bytes());
+        let db_path = resolve_db_path(overrides.db_path.as_deref(), env_db_path());
+        let db_pool_size = cpu_cores.max(MIN_DB_POOL_SIZE);
+        Self {
+            cpu_cores,
+            ram_budget_bytes,
+            max_resource_bytes,
+            db_pool_size,
+            db_path,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+
+    // ---- detection primitives ----
+
+    #[test]
+    fn test_detect_cpu_cores_matches_num_cpus() {
+        let detected = detect_cpu_cores();
+        let n = num_cpus::get();
+        let expected = if n == 0 { FALLBACK_CPU_CORES } else { n };
+        assert_eq!(detected, expected);
+    }
+
+    #[test]
+    fn test_ram_budget_from_none_falls_back_to_2gib() {
+        assert_eq!(ram_budget_from(None), FALLBACK_RAM_BUDGET_BYTES);
+        assert_eq!(FALLBACK_RAM_BUDGET_BYTES, 2 * GIB);
+    }
+
+    #[test]
+    fn test_ram_budget_from_32gib_machine() {
+        // 32 GiB total RAM = 33_554_432 KiB → 70% in bytes (truncated).
+        let total_kib: u64 = 32 * 1024 * 1024;
+        let expected = total_kib * 1024 * 7 / 10;
+        assert_eq!(ram_budget_from(Some(total_kib)), expected);
+        // Sanity: 70% of 32 GiB is ~22.4 GiB (> 15 GiB, < 24 GiB).
+        let result = ram_budget_from(Some(total_kib));
+        assert!(result > 15 * GIB && result < 24 * GIB);
+    }
+
+    #[test]
+    fn test_detect_ram_budget_is_nonzero_and_sane() {
+        let budget = detect_ram_budget();
+        assert!(budget > 0, "RAM budget must be positive");
+        // Either autodetected (> a few MiB) or the 2 GiB fallback.
+        assert!(budget >= FALLBACK_RAM_BUDGET_BYTES || budget > 100 * MIB);
+    }
+
+    #[test]
+    fn test_default_db_path_under_home() {
+        let p = default_db_path();
+        assert!(p.ends_with(DEFAULT_DB_FILE));
+        assert!(p.to_string_lossy().contains(DEFAULT_DB_DIR));
+    }
+
+    // ---- pure resolution priority (CLI > env > autodetect) ----
+
+    #[test]
+    fn test_resolve_cpu_cores_cli_wins() {
+        assert_eq!(resolve_cpu_cores(Some(4), Some(8)), 4);
+    }
+
+    #[test]
+    fn test_resolve_cpu_cores_env_beats_autodetect() {
+        assert_eq!(resolve_cpu_cores(None, Some(8)), 8);
+    }
+
+    #[test]
+    fn test_resolve_cpu_cores_autodetect_when_no_overrides() {
+        assert_eq!(resolve_cpu_cores(None, None), detect_cpu_cores());
+    }
+
+    #[test]
+    fn test_resolve_ram_budget_priority() {
+        assert_eq!(resolve_ram_budget(Some(8 * GIB), Some(4 * GIB)), 8 * GIB);
+        assert_eq!(resolve_ram_budget(None, Some(4 * GIB)), 4 * GIB);
+        assert_eq!(resolve_ram_budget(None, None), detect_ram_budget());
+    }
+
+    #[test]
+    fn test_resolve_max_resource_bytes_default_and_overrides() {
+        assert_eq!(
+            resolve_max_resource_bytes(Some(50 * MIB), Some(10 * MIB)),
+            50 * MIB
+        );
+        assert_eq!(resolve_max_resource_bytes(None, Some(10 * MIB)), 10 * MIB);
+        assert_eq!(
+            resolve_max_resource_bytes(None, None),
+            DEFAULT_MAX_RESOURCE_BYTES
+        );
+        assert_eq!(DEFAULT_MAX_RESOURCE_BYTES, 25 * MIB);
+    }
+
+    #[test]
+    fn test_resolve_db_path_priority() {
+        let cli = Path::new("/tmp/x.db");
+        assert_eq!(resolve_db_path(Some(cli), None), PathBuf::from("/tmp/x.db"));
+        assert_eq!(
+            resolve_db_path(None, Some(PathBuf::from("/c/d.db"))),
+            PathBuf::from("/c/d.db")
+        );
+        assert_eq!(resolve_db_path(None, None), default_db_path());
+    }
+
+    // ---- ElasticConfig.resolve ----
+
+    #[test]
+    fn test_elastic_config_resolve_with_full_overrides() {
+        let overrides = ElasticOverrides {
+            cpu_cores: Some(4),
+            ram_budget_bytes: Some(8 * GIB),
+            max_resource_bytes: Some(50 * MIB),
+            db_path: Some(PathBuf::from("/tmp/elastic.db")),
+        };
+        let cfg = ElasticConfig::resolve(&overrides);
+        assert_eq!(cfg.cpu_cores, 4);
+        assert_eq!(cfg.ram_budget_bytes, 8 * GIB);
+        assert_eq!(cfg.max_resource_bytes, 50 * MIB);
+        assert_eq!(cfg.db_pool_size, 4); // max(4, 4)
+        assert_eq!(cfg.db_path, PathBuf::from("/tmp/elastic.db"));
+    }
+
+    #[test]
+    fn test_elastic_config_db_pool_floor_when_cpu_below_4() {
+        // cpu override 2 → db_pool_size must floor at 4 (frozen decision #6).
+        let overrides = ElasticOverrides {
+            cpu_cores: Some(2),
+            ..Default::default()
+        };
+        let cfg = ElasticConfig::resolve(&overrides);
+        assert_eq!(cfg.cpu_cores, 2);
+        assert_eq!(cfg.db_pool_size, MIN_DB_POOL_SIZE);
+        assert_eq!(MIN_DB_POOL_SIZE, 4);
+    }
+
+    #[test]
+    fn test_elastic_config_db_pool_matches_cpu_when_above_floor() {
+        let overrides = ElasticOverrides {
+            cpu_cores: Some(8),
+            ..Default::default()
+        };
+        let cfg = ElasticConfig::resolve(&overrides);
+        assert_eq!(cfg.db_pool_size, 8);
+    }
+
+    // ---- parse_ram_bytes (env/CLI suffix parsing) ----
+
+    #[test]
+    fn test_parse_ram_bytes_plain_and_suffixed() {
+        assert_eq!(parse_ram_bytes("8589934592"), Some(8 * GIB));
+        assert_eq!(parse_ram_bytes("8GB"), Some(8 * GIB));
+        assert_eq!(parse_ram_bytes("8GiB"), Some(8 * GIB));
+        assert_eq!(parse_ram_bytes("8MB"), Some(8 * MIB));
+        assert_eq!(parse_ram_bytes("8"), Some(8));
+        assert_eq!(parse_ram_bytes("  4 gb "), Some(4 * GIB)); // trimmed + lowercase
+    }
+
+    #[test]
+    fn test_parse_ram_bytes_rejects_garbage() {
+        assert_eq!(parse_ram_bytes(""), None);
+        assert_eq!(parse_ram_bytes("garbage"), None);
+        assert_eq!(parse_ram_bytes("8XB"), None); // unknown unit
+        assert_eq!(parse_ram_bytes("-8GB"), None); // negative
+    }
+}

--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -343,6 +343,65 @@ impl clap::builder::TypedValueParser for ConcurrencyValueParser {
 }
 
 // ============================================================================
+// Elastic Ingestion Autotuning Config (Issue #51)
+// ============================================================================
+
+/// Hardware-autotuning configuration snapshot for the elastic ingestion
+/// pipeline (Issue #51).
+///
+/// Serializable so it can be written to / read from a config file. Holds the
+/// two core auto-detected sizing values; the fuller
+/// [`crate::infrastructure::autotuning::ElasticConfig`] adds DB/pool parameters.
+///
+/// Resolution priority (frozen design decision #12): explicit override >
+/// `RUST_SCRAPER_*` env var > auto-detected default.
+///
+/// # Examples
+///
+/// ```
+/// use rust_scraper::AutotuningConfig;
+///
+/// // Explicit overrides win.
+/// let cfg = AutotuningConfig::resolve(Some(4), Some(8 * 1024 * 1024 * 1024));
+/// assert_eq!(cfg.cpu_cores, 4);
+/// assert_eq!(cfg.ram_budget_bytes, 8 * 1024 * 1024 * 1024);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AutotuningConfig {
+    /// Detected/overridden CPU core count.
+    pub cpu_cores: usize,
+    /// Detected/overridden RAM budget in bytes.
+    pub ram_budget_bytes: u64,
+}
+
+impl AutotuningConfig {
+    /// Resolve the autotuning snapshot.
+    ///
+    /// Priority: `cpu_override`/`ram_override` > `RUST_SCRAPER_CPU_CORES` /
+    /// `RUST_SCRAPER_RAM_BUDGET` env > auto-detected defaults.
+    #[must_use]
+    pub fn resolve(cpu_override: Option<usize>, ram_override: Option<u64>) -> Self {
+        use crate::infrastructure::autotuning;
+        Self {
+            cpu_cores: autotuning::resolve_cpu_cores(cpu_override, autotuning::env_cpu_cores()),
+            ram_budget_bytes: autotuning::resolve_ram_budget(
+                ram_override,
+                autotuning::env_ram_budget(),
+            ),
+        }
+    }
+
+    /// Build a snapshot from a resolved [`ElasticConfig`].
+    #[must_use]
+    pub fn from_elastic(elastic: &crate::infrastructure::autotuning::ElasticConfig) -> Self {
+        Self {
+            cpu_cores: elastic.cpu_cores,
+            ram_budget_bytes: elastic.ram_budget_bytes,
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -423,5 +482,50 @@ mod tests {
     fn test_concurrency_config_from_str_invalid() {
         let config = ConcurrencyConfig::from("not-a-number");
         assert!(config.is_auto());
+    }
+
+    #[test]
+    fn test_autotuning_config_resolve_with_overrides() {
+        let cfg = AutotuningConfig::resolve(Some(4), Some(8 * 1024 * 1024 * 1024));
+        assert_eq!(cfg.cpu_cores, 4);
+        assert_eq!(cfg.ram_budget_bytes, 8 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_autotuning_config_resolve_without_overrides_is_sane() {
+        // No overrides → falls through env (likely unset) → auto-detected defaults.
+        let cfg = AutotuningConfig::resolve(None, None);
+        assert!(cfg.cpu_cores > 0, "cpu_cores must be positive");
+        assert!(
+            cfg.ram_budget_bytes > 0,
+            "ram_budget_bytes must be positive"
+        );
+    }
+
+    #[test]
+    fn test_autotuning_config_serializes_roundtrip() {
+        let cfg = AutotuningConfig {
+            cpu_cores: 8,
+            ram_budget_bytes: 16 * 1024 * 1024 * 1024,
+        };
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        assert!(json.contains("\"cpu_cores\":8"), "json: {json}");
+        assert!(json.contains("\"ram_budget_bytes\":"));
+        let back: AutotuningConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, cfg);
+    }
+
+    #[test]
+    fn test_autotuning_config_from_elastic() {
+        let elastic = crate::infrastructure::autotuning::ElasticConfig {
+            cpu_cores: 6,
+            ram_budget_bytes: 12 * 1024 * 1024 * 1024,
+            max_resource_bytes: 25 * 1024 * 1024,
+            db_pool_size: 6,
+            db_path: std::path::PathBuf::from("/tmp/elastic.db"),
+        };
+        let snap = AutotuningConfig::from_elastic(&elastic);
+        assert_eq!(snap.cpu_cores, 6);
+        assert_eq!(snap.ram_budget_bytes, 12 * 1024 * 1024 * 1024);
     }
 }

--- a/src/infrastructure/crawler/mod.rs
+++ b/src/infrastructure/crawler/mod.rs
@@ -5,12 +5,14 @@
 //! - Link extraction from HTML
 //! - Concurrent URL queue
 //! - Sitemap parsing (FASE 3)
+//! - Resource downloading with byte-weighted semaphore backpressure
 
 pub mod batch_processor;
 pub mod compression_handler;
 pub mod http_client;
 pub mod link_extractor;
 pub mod memory_manager;
+pub mod resource_downloader;
 pub mod retry_policy;
 pub mod sitemap_config;
 pub mod sitemap_parser;
@@ -19,6 +21,9 @@ pub mod url_validator;
 
 pub use http_client::{create_rate_limited_client, fetch_url};
 pub use link_extractor::{extract_links, is_internal_link, normalize_url};
+pub use resource_downloader::{
+    DownloadConfig, DownloadedResource, PermitGuard, ResourceDownloader,
+};
 pub use sitemap_config::{SitemapConfig, SitemapConfigBuilder};
 pub use sitemap_parser::{resolve_url, SitemapError, SitemapParser};
 pub use url_queue::UrlQueue;

--- a/src/infrastructure/crawler/resource_downloader.rs
+++ b/src/infrastructure/crawler/resource_downloader.rs
@@ -1,0 +1,740 @@
+//! Resource Downloader with Byte-Weighted Semaphore and Backpressure
+//!
+//! Implements elastic resource downloading with:
+//! - Byte-weighted semaphore for memory backpressure
+//! - PermitGuard for RAII permit management
+//! - 25MB hard limit with chunked encoding support
+//! - Concentric timeouts: 30s global, 5s per chunk (Anti-Slowloris)
+
+use crate::error::ScraperError;
+use bytes::BytesMut;
+use futures::StreamExt;
+use std::sync::Arc;
+use tokio::time::{timeout, Duration};
+use wreq::Client;
+
+/// RAII guard for semaphore permits.
+///
+/// Ensures permits are released back to the semaphore even on panic,
+/// preventing permit starvation in the pool.
+#[derive(Debug)]
+pub struct PermitGuard {
+    semaphore: Arc<tokio::sync::Semaphore>,
+    units_acquired: u64,
+}
+
+impl PermitGuard {
+    /// Creates a new PermitGuard with the given semaphore and initial units.
+    #[must_use]
+    pub fn new(semaphore: Arc<tokio::sync::Semaphore>, initial_units: u64) -> Self {
+        Self {
+            semaphore,
+            units_acquired: initial_units,
+        }
+    }
+
+    /// Updates the guard with additional units acquired.
+    pub fn update_reservation(&mut self, additional_units: u64) {
+        self.units_acquired = self.units_acquired.saturating_add(additional_units);
+    }
+
+    /// Returns the current number of units held by this guard.
+    #[must_use]
+    pub fn units_acquired(&self) -> u64 {
+        self.units_acquired
+    }
+}
+
+impl Drop for PermitGuard {
+    fn drop(&mut self) {
+        if self.units_acquired > 0 {
+            self.semaphore.add_permits(self.units_acquired as usize);
+        }
+    }
+}
+
+/// Configuration for resource downloading.
+#[derive(Debug, Clone)]
+pub struct DownloadConfig {
+    /// Maximum total size in bytes (default: 25MB)
+    pub max_size_bytes: u64,
+    /// Global download timeout in seconds
+    pub global_timeout_seconds: u64,
+    /// Per-chunk timeout in seconds (Anti-Slowloris)
+    pub chunk_timeout_seconds: u64,
+    /// Initial permit size in bytes (4KB)
+    pub initial_permit_bytes: u64,
+    /// Chunk size for permit acquisition (4KB)
+    pub chunk_size_bytes: u64,
+    /// Buffer pre-allocation size in bytes
+    pub buffer_capacity_bytes: usize,
+}
+
+impl Default for DownloadConfig {
+    fn default() -> Self {
+        Self {
+            max_size_bytes: 25 * 1024 * 1024, // 25MB
+            global_timeout_seconds: 30,
+            chunk_timeout_seconds: 5,
+            initial_permit_bytes: 4096,       // 4KB
+            chunk_size_bytes: 4096,           // 4KB
+            buffer_capacity_bytes: 16 * 1024, // 16KB
+        }
+    }
+}
+
+/// Result of a successful resource download.
+#[derive(Debug, Clone)]
+pub struct DownloadedResource {
+    /// The URL that was downloaded
+    pub url: String,
+    /// The raw bytes of the resource
+    pub bytes: Vec<u8>,
+    /// Content-Type header if available
+    pub content_type: Option<String>,
+    /// Total size in bytes
+    pub size_bytes: u64,
+}
+
+/// Resource downloader with byte-weighted semaphore backpressure.
+///
+/// Implements elastic resource downloading with memory backpressure
+/// via a byte-weighted semaphore and Anti-Slowloris protection.
+pub struct ResourceDownloader {
+    semaphore: Arc<tokio::sync::Semaphore>,
+    client: Client,
+    config: DownloadConfig,
+}
+
+impl ResourceDownloader {
+    /// Creates a new ResourceDownloader with the given semaphore and client.
+    pub fn new(semaphore: Arc<tokio::sync::Semaphore>, client: Client) -> Self {
+        Self {
+            semaphore,
+            client,
+            config: DownloadConfig::default(),
+        }
+    }
+
+    /// Creates a new ResourceDownloader with custom config.
+    pub fn with_config(
+        semaphore: Arc<tokio::sync::Semaphore>,
+        client: Client,
+        config: DownloadConfig,
+    ) -> Self {
+        Self {
+            semaphore,
+            client,
+            config,
+        }
+    }
+
+    /// Downloads a resource with byte-weighted semaphore backpressure.
+    ///
+    /// Permit lifecycle (spec: "Byte-Weighted Semaphore" + "Chunked Encoding
+    /// Protection" + "Hard Resource Size Limit"):
+    /// - No permits are acquired until response headers arrive, so a
+    ///   `Content-Length` rejection never holds any permits.
+    /// - Each streamed chunk acquires its own byte-weighted permits *before*
+    ///   being buffered. Permits are `forget()`ten so the `PermitGuard` owns
+    ///   the release, guaranteeing `permits released == permits acquired`
+    ///   (no double-release, no permit inflation).
+    ///
+    /// # Errors
+    /// Returns `ScraperError` if:
+    /// - Global timeout exceeded (`GlobalTimeout`)
+    /// - Per-chunk timeout exceeded — Anti-Slowloris (`SlowlorisTimeout`)
+    /// - `Content-Length` or accumulated size exceeds the limit (`PayloadTooLarge`)
+    /// - Network error occurs (`NetworkFailure`)
+    /// - Semaphore acquisition fails (`SemaphoreInanition`)
+    pub async fn download(&self, url: &str) -> Result<Vec<u8>, ScraperError> {
+        // Global timeout wraps the request (headers). Permits are acquired only
+        // AFTER headers, so oversized responses are rejected permit-free.
+        let response = timeout(
+            Duration::from_secs(self.config.global_timeout_seconds),
+            self.client.get(url).send(),
+        )
+        .await
+        .map_err(|_| {
+            tracing::error!(%url, reason = "global_timeout", "descarga abortada");
+            ScraperError::GlobalTimeout
+        })?
+        .map_err(|e| {
+            tracing::error!(%url, error = %e, "error de red al iniciar descarga");
+            ScraperError::from(e)
+        })?;
+
+        let _content_type = response
+            .headers()
+            .get(wreq::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        // Hard Resource Size Limit: reject oversized resources BEFORE acquiring
+        // any permits (spec: "no permits MUST be acquired").
+        let content_length = response
+            .headers()
+            .get(wreq::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+        if let Some(cl) = content_length {
+            if cl > self.config.max_size_bytes {
+                tracing::error!(
+                    %url,
+                    content_length = cl,
+                    max = self.config.max_size_bytes,
+                    reason = "payload_too_large",
+                    "recurso supera límite de tamaño: rechazado sin adquirir permisos"
+                );
+                return Err(ScraperError::PayloadTooLarge);
+            }
+        }
+
+        // Byte-weighted semaphore: every chunk acquires its own permits, which
+        // are `forget()`ten so the PermitGuard owns the release on Drop.
+        // Invariant: permits released on Drop == permits acquired mid-download.
+        let mut guard = PermitGuard::new(Arc::clone(&self.semaphore), 0);
+        let mut stream = response.bytes_stream();
+        let mut buffer = BytesMut::with_capacity(self.config.buffer_capacity_bytes);
+        let mut total_bytes: u64 = 0;
+
+        // Process stream with per-chunk timeout (Anti-Slowloris: 5s per chunk).
+        while let Some(chunk_result) = timeout(
+            Duration::from_secs(self.config.chunk_timeout_seconds),
+            stream.next(),
+        )
+        .await
+        .map_err(|_| {
+            tracing::error!(
+                %url,
+                bytes = total_bytes,
+                reason = "slowloris_timeout",
+                "descarga abortada: timeout de inactividad por chunk"
+            );
+            ScraperError::SlowlorisTimeout
+        })? {
+            let chunk = chunk_result.map_err(|e| {
+                tracing::error!(
+                    %url,
+                    bytes = total_bytes,
+                    error = %e,
+                    "error de red durante la descarga"
+                );
+                ScraperError::from(e)
+            })?;
+            let chunk_len = chunk.len() as u64;
+
+            // OOM prevention: abort when accumulated size exceeds the configured
+            // hard limit (default 25 MB; spec: "SHOULD be configurable").
+            if total_bytes + chunk_len > self.config.max_size_bytes {
+                tracing::error!(
+                    %url,
+                    bytes = total_bytes + chunk_len,
+                    max = self.config.max_size_bytes,
+                    reason = "chunked_limit_exceeded",
+                    "descarga abortada: supera límite de tamaño"
+                );
+                return Err(ScraperError::PayloadTooLarge);
+            }
+
+            // Acquire byte-weighted permits for THIS chunk before buffering it.
+            // `forget()` consumes the permit (no auto-release on Drop); the
+            // PermitGuard tracks the total and releases exactly this many on
+            // its own Drop — preventing the double-release / permit inflation.
+            //
+            // `chunk_len as u32` is safe: a network chunk is frame-sized (KB),
+            // and we just verified `total_bytes + chunk_len <= max_size_bytes`
+            // (≤ 25 MB), far below `u32::MAX`.
+            if chunk_len > 0 {
+                self.semaphore
+                    .acquire_many(chunk_len as u32)
+                    .await
+                    .map_err(|_| {
+                        tracing::error!(
+                            %url,
+                            bytes = total_bytes,
+                            reason = "semaphore_inanition",
+                            "semáforo agotado: no hay permisos disponibles"
+                        );
+                        ScraperError::SemaphoreInanition
+                    })?
+                    .forget();
+                guard.update_reservation(chunk_len);
+            }
+
+            total_bytes += chunk_len;
+            buffer.extend_from_slice(&chunk);
+        }
+
+        Ok(buffer.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+
+    #[test]
+    fn test_permit_guard_new() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(100));
+        let guard = PermitGuard::new(Arc::clone(&semaphore), 100);
+        assert_eq!(guard.units_acquired(), 100);
+    }
+
+    #[test]
+    fn test_permit_guard_update() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(100));
+        let mut guard = PermitGuard::new(Arc::clone(&semaphore), 100);
+        guard.update_reservation(50);
+        assert_eq!(guard.units_acquired(), 150);
+    }
+
+    #[test]
+    fn test_permit_guard_drop() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+        {
+            let _guard = PermitGuard::new(Arc::clone(&semaphore), 50);
+        }
+        // Permits should be returned on drop
+        assert_eq!(semaphore.available_permits(), 50);
+    }
+
+    #[test]
+    fn test_download_config_default() {
+        let config = DownloadConfig::default();
+        assert_eq!(config.max_size_bytes, 25 * 1024 * 1024);
+        assert_eq!(config.global_timeout_seconds, 30);
+        assert_eq!(config.chunk_timeout_seconds, 5);
+        assert_eq!(config.initial_permit_bytes, 4096);
+        assert_eq!(config.chunk_size_bytes, 4096);
+        assert_eq!(config.buffer_capacity_bytes, 16 * 1024);
+    }
+
+    // ========================================================================
+    // Task 2.5 — behavioral tests (wiremock + raw-socket Slowloris server)
+    //
+    // Short timeouts are used in every config to keep the suite under a few
+    // seconds and to avoid the 30s/5s production defaults.
+    // ========================================================================
+
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Builds a downloader wired to a large semaphore (no backpressure) and
+    /// a fresh `wreq` client.
+    fn downloader(config: DownloadConfig) -> ResourceDownloader {
+        let client = wreq::Client::builder()
+            .build()
+            .expect("fallo construyendo cliente wreq de prueba");
+        let semaphore = Arc::new(Semaphore::new(1 << 20)); // 1 MiB de permisos
+        ResourceDownloader::with_config(semaphore, client, config)
+    }
+
+    /// Spawns a raw HTTP/1.1 server that sends a `Transfer-Encoding: chunked`
+    /// response and then stalls between chunks for `inter_chunk_delay`.
+    ///
+    /// wiremock 0.6 only supports buffered bodies + a single response delay, so
+    /// it cannot reproduce a per-chunk stall. A raw socket gives full control
+    /// and deterministically triggers `SlowlorisTimeout` via the per-chunk
+    /// `timeout` wrapping `stream.next()`.
+    async fn spawn_slow_chunked_server(inter_chunk_delay: Duration) -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind slowloris server");
+        let port = listener
+            .local_addr()
+            .expect("local_addr slowloris server")
+            .port();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                tokio::spawn(async move {
+                    // Consume request headers (read until the terminating \r\n\r\n).
+                    let mut buf = vec![0u8; 1024];
+                    let mut filled = 0usize;
+                    loop {
+                        match sock.read(&mut buf[filled..]).await {
+                            Ok(0) => return,
+                            Ok(n) => {
+                                filled += n;
+                                if filled >= 4 && &buf[filled - 4..filled] == b"\r\n\r\n" {
+                                    break;
+                                }
+                                if filled == buf.len() {
+                                    buf.resize(buf.len() * 2, 0);
+                                }
+                            },
+                            Err(_) => return,
+                        }
+                    }
+
+                    // Chunked response: headers + one chunk ("hello"), then stall.
+                    let head = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
+                    let _ = sock.write_all(head).await;
+                    let _ = sock.write_all(b"5\r\nhello\r\n").await;
+                    // Stall longer than the configured per-chunk timeout.
+                    tokio::time::sleep(inter_chunk_delay).await;
+                    // Terminating chunk (usually never reached: client times out first).
+                    let _ = sock.write_all(b"0\r\n\r\n").await;
+                });
+            }
+        });
+        port
+    }
+
+    /// Spawns a raw HTTP/1.1 chunked server that sends each provided chunk as a
+    /// proper `Transfer-Encoding: chunked` frame, then waits `delay` before the
+    /// next. After the last chunk it sends the terminating `0\r\n\r\n` frame.
+    ///
+    /// Unlike `spawn_slow_chunked_server`, every chunk is delivered promptly;
+    /// only the *gap between* chunks is delayed. This lets a downloader acquire
+    /// per-chunk permits and hold them mid-stream — the precondition needed to
+    /// observe byte-weighted backpressure deterministically.
+    async fn spawn_multi_chunk_server(chunks: Vec<(Vec<u8>, Duration)>) -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind multi-chunk server");
+        let port = listener
+            .local_addr()
+            .expect("local_addr multi-chunk server")
+            .port();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                let parts = chunks.clone();
+                tokio::spawn(async move {
+                    // Consume request headers (read until the terminating \r\n\r\n).
+                    let mut buf = vec![0u8; 1024];
+                    let mut filled = 0usize;
+                    loop {
+                        match sock.read(&mut buf[filled..]).await {
+                            Ok(0) => return,
+                            Ok(n) => {
+                                filled += n;
+                                if filled >= 4 && &buf[filled - 4..filled] == b"\r\n\r\n" {
+                                    break;
+                                }
+                                if filled == buf.len() {
+                                    buf.resize(buf.len() * 2, 0);
+                                }
+                            },
+                            Err(_) => return,
+                        }
+                    }
+
+                    let head = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
+                    let _ = sock.write_all(head).await;
+                    for (data, delay) in parts {
+                        // Chunked frame: `<hexlen>\r\n<data>\r\n`.
+                        let frame = format!("{:X}\r\n", data.len());
+                        let _ = sock.write_all(frame.as_bytes()).await;
+                        let _ = sock.write_all(&data).await;
+                        let _ = sock.write_all(b"\r\n").await;
+                        tokio::time::sleep(delay).await;
+                    }
+                    // Terminating chunk.
+                    let _ = sock.write_all(b"0\r\n\r\n").await;
+                });
+            }
+        });
+        port
+    }
+
+    /// Normal small download returns the exact bytes.
+    #[tokio::test]
+    async fn test_download_normal() {
+        let mock_server = MockServer::start().await;
+        let body = b"<html><body>hola</body></html>";
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.to_vec()))
+            .mount(&mock_server)
+            .await;
+
+        let config = DownloadConfig {
+            global_timeout_seconds: 5,
+            chunk_timeout_seconds: 5,
+            max_size_bytes: 1024 * 1024,
+            ..DownloadConfig::default()
+        };
+        let downloader = downloader(config);
+        let url = format!("{}/", mock_server.uri());
+
+        let bytes = downloader
+            .download(&url)
+            .await
+            .expect("descarga normal falló");
+        assert_eq!(bytes, body);
+    }
+
+    /// Per-chunk stall beyond `chunk_timeout_seconds` → `SlowlorisTimeout`.
+    #[tokio::test]
+    async fn test_download_slowloris_chunk_timeout() {
+        let config = DownloadConfig {
+            // Generous global budget so the GLOBAL timeout cannot fire first.
+            global_timeout_seconds: 30,
+            chunk_timeout_seconds: 1, // short per-chunk timeout
+            max_size_bytes: 1024 * 1024,
+            ..DownloadConfig::default()
+        };
+        // Server stalls 3s between chunks (> 1s chunk timeout).
+        let port = spawn_slow_chunked_server(Duration::from_secs(3)).await;
+        let url = format!("http://127.0.0.1:{port}/");
+        let downloader = downloader(config);
+
+        let result = downloader.download(&url).await;
+        assert!(
+            matches!(result, Err(ScraperError::SlowlorisTimeout)),
+            "esperaba SlowlorisTimeout, obtuve: {result:?}"
+        );
+    }
+
+    /// Accumulated bytes beyond `max_size_bytes` → `PayloadTooLarge`.
+    ///
+    /// Uses a tiny configured limit (1 KiB) instead of allocating 26 MB, which
+    /// keeps the test fast and memory-light. This exercises the same abort
+    /// path as the 25 MB production default.
+    #[tokio::test]
+    async fn test_download_payload_too_large() {
+        let mock_server = MockServer::start().await;
+        // 2 KiB body > 1 KiB configured limit.
+        let body = vec![0u8; 2 * 1024];
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&mock_server)
+            .await;
+
+        let config = DownloadConfig {
+            global_timeout_seconds: 5,
+            chunk_timeout_seconds: 5,
+            max_size_bytes: 1024, // small limit
+            ..DownloadConfig::default()
+        };
+        let downloader = downloader(config);
+        let url = format!("{}/", mock_server.uri());
+
+        let result = downloader.download(&url).await;
+        assert!(
+            matches!(result, Err(ScraperError::PayloadTooLarge)),
+            "esperaba PayloadTooLarge, obtuve: {result:?}"
+        );
+    }
+
+    /// Initial response delayed beyond `global_timeout_seconds` → `GlobalTimeout`.
+    #[tokio::test]
+    async fn test_download_global_timeout() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("lento")
+                    .set_delay(Duration::from_secs(2)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let config = DownloadConfig {
+            global_timeout_seconds: 1, // fires before the 2s server delay
+            chunk_timeout_seconds: 5,
+            max_size_bytes: 1024 * 1024,
+            ..DownloadConfig::default()
+        };
+        let downloader = downloader(config);
+        let url = format!("{}/", mock_server.uri());
+
+        let result = downloader.download(&url).await;
+        assert!(
+            matches!(result, Err(ScraperError::GlobalTimeout)),
+            "esperaba GlobalTimeout, obtuve: {result:?}"
+        );
+    }
+
+    /// RED (TDD): proves the double-release / missing per-chunk acquire bug.
+    ///
+    /// After a download completes, the semaphore MUST conserve permits exactly
+    /// (`available == budget`). The buggy implementation acquires only an initial
+    /// 4 KB permit and releases `initial + Σchunks` on Drop — releasing permits
+    /// that were never acquired and inflating the available count ABOVE the
+    /// budget. This assertion fails on the buggy code (RED) and passes once
+    /// per-chunk byte-weighted acquire is implemented (GREEN).
+    #[tokio::test]
+    async fn test_no_permit_inflation_after_download() {
+        let mock_server = MockServer::start().await;
+        // 8 KiB body: large enough to span multiple wreq frames so per-chunk
+        // acquire is exercised (a single chunk would still expose the bug).
+        let body = vec![0x42u8; 8 * 1024];
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&mock_server)
+            .await;
+
+        let config = DownloadConfig {
+            global_timeout_seconds: 5,
+            chunk_timeout_seconds: 5,
+            max_size_bytes: 1024 * 1024,
+            ..DownloadConfig::default()
+        };
+        // Budget exactly equal to the body size: the download must acquire (and
+        // later release) precisely `body.len()` byte-weighted permits.
+        let budget = body.len();
+        let semaphore = Arc::new(Semaphore::new(budget));
+        let client = wreq::Client::builder()
+            .build()
+            .expect("fallo construyendo cliente wreq de prueba");
+        let downloader = ResourceDownloader::with_config(semaphore.clone(), client, config);
+        let url = format!("{}/", mock_server.uri());
+
+        let bytes = downloader
+            .download(&url)
+            .await
+            .expect("la descarga debió completarse");
+        assert_eq!(bytes, body);
+
+        // Invariant: permits released on Drop == permits acquired mid-download.
+        assert_eq!(
+            semaphore.available_permits(),
+            budget,
+            "inflación de permisos: available {} != budget {} \
+             (bug: double-release del permiso inicial + adquisición por chunk ausente)",
+            semaphore.available_permits(),
+            budget
+        );
+    }
+
+    /// Per-chunk byte-weighted backpressure: while a multi-chunk download is in
+    /// flight, it holds permits proportional to the bytes received so far, and a
+    /// concurrent acquire that would exceed the budget blocks.
+    ///
+    /// This replaces the former `test_semaphore_backpressure`, which only proved
+    /// the *initial* 4 KB acquire blocked. After the per-chunk fix that test
+    /// would pass for the wrong reason (response-delay timeout, not backpressure),
+    /// so it is superseded by this streaming-based assertion.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_per_chunk_backpressure_holds_permits_mid_stream() {
+        // Two 4 KB chunks with a 500 ms gap between them: after the first chunk
+        // the downloader holds 4 KB of permits while waiting for the second.
+        let chunk = vec![0x21u8; 4 * 1024];
+        let port = spawn_multi_chunk_server(vec![
+            (chunk.clone(), Duration::from_millis(500)),
+            (chunk.clone(), Duration::from_millis(50)),
+        ])
+        .await;
+        let url = format!("http://127.0.0.1:{port}/");
+
+        let config = DownloadConfig {
+            global_timeout_seconds: 5,
+            chunk_timeout_seconds: 5,
+            max_size_bytes: 1024 * 1024,
+            ..DownloadConfig::default()
+        };
+        // Budget exactly fits the two chunks (8 KB); the in-flight download must
+        // hold permits drawn from this shared budget.
+        let budget = 8 * 1024usize;
+        let semaphore = Arc::new(Semaphore::new(budget));
+        let client = wreq::Client::builder()
+            .build()
+            .expect("fallo construyendo cliente wreq de prueba");
+        let downloader = Arc::new(ResourceDownloader::with_config(
+            Arc::clone(&semaphore),
+            client,
+            config,
+        ));
+
+        let first = Arc::clone(&downloader);
+        let first_url = url.clone();
+        let handle = tokio::spawn(async move { first.download(&first_url).await });
+
+        // After chunk 1 arrives the downloader holds 4 KB while it waits 500 ms
+        // for chunk 2 — available must drop below the budget. This proves
+        // per-chunk acquire actually happens (not just bookkeeping).
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let mid = semaphore.available_permits();
+        assert!(
+            mid < budget,
+            "no hay permisos retenidos mid-stream: available {mid} >= budget {budget}"
+        );
+
+        // Backpressure: a concurrent full-budget acquire cannot complete while
+        // the in-flight download holds permits (only `budget - mid` available).
+        // `acquire_many` is cancellation-safe, so dropping the timed-out future
+        // releases no permits and never starves the semaphore.
+        let blocked = tokio::time::timeout(
+            Duration::from_millis(200),
+            semaphore.acquire_many(budget as u32),
+        )
+        .await;
+        assert!(
+            blocked.is_err(),
+            "el semáforo debió aplicar backpressure a una adquisición concurrente"
+        );
+
+        let result = handle.await.expect("join primera descarga");
+        assert!(
+            result.is_ok(),
+            "la primera descarga debió completarse: {result:?}"
+        );
+
+        // Conservation: all permits returned after completion (no leak, no inflation).
+        assert_eq!(
+            semaphore.available_permits(),
+            budget,
+            "pérdida o inflación de permisos tras completar"
+        );
+    }
+
+    /// Content-Length pre-check (spec: "Hard Resource Size Limit"): a response
+    /// whose `Content-Length` exceeds the limit is rejected with
+    /// `PayloadTooLarge` BEFORE any permits are acquired.
+    #[tokio::test]
+    async fn test_download_rejects_oversized_content_length() {
+        let mock_server = MockServer::start().await;
+        // 2 KiB body with a 1 KiB limit → Content-Length (2048) > limit (1024).
+        let body = vec![0u8; 2 * 1024];
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&mock_server)
+            .await;
+
+        let config = DownloadConfig {
+            global_timeout_seconds: 5,
+            chunk_timeout_seconds: 5,
+            max_size_bytes: 1024,
+            ..DownloadConfig::default()
+        };
+        // 1 MiB budget — far more than the body, so any acquire would be visible.
+        let budget = 1 << 20usize;
+        let semaphore = Arc::new(Semaphore::new(budget));
+        let client = wreq::Client::builder()
+            .build()
+            .expect("fallo construyendo cliente wreq de prueba");
+        let downloader = ResourceDownloader::with_config(semaphore.clone(), client, config);
+        let url = format!("{}/", mock_server.uri());
+
+        let result = downloader.download(&url).await;
+        assert!(
+            matches!(result, Err(ScraperError::PayloadTooLarge)),
+            "esperaba PayloadTooLarge, obtuve: {result:?}"
+        );
+
+        // Spec: "no permits MUST be acquired" on Content-Length rejection.
+        assert_eq!(
+            semaphore.available_permits(),
+            budget,
+            "se adquirieron permisos pese al rechazo por Content-Length"
+        );
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -23,5 +23,9 @@ pub mod output;
 pub mod scraper;
 pub mod user_agent;
 
+// Elastic ingestion (Issue #51) — hardware autotuning + SQLite persistence.
+pub mod autotuning;
+pub mod persistence;
+
 #[cfg(feature = "ai")]
 pub mod ai;

--- a/src/infrastructure/persistence/mod.rs
+++ b/src/infrastructure/persistence/mod.rs
@@ -1,0 +1,11 @@
+//! SQLite persistence layer for the elastic ingestion pipeline (Issue #51).
+//!
+//! Provides a WAL-mode [`deadpool_sqlite`] connection pool and explicit schema
+//! initialization for the `resources` and `chunks` tables. Per-connection
+//! pragmas (`journal_mode=WAL`, `synchronous=NORMAL`, `cache_size=-4000`) are
+//! applied via a `post_create` pool hook so **every** pooled connection honours
+//! the spec's "each connection MUST use WAL-mode pragmas" requirement.
+
+pub mod sqlite;
+
+pub use sqlite::{create_pool, setup_schema, SqliteVectorRepository};

--- a/src/infrastructure/persistence/sqlite.rs
+++ b/src/infrastructure/persistence/sqlite.rs
@@ -1,0 +1,291 @@
+//! SQLite schema, WAL pragmas, and connection pool for elastic ingestion.
+//!
+//! Schema is frozen per `design.md` (the authoritative frozen artifact). The
+//! task-list DDL transcription differed in three places; this implementation
+//! follows the frozen design:
+//! - `chunks.id` is `TEXT` (required by `VectorRepository::save_vector(id: &str)`
+//!   in PR4 — the task's `INTEGER` would force a destructive migration).
+//! - `created_at` is `TEXT` (SQLite stores timestamps as TEXT regardless; the
+//!   task's `TIMESTAMP` is cosmetic but diverges from design).
+//! - the `content_hash` index lives on `resources` (which has the column); the
+//!   task's `idx_chunks_hash ON chunks(content_hash)` referenced a non-existent
+//!   column and would fail `setup_schema`.
+
+use std::path::Path;
+
+use deadpool_sqlite::{Config, Hook, HookError, Manager, Pool, Runtime};
+
+use crate::error::ScraperError;
+
+// ============================================================================
+// Schema (frozen design.md §schema)
+// ============================================================================
+
+/// WAL + per-connection pragmas, applied on every new pooled connection via the
+/// `post_create` hook. `journal_mode=WAL` is persistent (DB header); the other
+/// two are per-connection and therefore MUST be set on each connection.
+const INIT_PRAGMAS: &str = "\
+PRAGMA journal_mode = WAL;\
+PRAGMA synchronous = NORMAL;\
+PRAGMA cache_size = -4000;";
+
+/// Forward-only schema (`CREATE ... IF NOT EXISTS`). Run once by
+/// [`SqliteVectorRepository::setup_schema`]. No destructive migration in v1.
+const SCHEMA_DDL: &str = "\
+CREATE TABLE IF NOT EXISTS resources (\
+    url TEXT PRIMARY KEY,\
+    title TEXT,\
+    content_hash TEXT,\
+    size_bytes INTEGER,\
+    status TEXT,\
+    created_at TEXT,\
+    updated_at TEXT,\
+    metadata_json TEXT\
+);\
+CREATE TABLE IF NOT EXISTS chunks (\
+    id TEXT PRIMARY KEY,\
+    resource_url TEXT NOT NULL REFERENCES resources(url),\
+    chunk_index INTEGER,\
+    content TEXT,\
+    embedding_vector BLOB,\
+    created_at TEXT\
+);\
+CREATE INDEX IF NOT EXISTS idx_chunks_resource ON chunks(resource_url);\
+CREATE INDEX IF NOT EXISTS idx_resources_content_hash ON resources(content_hash);";
+
+// ============================================================================
+// Pool construction
+// ============================================================================
+
+/// Build a WAL-mode SQLite connection pool backed by [`deadpool_sqlite`].
+///
+/// `pool_size` is clamped to at least 1 (the caller — `ElasticConfig` — already
+/// applies the frozen `cpu_cores`/floor-4 sizing). The parent directory of
+/// `db_path` is created if missing. Per-connection pragmas are applied via a
+/// `post_create` hook so every connection honours the WAL-mode contract.
+///
+/// The pool is created lazily — the database file is only materialized on the
+/// first [`Pool::get`] (i.e. inside [`SqliteVectorRepository::setup_schema`]),
+/// which is the explicit fail-fast point if the path is not writable.
+pub fn create_pool(db_path: &Path, pool_size: usize) -> Result<Pool, ScraperError> {
+    // Fail-fast: ensure the parent directory exists before opening the DB.
+    if let Some(parent) = db_path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                ScraperError::persistence(format!("crear directorio {parent:?}: {e}"))
+            })?;
+        }
+    }
+
+    let cfg = Config::new(db_path.to_path_buf());
+    let manager = Manager::from_config(&cfg, Runtime::Tokio1);
+    let pool = Pool::builder(manager)
+        .max_size(pool_size.max(1))
+        .runtime(Runtime::Tokio1)
+        .post_create(pragma_hook())
+        .build()
+        .map_err(|e| ScraperError::persistence(format!("construir pool SQLite: {e}")))?;
+    Ok(pool)
+}
+
+/// `post_create` hook applying the WAL-mode pragmas to each new connection.
+fn pragma_hook() -> Hook {
+    Hook::async_fn(|obj, _metrics| {
+        Box::pin(async move {
+            obj.interact(|conn| conn.execute_batch(INIT_PRAGMAS))
+                .await
+                .map_err(|e| HookError::message(format!("init pragmas (interact): {e}")))?
+                .map_err(|e| HookError::message(format!("init pragmas: {e}")))?;
+            Ok(())
+        })
+    })
+}
+
+// ============================================================================
+// SqliteVectorRepository (PR1: schema init; PR4 adds CRUD + dedup)
+// ============================================================================
+
+/// SQLite-backed vector repository for the elastic ingestion pipeline.
+///
+/// PR1 provides explicit schema initialization only; the `VectorRepository`
+/// trait CRUD (`save_vector`, `get_vector`) and content-hash deduplication land
+/// in PR4. Per frozen design decision #1, schema creation is **explicit** —
+/// [`SqliteVectorRepository::setup_schema`] MUST be called at startup. There is
+/// no implicit schema creation on first connection.
+#[derive(Debug, Clone)]
+pub struct SqliteVectorRepository {
+    pool: Pool,
+}
+
+impl SqliteVectorRepository {
+    /// Wrap an existing pool. The pool should already have had
+    /// [`setup_schema`] run against it.
+    #[must_use]
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    /// Borrow the underlying pool (used by PR2+ wiring and tests).
+    #[must_use]
+    pub fn pool(&self) -> &Pool {
+        &self.pool
+    }
+
+    /// Explicitly initialize the database schema (tables + indexes).
+    ///
+    /// **MUST** be called once at startup (frozen design decision #1). Acquires
+    /// a pooled connection — which also materializes the database file and runs
+    /// the per-connection pragmas via the `post_create` hook — making this the
+    /// fail-fast point if the configured `db_path` is not writable.
+    ///
+    /// The DDL is idempotent (`CREATE ... IF NOT EXISTS`), so calling it on an
+    /// already-initialized database is a safe no-op.
+    pub async fn setup_schema(pool: &Pool) -> Result<(), ScraperError> {
+        let conn = pool
+            .get()
+            .await
+            .map_err(|e| ScraperError::persistence(format!("obtener conexión del pool: {e}")))?;
+        conn.interact(|c| c.execute_batch(SCHEMA_DDL))
+            .await
+            .map_err(|e| ScraperError::persistence(format!("ddl (interact): {e}")))?
+            .map_err(|e| ScraperError::persistence(format!("ddl schema: {e}")))?;
+        Ok(())
+    }
+}
+
+/// Free-function alias for [`SqliteVectorRepository::setup_schema`] so callers
+/// that only hold a `&Pool` (without constructing the repository) can init the
+/// schema at startup.
+pub async fn setup_schema(pool: &Pool) -> Result<(), ScraperError> {
+    SqliteVectorRepository::setup_schema(pool).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a fresh pool over a temp-file DB and run the schema.
+    async fn fresh_pool(size: usize) -> (TempDir, Pool) {
+        let dir = TempDir::new().expect("tempdir");
+        let db_path = dir.path().join("crawl.db");
+        let pool = create_pool(&db_path, size).expect("create_pool");
+        SqliteVectorRepository::setup_schema(&pool)
+            .await
+            .expect("setup_schema");
+        (dir, pool)
+    }
+
+    /// Count rows in `sqlite_master` matching `type` and `name`.
+    async fn master_count(pool: &Pool, kind: &str, name: &str) -> i64 {
+        // Own the strings: the `interact` closure must be `Send + 'static`, so it
+        // cannot capture borrowed `&str` from this function's frame.
+        let kind = kind.to_string();
+        let name = name.to_string();
+        let conn = pool.get().await.expect("get");
+        conn.interact(move |c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
+                rusqlite::params![kind, name],
+                |row| row.get::<_, i64>(0),
+            )
+        })
+        .await
+        .expect("interact")
+        .expect("count")
+    }
+
+    async fn pragma_string(pool: &Pool, pragma: &str) -> String {
+        let sql = format!("PRAGMA {pragma}");
+        let conn = pool.get().await.expect("get");
+        conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, String>(0)))
+            .await
+            .expect("interact")
+            .expect("pragma row")
+    }
+
+    async fn pragma_int(pool: &Pool, pragma: &str) -> i64 {
+        let sql = format!("PRAGMA {pragma}");
+        let conn = pool.get().await.expect("get");
+        conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, i64>(0)))
+            .await
+            .expect("interact")
+            .expect("pragma row")
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_creates_resources_table() {
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(master_count(&pool, "table", "resources").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_creates_chunks_table() {
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(master_count(&pool, "table", "chunks").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_creates_indexes() {
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(
+            master_count(&pool, "index", "idx_chunks_resource").await,
+            1,
+            "idx_chunks_resource missing"
+        );
+        assert_eq!(
+            master_count(&pool, "index", "idx_resources_content_hash").await,
+            1,
+            "idx_resources_content_hash missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wal_pragmas_applied_to_connection() {
+        // A freshly-created pooled connection must carry all three pragmas
+        // (proves the post_create hook runs on each connection).
+        let (_dir, pool) = fresh_pool(4).await;
+        assert_eq!(pragma_string(&pool, "journal_mode").await, "wal");
+        // synchronous: 0=OFF,1=NORMAL,2=FULL,3=EXTRA — NORMAL must be 1.
+        assert_eq!(pragma_int(&pool, "synchronous").await, 1);
+        assert_eq!(pragma_int(&pool, "cache_size").await, -4000);
+    }
+
+    #[tokio::test]
+    async fn test_db_file_created_when_absent() {
+        let dir = TempDir::new().expect("tempdir");
+        let db_path = dir.path().join("nested").join("crawl.db");
+        assert!(!db_path.exists());
+        let pool = create_pool(&db_path, 4).expect("create_pool");
+        SqliteVectorRepository::setup_schema(&pool)
+            .await
+            .expect("setup_schema");
+        // setup_schema materializes the DB file (parent dir created by create_pool).
+        assert!(db_path.exists(), "DB file should exist after setup_schema");
+    }
+
+    #[tokio::test]
+    async fn test_pool_size_is_configurable() {
+        let (_dir, pool) = fresh_pool(8).await;
+        let status = pool.status();
+        assert_eq!(status.max_size, 8, "pool max_size must honor configuration");
+    }
+
+    #[tokio::test]
+    async fn test_setup_schema_is_idempotent() {
+        let (_dir, pool) = fresh_pool(4).await;
+        // Running setup_schema twice must not error (CREATE ... IF NOT EXISTS).
+        SqliteVectorRepository::setup_schema(&pool)
+            .await
+            .expect("second setup_schema should be a no-op");
+        assert_eq!(master_count(&pool, "table", "resources").await, 1);
+        assert_eq!(master_count(&pool, "table", "chunks").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_repository_wraps_pool() {
+        let (_dir, pool) = fresh_pool(4).await;
+        let repo = SqliteVectorRepository::new(pool.clone());
+        assert_eq!(repo.pool().status().max_size, 4);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,9 @@ pub use cli::{
 pub use infrastructure::observability::LogGuard;
 
 // Config types
-pub use infrastructure::config::{ConcurrencyConfig, OutputFormat, ScraperConfig};
+pub use infrastructure::config::{
+    AutotuningConfig, ConcurrencyConfig, OutputFormat, ScraperConfig,
+};
 
 // Error and result types
 pub use clap::{Parser, ValueEnum};

--- a/tests/resource_downloader_integration.rs
+++ b/tests/resource_downloader_integration.rs
@@ -1,0 +1,117 @@
+//! Integration tests for `ResourceDownloader` (elastic-ingestion-51, PR2).
+//!
+//! Exercises the public download surface end-to-end against a wiremock
+//! `MockServer`, including a shared-semaphore concurrency scenario.
+
+use rust_scraper::infrastructure::crawler::{DownloadConfig, ResourceDownloader};
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A realistic HTML page used as the download payload.
+const HTML_PAGE: &[u8] = b"<html><head><title>Rust Scraper</title></head>\
+<body><h1>Foo</h1><p>bar baz qux</p></body></html>";
+
+/// End-to-end download against a wiremock server returns the exact bytes.
+#[tokio::test]
+async fn test_end_to_end_download() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(HTML_PAGE.to_vec()))
+        .mount(&mock_server)
+        .await;
+
+    let config = DownloadConfig {
+        global_timeout_seconds: 5,
+        chunk_timeout_seconds: 5,
+        max_size_bytes: 1024 * 1024,
+        ..DownloadConfig::default()
+    };
+    let semaphore = Arc::new(Semaphore::new(1 << 20));
+    let client = wreq::Client::builder()
+        .build()
+        .expect("fallo construyendo cliente wreq de prueba");
+    let downloader = ResourceDownloader::with_config(semaphore, client, config);
+
+    let url = format!("{}/", mock_server.uri());
+    let bytes = downloader
+        .download(&url)
+        .await
+        .expect("la descarga end-to-end debió exitosa");
+
+    assert_eq!(
+        bytes, HTML_PAGE,
+        "los bytes descargados no coinciden con el cuerpo"
+    );
+}
+
+/// Several concurrent downloads sharing a semaphore all complete with correct
+/// bytes, and permits are conserved exactly (`available == budget` afterwards).
+///
+/// With per-chunk byte-weighted acquire, each 64 KiB download holds up to 64 KiB
+/// of permits while in flight. The budget is sized for two concurrent downloads
+/// (2 × 64 KiB = 128 KiB), so the remaining three serialize behind backpressure
+/// until in-flight ones release. Because each download acquires at most its body
+/// size and the budget is `2 × body`, the semaphore is deadlock-free (the budget
+/// can only be fully held once two downloads are *done*, about to release).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_downloads_under_semaphore() {
+    let mock_server = MockServer::start().await;
+    // 64 KiB body per download.
+    let body = vec![0xA5u8; 64 * 1024];
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+        .mount(&mock_server)
+        .await;
+
+    let config = DownloadConfig::default();
+    // Budget for 2 concurrent 64 KiB downloads (2 × body size). This is the
+    // tightest deadlock-free budget: each download acquires ≤ body size, so the
+    // budget can only be exhausted by two *completed* downloads (about to drop).
+    let budget = 2 * body.len();
+    let semaphore = Arc::new(Semaphore::new(budget));
+    let client = wreq::Client::builder()
+        .build()
+        .expect("fallo construyendo cliente wreq de prueba");
+    let downloader = Arc::new(ResourceDownloader::with_config(
+        Arc::clone(&semaphore),
+        client,
+        config,
+    ));
+
+    let url = format!("{}/", mock_server.uri());
+
+    let mut handles = Vec::new();
+    for _ in 0..5 {
+        let dl = Arc::clone(&downloader);
+        let url = url.clone();
+        handles.push(tokio::spawn(async move { dl.download(&url).await }));
+    }
+
+    let mut successes = 0usize;
+    for handle in handles {
+        let bytes = handle
+            .await
+            .expect("join tarea de descarga")
+            .expect("descarga concurrente debió exitosa");
+        assert_eq!(bytes, body, "los bytes descargados no coinciden");
+        successes += 1;
+    }
+
+    assert_eq!(
+        successes, 5,
+        "las 5 descargas concurrentes debieron completarse"
+    );
+
+    // Exact conservation: no permit leak (available < budget) and no inflation
+    // (available > budget). This is the integration guard against the PR2
+    // double-release / missing per-chunk acquire bug.
+    let available = semaphore.available_permits();
+    assert_eq!(
+        available, budget,
+        "permisos no conservados: available {available} != budget {budget}"
+    );
+}


### PR DESCRIPTION
## Elastic Ingestion Autotuning (Issue #51) — PR 2/5: Async I/O Layer & Backpressure

### What
Elastic resource downloader with byte-weighted semaphore backpressure, Anti-Slowloris timeouts, and 25MB chunked abort.

### Changes
- **PermitGuard**: RAII guard with `Arc<Semaphore>` + `u64 units_acquired`, unwind-safe `Drop` that releases exactly what was acquired (no double-release)
- **ResourceDownloader::download()**: per-chunk byte-weighted `acquire_many` — backpressure scales with actual bytes, not just connection count
- **Concentric timeouts**: 30s global deadline + 5s per-chunk inactivity (Anti-Slowloris via `tokio::time::timeout` wrapping stream)
- **25MB hard limit**: Content-Length pre-check rejects oversized resources before any permits acquired; streaming abort on cumulative bytes
- **tracing::error!**: structured logging on all abort paths (timeout, payload, semaphore)
- **wiremock tests**: normal download, slowloris chunk timeout, payload too large, global timeout, per-chunk backpressure, no-permit-inflation, Content-Length rejection
- **Integration tests**: end-to-end download + concurrent downloads under shared semaphore

### Bug Fixed During Development
Initial implementation had a CRITICAL double-release bug: `PermitGuard::drop()` returned more permits than acquired because `update_reservation()` was pure bookkeeping that never called `acquire_many()`. Fixed with per-chunk `acquire_many().forget()` tracked by the guard.

### Test Results
- 11 unit tests (PermitGuard + DownloadConfig + wiremock scenarios)
- 2 integration tests (end-to-end + concurrent)
- Full lib regression: 588 passed / 0 failed / 5 skipped
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅

### SDD Chain
Stacked-to-main | PR 2 of 5 | Depends on: PR1 (#60) | Blocks: PR3 (CPU pool)

<!-- SDD: elastic-ingestion-51/pr2 -->