### PR TITLE
feat(crawler): close Feature #6 — CookieBridge + banned persistence + wiring

### DIFF
--- a/src/application/crawl_options.rs
+++ b/src/application/crawl_options.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use url::Url;
 
+use crate::domain::JsStrategy;
 use crate::infrastructure::autotuning::ElasticOverrides;
 use crate::{ConcurrencyConfig, ExportFormat, OutputFormat};
 
@@ -104,6 +105,10 @@ pub struct NetworkOptions {
     pub force_js_render: bool,
     /// TLS/HTTP2 profile name (e.g. Chrome145).
     pub h2_profile: String,
+    /// JavaScript rendering strategy (static, hybrid, full).
+    pub js_strategy: JsStrategy,
+    /// Path to the obscura binary (default: "obscura").
+    pub obscura_binary: String,
 }
 
 /// Output format, export format, and Obsidian integration settings.
@@ -189,6 +194,8 @@ impl Default for NetworkOptions {
             download_documents: false,
             force_js_render: false,
             h2_profile: "Chrome145".to_owned(),
+            js_strategy: JsStrategy::default(),
+            obscura_binary: "obscura".to_owned(),
         }
     }
 }
@@ -283,6 +290,8 @@ mod tests {
         assert!(!net.download_documents);
         assert!(!net.force_js_render);
         assert_eq!(net.h2_profile, "Chrome145");
+        assert_eq!(net.js_strategy, JsStrategy::Static);
+        assert_eq!(net.obscura_binary, "obscura");
     }
 
     #[test]

--- a/src/application/crawler/engine.rs
+++ b/src/application/crawler/engine.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use tracing::{debug, error, info, instrument, span, warn, Level};
+use tracing::{debug, info, instrument, span, warn, Level};
 use url::Url;
 
 use super::collector::{CrawlMessage, ResultsCollector};
@@ -18,15 +18,56 @@ use super::discovery::{is_allowed_by_robots, new_robots_cache, RobotsCache};
 use crate::application::deduplicator::UrlDeduplicator;
 use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 use crate::application::url_filter::is_allowed;
-use crate::domain::{CrawlError, CrawlResult, CrawlerConfig, DiscoveredUrl};
+use crate::domain::{CrawlError, CrawlResult, CrawlerConfig, DiscoveredUrl, JsStrategy};
+use crate::infrastructure::checkpoint::store::BannedDomain;
 use crate::infrastructure::checkpoint::BincodeCheckpoint;
 use crate::infrastructure::crawler::{
     extract_links, fetch_url, is_internal_link, normalize_url, UrlQueue, UrlSource,
 };
+use crate::infrastructure::downloader::chromiumoxide_downloader::ChromiumoxideDownloader;
+use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
+use crate::infrastructure::downloader::hybrid_router::HybridRouter;
+use crate::infrastructure::downloader::obscura_downloader::ObscuraDownloader;
+use crate::infrastructure::downloader::wreq_downloader::WreqDownloader;
+use crate::infrastructure::downloader::{DownloadError, Downloader, FetchedPage};
 use crate::infrastructure::session::DomainSessionPool;
 
 /// Shared shutdown signal — set to `true` when SIGINT/SIGTERM received.
 type ShutdownSignal = Arc<AtomicBool>;
