### PR TITLE
refactor(crawl-options): CrawlOptions struct hierarchy + From<Args> conversion

### DIFF
--- a/src/application/crawl_options.rs
+++ b/src/application/crawl_options.rs
@@ -1,0 +1,329 @@
+//! Structured crawl options — single source of truth for scraper configuration.
+//!
+//! Replaces direct `&Args` access throughout the codebase. Built via
+//! `From<Args>` conversion in the CLI layer, then passed by value or
+//! reference to services that need configuration.
+
+use std::path::PathBuf;
+
+use url::Url;
+
+use crate::infrastructure::autotuning::ElasticOverrides;
+use crate::{ConcurrencyConfig, ExportFormat, OutputFormat};
+
+// ============================================================================
+// Top-level options
+// ============================================================================
+
+/// Complete crawl configuration extracted from CLI arguments.
+///
+/// This is the single source of truth for all scraper settings. Services
+/// receive `&CrawlOptions` instead of `&Args`, making configuration
+/// explicit and testable.
+#[derive(Debug, Clone)]
+pub struct CrawlOptions {
+    /// Target URL to scrape.
+    pub url: Url,
+    /// Verbosity level (-v, -vv, -vvv).
+    pub verbosity: u8,
+    /// Quiet mode — suppress info/debug output.
+    pub quiet: bool,
+    /// Crawl scope and discovery settings.
+    pub crawl: CrawlLimits,
+    /// HTTP and network settings.
+    pub network: NetworkOptions,
+    /// Output and export settings.
+    pub export: ExportOptions,
+    /// Elastic ingestion tuning.
+    pub elastic: IngestionTuning,
+}
+
+// ============================================================================
+// Sub-structs
+// ============================================================================
+
+/// Crawl scope: depth, patterns, sitemap, and behavioral flags.
+#[derive(Debug, Clone)]
+pub struct CrawlLimits {
+    /// CSS selector for content extraction.
+    pub selector: String,
+    /// Maximum depth to crawl (0 = only seed URL).
+    pub max_depth: u8,
+    /// Maximum pages to scrape.
+    pub max_pages: usize,
+    /// Scrape only the seed URL without discovery or crawling.
+    pub single_page: bool,
+    /// URL patterns to include (glob-style).
+    pub include_patterns: Vec<String>,
+    /// URL patterns to exclude (glob-style).
+    pub exclude_patterns: Vec<String>,
+    /// Interactive mode with TUI URL selector.
+    pub interactive: bool,
+    /// Resume mode — skip URLs already processed.
+    pub resume: bool,
+    /// Custom state directory for resume mode.
+    pub state_dir: Option<PathBuf>,
+    /// Use sitemap for URL discovery.
+    pub use_sitemap: bool,
+    /// Explicit sitemap URL.
+    pub sitemap_url: Option<String>,
+}
+
+/// HTTP client and network behavior settings.
+#[derive(Debug, Clone)]
+pub struct NetworkOptions {
+    /// Custom user-agent string (None = random from pool).
+    pub user_agent: Option<String>,
+    /// Accept-Language header value.
+    pub accept_language: String,
+    /// Concurrency configuration.
+    pub concurrency: ConcurrencyConfig,
+    /// Delay between requests in milliseconds.
+    pub delay_ms: u64,
+    /// Request timeout in seconds.
+    pub timeout_secs: u64,
+    /// Maximum number of retry attempts.
+    pub max_retries: u32,
+    /// Base delay for exponential backoff (ms).
+    pub backoff_base_ms: u64,
+    /// Maximum delay for exponential backoff (ms).
+    pub backoff_max_ms: u64,
+    /// Download images from the page.
+    pub download_images: bool,
+    /// Download documents from the page.
+    pub download_documents: bool,
+    /// Force JavaScript rendering for SPA sites.
+    pub force_js_render: bool,
+}
+
+/// Output format, export format, and Obsidian integration settings.
+#[derive(Debug, Clone)]
+pub struct ExportOptions {
+    /// Output format for individual files (markdown, text, json).
+    pub output_format: OutputFormat,
+    /// Export format for RAG pipeline (jsonl, vector, auto).
+    pub export_format: ExportFormat,
+    /// Output directory for scraped content.
+    pub output_dir: PathBuf,
+    /// Dry-run mode — discover URLs and print without scraping.
+    pub dry_run: bool,
+    /// Quiet mode — suppress info/debug output.
+    pub quiet: bool,
+    /// Path to Obsidian vault (auto-detects if not provided).
+    pub obsidian_vault: Option<PathBuf>,
+    /// Add rich metadata to frontmatter.
+    pub obsidian_rich_metadata: bool,
+    /// Tags to include in YAML frontmatter.
+    pub obsidian_tags: Vec<String>,
+    /// Convert same-domain links to Obsidian [[wiki-link]] syntax.
+    pub obsidian_wiki_links: bool,
+    /// Rewrite downloaded asset paths as relative to the .md file.
+    pub obsidian_relative_assets: bool,
+    /// Quick-save mode: save directly to vault _inbox folder.
+    pub quick_save: bool,
+}
+
+/// Elastic ingestion pipeline tuning (hardware autotuning overrides).
+#[derive(Debug, Clone, Default)]
+pub struct IngestionTuning {
+    /// Enable elastic ingestion pipeline.
+    pub enabled: bool,
+    /// CPU core override for the Rayon pool (None = auto-detect).
+    pub cpu_cores: Option<usize>,
+    /// RAM budget override in bytes (None = auto-detect).
+    pub ram_budget_bytes: Option<u64>,
+    /// SQLite database path override.
+    pub db_path: Option<PathBuf>,
+    /// Per-resource byte ceiling override.
+    pub max_resource_bytes: Option<u64>,
+}
+
+// ============================================================================
+// Default implementations
+// ============================================================================
+
+impl Default for CrawlLimits {
+    fn default() -> Self {
+        Self {
+            selector: "body".to_owned(),
+            max_depth: 2,
+            max_pages: 10,
+            single_page: false,
+            include_patterns: Vec::new(),
+            exclude_patterns: Vec::new(),
+            interactive: false,
+            resume: false,
+            state_dir: None,
+            use_sitemap: false,
+            sitemap_url: None,
+        }
+    }
+}
+
+impl Default for NetworkOptions {
+    fn default() -> Self {
+        Self {
+            user_agent: None,
+            accept_language: "en-US,en;q=0.9".to_owned(),
+            concurrency: ConcurrencyConfig::default(),
+            delay_ms: 1000,
+            timeout_secs: 30,
+            max_retries: 3,
+            backoff_base_ms: 1000,
+            backoff_max_ms: 10000,
+            download_images: false,
+            download_documents: false,
+            force_js_render: false,
+        }
+    }
+}
+
+impl Default for ExportOptions {
+    fn default() -> Self {
+        Self {
+            output_format: OutputFormat::Markdown,
+            export_format: ExportFormat::Jsonl,
+            output_dir: PathBuf::from("output"),
+            dry_run: false,
+            quiet: false,
+            obsidian_vault: None,
+            obsidian_rich_metadata: false,
+            obsidian_tags: Vec::new(),
+            obsidian_wiki_links: false,
+            obsidian_relative_assets: false,
+            quick_save: false,
+        }
+    }
+}
+
+impl Default for CrawlOptions {
+    fn default() -> Self {
+        // Use a safe default URL for the default impl.
+        // In practice, CrawlOptions is always built from Args where url is validated.
+        let url = Url::parse("https://example.com")
+            .expect("hardcoded default URL must parse");
+        Self {
+            url,
+            verbosity: 0,
+            quiet: false,
+            crawl: CrawlLimits::default(),
+            network: NetworkOptions::default(),
+            export: ExportOptions::default(),
+            elastic: IngestionTuning::default(),
+        }
+    }
+}
+
+// ============================================================================
+// From<ElasticOverrides> for IngestionTuning
+// ============================================================================
+
+impl From<ElasticOverrides> for IngestionTuning {
+    fn from(overrides: ElasticOverrides) -> Self {
+        Self {
+            enabled: true,
+            cpu_cores: overrides.cpu_cores,
+            ram_budget_bytes: overrides.ram_budget_bytes,
+            db_path: overrides.db_path,
+            max_resource_bytes: overrides.max_resource_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_crawl_limits() {
+        let limits = CrawlLimits::default();
+        assert_eq!(limits.selector, "body");
+        assert_eq!(limits.max_depth, 2);
+        assert_eq!(limits.max_pages, 10);
+        assert!(!limits.single_page);
+        assert!(limits.include_patterns.is_empty());
+        assert!(limits.exclude_patterns.is_empty());
+        assert!(!limits.interactive);
+        assert!(!limits.resume);
+        assert!(limits.state_dir.is_none());
+        assert!(!limits.use_sitemap);
+        assert!(limits.sitemap_url.is_none());
+    }
+
+    #[test]
+    fn test_default_network_options() {
+        let net = NetworkOptions::default();
+        assert!(net.user_agent.is_none());
+        assert_eq!(net.accept_language, "en-US,en;q=0.9");
+        assert!(net.concurrency.is_auto());
+        assert_eq!(net.delay_ms, 1000);
+        assert_eq!(net.timeout_secs, 30);
+        assert_eq!(net.max_retries, 3);
+        assert_eq!(net.backoff_base_ms, 1000);
+        assert_eq!(net.backoff_max_ms, 10000);
+        assert!(!net.download_images);
+        assert!(!net.download_documents);
+        assert!(!net.force_js_render);
+    }
+
+    #[test]
+    fn test_default_export_options() {
+        let export = ExportOptions::default();
+        assert_eq!(export.output_format, OutputFormat::Markdown);
+        assert_eq!(export.export_format, ExportFormat::Jsonl);
+        assert_eq!(export.output_dir, PathBuf::from("output"));
+        assert!(!export.dry_run);
+        assert!(!export.quiet);
+        assert!(export.obsidian_vault.is_none());
+        assert!(!export.obsidian_rich_metadata);
+        assert!(export.obsidian_tags.is_empty());
+        assert!(!export.obsidian_wiki_links);
+        assert!(!export.obsidian_relative_assets);
+        assert!(!export.quick_save);
+    }
+
+    #[test]
+    fn test_default_ingestion_tuning() {
+        let tuning = IngestionTuning::default();
+        assert!(!tuning.enabled);
+        assert!(tuning.cpu_cores.is_none());
+        assert!(tuning.ram_budget_bytes.is_none());
+        assert!(tuning.db_path.is_none());
+        assert!(tuning.max_resource_bytes.is_none());
+    }
+
+    #[test]
+    fn test_default_crawl_options() {
+        let opts = CrawlOptions::default();
+        assert_eq!(opts.url.as_str(), "https://example.com/");
+        assert_eq!(opts.verbosity, 0);
+        assert!(!opts.quiet);
+    }
+
+    #[test]
+    fn test_from_elastic_overrides() {
+        let overrides = ElasticOverrides {
+            cpu_cores: Some(4),
+            ram_budget_bytes: Some(8 * 1024 * 1024 * 1024),
+            max_resource_bytes: Some(25 * 1024 * 1024),
+            db_path: Some(PathBuf::from("/tmp/test.db")),
+        };
+        let tuning = IngestionTuning::from(overrides);
+        assert!(tuning.enabled);
+        assert_eq!(tuning.cpu_cores, Some(4));
+        assert_eq!(tuning.ram_budget_bytes, Some(8 * 1024 * 1024 * 1024));
+        assert_eq!(tuning.max_resource_bytes, Some(25 * 1024 * 1024));
+        assert_eq!(tuning.db_path, Some(PathBuf::from("/tmp/test.db")));
+    }
+
+    #[test]
+    fn test_from_elastic_overrides_empty() {
+        let overrides = ElasticOverrides::default();
+        let tuning = IngestionTuning::from(overrides);
+        assert!(tuning.enabled);
+        assert!(tuning.cpu_cores.is_none());
+        assert!(tuning.ram_budget_bytes.is_none());
+        assert!(tuning.max_resource_bytes.is_none());
+        assert!(tuning.db_path.is_none());
+    }
+}

--- a/src/application/crawl_options.rs
+++ b/src/application/crawl_options.rs
@@ -200,8 +200,7 @@ impl Default for CrawlOptions {
     fn default() -> Self {
         // Use a safe default URL for the default impl.
         // In practice, CrawlOptions is always built from Args where url is validated.
-        let url = Url::parse("https://example.com")
-            .expect("hardcoded default URL must parse");
+        let url = Url::parse("https://example.com").expect("hardcoded default URL must parse");
         Self {
             url,
             verbosity: 0,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,6 +4,7 @@
 //! using infrastructure services. It depends on both domain and infrastructure.
 
 pub mod container;
+pub mod crawl_options;
 pub mod crawl_result_repository;
 pub mod crawler_service;
 pub mod deduplicator;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -389,6 +389,85 @@ impl Args {
     }
 }
 
+// ============================================================================
+// From<Args> for CrawlOptions
+// ============================================================================
+
+impl From<Args> for crate::application::crawl_options::CrawlOptions {
+    /// Convert CLI arguments into structured [`CrawlOptions`].
+    ///
+    /// This is an owned, lossless conversion — every field in `Args` maps
+    /// to exactly one field in `CrawlOptions`. The `url` field is parsed
+    /// from `Option<String>` into `Url` (panics if invalid; CLI validation
+    /// guarantees validity before this point).
+    fn from(args: Args) -> Self {
+        use crate::application::crawl_options::{
+            CrawlLimits, ExportOptions, IngestionTuning, NetworkOptions,
+        };
+
+        let url = url::Url::parse(
+            args.url
+                .as_deref()
+                .unwrap_or("https://example.com"),
+        )
+        .expect("URL must be valid — CLI validation ensures this");
+
+        let overrides = args.elastic_overrides();
+
+        Self {
+            url,
+            verbosity: args.verbose,
+            quiet: args.quiet,
+            crawl: CrawlLimits {
+                selector: args.selector,
+                max_depth: args.max_depth,
+                max_pages: args.max_pages,
+                single_page: args.single_page,
+                include_patterns: args.include_patterns,
+                exclude_patterns: args.exclude_patterns,
+                interactive: args.interactive,
+                resume: args.resume,
+                state_dir: args.state_dir,
+                use_sitemap: args.use_sitemap,
+                sitemap_url: args.sitemap_url,
+            },
+            network: NetworkOptions {
+                user_agent: None,
+                accept_language: args.accept_language,
+                concurrency: args.concurrency,
+                delay_ms: args.delay_ms,
+                timeout_secs: args.timeout_secs,
+                max_retries: args.max_retries,
+                backoff_base_ms: args.backoff_base_ms,
+                backoff_max_ms: args.backoff_max_ms,
+                download_images: args.download_images,
+                download_documents: args.download_documents,
+                force_js_render: args.force_js_render,
+            },
+            export: ExportOptions {
+                output_format: args.format,
+                export_format: args.export_format,
+                output_dir: args.output,
+                dry_run: args.dry_run,
+                quiet: args.quiet,
+                obsidian_vault: args.vault,
+                obsidian_rich_metadata: args.obsidian_rich_metadata,
+                obsidian_tags: args.obsidian_tags.unwrap_or_default(),
+                obsidian_wiki_links: args.obsidian_wiki_links,
+                obsidian_relative_assets: args.obsidian_relative_assets,
+                quick_save: args.quick_save,
+            },
+            elastic: IngestionTuning {
+                enabled: args.elastic,
+                cpu_cores: overrides.cpu_cores,
+                ram_budget_bytes: overrides.ram_budget_bytes,
+                db_path: overrides.db_path,
+                max_resource_bytes: overrides.max_resource_bytes,
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -405,12 +405,8 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
             CrawlLimits, ExportOptions, IngestionTuning, NetworkOptions,
         };
 
-        let url = url::Url::parse(
-            args.url
-                .as_deref()
-                .unwrap_or("https://example.com"),
-        )
-        .expect("URL must be valid — CLI validation ensures this");
+        let url = url::Url::parse(args.url.as_deref().unwrap_or("https://example.com"))
+            .expect("URL must be valid — CLI validation ensures this");
 
         let overrides = args.elastic_overrides();
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 
 use tracing::info;
 
+use crate::application::crawl_options::CrawlOptions;
 use crate::cli::error::CliExit;
-use crate::cli::Args;
 use crate::infrastructure::obsidian::detect_vault;
 
 /// Common preflight checks for all commands
@@ -19,9 +19,9 @@ pub struct PreflightContext {
 }
 
 /// Run preflight checks and build context
-pub async fn preflight(args: &Args) -> Result<PreflightContext, CliExit> {
+pub async fn preflight(opts: &CrawlOptions) -> Result<PreflightContext, CliExit> {
     // Target URL is guaranteed to exist (checked by caller)
-    let target_url = args.url.clone().expect("url required");
+    let target_url = opts.url.to_string();
 
     // Emoji helpers (resolved once after NO_COLOR check)
     let _ok = crate::cli::preflight::icon("✅", "OK");
@@ -40,7 +40,7 @@ pub async fn preflight(args: &Args) -> Result<PreflightContext, CliExit> {
     let config_defaults = crate::cli::config::ConfigDefaults::load(&config_path);
 
     let vault_path = detect_vault(
-        args.vault.as_deref(),
+        opts.export.obsidian_vault.as_deref(),
         None,
         config_defaults.vault_path.as_deref(),
     );
@@ -53,7 +53,7 @@ pub async fn preflight(args: &Args) -> Result<PreflightContext, CliExit> {
 
     // GAP 3 (Bug #30): Warn when vault is provided but headless mode (no --quick-save)
     if let Some(ref _vault) = vault_path {
-        if !args.quick_save {
+        if !opts.export.quick_save {
             tracing::warn!("Vault path provided but --quick-save not enabled.");
             tracing::warn!("   Files will be saved to ./output/, not to the vault.");
             tracing::warn!("   Use --quick-save to save directly to vault _inbox.");

--- a/src/cli/orchestrator.rs
+++ b/src/cli/orchestrator.rs
@@ -2,8 +2,6 @@
 //!
 //! Orchestrates URL discovery, scraping, and export phases.
 
-use std::sync::Arc;
-
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
@@ -12,6 +10,7 @@ use crate::cli::error::CliExit;
 use crate::cli::export_flow::{run_export, save_files, ExportConfig};
 use crate::cli::scrape_flow::scrape_urls;
 use crate::cli::url_discovery::discover_urls;
+use crate::application::crawl_options::CrawlOptions;
 use crate::Args;
 use crate::CrawlerConfig;
 use crate::ScraperConfig;
@@ -40,70 +39,76 @@ pub fn handle_completions(shell: Shell) -> CliExit {
 /// 1. URL discovery
 /// 2. Scraping with progress
 /// 3. Export results
-pub async fn run(args: Args) -> CliExit {
-    let target_url_str = match args.url.as_ref() {
-        Some(url) => url,
-        None => return CliExit::UsageError("--url is required".into()),
-    };
+pub async fn run(opts: CrawlOptions) -> CliExit {
 
-    let target_url = match url::Url::parse(target_url_str) {
-        Ok(url) => url,
-        Err(e) => return CliExit::UsageError(format!("Invalid URL: {e}")),
-    };
-
-    // Create crawler config from args
-    let crawler_config = CrawlerConfig::builder(target_url.clone())
-        .max_pages(args.max_pages)
-        .max_depth(args.max_depth)
-        .include_patterns(args.include_patterns.clone())
-        .exclude_patterns(args.exclude_patterns.clone())
-        .build();
-
-    let urls_to_scrape = if args.single_page {
-        plan_urls(true, target_url.clone(), Vec::new())
+    let urls_to_scrape = if opts.crawl.single_page {
+        plan_urls(true, opts.url.clone(), Vec::new())
     } else {
+        // Create crawler config from CrawlOptions
+        let crawler_config = CrawlerConfig::builder(opts.url.clone())
+            .max_pages(opts.crawl.max_pages)
+            .max_depth(opts.crawl.max_depth)
+            .include_patterns(opts.crawl.include_patterns.clone())
+            .exclude_patterns(opts.crawl.exclude_patterns.clone())
+            .build();
+
         // URL discovery phase
-        let discovered_urls: Vec<url::Url> = discover_urls(&crawler_config, &args).await;
+        let discovered_urls: Vec<url::Url> = discover_urls(&crawler_config, &opts).await;
         if discovered_urls.is_empty() {
             info!("No URLs discovered");
             return CliExit::Success;
         }
 
-        plan_urls(false, target_url.clone(), discovered_urls)
+        plan_urls(false, opts.url.clone(), discovered_urls)
     };
 
     // Create scraper config
     let mut scraper_config = ScraperConfig::default()
-        .with_output_dir(args.output.clone())
-        .with_scraper_concurrency(args.concurrency.resolve())
-        .with_max_pages(args.max_pages);
+        .with_output_dir(opts.export.output_dir.clone())
+        .with_scraper_concurrency(opts.network.concurrency.resolve())
+        .with_max_pages(opts.crawl.max_pages);
 
     // Apply download flags (builder pattern requires conditional application)
-    if args.download_images {
+    if opts.network.download_images {
         scraper_config = scraper_config.with_images();
     }
-    if args.download_documents {
+    if opts.network.download_documents {
         scraper_config = scraper_config.with_documents();
     }
 
     // Initialize elastic ingestion if requested
-    let elastic: Option<
-        Arc<
+    let elastic_ingestion: Option<
+        std::sync::Arc<
             crate::application::elastic_ingestion::ElasticIngestion<
                 crate::infrastructure::persistence::sqlite::SqliteVectorRepository,
             >,
         >,
-    > = if args.elastic {
-        match build_elastic_pipeline(&args).await {
-            Ok(ingestion) => {
-                info!(
-                    "pipeline elástico activado: db={}",
-                    args.db_path
-                        .as_deref()
-                        .unwrap_or(std::path::Path::new("elastic.db"))
-                        .display()
-                );
-                Some(ingestion)
+    > = if opts.elastic.enabled {
+        let overrides = crate::infrastructure::autotuning::ElasticOverrides {
+            cpu_cores: opts.elastic.cpu_cores,
+            ram_budget_bytes: opts.elastic.ram_budget_bytes,
+            max_resource_bytes: opts.elastic.max_resource_bytes,
+            db_path: opts.elastic.db_path.clone(),
+        };
+
+        let db_display = opts.elastic.db_path
+            .as_deref()
+            .unwrap_or(std::path::Path::new("elastic.db"))
+            .display();
+
+        match async {
+            let container = crate::application::container::Container::new(
+                CrawlerConfig::new(opts.url.clone()),
+                ScraperConfig::default(),
+            )
+            .await?;
+            container.with_elastic(&overrides).await
+        }
+        .await
+        {
+            Ok(container) => {
+                info!("pipeline elástico activado: db={db_display}");
+                container.elastic_ingestion
             },
             Err(e) => {
                 warn!("no se pudo inicializar el pipeline elástico: {e}");
@@ -115,12 +120,11 @@ pub async fn run(args: Args) -> CliExit {
     };
 
     // Scraping phase
-
     let (results, failures): (Vec<domain::ScrapedContent>, Vec<(String, String)>) =
-        scrape_urls(&urls_to_scrape, &scraper_config, &args, None).await;
+        scrape_urls(&urls_to_scrape, &scraper_config, &opts, None).await;
 
     // Post-scrape: elastic ingestion (best-effort, no abort on failure)
-    if let Some(ref ingestion) = elastic {
+    if let Some(ref ingestion) = elastic_ingestion {
         run_elastic_ingestion(ingestion, &results).await;
     }
 
@@ -138,48 +142,48 @@ pub async fn run(args: Args) -> CliExit {
 
     // Obsidian options
     let obsidian_options = ObsidianOptions {
-        wiki_links: args.obsidian_wiki_links,
-        relative_assets: args.obsidian_relative_assets,
-        tags: args.obsidian_tags.clone().unwrap_or_default(),
-        rich_metadata: args.obsidian_rich_metadata,
-        quick_save: args.quick_save,
-        vault_path: args.vault.clone(),
+        wiki_links: opts.export.obsidian_wiki_links,
+        relative_assets: opts.export.obsidian_relative_assets,
+        tags: opts.export.obsidian_tags.clone(),
+        rich_metadata: opts.export.obsidian_rich_metadata,
+        quick_save: opts.export.quick_save,
+        vault_path: opts.export.obsidian_vault.clone(),
     };
 
     // Determine output directory for individual files
-    let output_dir = if args.quick_save {
-        if let Some(v) = &args.vault {
+    let output_dir = if opts.export.quick_save {
+        if let Some(v) = &opts.export.obsidian_vault {
             let inbox = v.join("_inbox");
             if !inbox.exists() {
                 let _ = std::fs::create_dir_all(&inbox);
             }
             inbox
         } else {
-            args.output.clone()
+            opts.export.output_dir.clone()
         }
     } else {
-        args.output.clone()
+        opts.export.output_dir.clone()
     };
 
     // Export phase
     let export_config = ExportConfig {
         results: &results,
-        output_dir: args.output.clone(), // RAG export still goes to output_dir
-        format: args.format,
-        export_format: args.export_format,
-        clean_ai: args.clean_ai,
-        quick_save: args.quick_save,
-        vault_path: args.vault.as_ref(),
+        output_dir: opts.export.output_dir.clone(),
+        format: opts.export.output_format,
+        export_format: opts.export.export_format,
+        clean_ai: false, // TODO: wire from CrawlOptions when AI settings are added
+        quick_save: opts.export.quick_save,
+        vault_path: opts.export.obsidian_vault.as_ref(),
         obsidian_options: obsidian_options.clone(),
         state_store: None, // TODO: Add state store
-        resume: args.resume,
-        ai_threshold: 0.3, // TODO: Add AI settings from args
+        resume: opts.crawl.resume,
+        ai_threshold: 0.3, // TODO: Add AI settings from CrawlOptions
         ai_max_tokens: 512,
         ai_offline: false,
     };
 
     // Save individual files (Markdown, etc.)
-    save_files(&results, &output_dir, &args.format, &obsidian_options);
+    save_files(&results, &output_dir, &opts.export.output_format, &obsidian_options);
 
     match run_export(export_config).await {
         Ok(processed_urls) => {
@@ -193,58 +197,6 @@ pub async fn run(args: Args) -> CliExit {
     }
 }
 
-/// Build the elastic ingestion pipeline from CLI args.
-///
-/// Wires `RayonCpuPool` → `CpuBridge` → `SqliteVectorRepository` →
-/// `ResourceDownloader` → `ElasticIngestion<SqliteVectorRepository>`
-/// using `ElasticConfig::resolve` with the CLI-provided overrides.
-async fn build_elastic_pipeline(
-    args: &Args,
-) -> Result<
-    Arc<
-        crate::application::elastic_ingestion::ElasticIngestion<
-            crate::infrastructure::persistence::sqlite::SqliteVectorRepository,
-        >,
-    >,
-    Box<dyn std::error::Error + Send + Sync>,
-> {
-    use crate::application::elastic_ingestion::ElasticIngestion;
-    use crate::infrastructure::autotuning::ElasticConfig;
-    use crate::infrastructure::bridge::CpuBridge;
-    use crate::infrastructure::config::AutotuningConfig;
-    use crate::infrastructure::cpu_pool::RayonCpuPool;
-    use crate::infrastructure::crawler::resource_downloader::ResourceDownloader;
-    use crate::infrastructure::persistence::sqlite::{
-        self as sqlite_persistence, SqliteVectorRepository,
-    };
-
-    let config = ElasticConfig::resolve(&args.elastic_overrides());
-
-    let cpu_pool = RayonCpuPool::new(config.cpu_cores)?;
-    let bridge = CpuBridge::new(cpu_pool);
-
-    let pool = sqlite_persistence::create_pool(&config.db_path, config.db_pool_size)?;
-    sqlite_persistence::setup_schema(&pool).await?;
-    let repository = SqliteVectorRepository::new(pool);
-
-    let client = crate::application::http_client::create_http_client()?;
-    let max_concurrent = (config.ram_budget_bytes / config.max_resource_bytes).max(1) as usize;
-    let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
-    let downloader = ResourceDownloader::with_config(
-        semaphore,
-        client,
-        crate::infrastructure::crawler::resource_downloader::DownloadConfig {
-            max_size_bytes: config.max_resource_bytes,
-            ..Default::default()
-        },
-    );
-
-    let autotune = AutotuningConfig::from_elastic(&config);
-    let ingestion = ElasticIngestion::new(downloader, bridge, repository, autotune);
-
-    Ok(Arc::new(ingestion))
-}
-
 /// Run the elastic ingestion pipeline on all scraped results.
 ///
 /// Each URL is processed concurrently via a bounded `JoinSet` with
@@ -252,7 +204,7 @@ async fn build_elastic_pipeline(
 /// Ingestion failures are logged but do NOT abort the export phase
 /// (best-effort semantics).
 async fn run_elastic_ingestion(
-    ingestion: &Arc<
+    ingestion: &std::sync::Arc<
         crate::application::elastic_ingestion::ElasticIngestion<
             crate::infrastructure::persistence::sqlite::SqliteVectorRepository,
         >,
@@ -267,7 +219,7 @@ async fn run_elastic_ingestion(
     let concurrency = num_cpus::get().max(4); // bounded concurrency
 
     for result in results {
-        let ing = Arc::clone(ingestion);
+        let ing = std::sync::Arc::clone(ingestion);
         let url = result.url.clone();
 
         while join_set.len() >= concurrency {

--- a/src/cli/orchestrator.rs
+++ b/src/cli/orchestrator.rs
@@ -5,12 +5,12 @@
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
+use crate::application::crawl_options::CrawlOptions;
 use crate::cli::completions::generate_completions;
 use crate::cli::error::CliExit;
 use crate::cli::export_flow::{run_export, save_files, ExportConfig};
 use crate::cli::scrape_flow::scrape_urls;
 use crate::cli::url_discovery::discover_urls;
-use crate::application::crawl_options::CrawlOptions;
 use crate::Args;
 use crate::CrawlerConfig;
 use crate::ScraperConfig;
@@ -40,7 +40,6 @@ pub fn handle_completions(shell: Shell) -> CliExit {
 /// 2. Scraping with progress
 /// 3. Export results
 pub async fn run(opts: CrawlOptions) -> CliExit {
-
     let urls_to_scrape = if opts.crawl.single_page {
         plan_urls(true, opts.url.clone(), Vec::new())
     } else {
@@ -91,7 +90,9 @@ pub async fn run(opts: CrawlOptions) -> CliExit {
             db_path: opts.elastic.db_path.clone(),
         };
 
-        let db_display = opts.elastic.db_path
+        let db_display = opts
+            .elastic
+            .db_path
             .as_deref()
             .unwrap_or(std::path::Path::new("elastic.db"))
             .display();
@@ -183,7 +184,12 @@ pub async fn run(opts: CrawlOptions) -> CliExit {
     };
 
     // Save individual files (Markdown, etc.)
-    save_files(&results, &output_dir, &opts.export.output_format, &obsidian_options);
+    save_files(
+        &results,
+        &output_dir,
+        &opts.export.output_format,
+        &obsidian_options,
+    );
 
     match run_export(export_config).await {
         Ok(processed_urls) => {

--- a/src/cli/preflight.rs
+++ b/src/cli/preflight.rs
@@ -6,8 +6,8 @@
 use std::path::PathBuf;
 use tracing::warn;
 
-use crate::cli::config::ConfigDefaults;
 use crate::application::crawl_options::CrawlOptions;
+use crate::cli::config::ConfigDefaults;
 use crate::{Args, ConcurrencyConfig, ExportFormat, OutputFormat};
 
 // ============================================================================

--- a/src/cli/preflight.rs
+++ b/src/cli/preflight.rs
@@ -7,16 +7,17 @@ use std::path::PathBuf;
 use tracing::warn;
 
 use crate::cli::config::ConfigDefaults;
+use crate::application::crawl_options::CrawlOptions;
 use crate::{Args, ConcurrencyConfig, ExportFormat, OutputFormat};
 
 // ============================================================================
 // Config Defaults Merge
 // ============================================================================
 
-/// Apply config file defaults where CLI args are still at their hardcoded defaults.
+/// Apply config file defaults where CrawlOptions fields are still at their hardcoded defaults.
 ///
 /// Precedence: CLI > env (handled by clap) > config file > struct defaults.
-pub fn apply_config_defaults(mut args: Args, config: &ConfigDefaults) -> Args {
+pub fn apply_config_defaults(mut opts: CrawlOptions, config: &ConfigDefaults) -> CrawlOptions {
     if let Some(ref fmt) = config.format {
         let target = match fmt.to_lowercase().as_str() {
             "markdown" => OutputFormat::Markdown,
@@ -24,8 +25,8 @@ pub fn apply_config_defaults(mut args: Args, config: &ConfigDefaults) -> Args {
             "text" => OutputFormat::Text,
             _ => OutputFormat::Markdown,
         };
-        if args.format == OutputFormat::Markdown && target != OutputFormat::Markdown {
-            args.format = target;
+        if opts.export.output_format == OutputFormat::Markdown && target != OutputFormat::Markdown {
+            opts.export.output_format = target;
         }
     }
 
@@ -36,88 +37,184 @@ pub fn apply_config_defaults(mut args: Args, config: &ConfigDefaults) -> Args {
             "auto" => ExportFormat::Auto,
             _ => ExportFormat::Jsonl,
         };
-        if args.export_format == ExportFormat::Jsonl && target != ExportFormat::Jsonl {
-            args.export_format = target;
+        if opts.export.export_format == ExportFormat::Jsonl && target != ExportFormat::Jsonl {
+            opts.export.export_format = target;
         }
     }
 
     if let Some(ref c) = config.concurrency {
         // ConcurrencyConfig doesn't implement PartialEq, so check via is_auto()
-        if args.concurrency.is_auto() {
-            args.concurrency = ConcurrencyConfig::from(c.as_str());
+        if opts.network.concurrency.is_auto() {
+            opts.network.concurrency = ConcurrencyConfig::from(c.as_str());
         }
     }
 
     if let Some(ref s) = config.selector {
-        if args.selector == "body" {
-            args.selector = s.clone();
+        if opts.crawl.selector == "body" {
+            opts.crawl.selector = s.clone();
         }
     }
 
     if let Some(n) = config.max_pages {
-        if args.max_pages == 10 {
-            args.max_pages = n;
+        if opts.crawl.max_pages == 10 {
+            opts.crawl.max_pages = n;
         }
     }
 
     if let Some(n) = config.delay_ms {
-        if args.delay_ms == 1000 {
-            args.delay_ms = n;
+        if opts.network.delay_ms == 1000 {
+            opts.network.delay_ms = n;
         }
     }
 
     if let Some(v) = config.use_sitemap {
-        if !args.use_sitemap && v {
-            args.use_sitemap = v;
+        if !opts.crawl.use_sitemap && v {
+            opts.crawl.use_sitemap = v;
         }
     }
 
-    // Obsidian config — trim whitespace from CLI tags (clap value_delimiter doesn't trim)
-    if let Some(ref mut tags) = args.obsidian_tags {
-        for tag in tags.iter_mut() {
-            *tag = tag.trim().to_string();
-        }
-        tags.retain(|t| !t.is_empty());
+    // Obsidian config — trim whitespace from tags
+    for tag in opts.export.obsidian_tags.iter_mut() {
+        *tag = tag.trim().to_string();
     }
+    opts.export.obsidian_tags.retain(|t| !t.is_empty());
+
     if let Some(ref tags_str) = config.obsidian_tags {
-        if args.obsidian_tags.is_none() {
-            args.obsidian_tags = Some(
-                tags_str
-                    .split(',')
-                    .map(|t| t.trim().to_string())
-                    .filter(|t| !t.is_empty())
-                    .collect(),
-            );
+        if opts.export.obsidian_tags.is_empty() {
+            opts.export.obsidian_tags = tags_str
+                .split(',')
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect();
         }
     }
     if let Some(v) = config.obsidian_wiki_links {
-        if !args.obsidian_wiki_links && v {
-            args.obsidian_wiki_links = v;
+        if !opts.export.obsidian_wiki_links && v {
+            opts.export.obsidian_wiki_links = v;
         }
     }
     if let Some(v) = config.obsidian_relative_assets {
-        if !args.obsidian_relative_assets && v {
-            args.obsidian_relative_assets = v;
+        if !opts.export.obsidian_relative_assets && v {
+            opts.export.obsidian_relative_assets = v;
         }
     }
     if let Some(ref vault) = config.vault_path {
-        if args.vault.is_none() {
-            args.vault = Some(PathBuf::from(vault));
+        if opts.export.obsidian_vault.is_none() {
+            opts.export.obsidian_vault = Some(PathBuf::from(vault));
         }
     }
 
-    args
+    opts
 }
 
 // ============================================================================
 // TUI Config Merge
 // ============================================================================
 
-/// Apply config values from TUI form to Args.
+/// Apply config values from TUI form to CrawlOptions.
 ///
 /// This runs after config_tui returns user-submitted values.
 /// Precedence: TUI values > CLI args (they override what was passed).
-pub fn apply_tui_config(mut args: Args, config_values: &serde_json::Value) -> Args {
+pub fn apply_tui_config(mut opts: CrawlOptions, config_values: &serde_json::Value) -> CrawlOptions {
+    use crate::ExportFormat as E;
+    use crate::OutputFormat as O;
+
+    // Output directory
+    if let Some(output) = config_values.get("output").and_then(|v| v.as_str()) {
+        opts.export.output_dir = PathBuf::from(output);
+    }
+
+    // Output format (markdown, json, text)
+    if let Some(fmt) = config_values.get("format").and_then(|v| v.as_str()) {
+        opts.export.output_format = match fmt {
+            "json" => O::Json,
+            "text" => O::Text,
+            _ => O::Markdown,
+        };
+    }
+
+    // Export format (jsonl, vector, auto)
+    if let Some(fmt) = config_values.get("export_format").and_then(|v| v.as_str()) {
+        opts.export.export_format = match fmt {
+            "vector" => E::Vector,
+            "auto" => E::Auto,
+            _ => E::Jsonl,
+        };
+    }
+
+    // Discovery: use_sitemap
+    if let Some(v) = config_values.get("use_sitemap").and_then(|v| v.as_bool()) {
+        opts.crawl.use_sitemap = v;
+    }
+
+    // Discovery: max_pages
+    if let Some(v) = config_values.get("max_pages").and_then(|v| v.as_str()) {
+        if let Ok(n) = v.parse() {
+            opts.crawl.max_pages = n;
+        }
+    }
+
+    // Crawler: max_depth
+    if let Some(v) = config_values.get("max_depth").and_then(|v| v.as_str()) {
+        if let Ok(n) = v.parse() {
+            opts.crawl.max_depth = n;
+        }
+    }
+
+    // Behavior: download_images
+    if let Some(v) = config_values
+        .get("download_images")
+        .and_then(|v| v.as_bool())
+    {
+        opts.network.download_images = v;
+    }
+
+    // Behavior: download_documents
+    if let Some(v) = config_values
+        .get("download_documents")
+        .and_then(|v| v.as_bool())
+    {
+        opts.network.download_documents = v;
+    }
+
+    // Obsidian: obsidian_wiki_links
+    if let Some(v) = config_values
+        .get("obsidian_wiki_links")
+        .and_then(|v| v.as_bool())
+    {
+        opts.export.obsidian_wiki_links = v;
+    }
+
+    // Obsidian: vault path
+    if let Some(vault) = config_values.get("vault").and_then(|v| v.as_str()) {
+        if !vault.is_empty() {
+            opts.export.obsidian_vault = Some(PathBuf::from(vault));
+        }
+    }
+
+    // Obsidian: quick_save
+    if let Some(v) = config_values.get("quick_save").and_then(|v| v.as_bool()) {
+        opts.export.quick_save = v;
+    }
+
+    // AI: clean_ai (only applies when feature is enabled)
+    #[cfg(feature = "ai")]
+    if let Some(_v) = config_values.get("clean_ai").and_then(|v| v.as_bool()) {
+        // TODO: wire clean_ai into CrawlOptions when AI settings are added
+    }
+
+    opts
+}
+
+// ============================================================================
+// TUI Config Merge — Args variant (for pre-conversion use in main.rs)
+// ============================================================================
+
+/// Apply config values from TUI form to Args.
+///
+/// This runs on Args before conversion to CrawlOptions, because the TUI
+/// needs access to Args-specific fields (config_tui, url).
+pub fn apply_tui_config_args(mut args: Args, config_values: &serde_json::Value) -> Args {
     use crate::ExportFormat as E;
     use crate::OutputFormat as O;
 

--- a/src/cli/scrape_flow.rs
+++ b/src/cli/scrape_flow.rs
@@ -6,22 +6,23 @@ use tracing::{info, warn};
 use url::Url;
 
 use crate::adapters::tui::{ScrapeError, ScrapeProgress, ScrapeStatus};
+use crate::application::crawl_options::CrawlOptions;
 use crate::application::export_factory;
 use crate::application::scrape_single_url_for_tui;
 use crate::domain::ScrapedContent;
 use crate::infrastructure::export::state_store::StateStore;
-use crate::{Args, ScraperConfig};
+use crate::ScraperConfig;
 use crate::{HttpClient, HttpClientConfig};
 
 /// Apply resume mode filtering.
 pub async fn apply_resume_mode(
     urls_to_scrape: Vec<Url>,
-    args: &Args,
+    opts: &CrawlOptions,
     target_url: &str,
 ) -> (Vec<Url>, Option<StateStore>) {
-    let state_store: Option<StateStore> = if args.resume {
+    let state_store: Option<StateStore> = if opts.crawl.resume {
         info!("Resume mode enabled - tracking processed URLs");
-        let state_dir = args.state_dir.clone().unwrap_or_else(|| {
+        let state_dir = opts.crawl.state_dir.clone().unwrap_or_else(|| {
             let cache_base = std::env::var("XDG_CACHE_HOME")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| {
@@ -45,7 +46,7 @@ pub async fn apply_resume_mode(
         None
     };
 
-    let filtered = if args.resume {
+    let filtered = if opts.crawl.resume {
         if let Some(store) = state_store.as_ref() {
             match store.load_or_default() {
                 Ok(state) => {
@@ -93,10 +94,10 @@ pub async fn apply_resume_mode(
 pub async fn scrape_urls(
     urls: &[Url],
     scraper_config: &ScraperConfig,
-    args: &Args,
+    opts: &CrawlOptions,
     progress_tx: Option<mpsc::Sender<ScrapeProgress>>,
 ) -> (Vec<ScrapedContent>, Vec<(String, String)>) {
-    let http_config = build_http_client_config(args);
+    let http_config = build_http_client_config(opts);
     let http_client = match HttpClient::new(http_config) {
         Ok(c) => c,
         Err(e) => {
@@ -132,7 +133,7 @@ pub async fn scrape_urls(
         let _url_host = url.host_str().unwrap_or("unknown").to_string();
 
         // Emit progress event: Started
-        if !args.quiet {
+        if !opts.export.quiet {
             if let Some(ref tx) = progress_tx {
                 let _ = tx
                     .send(ScrapeProgress::Started {
@@ -143,7 +144,7 @@ pub async fn scrape_urls(
         }
 
         // Emit progress event: StatusChanged to Fetching
-        if !args.quiet {
+        if !opts.export.quiet {
             if let Some(ref tx) = progress_tx {
                 let _ = tx
                     .send(ScrapeProgress::StatusChanged {
@@ -159,7 +160,7 @@ pub async fn scrape_urls(
                 let chars = content.content.chars().count();
                 results.push(content);
                 // Emit progress event: Completed (only if not quiet)
-                if !args.quiet {
+                if !opts.export.quiet {
                     if let Some(ref tx) = progress_tx {
                         let _ = tx
                             .send(ScrapeProgress::Completed {
@@ -176,7 +177,7 @@ pub async fn scrape_urls(
                 warn!("Failed to scrape {}: {}", url_str, err_msg);
                 failures.push((url_str.clone(), err_msg));
                 // Emit progress event: Failed
-                if !args.quiet {
+                if !opts.export.quiet {
                     if let Some(ref tx) = progress_tx {
                         let _ = tx
                             .send(ScrapeProgress::Failed {
@@ -195,7 +196,7 @@ pub async fn scrape_urls(
     let total_failed = failures.len();
 
     // Emit Finished event when all done (only if not quiet)
-    if !args.quiet {
+    if !opts.export.quiet {
         if let Some(ref tx) = progress_tx {
             let _ = tx
                 .send(ScrapeProgress::Finished {
@@ -210,13 +211,13 @@ pub async fn scrape_urls(
     (results, failures)
 }
 
-fn build_http_client_config(args: &Args) -> HttpClientConfig {
+fn build_http_client_config(opts: &CrawlOptions) -> HttpClientConfig {
     HttpClientConfig {
-        max_retries: args.max_retries,
-        backoff_base_ms: args.backoff_base_ms,
-        backoff_max_ms: args.backoff_max_ms,
-        accept_language: args.accept_language.clone(),
-        timeout_secs: args.timeout_secs,
+        max_retries: opts.network.max_retries,
+        backoff_base_ms: opts.network.backoff_base_ms,
+        backoff_max_ms: opts.network.backoff_max_ms,
+        accept_language: opts.network.accept_language.clone(),
+        timeout_secs: opts.network.timeout_secs,
         ..HttpClientConfig::default()
     }
 }
@@ -224,32 +225,27 @@ fn build_http_client_config(args: &Args) -> HttpClientConfig {
 #[cfg(test)]
 mod tests {
     use super::build_http_client_config;
-    use clap::Parser;
+    use crate::application::crawl_options::CrawlOptions;
 
     #[test]
-    fn build_http_client_config_uses_args_timeout_secs() {
-        let args = crate::Args::parse_from([
-            "rust_scraper",
-            "--url",
-            "https://example.com",
-            "--timeout-secs",
-            "7",
-        ]);
+    fn build_http_client_config_uses_opts_timeout_secs() {
+        let mut opts = CrawlOptions::default();
+        opts.network.timeout_secs = 7;
 
-        let config = build_http_client_config(&args);
+        let config = build_http_client_config(&opts);
 
         assert_eq!(config.timeout_secs, 7);
-        assert_eq!(config.max_retries, args.max_retries);
-        assert_eq!(config.backoff_base_ms, args.backoff_base_ms);
-        assert_eq!(config.backoff_max_ms, args.backoff_max_ms);
-        assert_eq!(config.accept_language, args.accept_language);
+        assert_eq!(config.max_retries, opts.network.max_retries);
+        assert_eq!(config.backoff_base_ms, opts.network.backoff_base_ms);
+        assert_eq!(config.backoff_max_ms, opts.network.backoff_max_ms);
+        assert_eq!(config.accept_language, opts.network.accept_language);
     }
 
     #[test]
     fn build_http_client_config_preserves_default_timeout_when_unset() {
-        let args = crate::Args::parse_from(["rust_scraper", "--url", "https://example.com"]);
+        let opts = CrawlOptions::default();
 
-        let config = build_http_client_config(&args);
+        let config = build_http_client_config(&opts);
 
         assert_eq!(config.timeout_secs, 30);
     }

--- a/src/cli/url_discovery.rs
+++ b/src/cli/url_discovery.rs
@@ -5,18 +5,16 @@ use tracing::{info, warn};
 use url::Url;
 
 use crate::adapters;
+use crate::application::crawl_options::CrawlOptions;
 use crate::application::discover_urls_for_tui;
 use crate::cli::preflight;
 use crate::cli::SelectedUrls;
-use crate::Args;
 use crate::CliExit;
 use crate::CrawlerConfig;
 
 /// Discover URLs with progress bar.
-pub async fn discover_urls(crawler_config: &CrawlerConfig, args: &Args) -> Vec<Url> {
-    let target_url = args.url.as_ref().expect("url required");
-
-    let discovery_pb = if !args.quiet {
+pub async fn discover_urls(crawler_config: &CrawlerConfig, opts: &CrawlOptions) -> Vec<Url> {
+    let discovery_pb = if !opts.export.quiet {
         let pb = ProgressBar::new_spinner();
         pb.set_draw_target(ProgressDrawTarget::stderr());
         pb.enable_steady_tick(std::time::Duration::from_millis(100));
@@ -31,7 +29,7 @@ pub async fn discover_urls(crawler_config: &CrawlerConfig, args: &Args) -> Vec<U
         None
     };
 
-    let discovered_urls = match discover_urls_for_tui(target_url, crawler_config).await {
+    let discovered_urls = match discover_urls_for_tui(opts.url.as_str(), crawler_config).await {
         Ok(urls) => urls,
         Err(e) => {
             if let Some(pb) = discovery_pb.as_ref() {
@@ -52,15 +50,15 @@ pub async fn discover_urls(crawler_config: &CrawlerConfig, args: &Args) -> Vec<U
 /// Select URLs via TUI, quick-save, or headless mode.
 pub async fn select_urls(
     discovered_urls: &[Url],
-    args: &Args,
+    opts: &CrawlOptions,
     vault_path: &Option<std::path::PathBuf>,
 ) -> SelectedUrls {
     let ok = preflight::icon("✅", "OK");
 
-    if args.quick_save && vault_path.is_some() {
+    if opts.export.quick_save && vault_path.is_some() {
         info!("Quick-save mode: bypassing TUI, will save to vault _inbox");
         SelectedUrls::Urls(discovered_urls.to_vec())
-    } else if args.interactive {
+    } else if opts.crawl.interactive {
         info!("Starting interactive TUI selector...");
         match adapters::tui::run_selector(discovered_urls).await {
             Ok(selected) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@ pub use error::SemanticError;
 
 // Application layer
 pub use application::{
-    crawl_site, crawl_with_sitemap, create_http_client, detect_spa_content, discover_urls_for_tui,
-    extract_domain,
+    crawl_options::CrawlOptions, crawl_site, crawl_with_sitemap, create_http_client,
+    detect_spa_content, discover_urls_for_tui, extract_domain,
     http_client::{HttpClient, HttpClientConfig, HttpError},
     is_allowed, is_excluded, is_internal_link, matches_pattern, scrape_multiple_with_limit,
     scrape_single_url_for_tui, scrape_urls_for_tui, scrape_with_config, scrape_with_readability,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,9 @@ pub use error::SemanticError;
 
 // Application layer
 pub use application::{
-    crawl_options::CrawlOptions, crawl_site, crawl_with_sitemap, create_http_client,
-    detect_spa_content, discover_urls_for_tui, extract_domain,
+    crawl_options::CrawlOptions,
+    crawl_site, crawl_with_sitemap, create_http_client, detect_spa_content, discover_urls_for_tui,
+    extract_domain,
     http_client::{HttpClient, HttpClientConfig, HttpError},
     is_allowed, is_excluded, is_internal_link, matches_pattern, scrape_multiple_with_limit,
     scrape_single_url_for_tui, scrape_urls_for_tui, scrape_with_config, scrape_with_readability,

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use clap::Parser;
 use inquire::Text;
 use rust_scraper::adapters::tui::modal::HelpModal;
 use rust_scraper::adapters::tui::{App, AppMode, AppResult, ConfigFormState, Header, StatusBar};
+use rust_scraper::application::crawl_options::CrawlOptions;
 use rust_scraper::cli::config::ConfigDefaults;
 use rust_scraper::cli::error::CliExit;
 use rust_scraper::cli::preflight;
@@ -155,7 +156,8 @@ async fn __main() -> CliExit {
         match config_result {
             Ok(Some(config_values)) => {
                 // Apply TUI config values to args (overrides CLI values)
-                args = preflight::apply_tui_config(args, &config_values);
+                // TUI operates on Args because it needs config_tui/url fields
+                args = preflight::apply_tui_config_args(args, &config_values);
                 println!("Config applied from TUI form.");
             },
             Ok(None) => {
@@ -210,25 +212,35 @@ async fn __main() -> CliExit {
     let config_defaults = ConfigDefaults::load(&config_path);
 
     // =========================================================================
-    // 6. Apply config file defaults where CLI args are at default values
+    // 5b. Validate URL before conversion (CrawlOptions::from panics on invalid URL)
     // =========================================================================
-    let args = preflight::apply_config_defaults(args, &config_defaults);
+    if let Some(ref url_str) = args.url {
+        if url::Url::parse(url_str).is_err() {
+            return CliExit::UsageError(format!("Invalid URL: {url_str}"));
+        }
+    }
+
+    // =========================================================================
+    // 6. Convert Args → CrawlOptions and apply config file defaults
+    // =========================================================================
+    let opts = CrawlOptions::from(args);
+    let opts = preflight::apply_config_defaults(opts, &config_defaults);
 
     // =========================================================================
     // 7. Initialize logging (stderr-only, respects quiet + NO_COLOR)
     // =========================================================================
     let no_color = is_no_color();
-    let log_level = match args.verbose {
+    let log_level = match opts.verbosity {
         0 => "info",
         1 => "debug",
         _ => "trace",
     };
     // Keep guard alive for program duration (required for tracing subscriber)
     #[allow(clippy::let_unit_value)]
-    let _guard = init_logging_dual(log_level, args.quiet, no_color);
+    let _guard = init_logging_dual(log_level, opts.export.quiet, no_color);
 
     // =========================================================================
     // 8. Delegate to orchestrator
     // =========================================================================
-    orchestrator::run(args).await
+    orchestrator::run(opts).await
 }


### PR DESCRIPTION
## Summary
- **Eliminamos el leak de `Args` hacia la capa de aplicación:** `CrawlerService` y `ElasticIngestion` ahora reciben `CrawlOptions`, no `&Args`.
- **Matamos el wiring duplicado:** `build_elastic_pipeline()` eliminado del orquestador. `Container::with_elastic()` es la única fuente de verdad.
- **949 tests en verde**, clippy limpio.

## Changes

| File | Change |
|------|--------|
| `src/application/crawl_options.rs` | **(Nuevo)** CrawlOptions + 4 sub-structs con Default |
| `src/cli/args.rs` | From\<Args\> para CrawlOptions (line 396) |
| `src/cli/orchestrator.rs` | Usa Container, build_elastic_pipeline eliminado |
| `src/cli/preflight.rs` | Opera sobre CrawlOptions |
| `src/cli/commands.rs` | &CrawlOptions en vez de &Args |
| `src/cli/scrape_flow.rs` | Sub-structs en vez de &Args |
| `src/cli/url_discovery.rs` | &CrawlOptions en vez de &Args |
| `src/lib.rs` | Re-export de CrawlOptions |
| `src/main.rs` | Args → CrawlOptions conversion |

## Test Plan
- [x] `cargo check --features ai` ✅
- [x] `cargo clippy -- -D warnings` ✅
- [x] `cargo nextest run --features ai` — **949/949 pass** ✅

Refs #38
