### PR TITLE
feat(infra): Rayon CPU pool + Tokio-to-Rayon bridge with panic isolation (PR 3/5)

### DIFF
--- a/src/infrastructure/bridge.rs
+++ b/src/infrastructure/bridge.rs
@@ -1,0 +1,447 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use tokio::sync::oneshot;
+use tracing::warn;
+
+use crate::error::ScraperError;
+use crate::infrastructure::cpu_pool::RayonCpuPool;
+use crate::infrastructure::crawler::resource_downloader::DownloadedResource;
+
+/// One chunk of cleaned content produced by the bridge.
+///
+/// `embedding` is `None` until PR5 wires the ONNX inference engine
+/// (frozen: PR3 ships the CPU-bound isolation mechanism, not the model).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedChunk {
+    /// Cleaned, visible text for this chunk.
+    pub content: String,
+    /// 384-dim embedding once PR5 ONNX inference is wired; `None` for the stub.
+    pub embedding: Option<Vec<f32>>,
+}
+
+/// Result of dispatching a [`DownloadedResource`] through the CPU bridge.
+#[derive(Debug, Clone)]
+pub struct ProcessedResource {
+    /// Source URL of the downloaded resource.
+    pub resource_url: String,
+    /// Cleaned content chunks (stub produces one; PR5 chunks via `HtmlChunker`).
+    pub chunks: Vec<ProcessedChunk>,
+    /// Processing metadata (size, chunk count, cleaner provenance).
+    pub metadata: serde_json::Value,
+}
+
+/// Tokio→Rayon crossing for CPU-bound ingestion work (frozen design decision #3).
+///
+/// Holds a dedicated [`RayonCpuPool`] (cloned cheaply — it wraps an `Arc`) and
+/// exposes a generic [`dispatch`](CpuBridge::dispatch) that moves any CPU-bound
+/// closure off the event loop, plus a typed
+/// [`dispatch_resource`](CpuBridge::dispatch_resource) stub that demonstrates
+/// the `DownloadedResource` → `ProcessedResource` wiring (PR5 replaces the stub
+/// cleaner with real `lol_html` + ONNX).
+///
+/// `CpuBridge` is `Send + Sync` (spec: "dispatch gateway MUST be Send + Sync"),
+/// so it can be shared across Tokio tasks via `Arc<CpuBridge>`.
+#[derive(Clone)]
+pub struct CpuBridge {
+    pool: RayonCpuPool,
+}
+
+impl CpuBridge {
+    /// Wrap a dedicated [`RayonCpuPool`] in a bridge.
+    #[must_use]
+    pub fn new(pool: RayonCpuPool) -> Self {
+        Self { pool }
+    }
+
+    /// Borrow the underlying CPU pool.
+    #[must_use]
+    pub fn pool(&self) -> &RayonCpuPool {
+        &self.pool
+    }
+
+    /// Dispatch an arbitrary CPU-bound closure onto the Rayon pool and return
+    /// a [`oneshot::Receiver`] holding `Result<R, ScraperError>`.
+    ///
+    /// The work runs under `tokio::task::spawn_blocking` + `pool.install`, so
+    /// the Tokio event loop stays unblocked and any nested `par_iter` routes to
+    /// the sized dedicated pool. CPU panics are caught via
+    /// `catch_unwind(AssertUnwindSafe(…))` (frozen user decision #1) and
+    /// mapped to [`ScraperError::Ingestion`] so Rayon threads stay alive.
+    ///
+    /// If the caller drops the receiver before the work finishes (Tokio task
+    /// abort), `tx.send()` fails and the bridge logs a `tracing::warn!` but
+    /// does NOT panic (Trap 2).
+    pub fn dispatch<F, R>(&self, work: F) -> oneshot::Receiver<Result<R, ScraperError>>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let caught = catch_unwind(AssertUnwindSafe(move || pool.install(work)));
+            let mapped: Result<R, ScraperError> = caught.map_err(|panic| {
+                let msg = panic_message(&*panic);
+                ScraperError::ingestion(format!("CPU pool panic: {msg}"))
+            });
+            if tx.send(mapped).is_err() {
+                warn!(
+                    reason = "receptor oneshot descartado",
+                    "canal CPU bridge descartado: tarea Tokio abortada antes de recibir el resultado"
+                );
+            }
+        });
+        rx
+    }
+
+    /// Typed dispatch: clean a [`DownloadedResource`] into a
+    /// [`ProcessedResource`] on the Rayon pool.
+    ///
+    /// PR3 ships a **stub** cleaner (naive tag strip) that cannot fail, so the
+    /// work returns `ProcessedResource` directly and reuses [`dispatch`]'s
+    /// single `Result` wrap. PR5 replaces the stub with real `lol_html` +
+    /// `SemanticCleanerImpl` ONNX inference (which CAN fail) and will switch
+    /// the closure to return `Result` — that is PR5's scope, not PR3's.
+    pub fn dispatch_resource(
+        &self,
+        payload: DownloadedResource,
+    ) -> oneshot::Receiver<Result<ProcessedResource, ScraperError>> {
+        let url = payload.url.clone();
+        let size = payload.size_bytes;
+        self.dispatch(move || {
+            let text = clean_html_stub(&payload.bytes);
+            let chunk = ProcessedChunk {
+                content: text,
+                embedding: None,
+            };
+            let metadata = serde_json::json!({
+                "size_bytes": size,
+                "chunk_count": 1u64,
+                "cleaner": "stub",
+            });
+            ProcessedResource {
+                resource_url: url,
+                chunks: vec![chunk],
+                metadata,
+            }
+        })
+    }
+}
+
+/// Extract a human-readable message from a captured panic payload.
+///
+/// Panics raised with `&str` / `String` (the common case, including
+/// `panic!` macros and `assert!`) yield their message; other payload types
+/// fall back to a Spanish placeholder.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "tipo de pánico desconocido (no es String ni &str)".to_string()
+    }
+}
+
+/// Stub HTML cleaner: strips `<script>`/`<style>` blocks and all tags, then
+/// collapses whitespace.
+///
+/// TODO(PR5): replace with `lol_html` boilerplate strip + `SemanticCleanerImpl`
+/// for production-grade cleaning. This naive stripper is UTF-8 safe (operates on
+/// `char` boundaries) but does not handle entities, comments, or CDATA.
+fn clean_html_stub(bytes: &[u8]) -> String {
+    // `from_utf8_lossy` never panics on invalid UTF-8 (replaces with U+FFFD),
+    // so malformed payloads do not crash the Rayon pool.
+    let html = String::from_utf8_lossy(bytes);
+    strip_html_tags(&html)
+}
+
+/// Naive, UTF-8-safe tag stripper used by the stub cleaner.
+fn strip_html_tags(html: &str) -> String {
+    let lower = html.to_ascii_lowercase();
+    let lbytes = lower.as_bytes();
+    let n = html.len();
+    let mut out = String::with_capacity(n);
+    let mut i = 0;
+    while i < n {
+        if lbytes[i] == b'<' {
+            let rest = &lower[i..];
+            if rest.starts_with("<script") {
+                if let Some(rel) = rest.find("</script>") {
+                    i += rel + "</script>".len();
+                    continue;
+                } else {
+                    break; // unterminated script: drop the rest
+                }
+            }
+            if rest.starts_with("<style") {
+                if let Some(rel) = rest.find("</style>") {
+                    i += rel + "</style>".len();
+                    continue;
+                } else {
+                    break;
+                }
+            }
+            // Regular tag: skip to '>'.
+            i += 1;
+            while i < n && lbytes[i] != b'>' {
+                i += 1;
+            }
+            if i < n {
+                i += 1; // consume '>'
+            }
+            if !out.is_empty() && !out.ends_with(' ') {
+                out.push(' ');
+            }
+        } else {
+            // Push one char on its proper UTF-8 boundary.
+            let next = html[i..]
+                .char_indices()
+                .nth(1)
+                .map(|(j, _)| i + j)
+                .unwrap_or(n);
+            out.push_str(&html[i..next]);
+            i = next;
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CpuBridge, ProcessedChunk, ProcessedResource};
+    use crate::error::ScraperError;
+    use crate::infrastructure::cpu_pool::RayonCpuPool;
+    use crate::infrastructure::crawler::resource_downloader::DownloadedResource;
+
+    fn make_bridge(threads: usize) -> CpuBridge {
+        let pool = RayonCpuPool::new(threads).expect("pool should build");
+        CpuBridge::new(pool)
+    }
+
+    fn html_payload(html: &str) -> DownloadedResource {
+        DownloadedResource {
+            url: "https://example.com/page".to_string(),
+            bytes: html.as_bytes().to_vec(),
+            content_type: Some("text/html".to_string()),
+            size_bytes: html.len() as u64,
+        }
+    }
+
+    // ---- Spec: "result returned via oneshot channel" ----
+
+    #[tokio::test]
+    async fn test_dispatch_returns_result_via_oneshot() {
+        let bridge = make_bridge(2);
+        let rx = bridge.dispatch(|| 42);
+        let result = rx
+            .await
+            .expect("oneshot must not be closed (sender alive)")
+            .expect("work returned Ok, not an error");
+        assert_eq!(result, 42);
+    }
+
+    // ---- Spec: "CPU task returns error" / user decision #1 (panic isolation) ----
+
+    #[tokio::test]
+    async fn test_dispatch_panic_isolated_returns_ingestion_err_and_pool_survives() {
+        let bridge = make_bridge(2);
+        // Inject a panic as lol_html / the tokenizer might on malformed payload.
+        let rx = bridge.dispatch(|| panic!("boom from lol_html"));
+        let outcome = rx
+            .await
+            .expect("oneshot must deliver the captured panic, not close");
+        assert!(
+            outcome.is_err(),
+            "panic must surface as Err, not Ok or abort"
+        );
+        let err = outcome.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("panic"),
+            "error must mention panic, got: {msg}"
+        );
+        assert!(
+            msg.contains("boom from lol_html"),
+            "error must carry the panic payload, got: {msg}"
+        );
+        // The Rayon pool MUST survive the panic — a second dispatch works.
+        let rx2 = bridge.dispatch(|| 7);
+        let result2 = rx2
+            .await
+            .expect("second oneshot must not be closed")
+            .expect("second work returns Ok");
+        assert_eq!(result2, 7);
+    }
+
+    // ---- Spec: "CPU task returns error" (work-Err propagates via oneshot) ----
+
+    #[tokio::test]
+    async fn test_dispatch_propagates_work_error_via_oneshot() {
+        // A work closure returning its own Err (e.g. ONNX inference failure in
+        // PR5) must surface that Err through the oneshot, distinct from a panic.
+        let bridge = make_bridge(2);
+        let rx = bridge.dispatch(|| Err::<(), _>(ScraperError::ingestion("inferencia ONNX falló")));
+        // dispatch wraps the work's R in Result<R, ScraperError>; here R is
+        // itself Result<(), ScraperError>, so awaiting yields Result<Result<(), E>, E>.
+        let outer = rx
+            .await
+            .expect("oneshot must deliver the work result, not close");
+        let work_result = outer.expect("panic level must be Ok (work did not panic)");
+        assert!(work_result.is_err(), "work Err must propagate as inner Err");
+        assert!(
+            work_result.unwrap_err().to_string().contains("ONNX"),
+            "work error context must survive the crossing"
+        );
+    }
+
+    // ---- Trap 2: oneshot receiver dropped (Tokio task abort) ----
+
+    #[tokio::test]
+    async fn test_dispatch_channel_drop_pool_survives_and_no_panic() {
+        let bridge = make_bridge(2);
+        // Slow work so the receiver is dropped WHILE Rayon is still processing.
+        let rx = bridge.dispatch(|| {
+            std::thread::sleep(std::time::Duration::from_millis(60));
+            42
+        });
+        drop(rx); // simulate Tokio aborting the outer task
+                  // Let the Rayon work finish; tx.send() will fail (receiver gone) and the
+                  // bridge must log via tracing::warn! and NOT panic.
+        tokio::time::sleep(std::time::Duration::from_millis(140)).await;
+        // Pool MUST survive — a subsequent dispatch succeeds.
+        let rx2 = bridge.dispatch(|| 9);
+        let result2 = rx2
+            .await
+            .expect("second oneshot must not be closed after a dropped receiver")
+            .expect("second work returns Ok");
+        assert_eq!(result2, 9);
+    }
+
+    // ---- Spec: "dispatch gateway is thread-safe" (concurrent dispatch) ----
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_dispatch_concurrent_under_shared_pool() {
+        let bridge = std::sync::Arc::new(make_bridge(4));
+        let mut handles = Vec::new();
+        for i in 0u32..16 {
+            let b = std::sync::Arc::clone(&bridge);
+            handles.push(tokio::spawn(async move {
+                let rx = b.dispatch(move || i * i);
+                rx.await
+                    .expect("oneshot must not be closed")
+                    .expect("work must return Ok")
+            }));
+        }
+        let mut results = Vec::new();
+        for h in handles {
+            results.push(h.await.expect("join task must not panic"));
+        }
+        // Every i*i must be present exactly once — no lost/duplicated results.
+        results.sort_unstable();
+        let expected: Vec<u32> = (0u32..16).map(|i| i * i).collect();
+        assert_eq!(results, expected, "concurrent dispatch must be race-free");
+    }
+
+    // ---- Task 3.3: typed dispatch_resource (lol_html stub) ----
+
+    #[tokio::test]
+    async fn test_dispatch_resource_returns_processed_resource_with_stub_cleaning() {
+        let bridge = make_bridge(2);
+        let html = "<article><h1>Title</h1><p>Hello <b>world</b>.</p></article>";
+        let rx = bridge.dispatch_resource(html_payload(html));
+        let resource: ProcessedResource = rx
+            .await
+            .expect("oneshot must not be closed")
+            .expect("stub cleaning must succeed");
+        assert_eq!(resource.resource_url, "https://example.com/page");
+        assert!(
+            !resource.chunks.is_empty(),
+            "stub must produce at least one chunk"
+        );
+        let metadata = resource
+            .metadata
+            .as_object()
+            .expect("metadata is an object");
+        assert!(
+            metadata.get("size_bytes").is_some(),
+            "metadata must record size_bytes"
+        );
+        assert_eq!(
+            metadata.get("chunk_count").and_then(|v| v.as_u64()),
+            Some(1),
+            "stub produces exactly one chunk"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_resource_stub_strips_html_tags() {
+        // The stub cleaner must extract visible text, not raw markup.
+        let bridge = make_bridge(2);
+        let html = "<p>Hello <script>bad()</script> there</p>";
+        let rx = bridge.dispatch_resource(html_payload(html));
+        let resource = rx
+            .await
+            .expect("oneshot must not be closed")
+            .expect("stub cleaning must succeed");
+        let text = resource
+            .chunks
+            .first()
+            .expect("at least one chunk")
+            .content
+            .as_str();
+        assert!(!text.contains('<'), "no raw tags in cleaned text: {text}");
+        assert!(!text.contains("bad()"), "script body must be gone: {text}");
+        assert!(text.contains("Hello"), "visible text preserved: {text}");
+        assert!(text.contains("there"), "visible text preserved: {text}");
+        // Embedding is None until PR5 ONNX wiring.
+        assert!(
+            resource.chunks[0].embedding.is_none(),
+            "stub must leave embedding None (PR5 wires ONNX)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_resource_tolerates_invalid_utf8_via_lossy() {
+        // Invalid UTF-8 must NOT crash the Rayon pool (from_utf8_lossy replaces).
+        let bridge = make_bridge(2);
+        let mut bytes = "<p>ok</p>".as_bytes().to_vec();
+        bytes.extend_from_slice(&[0xFF, 0xFE]);
+        let payload = DownloadedResource {
+            url: "https://example.com/x".to_string(),
+            bytes,
+            content_type: Some("text/html".to_string()),
+            size_bytes: 12,
+        };
+        let rx = bridge.dispatch_resource(payload);
+        let outcome = rx.await.expect("oneshot must not be closed");
+        assert!(
+            outcome.is_ok(),
+            "stub must tolerate invalid UTF-8 via lossy, got: {:?}",
+            outcome.err()
+        );
+    }
+
+    // ---- Static Send + Sync assertion (spec: "gateway MUST be Send + Sync") ----
+
+    #[test]
+    fn test_cpu_bridge_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CpuBridge>();
+        assert_send_sync::<ProcessedResource>();
+        assert_send_sync::<ProcessedChunk>();
+    }
+
+    #[test]
+    fn test_processed_chunk_debug_clone() {
+        let chunk = ProcessedChunk {
+            content: "hi".to_string(),
+            embedding: None,
+        };
+        let cloned = chunk.clone();
+        assert_eq!(cloned.content, "hi");
+        assert_eq!(cloned.embedding, None);
+        let s = format!("{cloned:?}");
+        assert!(s.contains("ProcessedChunk"));
+    }
+}

--- a/src/infrastructure/cpu_pool.rs
+++ b/src/infrastructure/cpu_pool.rs
@@ -1,0 +1,134 @@
+//! Dedicated Rayon CPU pool for the elastic ingestion pipeline (Issue #51, PR3).
+//!
+//! Isolates CPU-bound work (semantic cleaning, ONNX inference) from the Tokio
+//! async runtime via a dedicated, sized `rayon::ThreadPool` (frozen design
+//! decision #4). Pool sizing honours `ElasticConfig.cpu_cores` with a
+//! cooperative mono-core floor of 1 (frozen user decision #2).
+
+use std::sync::Arc;
+
+use crate::error::ScraperError;
+use crate::infrastructure::autotuning::ElasticConfig;
+
+/// Dedicated, isolated Rayon thread pool for CPU-bound ingestion work.
+///
+/// Wraps a `rayon::ThreadPool` in an `Arc` so it can be cheaply cloned and
+/// shared across Tokio tasks (the bridge spawns a fresh blocking task per
+/// dispatch). Created via [`RayonCpuPool::new`] or
+/// [`RayonCpuPool::from_config`].
+///
+/// # Mono-core behaviour
+///
+/// When `cpu_cores == 1` the pool contains exactly one Rayon thread and the
+/// OS cooperatively time-slices between Tokio and Rayon (frozen user decision
+/// #2). A thread count of `0` is floored to `1` rather than panicking.
+#[derive(Clone)]
+pub struct RayonCpuPool {
+    pool: Arc<rayon::ThreadPool>,
+    threads: usize,
+}
+
+impl RayonCpuPool {
+    /// Build a pool with `threads` worker threads.
+    ///
+    /// The thread count is floored to at least `1` (frozen user decision #2:
+    /// mono-core cooperative scheduling) so `new(0)` yields a single-thread
+    /// pool rather than panicking or erroring.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScraperError::Ingestion`] if Rayon fails to build the pool
+    /// (e.g. the host refuses to spawn the requested threads).
+    pub fn new(threads: usize) -> Result<Self, ScraperError> {
+        let threads = threads.max(1);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .map_err(ScraperError::ingestion)?;
+        Ok(Self {
+            pool: Arc::new(pool),
+            threads,
+        })
+    }
+
+    /// Build a pool sized from a resolved [`ElasticConfig`]'s `cpu_cores`
+    /// (frozen design: pool size = detected CPU cores, overridable via
+    /// `--cpu-cores`).
+    pub fn from_config(cfg: &ElasticConfig) -> Result<Self, ScraperError> {
+        Self::new(cfg.cpu_cores)
+    }
+
+    /// Number of worker threads in this pool (guaranteed `>= 1`).
+    #[must_use]
+    pub fn thread_count(&self) -> usize {
+        self.threads
+    }
+
+    /// Run `f` on the current thread with this pool installed as the active
+    /// Rayon pool, so any nested `par_iter` / `rayon::spawn` routes to it
+    /// (frozen design decision #3).
+    ///
+    /// The `Send` bounds mirror `rayon::ThreadPool::install`'s real signature
+    /// (the design contract's `impl FnOnce() -> R` is shorthand).
+    pub fn install<R>(&self, f: impl FnOnce() -> R + Send) -> R
+    where
+        R: Send,
+    {
+        self.pool.install(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RayonCpuPool;
+    use crate::infrastructure::autotuning::{ElasticConfig, ElasticOverrides};
+
+    #[test]
+    fn test_pool_creates_with_requested_thread_count() {
+        let pool = RayonCpuPool::new(4).expect("pool of 4 threads should build");
+        assert_eq!(pool.thread_count(), 4);
+    }
+
+    #[test]
+    fn test_pool_thread_count_matches_resolved_cpu_cores() {
+        let cfg = ElasticConfig::resolve(&ElasticOverrides::default());
+        let pool = RayonCpuPool::from_config(&cfg).expect("pool from config should build");
+        assert_eq!(pool.thread_count(), cfg.cpu_cores);
+        assert!(pool.thread_count() >= 1);
+    }
+
+    #[test]
+    fn test_pool_zero_threads_floors_to_one() {
+        // Frozen user decision #2: pool size MUST be >= 1 (mono-core cooperative).
+        // new(0) must NOT panic and must yield at least 1 thread.
+        let pool = RayonCpuPool::new(0).expect("zero must floor to 1, not error");
+        assert!(pool.thread_count() >= 1);
+        assert_eq!(pool.thread_count(), 1);
+    }
+
+    #[test]
+    fn test_pool_install_scopes_nested_rayon_to_dedicated_pool() {
+        // Spec "CPU work dispatched to Rayon": install() must route nested rayon
+        // operations to THIS pool. Prove it by reading the current pool's thread
+        // count from inside the installed closure — it must equal the pool's size,
+        // not the global rayon pool's size.
+        let pool = RayonCpuPool::new(3).expect("pool of 3 threads should build");
+        let observed = pool.install(rayon::current_num_threads);
+        assert_eq!(observed, 3, "install() must scope nested rayon to the pool");
+    }
+
+    #[test]
+    fn test_pool_mono_core_single_thread_works() {
+        let pool = RayonCpuPool::new(1).expect("mono-core pool should build");
+        assert_eq!(pool.thread_count(), 1);
+        let sum = pool.install(|| (1..=100).sum::<u64>());
+        assert_eq!(sum, 5050);
+    }
+
+    #[test]
+    fn test_pool_install_returns_closure_value() {
+        let pool = RayonCpuPool::new(2).expect("pool of 2 threads should build");
+        let s = pool.install(|| String::from("processed"));
+        assert_eq!(s, "processed");
+    }
+}

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -25,6 +25,8 @@ pub mod user_agent;
 
 // Elastic ingestion (Issue #51) — hardware autotuning + SQLite persistence.
 pub mod autotuning;
+pub mod bridge;
+pub mod cpu_pool;
 pub mod persistence;
 
 #[cfg(feature = "ai")]


### PR DESCRIPTION
## Elastic Ingestion Autotuning (Issue #51) — PR 3/5: CPU Pool & Tokio-to-Rayon Bridge

### What
Dedicated isolated Rayon CPU pool and the Tokio→Rayon crossing bridge that moves CPU-bound work (HTML cleaning, tokenization, ONNX inference) off the Tokio event loop.

### Changes
- **RayonCpuPool**: adaptive `rayon::ThreadPoolBuilder` sized from PR1's `AutotuningConfig.cpu_cores` with floor-1 assertion (mono-core cooperative scheduling)
- **CpuBridge::dispatch**: `spawn_blocking` + `pool.install()` + `oneshot` channel — Tokio threads stay free for socket I/O
- **Panic isolation**: `catch_unwind(AssertUnwindSafe)` wraps Rayon work — panics return `ScraperError::Ingestion` via oneshot, Rayon threads survive
- **Channel drop handling**: if Tokio aborts the outer task, Rayon completes + `tracing::warn!` on dropped receiver (no silent leak)
- **lol_html stub**: `clean_html_stub` strips tags naively; real lol_html + ONNX wiring deferred to PR5
- **No separate CpuBridgeError**: both panic + channel-drop map to existing `ScraperError::Ingestion` (avoids error-enum proliferation)

### Test Results
- 16 new unit tests (6 cpu_pool + 10 bridge)
- Full lib regression: 604 passed / 0 failed / 5 skipped
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅

### Key Tests
- `test_pool_zero_threads_floors_to_one` — mono-core assertion
- `test_dispatch_panic_isolated_pool_survives` — panic doesn't kill pool
- `test_dispatch_channel_drop_pool_survives_and_no_panic` — Tokio abort safety
- `test_dispatch_16_concurrent_tasks` — concurrent dispatch under shared pool

### SDD Chain
Stacked-to-main | PR 3 of 5 | Depends on: PR1+PR2 (merged) | Blocks: PR4 (persistence), PR5 (integration)

<!-- SDD: elastic-ingestion-51/pr3 -->