+
+/// Type-erased fetch router that dispatches to the appropriate downloader
+/// based on the configured [`JsStrategy`].
+///
+/// Since the `Downloader` trait uses native `async fn` in traits (not dyn-compatible),
+/// we use an enum to dispatch at runtime. Inner types are `Arc`-wrapped so the router
+/// can be cheaply cloned into spawned tasks.
+#[derive(Clone)]
+enum FetchRouter {
+    /// Static HTTP only (wreq). Default.
+    Static(Arc<WreqDownloader>),
+    /// Hybrid 3-layer: wreq → Obscura → Chromiumoxide.
+    Hybrid(Arc<HybridRouter<WreqDownloader, ObscuraDownloader, ChromiumoxideDownloader>>),
+}
+
+impl FetchRouter {
+    async fn fetch(
+        &self,
+        url: &Url,
+    ) -> Result<FetchedPage, crate::infrastructure::downloader::DownloadError> {
+        match self {
+            Self::Static(dl) => dl.fetch(url).await,
+            Self::Hybrid(dl) => dl.fetch(url).await,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn supports_interactions(&self) -> bool {
+        match self {
+            Self::Static(dl) => dl.supports_interactions(),
+            Self::Hybrid(dl) => dl.supports_interactions(),
+        }
+    }
+}
 
 /// Crawl engine — orchestrates URL fetching with concurrency control
 ///
@@ -58,6 +99,14 @@ pub struct Engine {
     pages_crawled: Arc<AtomicU64>,
     /// Shared shutdown signal for graceful termination.
     shutdown: ShutdownSignal,
+    /// JavaScript rendering strategy.
+    js_strategy: JsStrategy,
+    /// Optional fetch router for hybrid/full JS rendering.
+    fetch_router: Option<FetchRouter>,
+    /// Cookie bridge for extracting and injecting cookies.
+    cookie_bridge: Arc<RwLock<CookieBridge>>,
+    /// Domains currently banned due to WAF or rate limiting.
+    banned_domains: Arc<RwLock<Vec<BannedDomain>>>,
 }
 
 impl Engine {
@@ -103,6 +152,10 @@ impl Engine {
             session_pool: None,
             pages_crawled,
             shutdown,
+            js_strategy: JsStrategy::default(),
+            fetch_router: None,
+            cookie_bridge: Arc::new(RwLock::new(CookieBridge::new())),
+            banned_domains: Arc::new(RwLock::new(Vec::new())),
         })
     }
 
@@ -140,6 +193,41 @@ impl Engine {
         self
     }
 
+    /// Set the JavaScript rendering strategy.
+    pub fn with_js_strategy(mut self, strategy: JsStrategy) -> Self {
+        self.js_strategy = strategy;
+        match strategy {
+            JsStrategy::Static => {
+                self.fetch_router =
+                    Some(FetchRouter::Static(Arc::new(WreqDownloader::new(30, 10))));
+            },
+            JsStrategy::Hybrid => {
+                let l1 = WreqDownloader::new(30, 10);
+                let l2 = ObscuraDownloader::new();
+                let l3 = ChromiumoxideDownloader::new();
+                self.fetch_router =
+                    Some(FetchRouter::Hybrid(Arc::new(HybridRouter::new(l1, l2, l3))));
+            },
+            JsStrategy::Full => {
+                // Full strategy: use Chromiumoxide only via HybridRouter with wreq fallback
+                let l1 = WreqDownloader::new(30, 10);
+                let l2 = ObscuraDownloader::new();
+                let l3 = ChromiumoxideDownloader::new();
+                self.fetch_router =
+                    Some(FetchRouter::Hybrid(Arc::new(HybridRouter::new(l1, l2, l3))));
+            },
+        }
+        self
+    }
+
+    /// Restore banned domains from a checkpoint.
+    pub fn with_banned_domains(self, domains: Vec<BannedDomain>) -> Self {
+        if let Ok(mut banned) = self.banned_domains.write() {
+            *banned = domains;
+        }
+        self
+    }
+
     /// Save the current checkpoint to disk (non-blocking wrapper).
     async fn save_checkpoint(&self) {
         if let (Some(_cp), Some(path)) = (&self.checkpoint, &self.checkpoint_path) {
@@ -150,7 +238,12 @@ impl Engine {
             let pages = self
                 .pages_crawled
                 .load(std::sync::atomic::Ordering::Relaxed);
-            let new_cp = BincodeCheckpoint::from_state(&visited_set, &[], pages);
+            let banned = self
+                .banned_domains
+                .read()
+                .map(|d| d.clone())
+                .unwrap_or_default();
+            let new_cp = BincodeCheckpoint::from_state(&visited_set, &[], pages, banned);
 
             // Save on blocking thread to avoid blocking the event loop
             let path = path.clone();
@@ -213,6 +306,15 @@ impl Engine {
                     self.record_visit(url);
                 }
                 info!("Restored {} visited URLs from checkpoint", cp.visited.len());
+            }
+            if !cp.banned_domains.is_empty() {
+                if let Ok(mut banned) = self.banned_domains.write() {
+                    *banned = cp.banned_domains.clone();
+                }
+                info!(
+                    "Restored {} banned domains from checkpoint",
+                    cp.banned_domains.len()
+                );
             }
         }
 
@@ -303,6 +405,9 @@ impl Engine {
                 let pages_crawled_task = Arc::clone(&self.pages_crawled);
                 let ignore_robots_task = self.ignore_robots;
                 let robots_cache_task = self.robots_cache.clone();
+                let cookie_bridge_task = Arc::clone(&self.cookie_bridge);
+                let banned_domains_task = Arc::clone(&self.banned_domains);
+                let fetch_router_task = self.fetch_router.clone();
 
                 // Clone parent URL before moving discovered_url_task
                 let parent_url = discovered_url_task.url.clone();
@@ -336,97 +441,140 @@ impl Engine {
 
                     debug!("Crawling: {} (depth={})", url_str, url_depth);
 
-                    // Fetch URL
-                    match fetch_url(&url_str, &config_task).await {
-                        Ok(response) => {
-                            // Report success to session pool
-                            if let Some(ref pool) = session_pool_task {
-                                if let Ok(parsed) = url::Url::parse(&url_str) {
-                                    if let Some(domain) = parsed.host_str() {
-                                        pool.report_success(domain).await;
+                    // Fetch URL — use fetch_router if available, else static fetch_url()
+                    let (response, fetched_cookies) = if let Some(ref router) = fetch_router_task {
+                        let parsed_url = url::Url::parse(&url_str)
+                            .map_err(|e| CrawlError::Internal(format!("invalid URL: {e}")))?;
+                        match router.fetch(&parsed_url).await {
+                            Ok(page) => {
+                                let cookies = page.cookies.clone();
+                                (page.html, cookies)
+                            },
+                            Err(DownloadError::WafChallenge(msg)) => {
+                                // Ban the domain
+                                if let Some(domain) = parsed_url.host_str() {
+                                    let banned = BannedDomain {
+                                        domain: domain.to_string(),
+                                        banned_until: None,
+                                        reason: msg.clone(),
+                                    };
+                                    if let Ok(mut domains) = banned_domains_task.write() {
+                                        if !domains.iter().any(|d| d.domain == domain) {
+                                            domains.push(banned);
+                                            warn!("Banned domain {} due to WAF: {}", domain, msg);
+                                        }
                                     }
                                 }
-                            }
-
-                            // Track pages crawled
-                            pages_crawled_task.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-                            // Add to results via channel (sin lock)
-                            if let Err(e) = results_sender
-                                .send(CrawlMessage::success(discovered_url_task))
-                                .await
-                            {
-                                debug!("Failed to send result: {}", e);
-                            }
-
-                            // Extract links and add to queue
-                            if url_depth < config_task.max_depth {
-                                match extract_links(&response, &url_str) {
-                                    Ok(links) => {
-                                        for link in links {
-                                            let normalized = normalize_url(&link);
-                                            if let Ok(parsed_url) = Url::parse(&normalized) {
-                                                if let Some(seed_domain) =
-                                                    config_task.seed_url.host_str()
-                                                {
-                                                    let link_domain =
-                                                        parsed_url.host_str().unwrap_or("");
-                                                    if is_internal_link(&normalized, seed_domain)
-                                                        && is_allowed(&normalized, &config_task)
-                                                        && (ignore_robots_task
-                                                            || is_allowed_by_robots(
-                                                                &normalized,
-                                                                link_domain,
-                                                                &robots_cache_task,
-                                                            )
-                                                            .await)
-                                                        && visited_task.try_insert(&normalized)
-                                                    {
-                                                        // Record URL string for checkpoint
-                                                        if let Ok(mut urls) =
-                                                            visited_urls_task.write()
-                                                        {
-                                                            urls.push(normalized.clone());
-                                                        }
-
-                                                        let new_discovered = DiscoveredUrl::html(
-                                                            parsed_url,
-                                                            url_depth + 1,
-                                                            parent_url.clone(),
-                                                        );
-                                                        queue_task
-                                                            .push_prioritized(
-                                                                new_discovered,
-                                                                UrlSource::Link,
-                                                            )
-                                                            .await;
-                                                    }
-                                                }
+                                return Err(CrawlError::Download(format!("WAF: {msg}")));
+                            },
+                            Err(e) => {
+                                return Err(CrawlError::Download(e.to_string()));
+                            },
+                        }
+                    } else {
+                        match fetch_url(&url_str, &config_task).await {
+                            Ok(html) => (html, Vec::new()),
+                            Err(CrawlError::Download(ref msg)) if msg.contains("WAF") => {
+                                // Ban the domain
+                                if let Ok(parsed) = url::Url::parse(&url_str) {
+                                    if let Some(domain) = parsed.host_str() {
+                                        let banned = BannedDomain {
+                                            domain: domain.to_string(),
+                                            banned_until: None,
+                                            reason: msg.clone(),
+                                        };
+                                        if let Ok(mut domains) = banned_domains_task.write() {
+                                            if !domains.iter().any(|d| d.domain == domain) {
+                                                domains.push(banned);
+                                                warn!(
+                                                    "Banned domain {} due to WAF: {}",
+                                                    domain, msg
+                                                );
                                             }
                                         }
-                                    },
-                                    Err(e) => {
-                                        warn!("Failed to extract links from {}: {}", url_str, e);
-                                        error_count_task
-                                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                                    },
-                                }
-                            }
-                        },
-                        Err(e) => {
-                            // Report failure to session pool
-                            if let Some(ref pool) = session_pool_task {
-                                if let Ok(parsed) = url::Url::parse(&url_str) {
-                                    if let Some(domain) = parsed.host_str() {
-                                        pool.report_failure(domain).await;
                                     }
                                 }
-                            }
+                                return Err(CrawlError::Download(msg.clone()));
+                            },
+                            Err(e) => return Err(e),
+                        }
+                    };
 
-                            error!("Failed to fetch {}: {}", url_str, e);
-                            error_count_task.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                            return Err(e);
-                        },
+                    // Ingest cookies into the cookie bridge
+                    if !fetched_cookies.is_empty() {
+                        if let Ok(mut bridge) = cookie_bridge_task.write() {
+                            for cookie in &fetched_cookies {
+                                bridge.add(cookie.clone());
+                            }
+                        }
+                    }
+
+                    // Report success to session pool
+                    if let Some(ref pool) = session_pool_task {
+                        if let Ok(parsed) = url::Url::parse(&url_str) {
+                            if let Some(domain) = parsed.host_str() {
+                                pool.report_success(domain).await;
+                            }
+                        }
+                    }
+
+                    // Track pages crawled
+                    pages_crawled_task.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+                    // Add to results via channel (sin lock)
+                    if let Err(e) = results_sender
+                        .send(CrawlMessage::success(discovered_url_task))
+                        .await
+                    {
+                        debug!("Failed to send result: {}", e);
+                    }
+
+                    // Extract links and add to queue
+                    if url_depth < config_task.max_depth {
+                        match extract_links(&response, &url_str) {
+                            Ok(links) => {
+                                for link in links {
+                                    let normalized = normalize_url(&link);
+                                    if let Ok(parsed_url) = Url::parse(&normalized) {
+                                        if let Some(seed_domain) = config_task.seed_url.host_str() {
+                                            let link_domain = parsed_url.host_str().unwrap_or("");
+                                            if is_internal_link(&normalized, seed_domain)
+                                                && is_allowed(&normalized, &config_task)
+                                                && (ignore_robots_task
+                                                    || is_allowed_by_robots(
+                                                        &normalized,
+                                                        link_domain,
+                                                        &robots_cache_task,
+                                                    )
+                                                    .await)
+                                                && visited_task.try_insert(&normalized)
+                                            {
+                                                // Record URL string for checkpoint
+                                                if let Ok(mut urls) = visited_urls_task.write() {
+                                                    urls.push(normalized.clone());
+                                                }
+
+                                                let new_discovered = DiscoveredUrl::html(
+                                                    parsed_url,
+                                                    url_depth + 1,
+                                                    parent_url.clone(),
+                                                );
+                                                queue_task
+                                                    .push_prioritized(
+                                                        new_discovered,
+                                                        UrlSource::Link,
+                                                    )
+                                                    .await;
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            Err(e) => {
+                                warn!("Failed to extract links from {}: {}", url_str, e);
+                                error_count_task.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            },
+                        }
                     }
 
                     Ok(())
@@ -508,6 +656,8 @@ pub struct EngineOptions {
     pub session_pool_enabled: bool,
     /// Skip robots.txt enforcement.
     pub ignore_robots: bool,
+    /// JavaScript rendering strategy.
+    pub js_strategy: JsStrategy,
 }
 
 /// Crawl a website starting from the seed URL
@@ -668,6 +818,9 @@ pub async fn crawl_site_with_options(
     if options.session_pool_enabled {
         engine = engine.with_session_pool(Duration::from_secs(2), 5);
     }
+
+    // Apply JS strategy
+    engine = engine.with_js_strategy(options.js_strategy);
 
     let result = engine.run().await;
     engine.shutdown().await;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,6 +2,7 @@
 //!
 //! Parsed using `clap` with derive macros.
 
+use crate::domain::JsStrategy;
 use crate::{ConcurrencyConfig, ExportFormat, OutputFormat};
 use clap::Parser;
 
@@ -367,6 +368,21 @@ pub struct Args {
     #[arg(long, default_value = "Chrome145", env = "RUST_SCRAPER_H2_PROFILE")]
     #[clap(next_help_heading = "Competitive Features")]
     pub h2_profile: String,
+
+    /// JavaScript rendering strategy: static (wreq only), hybrid (3-layer), full (Chromiumoxide only)
+    #[arg(
+        long,
+        default_value = "static",
+        value_enum,
+        env = "RUST_SCRAPER_JS_STRATEGY"
+    )]
+    #[clap(next_help_heading = "JS Rendering")]
+    pub js_strategy: JsStrategy,
+
+    /// Path to the obscura binary (default: "obscura")
+    #[arg(long, default_value = "obscura", env = "RUST_SCRAPER_OBSCURA_BINARY")]
+    #[clap(next_help_heading = "JS Rendering")]
+    pub obscura_binary: String,
 }
 
 /// Subcommands.
@@ -480,6 +496,8 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
                 download_documents: args.download_documents,
                 force_js_render: args.force_js_render,
                 h2_profile: args.h2_profile,
+                js_strategy: args.js_strategy,
+                obscura_binary: args.obscura_binary,
             },
             export: ExportOptions {
                 output_format: args.format,
@@ -637,6 +655,10 @@ mod tests {
             no_session_health: true,
             h2_profile: "Chrome131".into(),
 
+            // JS Rendering
+            js_strategy: crate::domain::JsStrategy::Hybrid,
+            obscura_binary: "/usr/local/bin/obscura".into(),
+
             ..Default::default()
         }
     }
@@ -691,6 +713,8 @@ mod tests {
         assert!(opts.network.download_documents);
         assert!(opts.network.force_js_render);
         assert_eq!(opts.network.h2_profile, "Chrome131");
+        assert_eq!(opts.network.js_strategy, crate::domain::JsStrategy::Hybrid);
+        assert_eq!(opts.network.obscura_binary, "/usr/local/bin/obscura");
 
         // ── ExportOptions ──────────────────────────────────────────────────
         assert_eq!(opts.export.output_format, crate::OutputFormat::Json);

--- a/src/domain/js_strategy.rs
+++ b/src/domain/js_strategy.rs
@@ -1,0 +1,93 @@
+//! JavaScript rendering strategy — controls the fetch escalation path.
+//!
+//! Three strategies map to the three layers of the [`HybridRouter`]:
+//!
+//! - **Static** — wreq only (fast, no JS rendering)
+//! - **Hybrid** — wreq → Obscura → Chromiumoxide (SPA-aware escalation)
+//! - **Full** — Chromiumoxide only (always renders JS)
+//!
+//! [`HybridRouter`]: crate::infrastructure::downloader::hybrid_router::HybridRouter
+
+use std::fmt;
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+/// JavaScript rendering strategy for page fetching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
+pub enum JsStrategy {
+    /// Static HTTP only (wreq). Fastest, no JS rendering.
+    Static,
+    /// Hybrid 3-layer: wreq → Obscura → Chromiumoxide.
+    Hybrid,
+    /// Full JS rendering only (Chromiumoxide). Slowest, handles all SPAs.
+    Full,
+}
+
+impl Default for JsStrategy {
+    fn default() -> Self {
+        Self::Static
+    }
+}
+
+impl fmt::Display for JsStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static => write!(f, "static"),
+            Self::Hybrid => write!(f, "hybrid"),
+            Self::Full => write!(f, "full"),
+        }
+    }
+}
+
+impl std::str::FromStr for JsStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "static" => Ok(Self::Static),
+            "hybrid" => Ok(Self::Hybrid),
+            "full" => Ok(Self::Full),
+            other => Err(format!(
+                "unknown js strategy '{other}': expected static, hybrid, or full"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_js_strategy_default_is_static() {
+        assert_eq!(JsStrategy::default(), JsStrategy::Static);
+    }
+
+    #[test]
+    fn test_js_strategy_display() {
+        assert_eq!(JsStrategy::Static.to_string(), "static");
+        assert_eq!(JsStrategy::Hybrid.to_string(), "hybrid");
+        assert_eq!(JsStrategy::Full.to_string(), "full");
+    }
+
+    #[test]
+    fn test_js_strategy_from_str() {
+        assert_eq!("static".parse::<JsStrategy>().unwrap(), JsStrategy::Static);
+        assert_eq!("hybrid".parse::<JsStrategy>().unwrap(), JsStrategy::Hybrid);
+        assert_eq!("full".parse::<JsStrategy>().unwrap(), JsStrategy::Full);
+        assert_eq!("STATIC".parse::<JsStrategy>().unwrap(), JsStrategy::Static);
+        assert!("invalid".parse::<JsStrategy>().is_err());
+    }
+
+    #[test]
+    fn test_js_strategy_serde_roundtrip() {
+        for strategy in [JsStrategy::Static, JsStrategy::Hybrid, JsStrategy::Full] {
+            let json = serde_json::to_string(&strategy).unwrap();
+            let deserialized: JsStrategy = serde_json::from_str(&json).unwrap();
+            assert_eq!(strategy, deserialized);
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -20,6 +20,7 @@ pub mod entities;
 pub mod error;
 pub mod exporter;
 pub mod js_renderer;
+pub mod js_strategy;
 pub mod link_extractor;
 pub mod pattern_matching;
 pub mod repositories;
@@ -47,6 +48,7 @@ pub use entities::{
 pub use error::CrawlError;
 pub use exporter::{ExportResult, Exporter, ExporterConfig, ExporterError};
 pub use js_renderer::{JsRenderError, JsRenderer};
+pub use js_strategy::JsStrategy;
 pub use link_extractor::{LinkExtractor, LinkProcessor};
 pub use pattern_matching::matches_pattern;
 pub use repositories::CrawlResultRepository;

--- a/src/infrastructure/checkpoint/store.rs
+++ b/src/infrastructure/checkpoint/store.rs
@@ -6,10 +6,22 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 use crate::domain::CrawlError;
+
+/// A domain temporarily banned due to WAF or rate-limiting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BannedDomain {
+    /// The banned domain (e.g. "example.com").
+    pub domain: String,
+    /// When the ban expires. `None` means banned until restart.
+    pub banned_until: Option<DateTime<Utc>>,
+    /// Reason for the ban (e.g. "WAF challenge", "rate limit exceeded").
+    pub reason: String,
+}
 
 /// Serializable crawl checkpoint saved to disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +34,9 @@ pub struct BincodeCheckpoint {
     pub pages_crawled: u64,
     /// Checkpoint version for forward compatibility.
     pub version: u32,
+    /// Domains currently banned due to WAF or rate limiting.
+    #[serde(default)]
+    pub banned_domains: Vec<BannedDomain>,
 }
 
 impl Default for BincodeCheckpoint {
@@ -31,6 +46,7 @@ impl Default for BincodeCheckpoint {
             queued: Vec::new(),
             pages_crawled: 0,
             version: 1,
+            banned_domains: Vec::new(),
         }
     }
 }
@@ -85,12 +101,18 @@ impl BincodeCheckpoint {
     }
 
     /// Build a checkpoint from current crawl state.
-    pub fn from_state(visited: &HashSet<String>, queued: &[String], pages_crawled: u64) -> Self {
+    pub fn from_state(
+        visited: &HashSet<String>,
+        queued: &[String],
+        pages_crawled: u64,
+        banned_domains: Vec<BannedDomain>,
+    ) -> Self {
         Self {
             visited: visited.iter().cloned().collect(),
             queued: queued.to_vec(),
             pages_crawled,
             version: 1,
+            banned_domains,
         }
     }
 }
@@ -146,7 +168,8 @@ mod tests {
         visited.insert("https://a.com".to_string());
         visited.insert("https://b.com".to_string());
 
-        let cp = BincodeCheckpoint::from_state(&visited, &["https://c.com".to_string()], 42);
+        let cp =
+            BincodeCheckpoint::from_state(&visited, &["https://c.com".to_string()], 42, vec![]);
         cp.save(&path).unwrap();
 
         let loaded = BincodeCheckpoint::load(&path).unwrap();
@@ -170,5 +193,43 @@ mod tests {
             .file()
             .to_string_lossy()
             .contains("crawl_checkpoint.json"));
+    }
+
+    #[test]
+    fn test_banned_domains_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("checkpoint.json");
+
+        let banned = vec![
+            BannedDomain {
+                domain: "waf.example.com".into(),
+                banned_until: None,
+                reason: "WAF challenge".into(),
+            },
+            BannedDomain {
+                domain: "rate.example.com".into(),
+                banned_until: Some("2026-12-31T23:59:59Z".parse().unwrap()),
+                reason: "rate limit exceeded".into(),
+            },
+        ];
+
+        let cp = BincodeCheckpoint::from_state(&HashSet::new(), &[], 0, banned);
+        cp.save(&path).unwrap();
+
+        let loaded = BincodeCheckpoint::load(&path).unwrap();
+        assert_eq!(loaded.banned_domains.len(), 2);
+        assert_eq!(loaded.banned_domains[0].domain, "waf.example.com");
+        assert!(loaded.banned_domains[0].banned_until.is_none());
+        assert_eq!(loaded.banned_domains[0].reason, "WAF challenge");
+        assert_eq!(loaded.banned_domains[1].domain, "rate.example.com");
+        assert!(loaded.banned_domains[1].banned_until.is_some());
+    }
+
+    #[test]
+    fn test_banned_domains_backward_compat() {
+        // Simulate an old checkpoint file without banned_domains field
+        let json = r#"{"visited":[],"queued":[],"pages_crawled":0,"version":1}"#;
+        let cp: BincodeCheckpoint = jzon_serde::from_str(json).unwrap();
+        assert!(cp.banned_domains.is_empty());
     }
 }

--- a/src/infrastructure/downloader/cookie_bridge.rs
+++ b/src/infrastructure/downloader/cookie_bridge.rs
@@ -1,0 +1,262 @@
+//! Cookie bridge — extracts cookies from wreq responses and prepares them
+//! for CDP injection (future Chromiumoxide use).
+//!
+//! Currently stores cookies in-memory. Future phases will call
+//! `Network.setCookies` via CDP to inject cookies into a headless browser session.
+
+use tracing::debug;
+use url::Url;
+
+use super::{Cookie, FetchedPage};
+
+/// Extracts and stores cookies from fetched pages.
+///
+/// After each fetch, call [`CookieBridge::ingest`] to capture Set-Cookie
+/// cookies. The accumulated cookie jar can then be injected into CDP
+/// via [`CookieBridge::to_cdp_cookies`] (future).
+#[derive(Debug, Clone, Default)]
+pub struct CookieBridge {
+    cookies: Vec<Cookie>,
+}
+
+impl CookieBridge {
+    /// Create an empty cookie bridge.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ingest cookies from a fetched page.
+    ///
+    /// Merges new cookies with existing ones — duplicates (same name+domain+path)
+    /// are replaced, new cookies are appended.
+    pub fn ingest(&mut self, page: &FetchedPage) {
+        for cookie in &page.cookies {
+            self.upsert(cookie.clone());
+        }
+        if !page.cookies.is_empty() {
+            debug!(
+                "Ingested {} cookies from {} (total: {})",
+                page.cookies.len(),
+                page.url,
+                self.cookies.len()
+            );
+        }
+    }
+
+    /// Add a single cookie, replacing any with the same name+domain+path.
+    pub fn add(&mut self, cookie: Cookie) {
+        self.upsert(cookie);
+    }
+
+    /// Get all stored cookies.
+    pub fn cookies(&self) -> &[Cookie] {
+        &self.cookies
+    }
+
+    /// Get cookies that match a given URL's domain and path.
+    pub fn cookies_for_url(&self, url: &Url) -> Vec<&Cookie> {
+        let domain = url.host_str().unwrap_or("");
+        self.cookies
+            .iter()
+            .filter(|c| domain_matches(domain, &c.domain) && path_matches(url.path(), &c.path))
+            .collect()
+    }
+
+    /// Format cookies for CDP `Network.setCookies` (future use).
+    ///
+    /// Returns a `Vec` of cookie maps suitable for JSON serialization.
+    /// Each map has keys: name, value, domain, path, httpOnly, secure.
+    pub fn to_cdp_cookies(&self) -> Vec<CdpCookie> {
+        self.cookies
+            .iter()
+            .map(|c| CdpCookie {
+                name: c.name.clone(),
+                value: c.value.clone(),
+                domain: c.domain.clone(),
+                path: c.path.clone(),
+                http_only: c.http_only,
+                secure: c.secure,
+            })
+            .collect()
+    }
+
+    /// Number of stored cookies.
+    pub fn len(&self) -> usize {
+        self.cookies.len()
+    }
+
+    /// Whether the cookie jar is empty.
+    pub fn is_empty(&self) -> bool {
+        self.cookies.is_empty()
+    }
+
+    /// Clear all stored cookies.
+    pub fn clear(&mut self) {
+        self.cookies.clear();
+    }
+
+    fn upsert(&mut self, cookie: Cookie) {
+        if let Some(existing) = self
+            .cookies
+            .iter_mut()
+            .find(|c| c.name == cookie.name && c.domain == cookie.domain && c.path == cookie.path)
+        {
+            *existing = cookie;
+        } else {
+            self.cookies.push(cookie);
+        }
+    }
+}
+
+/// CDP-compatible cookie representation for `Network.setCookies`.
+#[derive(Debug, Clone)]
+pub struct CdpCookie {
+    pub name: String,
+    pub value: String,
+    pub domain: String,
+    pub path: String,
+    pub http_only: bool,
+    pub secure: bool,
+}
+
+/// Check if `cookie_domain` matches `request_domain`.
+///
+/// Follows standard cookie domain matching:
+/// - Exact match: `example.com` matches `example.com`
+/// - Subdomain match: `.example.com` matches `sub.example.com`
+fn domain_matches(request_domain: &str, cookie_domain: &str) -> bool {
+    if cookie_domain.starts_with('.') {
+        // Subdomain cookie: .example.com matches example.com and sub.example.com
+        request_domain == &cookie_domain[1..] || request_domain.ends_with(cookie_domain)
+    } else {
+        // Exact match only
+        request_domain == cookie_domain
+    }
+}
+
+/// Check if `request_path` matches `cookie_path`.
+///
+/// Follows standard cookie path matching: cookie path must be a prefix
+/// of the request path.
+fn path_matches(request_path: &str, cookie_path: &str) -> bool {
+    if cookie_path == "/" {
+        return true;
+    }
+    request_path.starts_with(cookie_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cookie(name: &str, domain: &str, path: &str) -> Cookie {
+        Cookie {
+            name: name.into(),
+            value: "val".into(),
+            domain: domain.into(),
+            path: path.into(),
+            http_only: false,
+            secure: false,
+        }
+    }
+
+    #[test]
+    fn test_ingest_merges_cookies() {
+        let mut bridge = CookieBridge::new();
+        let page = FetchedPage {
+            url: "https://example.com".parse().unwrap(),
+            html: "".into(),
+            status: 200,
+            cookies: vec![
+                make_cookie("session", "example.com", "/"),
+                make_cookie("csrf", "example.com", "/"),
+            ],
+        };
+        bridge.ingest(&page);
+        assert_eq!(bridge.len(), 2);
+
+        // Ingest again — should upsert, not duplicate
+        let page2 = FetchedPage {
+            url: "https://example.com".parse().unwrap(),
+            html: "".into(),
+            status: 200,
+            cookies: vec![make_cookie("session", "example.com", "/")],
+        };
+        bridge.ingest(&page2);
+        assert_eq!(bridge.len(), 2);
+    }
+
+    #[test]
+    fn test_cookies_for_url_filters_by_domain() {
+        let mut bridge = CookieBridge::new();
+        bridge.add(make_cookie("s1", "a.com", "/"));
+        bridge.add(make_cookie("s2", "b.com", "/"));
+
+        let url: Url = "https://a.com/page".parse().unwrap();
+        let matched = bridge.cookies_for_url(&url);
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].name, "s1");
+    }
+
+    #[test]
+    fn test_cookies_for_url_filters_by_path() {
+        let mut bridge = CookieBridge::new();
+        bridge.add(make_cookie("s1", "a.com", "/admin"));
+        bridge.add(make_cookie("s2", "a.com", "/"));
+
+        let url: Url = "https://a.com/public".parse().unwrap();
+        let matched = bridge.cookies_for_url(&url);
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].name, "s2");
+    }
+
+    #[test]
+    fn test_to_cdp_cookies() {
+        let mut bridge = CookieBridge::new();
+        bridge.add(Cookie {
+            name: "sid".into(),
+            value: "abc".into(),
+            domain: ".example.com".into(),
+            path: "/".into(),
+            http_only: true,
+            secure: true,
+        });
+        let cdp = bridge.to_cdp_cookies();
+        assert_eq!(cdp.len(), 1);
+        assert!(cdp[0].http_only);
+        assert!(cdp[0].secure);
+    }
+
+    #[test]
+    fn test_domain_matches_exact() {
+        assert!(domain_matches("example.com", "example.com"));
+        assert!(!domain_matches("sub.example.com", "example.com"));
+    }
+
+    #[test]
+    fn test_domain_matches_subdomain() {
+        assert!(domain_matches("example.com", ".example.com"));
+        assert!(domain_matches("sub.example.com", ".example.com"));
+        assert!(!domain_matches("other.com", ".example.com"));
+    }
+
+    #[test]
+    fn test_path_matches_root() {
+        assert!(path_matches("/anything", "/"));
+    }
+
+    #[test]
+    fn test_path_matches_prefix() {
+        assert!(path_matches("/admin/settings", "/admin"));
+        assert!(!path_matches("/public", "/admin"));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut bridge = CookieBridge::new();
+        bridge.add(make_cookie("s1", "a.com", "/"));
+        assert!(!bridge.is_empty());
+        bridge.clear();
+        assert!(bridge.is_empty());
+    }
+}

--- a/src/infrastructure/downloader/mod.rs
+++ b/src/infrastructure/downloader/mod.rs
@@ -16,6 +16,7 @@
 #![allow(async_fn_in_trait)]
 
 pub mod chromiumoxide_downloader;
+pub mod cookie_bridge;
 pub mod hybrid_router;
 pub mod obscura_downloader;
 pub mod resource_governor;


### PR DESCRIPTION
Feature #6 complete. CookieBridge, banned domain persistence in checkpoint (serde default backward compat), FetchRouter with HybridRouter, --js-strategy and --obscura-binary CLI flags. 1062 tests.