### PR TITLE
refactor(miri): layer isolation with #[cfg(not(miri))]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,11 @@ jobs:
         group: [core, domain, infra]
         include:
           - group: core
-            filter: "--skip application::elastic_ingestion::tests::test_run_dedup_short_circuits_when_hash_exists -- adapters:: application:: cli:: config:: di:: error::"
+            filter: "-- adapters:: application:: cli:: config:: di:: error::"
           - group: domain
             filter: "-- domain::"
           - group: infra
-            filter: "--skip infrastructure::mcp_server::server::tests::test_highlight_code_blocks_logic -- infrastructure::"
+            filter: "-- infrastructure::"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,11 @@ jobs:
         group: [core, domain, infra]
         include:
           - group: core
-            filter: "-- adapters:: application:: cli:: config:: di:: error::"
+            filter: "--skip application::elastic_ingestion::tests::test_run_dedup_short_circuits_when_hash_exists -- adapters:: application:: cli:: config:: di:: error::"
           - group: domain
             filter: "-- domain::"
           - group: infra
-            filter: "-- infrastructure::"
+            filter: "--skip infrastructure::mcp_server::server::tests::test_highlight_code_blocks_logic -- infrastructure::"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/src/application/elastic_ingestion.rs
+++ b/src/application/elastic_ingestion.rs
@@ -365,8 +365,7 @@ mod tests {
     mod wreq {
         use super::*;
 
-        fn make_orchestrator
-        (repo: InMemoryRepo) -> ElasticIngestion<InMemoryRepo> {
+        fn make_orchestrator(repo: InMemoryRepo) -> ElasticIngestion<InMemoryRepo> {
             let client = ::wreq::Client::builder()
                 .build()
                 .expect("fallo construyendo cliente wreq de prueba");
@@ -411,7 +410,11 @@ mod tests {
             orc.run(&url).await.expect("pipeline debe completarse");
 
             let state = repo.state.lock().expect("repo mutex poisoned");
-            assert_eq!(state.resources.len(), 1, "exactamente un recurso persistido");
+            assert_eq!(
+                state.resources.len(),
+                1,
+                "exactamente un recurso persistido"
+            );
             let (_hash, (saved_url, _title, size)) =
                 state.resources.iter().next().expect("un recurso");
             assert_eq!(saved_url, &url);

--- a/src/application/elastic_ingestion.rs
+++ b/src/application/elastic_ingestion.rs
@@ -351,133 +351,134 @@ mod tests {
         }
     }
 
-    fn make_orchestrator(repo: InMemoryRepo) -> ElasticIngestion<InMemoryRepo> {
-        let client = wreq::Client::builder()
-            .build()
-            .expect("fallo construyendo cliente wreq de prueba");
-        let semaphore = Arc::new(tokio::sync::Semaphore::new(1 << 20));
-        let downloader = ResourceDownloader::with_config(
-            semaphore,
-            client,
-            DownloadConfig {
-                global_timeout_seconds: 5,
-                chunk_timeout_seconds: 5,
-                max_size_bytes: 1024 * 1024,
-                ..DownloadConfig::default()
-            },
-        );
-        let pool = RayonCpuPool::new(2).expect("pool de 2 hilos");
-        let bridge = CpuBridge::new(pool);
-        let config = AutotuningConfig {
-            cpu_cores: 2,
-            ram_budget_bytes: 1 << 20,
-        };
-        ElasticIngestion::new(downloader, bridge, repo, config)
-    }
+    // ====================================================================
+    // wreq/HTTP-dependent orchestrator tests
+    //
+    // Miri interpreta MIR y no puede ejecutar C FFI. make_orchestrator()
+    // construye un wreq::Client que depende de boring-sys2 (BoringSSL →
+    // TLS_method FFI). Aislar estos tests en un solo bloque #[cfg(not(miri))]
+    // evita parchear test por test y mantiene Miri enfocado en detectar UB
+    // en la lógica Rust pura.
+    // ====================================================================
 
-    async fn serve_html(body: &str) -> (MockServer, String) {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/"))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.as_bytes().to_vec()))
-            .mount(&server)
-            .await;
-        let url = format!("{}/", server.uri());
-        (server, url)
-    }
+    #[cfg(not(miri))]
+    mod wreq {
+        use super::*;
 
-    // ---- Task 5.1: full pipeline persists a resource + chunk ----
+        fn make_orchestrator
+        (repo: InMemoryRepo) -> ElasticIngestion<InMemoryRepo> {
+            let client = ::wreq::Client::builder()
+                .build()
+                .expect("fallo construyendo cliente wreq de prueba");
+            let semaphore = Arc::new(tokio::sync::Semaphore::new(1 << 20));
+            let downloader = ResourceDownloader::with_config(
+                semaphore,
+                client,
+                DownloadConfig {
+                    global_timeout_seconds: 5,
+                    chunk_timeout_seconds: 5,
+                    max_size_bytes: 1024 * 1024,
+                    ..DownloadConfig::default()
+                },
+            );
+            let pool = RayonCpuPool::new(2).expect("pool de 2 hilos");
+            let bridge = CpuBridge::new(pool);
+            let config = AutotuningConfig {
+                cpu_cores: 2,
+                ram_budget_bytes: 1 << 20,
+            };
+            ElasticIngestion::new(downloader, bridge, repo, config)
+        }
 
-    #[tokio::test]
-    async fn test_run_persists_resource_and_chunk() {
-        let repo = InMemoryRepo::default();
-        let orc = make_orchestrator(repo.clone());
-        let (_server, url) =
-            serve_html("<nav>menu</nav><main><p>hello elastic world</p></main>").await;
+        async fn serve_html(body: &str) -> (MockServer, String) {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/"))
+                .respond_with(ResponseTemplate::new(200).set_body_bytes(body.as_bytes().to_vec()))
+                .mount(&server)
+                .await;
+            let url = format!("{}/", server.uri());
+            (server, url)
+        }
 
-        orc.run(&url).await.expect("pipeline debe completarse");
+        #[tokio::test]
+        async fn test_run_persists_resource_and_chunk() {
+            let repo = InMemoryRepo::default();
+            let orc = make_orchestrator(repo.clone());
+            let (_server, url) =
+                serve_html("<nav>menu</nav><main><p>hello elastic world</p></main>").await;
 
-        let state = repo.state.lock().expect("repo mutex poisoned");
-        assert_eq!(
-            state.resources.len(),
-            1,
-            "exactamente un recurso persistido"
-        );
-        let (_hash, (saved_url, _title, size)) = state.resources.iter().next().expect("un recurso");
-        assert_eq!(saved_url, &url);
-        assert!(*size > 0, "size_bytes debe ser positivo");
-        assert_eq!(state.chunks.len(), 1, "exactamente un chunk persistido");
-        let chunk = &state.chunks[0];
-        assert_eq!(chunk.1, url, "chunk enlaza al recurso correcto");
-        assert_eq!(chunk.2, 0, "primer chunk_index == 0");
-        assert!(
-            chunk.3.contains("hello elastic world"),
-            "contenido limpio persistido: {}",
-            chunk.3
-        );
-        assert!(
-            !chunk.3.contains("menu"),
-            "el boilerplate (nav) no debe persistir: {}",
-            chunk.3
-        );
-        assert!(
-            chunk.4.is_none(),
-            "sin limpiador ONNX, embedding debe ser None"
-        );
-    }
+            orc.run(&url).await.expect("pipeline debe completarse");
 
-    // ---- Task 5.1: dedup short-circuit (frozen Decision 3) ----
+            let state = repo.state.lock().expect("repo mutex poisoned");
+            assert_eq!(state.resources.len(), 1, "exactamente un recurso persistido");
+            let (_hash, (saved_url, _title, size)) =
+                state.resources.iter().next().expect("un recurso");
+            assert_eq!(saved_url, &url);
+            assert!(*size > 0, "size_bytes debe ser positivo");
+            assert_eq!(state.chunks.len(), 1, "exactamente un chunk persistido");
+            let chunk = &state.chunks[0];
+            assert_eq!(chunk.1, url, "chunk enlaza al recurso correcto");
+            assert_eq!(chunk.2, 0, "primer chunk_index == 0");
+            assert!(
+                chunk.3.contains("hello elastic world"),
+                "contenido limpio persistido: {}",
+                chunk.3
+            );
+            assert!(
+                !chunk.3.contains("menu"),
+                "el boilerplate (nav) no debe persistir: {}",
+                chunk.3
+            );
+            assert!(
+                chunk.4.is_none(),
+                "sin limpiador ONNX, embedding debe ser None"
+            );
+        }
 
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_run_dedup_short_circuits_when_hash_exists() {
-        let repo = InMemoryRepo::default();
-        let orc = make_orchestrator(repo.clone());
-        let (_server, url) = serve_html("<main><p>duplicate content</p></main>").await;
+        #[tokio::test]
+        async fn test_run_dedup_short_circuits_when_hash_exists() {
+            let repo = InMemoryRepo::default();
+            let orc = make_orchestrator(repo.clone());
+            let (_server, url) = serve_html("<main><p>duplicate content</p></main>").await;
 
-        // First run persists.
-        orc.run(&url).await.expect("primera ingestión ok");
-        let after_first = {
-            let s = repo.state.lock().expect("poisoned");
-            (s.resources.len(), s.chunks.len())
-        };
-        assert_eq!(after_first, (1, 1));
+            orc.run(&url).await.expect("primera ingestión ok");
+            let after_first = {
+                let s = repo.state.lock().expect("poisoned");
+                (s.resources.len(), s.chunks.len())
+            };
+            assert_eq!(after_first, (1, 1));
 
-        // Second run of the SAME content → dedup: no new resource/chunk rows.
-        orc.run(&url).await.expect("segunda ingestión (dedup) ok");
-        let after_second = {
-            let s = repo.state.lock().expect("poisoned");
-            (s.resources.len(), s.chunks.len())
-        };
-        assert_eq!(
-            after_second,
-            (1, 1),
-            "dedup debe impedir filas duplicadas para el mismo content_hash"
-        );
-    }
+            orc.run(&url).await.expect("segunda ingestión (dedup) ok");
+            let after_second = {
+                let s = repo.state.lock().expect("poisoned");
+                (s.resources.len(), s.chunks.len())
+            };
+            assert_eq!(
+                after_second,
+                (1, 1),
+                "dedup debe impedir filas duplicadas para el mismo content_hash"
+            );
+        }
 
-    // ---- Task 5.1: fail-fast on network error (frozen Decision 3) ----
+        #[tokio::test]
+        async fn test_run_network_error_propagates_without_retry() {
+            let repo = InMemoryRepo::default();
+            let orc = make_orchestrator(repo.clone());
+            let port = {
+                let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+                listener.local_addr().expect("addr").port()
+            };
+            let url = format!("http://127.0.0.1:{port}/");
 
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_run_network_error_propagates_without_retry() {
-        let repo = InMemoryRepo::default();
-        let orc = make_orchestrator(repo.clone());
-        // Bind a loopback port then drop the listener → connections are refused
-        // (deterministic wreq network error, not a 404 body wiremock would serve).
-        let port = {
-            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-            listener.local_addr().expect("addr").port()
-        };
-        let url = format!("http://127.0.0.1:{port}/");
-
-        let result = orc.run(&url).await;
-        assert!(result.is_err(), "error de red debe propagarse (fail-fast)");
-        let state = repo.state.lock().expect("repo mutex poisoned");
-        assert!(
-            state.resources.is_empty() && state.chunks.is_empty(),
-            "ningún recurso/chunk debe persistirse tras un fallo de red"
-        );
+            let result = orc.run(&url).await;
+            assert!(result.is_err(), "error de red debe propagarse (fail-fast)");
+            let state = repo.state.lock().expect("repo mutex poisoned");
+            assert!(
+                state.resources.is_empty() && state.chunks.is_empty(),
+                "ningún recurso/chunk debe persistirse tras un fallo de red"
+            );
+        }
     }
 
     // ---- Task 5.1: static Send + Sync (orchestrator is shareable) ----

--- a/src/application/elastic_ingestion.rs
+++ b/src/application/elastic_ingestion.rs
@@ -428,6 +428,7 @@ mod tests {
 
     // ---- Task 5.1: dedup short-circuit (frozen Decision 3) ----
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_run_dedup_short_circuits_when_hash_exists() {
         let repo = InMemoryRepo::default();
@@ -457,6 +458,7 @@ mod tests {
 
     // ---- Task 5.1: fail-fast on network error (frozen Decision 3) ----
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_run_network_error_propagates_without_retry() {
         let repo = InMemoryRepo::default();

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -23,7 +23,7 @@ use clap::Parser;
 ///
 /// assert_eq!(args.url, "https://example.com");
 /// ```
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[command(name = "rust_scraper", version)]
 #[command(about = "Production-ready web scraper with Clean Architecture", long_about = None)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -593,6 +593,7 @@ mod tests {
             ram_budget: Some("4GB".into()),
             db_path: Some(std::path::PathBuf::from("/tmp/test.db")),
             elastic: true,
+            ..Default::default()
         }
     }
 
@@ -816,6 +817,7 @@ mod tests {
                 ram_budget: None,
                 db_path: None,
                 elastic,
+                ..Default::default()
             };
 
             let opts = crate::application::crawl_options::CrawlOptions::from(args);
@@ -898,6 +900,7 @@ mod tests {
                 ram_budget: None,
                 db_path: None,
                 elastic: false,
+                ..Default::default()
             };
 
             let opts = crate::application::crawl_options::CrawlOptions::from(args);
@@ -972,6 +975,7 @@ mod tests {
                 ram_budget: None,
                 db_path: None,
                 elastic: false,
+                ..Default::default()
             };
 
             let expected_selector = args.selector.clone();
@@ -1040,6 +1044,7 @@ mod tests {
                 ram_budget: None,
                 db_path: db_path.as_deref().map(std::path::PathBuf::from),
                 elastic: false,
+                ..Default::default()
             };
 
             let opts = crate::application::crawl_options::CrawlOptions::from(args);
@@ -1108,6 +1113,7 @@ mod tests {
                 ram_budget: None,
                 db_path: None,
                 elastic: false,
+                ..Default::default()
             };
 
             let opts = crate::application::crawl_options::CrawlOptions::from(args);
@@ -1172,6 +1178,7 @@ mod tests {
                 ram_budget: None,
                 db_path: None,
                 elastic: false,
+                ..Default::default()
             };
 
             let opts = crate::application::crawl_options::CrawlOptions::from(args);
@@ -1231,6 +1238,7 @@ mod tests {
                 ram_budget: ram_budget.clone(),
                 db_path: None,
                 elastic: true,
+                ..Default::default()
             };
 
             let opts = crate::application::crawl_options::CrawlOptions::from(args);

--- a/src/domain/entities.rs
+++ b/src/domain/entities.rs
@@ -179,10 +179,13 @@ pub struct ScrapedContent {
 /// |--------|-----------|----------|
 /// | Jsonl | .jsonl | One JSON object per line, optimal for RAG |
 /// | Auto | .auto | Auto-detect from existing files |
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum, Default,
+)]
 pub enum ExportFormat {
     /// JSONL format (JSON Lines - one JSON object per line)
     /// Optimal for RAG pipelines and vector database ingestion
+    #[default]
     Jsonl,
     /// Vector format (JSON with metadata header)
     /// Supports embeddings and cosine similarity

--- a/src/error.rs
+++ b/src/error.rs
@@ -387,6 +387,7 @@ mod tests {
         assert_eq!(err.to_string(), "Error de ingestión: pipeline abortó");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_persistence_error_from_rusqlite() {
         // Triangulation: the Display-based helper must carry the real rusqlite

--- a/src/infrastructure/config.rs
+++ b/src/infrastructure/config.rs
@@ -19,9 +19,10 @@ use clap::ValueEnum;
 /// let format = OutputFormat::Markdown;
 /// assert_eq!(format, OutputFormat::Markdown);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
 pub enum OutputFormat {
     /// Markdown format with YAML frontmatter (recommended for RAG)
+    #[default]
     Markdown,
     /// Structured JSON with metadata
     Json,

--- a/src/infrastructure/mcp_server/server.rs
+++ b/src/infrastructure/mcp_server/server.rs
@@ -172,6 +172,7 @@ mod tests {
         assert!(fm.contains("example.com"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_highlight_code_blocks_logic() {
         let md = "```rust\nfn main() {}\n```";

--- a/src/infrastructure/persistence/sqlite.rs
+++ b/src/infrastructure/persistence/sqlite.rs
@@ -373,160 +373,9 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    /// Build a fresh pool over a temp-file DB and run the schema.
-    async fn fresh_pool(size: usize) -> (TempDir, Pool) {
-        let dir = TempDir::new().expect("tempdir");
-        let db_path = dir.path().join("crawl.db");
-        let pool = create_pool(&db_path, size).expect("create_pool");
-        SqliteVectorRepository::setup_schema(&pool)
-            .await
-            .expect("setup_schema");
-        (dir, pool)
-    }
-
-    /// Count rows in `sqlite_master` matching `type` and `name`.
-    async fn master_count(pool: &Pool, kind: &str, name: &str) -> i64 {
-        // Own the strings: the `interact` closure must be `Send + 'static`, so it
-        // cannot capture borrowed `&str` from this function's frame.
-        let kind = kind.to_string();
-        let name = name.to_string();
-        let conn = pool.get().await.expect("get");
-        conn.interact(move |c| {
-            c.query_row(
-                "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
-                rusqlite::params![kind, name],
-                |row| row.get::<_, i64>(0),
-            )
-        })
-        .await
-        .expect("interact")
-        .expect("count")
-    }
-
-    async fn pragma_string(pool: &Pool, pragma: &str) -> String {
-        let sql = format!("PRAGMA {pragma}");
-        let conn = pool.get().await.expect("get");
-        conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, String>(0)))
-            .await
-            .expect("interact")
-            .expect("pragma row")
-    }
-
-    async fn pragma_int(pool: &Pool, pragma: &str) -> i64 {
-        let sql = format!("PRAGMA {pragma}");
-        let conn = pool.get().await.expect("get");
-        conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, i64>(0)))
-            .await
-            .expect("interact")
-            .expect("pragma row")
-    }
-
-    #[tokio::test]
-    async fn test_setup_schema_creates_resources_table() {
-        let (_dir, pool) = fresh_pool(4).await;
-        assert_eq!(master_count(&pool, "table", "resources").await, 1);
-    }
-
-    #[tokio::test]
-    async fn test_setup_schema_creates_chunks_table() {
-        let (_dir, pool) = fresh_pool(4).await;
-        assert_eq!(master_count(&pool, "table", "chunks").await, 1);
-    }
-
-    #[tokio::test]
-    async fn test_setup_schema_creates_indexes() {
-        let (_dir, pool) = fresh_pool(4).await;
-        assert_eq!(
-            master_count(&pool, "index", "idx_chunks_resource").await,
-            1,
-            "idx_chunks_resource missing"
-        );
-        assert_eq!(
-            master_count(&pool, "index", "idx_resources_content_hash").await,
-            1,
-            "idx_resources_content_hash missing"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_wal_pragmas_applied_to_connection() {
-        // A freshly-created pooled connection must carry all three pragmas
-        // (proves the post_create hook runs on each connection).
-        let (_dir, pool) = fresh_pool(4).await;
-        assert_eq!(pragma_string(&pool, "journal_mode").await, "wal");
-        // synchronous: 0=OFF,1=NORMAL,2=FULL,3=EXTRA — NORMAL must be 1.
-        assert_eq!(pragma_int(&pool, "synchronous").await, 1);
-        assert_eq!(pragma_int(&pool, "cache_size").await, -4000);
-    }
-
-    #[tokio::test]
-    async fn test_db_file_created_when_absent() {
-        let dir = TempDir::new().expect("tempdir");
-        let db_path = dir.path().join("nested").join("crawl.db");
-        assert!(!db_path.exists());
-        let pool = create_pool(&db_path, 4).expect("create_pool");
-        SqliteVectorRepository::setup_schema(&pool)
-            .await
-            .expect("setup_schema");
-        // setup_schema materializes the DB file (parent dir created by create_pool).
-        assert!(db_path.exists(), "DB file should exist after setup_schema");
-    }
-
-    #[tokio::test]
-    async fn test_pool_size_is_configurable() {
-        let (_dir, pool) = fresh_pool(8).await;
-        let status = pool.status();
-        assert_eq!(status.max_size, 8, "pool max_size must honor configuration");
-    }
-
-    #[tokio::test]
-    async fn test_setup_schema_is_idempotent() {
-        let (_dir, pool) = fresh_pool(4).await;
-        // Running setup_schema twice must not error (CREATE ... IF NOT EXISTS).
-        SqliteVectorRepository::setup_schema(&pool)
-            .await
-            .expect("second setup_schema should be a no-op");
-        assert_eq!(master_count(&pool, "table", "resources").await, 1);
-        assert_eq!(master_count(&pool, "table", "chunks").await, 1);
-    }
-
-    #[tokio::test]
-    async fn test_repository_wraps_pool() {
-        let (_dir, pool) = fresh_pool(4).await;
-        let repo = SqliteVectorRepository::new(pool.clone());
-        assert_eq!(repo.pool().status().max_size, 4);
-    }
-
-    // ========================================================================
-    // PR4: VectorRepository CRUD + content-hash dedup (Strict TDD)
-    // Frozen design: BLOB = raw LE f32 bytes (decision #7); dedup short-circuit
-    // (decision #3); no separate StorageError enum (decision #4).
-    // ========================================================================
-
-    /// Build a fresh schema-initialized repo over a temp-file DB.
-    async fn fresh_repo(size: usize) -> (TempDir, SqliteVectorRepository) {
-        let (dir, pool) = fresh_pool(size).await;
-        let repo = SqliteVectorRepository::new(pool);
-        (dir, repo)
-    }
-
-    /// Count rows in `resources` matching a content_hash (test inspection only).
-    async fn count_resources_by_hash(repo: &SqliteVectorRepository, hash: &str) -> i64 {
-        let hash = hash.to_string();
-        let conn = repo.pool().get().await.expect("get");
-        conn.interact(move |c| {
-            c.query_row(
-                "SELECT COUNT(*) FROM resources WHERE content_hash = ?1",
-                rusqlite::params![hash],
-                |row| row.get::<_, i64>(0),
-            )
-        })
-        .await
-        .expect("interact")
-        .expect("count")
-    }
-
-    // --- Pure serialization functions (frozen design decision #7) ---
+    // ====================================================================
+    // Pure serialization round-trips (Miri-safe — no FFI, no I/O)
+    // ====================================================================
 
     #[test]
     fn test_embedding_roundtrip() {
@@ -555,182 +404,339 @@ mod tests {
         assert!(msg.contains('5'), "missing length in message: {msg}");
     }
 
-    // --- resource_exists_by_hash ---
+    // ====================================================================
+    // SQLite-backed integration tests
+    //
+    // Miri es un intérprete de MIR, no un emulador de binarios. No puede
+    // ejecutar código C nativo (libsqlite3-sys → sqlite3_threadsafe FFI).
+    // Estos tests requieren SQLite3 real del sistema operativo.
+    //
+    // Estrategia: Aislamiento de Capas (Layer Isolation) — el bloque entero
+    // se excluye de Miri con #[cfg(not(miri))] en lugar de parchear cada
+    // test uno por uno. Misma práctica que tokio, serde, regex.
+    // ====================================================================
 
-    #[tokio::test]
-    async fn test_resource_exists_by_hash_returns_none_when_empty() {
-        let (_dir, repo) = fresh_repo(4).await;
-        let got = repo.resource_exists_by_hash("nope").await.expect("query");
-        assert!(got.is_none(), "fresh DB has no resources");
-    }
+    #[cfg(not(miri))]
+    mod sqlite {
+        use super::*;
 
-    // --- save_resource + dedup (frozen decision #3) ---
-
-    #[tokio::test]
-    async fn test_save_and_get_resource() {
-        let (_dir, repo) = fresh_repo(4).await;
-        let url = repo
-            .save_resource("https://example.com/a", "Example", "hash-aaa", 1234)
-            .await
-            .expect("save_resource");
-        assert_eq!(
-            url, "https://example.com/a",
-            "save_resource must return the URL"
-        );
-        // Triangulation: the hash is now retrievable and exactly one row exists.
-        let found = repo
-            .resource_exists_by_hash("hash-aaa")
-            .await
-            .expect("query");
-        assert_eq!(found.as_deref(), Some("https://example.com/a"));
-        assert_eq!(count_resources_by_hash(&repo, "hash-aaa").await, 1);
-    }
-
-    #[tokio::test]
-    async fn test_dedup_skips_duplicate_hash() {
-        let (_dir, repo) = fresh_repo(4).await;
-        let first = repo
-            .save_resource("https://example.com/first", "First", "dup-hash", 100)
-            .await
-            .expect("save_resource #1");
-        // Same content_hash, different URL → must short-circuit and return the
-        // existing URL without inserting a duplicate row.
-        let second = repo
-            .save_resource("https://example.com/second", "Second", "dup-hash", 200)
-            .await
-            .expect("save_resource #2 (dedup)");
-        assert_eq!(
-            first, "https://example.com/first",
-            "dedup returns existing URL"
-        );
-        assert_eq!(second, first, "dedup must return the SAME (existing) URL");
-        assert_eq!(
-            count_resources_by_hash(&repo, "dup-hash").await,
-            1,
-            "no duplicate row must be inserted on dedup hit"
-        );
-    }
-
-    // --- save_chunk + get_vector ---
-
-    #[tokio::test]
-    async fn test_save_and_get_chunk_with_embedding() {
-        let (_dir, repo) = fresh_repo(4).await;
-        repo.save_resource("https://example.com/c", "C", "hash-c", 10)
-            .await
-            .expect("save_resource");
-        let emb = vec![0.1_f32, 0.2, 0.3, 0.4];
-        repo.save_chunk(
-            "chunk-1",
-            "https://example.com/c",
-            0,
-            "hello world",
-            Some(&emb),
-        )
-        .await
-        .expect("save_chunk");
-        let got = repo.get_vector("chunk-1").await.expect("get_vector");
-        assert_eq!(
-            got.as_deref(),
-            Some(emb.as_slice()),
-            "embedding must round-trip through BLOB"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_save_chunk_without_embedding_returns_none() {
-        let (_dir, repo) = fresh_repo(4).await;
-        repo.save_resource("https://example.com/n", "N", "hash-n", 10)
-            .await
-            .expect("save_resource");
-        repo.save_chunk(
-            "chunk-none",
-            "https://example.com/n",
-            0,
-            "no vec here",
-            None,
-        )
-        .await
-        .expect("save_chunk");
-        let got = repo.get_vector("chunk-none").await.expect("get_vector");
-        assert!(
-            got.is_none(),
-            "chunk saved without embedding must yield None"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_get_vector_nonexistent_chunk() {
-        let (_dir, repo) = fresh_repo(4).await;
-        let got = repo.get_vector("does-not-exist").await.expect("get_vector");
-        assert!(
-            got.is_none(),
-            "missing chunk must yield Ok(None), not an error"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_corrupt_blob_returns_error() {
-        let (_dir, repo) = fresh_repo(4).await;
-        repo.save_resource("https://example.com/bad", "Bad", "hash-bad", 1)
-            .await
-            .expect("save_resource");
-        // Inject a corrupt 5-byte BLOB directly via SQL (bypasses the serializer).
-        let url = "https://example.com/bad".to_string();
-        let conn = repo.pool().get().await.expect("get");
-        conn.interact(move |c| {
-            c.execute(
-                "INSERT INTO chunks \
-                 (id, resource_url, chunk_index, content, embedding_vector, created_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
-                rusqlite::params!["bad-chunk", url, 0_i64, "", vec![1_u8, 2, 3, 4, 5]],
-            )
-        })
-        .await
-        .expect("interact")
-        .expect("raw insert");
-        // get_vector must reject the corrupt BLOB with a Persistence error.
-        let err = repo
-            .get_vector("bad-chunk")
-            .await
-            .expect_err("corrupt BLOB must surface as an error");
-        let msg = err.to_string();
-        assert!(msg.contains("corrupto"), "missing Spanish marker: {msg}");
-        assert!(msg.contains('5'), "missing length in message: {msg}");
-    }
-
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_concurrent_writes_via_pool() {
-        // Spec §Connection Pooling "concurrent writes via pool": 4 concurrent
-        // writes on a pool of size 4 must all complete without blocking the
-        // runtime. Native async-trait futures are NOT `Send`, so we run them
-        // concurrently on the test task via `join_all` (no `tokio::spawn`).
-        let (_dir, repo) = fresh_repo(4).await;
-        let futures = (0..4_u8).map(|i| {
-            let repo = repo.clone();
-            async move {
-                repo.save_resource(
-                    &format!("https://example.com/c{i}"),
-                    "Concurrent",
-                    &format!("hash-c{i}"),
-                    1,
-                )
+        /// Build a fresh pool over a temp-file DB and run the schema.
+        async fn fresh_pool(size: usize) -> (TempDir, Pool) {
+            let dir = TempDir::new().expect("tempdir");
+            let db_path = dir.path().join("crawl.db");
+            let pool = create_pool(&db_path, size).expect("create_pool");
+            SqliteVectorRepository::setup_schema(&pool)
                 .await
-            }
-        });
-        let results: Vec<_> = futures::future::join_all(futures).await;
-        assert_eq!(results.len(), 4, "all 4 concurrent saves must complete");
-        for r in &results {
-            assert!(r.is_ok(), "concurrent save must not error: {r:?}");
+                .expect("setup_schema");
+            (dir, pool)
         }
-        // All 4 rows present (distinct hashes → no dedup).
-        for i in 0..4_u8 {
+
+        /// Count rows in `sqlite_master` matching `type` and `name`.
+        async fn master_count(pool: &Pool, kind: &str, name: &str) -> i64 {
+            // Own the strings: the `interact` closure must be `Send + 'static`, so it
+            // cannot capture borrowed `&str` from this function's frame.
+            let kind = kind.to_string();
+            let name = name.to_string();
+            let conn = pool.get().await.expect("get");
+            conn.interact(move |c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = ?1 AND name = ?2",
+                    rusqlite::params![kind, name],
+                    |row| row.get::<_, i64>(0),
+                )
+            })
+            .await
+            .expect("interact")
+            .expect("count")
+        }
+
+        async fn pragma_string(pool: &Pool, pragma: &str) -> String {
+            let sql = format!("PRAGMA {pragma}");
+            let conn = pool.get().await.expect("get");
+            conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, String>(0)))
+                .await
+                .expect("interact")
+                .expect("pragma row")
+        }
+
+        async fn pragma_int(pool: &Pool, pragma: &str) -> i64 {
+            let sql = format!("PRAGMA {pragma}");
+            let conn = pool.get().await.expect("get");
+            conn.interact(move |c| c.query_row(&sql, [], |row| row.get::<_, i64>(0)))
+                .await
+                .expect("interact")
+                .expect("pragma row")
+        }
+
+        #[tokio::test]
+        async fn test_setup_schema_creates_resources_table() {
+            let (_dir, pool) = fresh_pool(4).await;
+            assert_eq!(master_count(&pool, "table", "resources").await, 1);
+        }
+
+        #[tokio::test]
+        async fn test_setup_schema_creates_chunks_table() {
+            let (_dir, pool) = fresh_pool(4).await;
+            assert_eq!(master_count(&pool, "table", "chunks").await, 1);
+        }
+
+        #[tokio::test]
+        async fn test_setup_schema_creates_indexes() {
+            let (_dir, pool) = fresh_pool(4).await;
             assert_eq!(
-                count_resources_by_hash(&repo, &format!("hash-c{i}")).await,
+                master_count(&pool, "index", "idx_chunks_resource").await,
                 1,
-                "row for hash-c{i} must exist after concurrent writes"
+                "idx_chunks_resource missing"
             );
+            assert_eq!(
+                master_count(&pool, "index", "idx_resources_content_hash").await,
+                1,
+                "idx_resources_content_hash missing"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_wal_pragmas_applied_to_connection() {
+            // A freshly-created pooled connection must carry all three pragmas
+            // (proves the post_create hook runs on each connection).
+            let (_dir, pool) = fresh_pool(4).await;
+            assert_eq!(pragma_string(&pool, "journal_mode").await, "wal");
+            // synchronous: 0=OFF,1=NORMAL,2=FULL,3=EXTRA — NORMAL must be 1.
+            assert_eq!(pragma_int(&pool, "synchronous").await, 1);
+            assert_eq!(pragma_int(&pool, "cache_size").await, -4000);
+        }
+
+        #[tokio::test]
+        async fn test_db_file_created_when_absent() {
+            let dir = TempDir::new().expect("tempdir");
+            let db_path = dir.path().join("nested").join("crawl.db");
+            assert!(!db_path.exists());
+            let pool = create_pool(&db_path, 4).expect("create_pool");
+            SqliteVectorRepository::setup_schema(&pool)
+                .await
+                .expect("setup_schema");
+            // setup_schema materializes the DB file (parent dir created by create_pool).
+            assert!(db_path.exists(), "DB file should exist after setup_schema");
+        }
+
+        #[tokio::test]
+        async fn test_pool_size_is_configurable() {
+            let (_dir, pool) = fresh_pool(8).await;
+            let status = pool.status();
+            assert_eq!(status.max_size, 8, "pool max_size must honor configuration");
+        }
+
+        #[tokio::test]
+        async fn test_setup_schema_is_idempotent() {
+            let (_dir, pool) = fresh_pool(4).await;
+            // Running setup_schema twice must not error (CREATE ... IF NOT EXISTS).
+            SqliteVectorRepository::setup_schema(&pool)
+                .await
+                .expect("second setup_schema should be a no-op");
+            assert_eq!(master_count(&pool, "table", "resources").await, 1);
+            assert_eq!(master_count(&pool, "table", "chunks").await, 1);
+        }
+
+        #[tokio::test]
+        async fn test_repository_wraps_pool() {
+            let (_dir, pool) = fresh_pool(4).await;
+            let repo = SqliteVectorRepository::new(pool.clone());
+            assert_eq!(repo.pool().status().max_size, 4);
+        }
+
+        // ================================================================
+        // PR4: VectorRepository CRUD + content-hash dedup (Strict TDD)
+        // ================================================================
+
+        /// Build a fresh schema-initialized repo over a temp-file DB.
+        async fn fresh_repo(size: usize) -> (TempDir, SqliteVectorRepository) {
+            let (dir, pool) = fresh_pool(size).await;
+            let repo = SqliteVectorRepository::new(pool);
+            (dir, repo)
+        }
+
+        /// Count rows in `resources` matching a content_hash (test inspection only).
+        async fn count_resources_by_hash(repo: &SqliteVectorRepository, hash: &str) -> i64 {
+            let hash = hash.to_string();
+            let conn = repo.pool().get().await.expect("get");
+            conn.interact(move |c| {
+                c.query_row(
+                    "SELECT COUNT(*) FROM resources WHERE content_hash = ?1",
+                    rusqlite::params![hash],
+                    |row| row.get::<_, i64>(0),
+                )
+            })
+            .await
+            .expect("interact")
+            .expect("count")
+        }
+
+        // --- resource_exists_by_hash ---
+
+        #[tokio::test]
+        async fn test_resource_exists_by_hash_returns_none_when_empty() {
+            let (_dir, repo) = fresh_repo(4).await;
+            let got = repo.resource_exists_by_hash("nope").await.expect("query");
+            assert!(got.is_none(), "fresh DB has no resources");
+        }
+
+        // --- save_resource + dedup (frozen decision #3) ---
+
+        #[tokio::test]
+        async fn test_save_and_get_resource() {
+            let (_dir, repo) = fresh_repo(4).await;
+            let url = repo
+                .save_resource("https://example.com/a", "Example", "hash-aaa", 1234)
+                .await
+                .expect("save_resource");
+            assert_eq!(
+                url, "https://example.com/a",
+                "save_resource must return the URL"
+            );
+            let found = repo
+                .resource_exists_by_hash("hash-aaa")
+                .await
+                .expect("query");
+            assert_eq!(found.as_deref(), Some("https://example.com/a"));
+            assert_eq!(count_resources_by_hash(&repo, "hash-aaa").await, 1);
+        }
+
+        #[tokio::test]
+        async fn test_dedup_skips_duplicate_hash() {
+            let (_dir, repo) = fresh_repo(4).await;
+            let first = repo
+                .save_resource("https://example.com/first", "First", "dup-hash", 100)
+                .await
+                .expect("save_resource #1");
+            let second = repo
+                .save_resource("https://example.com/second", "Second", "dup-hash", 200)
+                .await
+                .expect("save_resource #2 (dedup)");
+            assert_eq!(
+                first, "https://example.com/first",
+                "dedup returns existing URL"
+            );
+            assert_eq!(second, first, "dedup must return the SAME (existing) URL");
+            assert_eq!(
+                count_resources_by_hash(&repo, "dup-hash").await,
+                1,
+                "no duplicate row must be inserted on dedup hit"
+            );
+        }
+
+        // --- save_chunk + get_vector ---
+
+        #[tokio::test]
+        async fn test_save_and_get_chunk_with_embedding() {
+            let (_dir, repo) = fresh_repo(4).await;
+            repo.save_resource("https://example.com/c", "C", "hash-c", 10)
+                .await
+                .expect("save_resource");
+            let emb = vec![0.1_f32, 0.2, 0.3, 0.4];
+            repo.save_chunk(
+                "chunk-1",
+                "https://example.com/c",
+                0,
+                "hello world",
+                Some(&emb),
+            )
+            .await
+            .expect("save_chunk");
+            let got = repo.get_vector("chunk-1").await.expect("get_vector");
+            assert_eq!(
+                got.as_deref(),
+                Some(emb.as_slice()),
+                "embedding must round-trip through BLOB"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_save_chunk_without_embedding_returns_none() {
+            let (_dir, repo) = fresh_repo(4).await;
+            repo.save_resource("https://example.com/n", "N", "hash-n", 10)
+                .await
+                .expect("save_resource");
+            repo.save_chunk(
+                "chunk-none",
+                "https://example.com/n",
+                0,
+                "no vec here",
+                None,
+            )
+            .await
+            .expect("save_chunk");
+            let got = repo.get_vector("chunk-none").await.expect("get_vector");
+            assert!(
+                got.is_none(),
+                "chunk saved without embedding must yield None"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_get_vector_nonexistent_chunk() {
+            let (_dir, repo) = fresh_repo(4).await;
+            let got = repo.get_vector("does-not-exist").await.expect("get_vector");
+            assert!(
+                got.is_none(),
+                "missing chunk must yield Ok(None), not an error"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_corrupt_blob_returns_error() {
+            let (_dir, repo) = fresh_repo(4).await;
+            repo.save_resource("https://example.com/bad", "Bad", "hash-bad", 1)
+                .await
+                .expect("save_resource");
+            let url = "https://example.com/bad".to_string();
+            let conn = repo.pool().get().await.expect("get");
+            conn.interact(move |c| {
+                c.execute(
+                    "INSERT INTO chunks \
+                     (id, resource_url, chunk_index, content, embedding_vector, created_at) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
+                    rusqlite::params!["bad-chunk", url, 0_i64, "", vec![1_u8, 2, 3, 4, 5]],
+                )
+            })
+            .await
+            .expect("interact")
+            .expect("raw insert");
+            let err = repo
+                .get_vector("bad-chunk")
+                .await
+                .expect_err("corrupt BLOB must surface as an error");
+            let msg = err.to_string();
+            assert!(msg.contains("corrupto"), "missing Spanish marker: {msg}");
+            assert!(msg.contains('5'), "missing length in message: {msg}");
+        }
+
+        #[tokio::test]
+        async fn test_concurrent_writes_via_pool() {
+            let (_dir, repo) = fresh_repo(4).await;
+            let futures = (0..4_u8).map(|i| {
+                let repo = repo.clone();
+                async move {
+                    repo.save_resource(
+                        &format!("https://example.com/c{i}"),
+                        "Concurrent",
+                        &format!("hash-c{i}"),
+                        1,
+                    )
+                    .await
+                }
+            });
+            let results: Vec<_> = futures::future::join_all(futures).await;
+            assert_eq!(results.len(), 4, "all 4 concurrent saves must complete");
+            for r in &results {
+                assert!(r.is_ok(), "concurrent save must not error: {r:?}");
+            }
+            for i in 0..4_u8 {
+                assert_eq!(
+                    count_resources_by_hash(&repo, &format!("hash-c{i}")).await,
+                    1,
+                    "row for hash-c{i} must exist after concurrent writes"
+                );
+            }
         }
     }
 }

--- a/src/infrastructure/persistence/sqlite.rs
+++ b/src/infrastructure/persistence/sqlite.rs
@@ -699,6 +699,7 @@ mod tests {
         assert!(msg.contains('5'), "missing length in message: {msg}");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_concurrent_writes_via_pool() {
         // Spec §Connection Pooling "concurrent writes via pool": 4 concurrent

--- a/src/infrastructure/user_agent.rs
+++ b/src/infrastructure/user_agent.rs
@@ -233,6 +233,7 @@ pub fn get_random_user_agent() -> String {
 mod tests {
     use super::*;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_user_agent_cache_load() {
         let agents = UserAgentCache::load().await;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -45,11 +45,13 @@ use deadpool_sqlite::Pool;
 ///     assert!(response.is_ok());
 /// }
 /// ```
+#[allow(dead_code)]
 pub struct TestHttpServer {
     server: wiremock::MockServer,
     base_url: String,
 }
 
+#[allow(dead_code)]
 impl TestHttpServer {
     /// Create a new mock server on a random available port.
     ///
@@ -159,6 +161,7 @@ pub fn mock_scraped_content(url: &str, title: &str, content: &str) -> rust_scrap
 }
 
 /// Create a ScrapedContent with raw HTML included.
+#[allow(dead_code)]
 pub fn mock_scraped_content_with_html(
     url: &str,
     title: &str,
@@ -198,11 +201,13 @@ pub fn mock_scraped_content_with_html(
 ///     // vault.vault_json() gives you the obsidian.json path
 /// }
 /// ```
+#[allow(dead_code)]
 pub struct MockVault {
     _temp_dir: TempDir,
     vault_path: PathBuf,
 }
 
+#[allow(dead_code)]
 impl MockVault {
     /// Create a new mock Obsidian vault in a temporary directory.
     ///
@@ -277,10 +282,12 @@ impl MockVault {
 ///     // ... use pool for testing
 /// }
 /// ```
+#[allow(dead_code)]
 pub struct MemoryDb {
     pool: Pool,
 }
 
+#[allow(dead_code)]
 impl MemoryDb {
     /// Create a new in-memory SQLite database with a single-connection pool.
     pub fn new() -> Self {

--- a/tests/flag_audit_core_display_test.rs
+++ b/tests/flag_audit_core_display_test.rs
@@ -66,6 +66,7 @@ fn base_args() -> Args {
         ram_budget: None,
         db_path: None,
         elastic: false,
+        ..Default::default()
     }
 }
 

--- a/tests/flag_audit_downloads_test.rs
+++ b/tests/flag_audit_downloads_test.rs
@@ -61,6 +61,7 @@ fn base_args() -> Args {
         ram_budget: None,
         db_path: None,
         elastic: false,
+        ..Default::default()
     }
 }
 

--- a/tests/flag_audit_http_crawler_test.rs
+++ b/tests/flag_audit_http_crawler_test.rs
@@ -61,6 +61,7 @@ fn base_args() -> Args {
         ram_budget: None,
         db_path: None,
         elastic: false,
+        ..Default::default()
     }
 }
 

--- a/tests/flag_audit_obsidian_test.rs
+++ b/tests/flag_audit_obsidian_test.rs
@@ -70,6 +70,7 @@ fn base_args() -> Args {
         ram_budget: None,
         db_path: None,
         elastic: false,
+        ..Default::default()
     }
 }
 

--- a/tests/flag_audit_sitemap_resume_test.rs
+++ b/tests/flag_audit_sitemap_resume_test.rs
@@ -66,6 +66,7 @@ fn base_args() -> Args {
         ram_budget: None,
         db_path: None,
         elastic: false,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Replace per-test #[cfg_attr(miri, ignore)] with module-level #[cfg(not(miri))] blocks covering entire FFI-dependent layers at once — same pattern as tokio, serde, regex.

- **sqlite.rs**: 16 SQLite-backed tests under #[cfg(not(miri))], 2 pure serialization tests stay Miri-safe
- **elastic_ingestion.rs**: 3 wreq-dependent tests grouped under #[cfg(not(miri))], make_orchestrator + serve_html moved alongside
- **error.rs**: test_persistence_error_from_rusqlite — #[cfg_attr(miri, ignore)] (rusqlite FFI)
- **user_agent.rs**: test_user_agent_cache_load — #[cfg_attr(miri, ignore)] (wreq/btls FFI)

CI verde: Miri core (35m), infra (17m), domain (5m) — todos pasan.