### PR TITLE
feat(observability): Complete OTel metrics coverage across all 14 components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,7 +2142,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2941,6 +2941,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -4144,6 +4153,7 @@ dependencies = [
  "smallvec",
  "syntect",
  "sys-info",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -4841,6 +4851,21 @@ checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -5933,6 +5958,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-core"

--- a/src/application/batch/manager.rs
+++ b/src/application/batch/manager.rs
@@ -29,6 +29,11 @@ use super::processor::{BatchError, BatchProcessor, BatchResult};
 use super::{BatchJob, BatchJobStatus};
 use crate::domain::CrawlerConfig;
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    BATCH_JOBS_COMPLETED, BATCH_JOBS_FAILED, BATCH_JOBS_TOTAL,
+};
+
 /// Queue-based manager for batch crawl jobs
 ///
 /// Holds pending jobs and processes them through [`BatchProcessor`].
@@ -127,14 +132,20 @@ impl BatchManager {
         let mut summary = BatchManagerSummary::default();
 
         for result in &results {
+            #[cfg(feature = "otel-metrics")]
+            BATCH_JOBS_TOTAL.add(1, &[]);
             match result {
                 Ok(r) => {
+                    #[cfg(feature = "otel-metrics")]
+                    BATCH_JOBS_COMPLETED.add(1, &[]);
                     summary.total_urls += r.total;
                     summary.succeeded += r.succeeded;
                     summary.failed += r.failed;
                     summary.errors.extend(r.errors.clone());
                 },
                 Err(e) => {
+                    #[cfg(feature = "otel-metrics")]
+                    BATCH_JOBS_FAILED.add(1, &[]);
                     summary.failed += 1;
                     summary
                         .errors

--- a/src/application/batch/processor.rs
+++ b/src/application/batch/processor.rs
@@ -37,6 +37,11 @@ use tracing::{error, info, instrument, warn};
 use super::BatchJob;
 use crate::domain::{CrawlError, CrawlerConfig};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    update_batch_concurrency, BATCH_URLS_PROCESSED,
+};
+
 /// Result of processing a batch job
 #[derive(Debug, Clone)]
 pub struct BatchResult {
@@ -128,6 +133,9 @@ impl BatchProcessor {
 
             progress.start_one();
 
+            #[cfg(feature = "otel-metrics")]
+            update_batch_concurrency(join_set.len() as u64 + 1);
+
             join_set.spawn(async move {
                 let _permit = permit; // Hold permit for duration of task
                 let result = process_single_url(&url, config).await;
@@ -139,6 +147,8 @@ impl BatchProcessor {
         while let Some(result) = join_set.join_next().await {
             match result {
                 Ok((url, Ok(_))) => {
+                    #[cfg(feature = "otel-metrics")]
+                    BATCH_URLS_PROCESSED.add(1, &[]);
                     progress.complete_one();
                     info!("Completed crawl for {url}");
                 },
@@ -154,6 +164,8 @@ impl BatchProcessor {
                     errors.push(("unknown".to_string(), format!("Task panicked: {e}")));
                 },
             }
+            #[cfg(feature = "otel-metrics")]
+            update_batch_concurrency(join_set.len() as u64);
         }
 
         let succeeded = progress.completed();

--- a/src/application/crawler/checkpoint.rs
+++ b/src/application/crawler/checkpoint.rs
@@ -20,6 +20,11 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, instrument, warn};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    CHECKPOINT_CORRUPTED, CHECKPOINT_LOADS, CHECKPOINT_SAVES,
+};
+
 // ---------------------------------------------------------------------------
 // Sealed trait
 // ---------------------------------------------------------------------------
@@ -152,6 +157,10 @@ impl CheckpointStore for BincodeCheckpoint {
             path.display(),
             payload.len()
         );
+
+        #[cfg(feature = "otel-metrics")]
+        CHECKPOINT_SAVES.add(1, &[]);
+
         Ok(())
     }
 
@@ -184,6 +193,10 @@ impl CheckpointStore for BincodeCheckpoint {
                 "checkpoint CRC32 mismatch: stored={:#x}, computed={:#x}",
                 stored_checksum, computed_checksum
             );
+
+            #[cfg(feature = "otel-metrics")]
+            CHECKPOINT_CORRUPTED.add(1, &[]);
+
             return None;
         }
 
@@ -197,10 +210,18 @@ impl CheckpointStore for BincodeCheckpoint {
                     state.queued.len(),
                     state.pages_crawled
                 );
+
+                #[cfg(feature = "otel-metrics")]
+                CHECKPOINT_LOADS.add(1, &[]);
+
                 Some(state)
             },
             Err(e) => {
                 warn!("checkpoint deserialization failed: {e}");
+
+                #[cfg(feature = "otel-metrics")]
+                CHECKPOINT_CORRUPTED.add(1, &[]);
+
                 None
             },
         }
@@ -414,5 +435,66 @@ mod tests {
         assert!(display.contains("pages=42"));
         assert!(display.contains("visited=2"));
         assert!(display.contains("queued=2"));
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    use super::*;
+
+    #[test]
+    fn test_checkpoint_saves_instrument_init() {
+        let _ = &*CHECKPOINT_SAVES;
+    }
+
+    #[test]
+    fn test_checkpoint_loads_instrument_init() {
+        let _ = &*CHECKPOINT_LOADS;
+    }
+
+    #[test]
+    fn test_checkpoint_corrupted_instrument_init() {
+        let _ = &*CHECKPOINT_CORRUPTED;
+    }
+
+    #[test]
+    fn test_save_records_metric() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("checkpoint.json");
+        let store = BincodeCheckpoint::new();
+        let state = CrawlCheckpoint::new();
+        // Should not panic — metric recording is a no-op side effect
+        store.save(&state, &path).unwrap();
+    }
+
+    #[test]
+    fn test_load_success_records_metric() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("checkpoint.json");
+        let store = BincodeCheckpoint::new();
+        let state = CrawlCheckpoint::new();
+        store.save(&state, &path).unwrap();
+        // Should not panic — metric recording is a no-op side effect
+        let loaded = store.load(&path);
+        assert!(loaded.is_some());
+    }
+
+    #[test]
+    fn test_load_corruption_records_metric() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("checkpoint.json");
+        let store = BincodeCheckpoint::new();
+        let state = CrawlCheckpoint::new();
+        store.save(&state, &path).unwrap();
+
+        // Tamper to trigger corruption
+        let mut data = std::fs::read(&path).unwrap();
+        data[0] ^= 0xFF;
+        std::fs::write(&path, &data).unwrap();
+
+        // Should not panic — metric recording is a no-op side effect
+        let loaded = store.load(&path);
+        assert!(loaded.is_none());
     }
 }

--- a/src/application/crawler/concurrency_level.rs
+++ b/src/application/crawler/concurrency_level.rs
@@ -14,6 +14,9 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::AUTOSCALE_LEVEL_TRANSITIONS;
+
 /// Memory-pressure concurrency level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConcurrencyLevel {
@@ -50,6 +53,22 @@ impl SharedConcurrencyLevel {
             ConcurrencyLevel::Reduced => 1,
             ConcurrencyLevel::Critical => 2,
         };
+
+        #[cfg(feature = "otel-metrics")]
+        {
+            let old = self.level.swap(val, Ordering::Relaxed);
+            if old != val {
+                let direction = match (old, val) {
+                    (0, 1) | (0, 2) | (1, 2) => "down",
+                    (1, 0) | (2, 0) | (2, 1) => "up",
+                    _ => "same",
+                };
+                AUTOSCALE_LEVEL_TRANSITIONS
+                    .add(1, &[opentelemetry::KeyValue::new("direction", direction)]);
+            }
+        }
+
+        #[cfg(not(feature = "otel-metrics"))]
         self.level.store(val, Ordering::Relaxed);
     }
 
@@ -172,6 +191,42 @@ mod tests {
         for h in handles {
             h.join().unwrap();
         }
+        assert_eq!(scl.get(), ConcurrencyLevel::Normal);
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    use super::*;
+
+    #[test]
+    fn test_autoscale_transition_instrument_init() {
+        let _ = &*AUTOSCALE_LEVEL_TRANSITIONS;
+    }
+
+    #[test]
+    fn test_set_records_direction_down() {
+        let scl = SharedConcurrencyLevel::new();
+        // Normal -> Reduced = "down"
+        scl.set(ConcurrencyLevel::Reduced);
+        assert_eq!(scl.get(), ConcurrencyLevel::Reduced);
+    }
+
+    #[test]
+    fn test_set_records_direction_up() {
+        let scl = SharedConcurrencyLevel::new();
+        scl.set(ConcurrencyLevel::Critical);
+        // Critical -> Normal = "up"
+        scl.set(ConcurrencyLevel::Normal);
+        assert_eq!(scl.get(), ConcurrencyLevel::Normal);
+    }
+
+    #[test]
+    fn test_same_level_no_duplicate_metric() {
+        let scl = SharedConcurrencyLevel::new();
+        // Setting same level should not panic (no-op)
+        scl.set(ConcurrencyLevel::Normal);
         assert_eq!(scl.get(), ConcurrencyLevel::Normal);
     }
 }

--- a/src/application/crawler/engine.rs
+++ b/src/application/crawler/engine.rs
@@ -35,6 +35,11 @@ use crate::infrastructure::downloader::wreq_downloader::WreqDownloader;
 use crate::infrastructure::downloader::{DownloadError, Downloader, FetchedPage};
 use crate::infrastructure::session::DomainSessionPool;
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    update_engine_concurrency, ENGINE_CHECKPOINT_SAVES, ENGINE_PAGES_CRAWLED,
+};
+
 /// Shared shutdown signal — set to `true` when SIGINT/SIGTERM received.
 type ShutdownSignal = Arc<AtomicBool>;
 
@@ -260,6 +265,9 @@ impl Engine {
                         new_level
                     );
                     level_clone.set(new_level);
+
+                    #[cfg(feature = "otel-metrics")]
+                    update_engine_concurrency(level_clone.get() as u64);
                 }
             }
         });
@@ -307,6 +315,9 @@ impl Engine {
             // Save on blocking thread to avoid blocking the event loop
             let path = path.clone();
             let _ = tokio::task::spawn_blocking(move || new_cp.save(&path)).await;
+
+            #[cfg(feature = "otel-metrics")]
+            ENGINE_CHECKPOINT_SAVES.add(1, &[]);
         }
     }
 
@@ -587,6 +598,9 @@ impl Engine {
 
                     // Track pages crawled
                     pages_crawled_task.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+                    #[cfg(feature = "otel-metrics")]
+                    ENGINE_PAGES_CRAWLED.add(1, &[]);
 
                     // Pipeline processing: convert to ScrapedItem and run through pipeline
                     if let Some(ref pipeline) = pipeline_task {
@@ -936,4 +950,36 @@ pub async fn crawl_site_with_options(
     let result = engine.run().await;
     engine.shutdown().await;
     result
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    use crate::infrastructure::observability::metrics_instruments::{
+        ENGINE_CHECKPOINT_SAVES, ENGINE_CONCURRENCY_LEVEL, ENGINE_PAGES_CRAWLED,
+        engine_concurrency_get, update_engine_concurrency,
+    };
+
+    #[test]
+    fn test_engine_pages_crawled_instrument_init() {
+        let _ = &*ENGINE_PAGES_CRAWLED;
+    }
+
+    #[test]
+    fn test_engine_checkpoint_saves_instrument_init() {
+        let _ = &*ENGINE_CHECKPOINT_SAVES;
+    }
+
+    #[test]
+    fn test_update_engine_concurrency_init() {
+        // Should not panic — setting gauge value
+        update_engine_concurrency(5);
+        let val = engine_concurrency_get();
+        assert_eq!(val, 5);
+    }
+
+    #[test]
+    fn test_engine_concurrency_level_gauge_init() {
+        let _ = &*ENGINE_CONCURRENCY_LEVEL;
+    }
 }

--- a/src/application/pipeline/executor.rs
+++ b/src/application/pipeline/executor.rs
@@ -1,5 +1,10 @@
 use super::{PipelineStage, ScrapedItem, StageOutcome};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    PIPELINE_ITEMS_REJECTED, PIPELINE_ITEMS_SKIPPED, PIPELINE_ITEMS_TOTAL,
+};
+
 /// Executes a sequence of [`PipelineStage`]s on [`ScrapedItem`]s.
 ///
 /// Stages are processed in insertion order. The first stage to return
@@ -28,9 +33,24 @@ impl PipelineExecutor {
         for stage in &self.stages {
             match stage.process(item).await {
                 StageOutcome::Continue(updated) => item = updated,
-                outcome => return outcome,
+                StageOutcome::Reject(reason) => {
+                    #[cfg(feature = "otel-metrics")]
+                    {
+                        use opentelemetry::KeyValue;
+                        let stage_name = stage.name().to_owned();
+                        PIPELINE_ITEMS_REJECTED.add(1, &[KeyValue::new("stage", stage_name)]);
+                    }
+                    return StageOutcome::Reject(reason);
+                },
+                StageOutcome::Skip => {
+                    #[cfg(feature = "otel-metrics")]
+                    PIPELINE_ITEMS_SKIPPED.add(1, &[]);
+                    return StageOutcome::Skip;
+                },
             }
         }
+        #[cfg(feature = "otel-metrics")]
+        PIPELINE_ITEMS_TOTAL.add(1, &[]);
         StageOutcome::Continue(item)
     }
 

--- a/src/application/pipeline/stages/clean.rs
+++ b/src/application/pipeline/stages/clean.rs
@@ -9,6 +9,11 @@ use std::pin::Pin;
 
 use crate::domain::pipeline_item::{PipelineStage, ScrapedItem, StageOutcome};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    CLEAN_REDUCTION_PCT, CLEAN_SPA_DETECTED,
+};
+
 /// Minimum cleaned text length (in characters) to be considered real content.
 /// Items shorter than this are tagged as potential SPA (single-page app)
 /// shells that rendered no meaningful content.
@@ -78,10 +83,15 @@ fn clean(mut item: ScrapedItem) -> StageOutcome {
     item.metadata
         .insert(META_REDUCTION_PCT.into(), reduction_pct.to_string());
 
+    #[cfg(feature = "otel-metrics")]
+    CLEAN_REDUCTION_PCT.record(reduction_pct as f64, &[]);
+
     // 6. Tag potential SPA if cleaned content is too short
     if cleaned_size < MIN_TEXT_LENGTH {
         item.metadata
             .insert(META_POTENTIAL_SPA.into(), "true".into());
+        #[cfg(feature = "otel-metrics")]
+        CLEAN_SPA_DETECTED.add(1, &[]);
     }
 
     StageOutcome::Continue(item)

--- a/src/application/pipeline/stages/multi_sink.rs
+++ b/src/application/pipeline/stages/multi_sink.rs
@@ -6,6 +6,11 @@ use std::pin::Pin;
 use crate::application::pipeline::stages::output::{OutputError, OutputStage};
 use crate::domain::pipeline_item::ScrapedItem;
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::OUTPUT_SINK_ERRORS;
+#[cfg(feature = "otel-metrics")]
+use opentelemetry::KeyValue;
+
 /// Output stage that writes to all inner sinks sequentially.
 ///
 /// If a sink fails, the error is logged and remaining sinks are still attempted.
@@ -49,6 +54,11 @@ impl OutputStage for MultiSinkOutput {
                     Ok(()) => any_ok = true,
                     Err(e) => {
                         eprintln!("[multi_sink] sink '{}' failed: {}", sink.name(), e);
+                        #[cfg(feature = "otel-metrics")]
+                        {
+                            let sink_name = sink.name().to_owned();
+                            OUTPUT_SINK_ERRORS.add(1, &[KeyValue::new("sink", sink_name)]);
+                        }
                         if last_err.is_none() {
                             last_err = Some(e);
                         }

--- a/src/application/pipeline/stages/validate.rs
+++ b/src/application/pipeline/stages/validate.rs
@@ -8,6 +8,11 @@ use std::pin::Pin;
 
 use crate::domain::pipeline_item::{PipelineStage, ScrapedItem, StageOutcome};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::VALIDATE_REJECTS;
+#[cfg(feature = "otel-metrics")]
+use opentelemetry::KeyValue;
+
 /// Patterns in URLs that indicate non-content pages.
 const SKIP_PATHS: &[&str] = &[
     "/robots.txt",
@@ -44,25 +49,35 @@ impl PipelineStage for ValidateStage {
 fn validate(item: ScrapedItem) -> StageOutcome {
     // 1. URL must be non-empty
     if item.url.is_empty() {
+        #[cfg(feature = "otel-metrics")]
+        VALIDATE_REJECTS.add(1, &[KeyValue::new("reason", "empty_url")]);
         return StageOutcome::Reject("URL is empty".into());
     }
 
     // 2. URL must be parseable with http(s) scheme
     let parsed = match url::Url::parse(&item.url) {
         Ok(u) => u,
-        Err(_) => return StageOutcome::Reject(format!("URL is not valid: {}", item.url)),
+        Err(_) => {
+            #[cfg(feature = "otel-metrics")]
+            VALIDATE_REJECTS.add(1, &[KeyValue::new("reason", "invalid_url")]);
+            return StageOutcome::Reject(format!("URL is not valid: {}", item.url));
+        },
     };
 
     match parsed.scheme() {
         "http" | "https" => {},
         scheme => {
+            #[cfg(feature = "otel-metrics")]
+            VALIDATE_REJECTS.add(1, &[KeyValue::new("reason", "unsupported_scheme")]);
             return StageOutcome::Reject(format!(
                 "URL scheme '{scheme}' is not supported (requires http or https)"
-            ))
+            ));
         },
     }
 
     if parsed.host_str().is_none() {
+        #[cfg(feature = "otel-metrics")]
+        VALIDATE_REJECTS.add(1, &[KeyValue::new("reason", "no_host")]);
         return StageOutcome::Reject("URL has no host".into());
     }
 
@@ -74,6 +89,8 @@ fn validate(item: ScrapedItem) -> StageOutcome {
 
     // 4. Status code must be in 200..=399
     if !(200..=399).contains(&item.status_code) {
+        #[cfg(feature = "otel-metrics")]
+        VALIDATE_REJECTS.add(1, &[KeyValue::new("reason", "bad_status")]);
         return StageOutcome::Reject(format!(
             "HTTP status {} indicates an error",
             item.status_code
@@ -82,6 +99,8 @@ fn validate(item: ScrapedItem) -> StageOutcome {
 
     // 5. raw_html must not be empty
     if item.raw_html.trim().is_empty() {
+        #[cfg(feature = "otel-metrics")]
+        VALIDATE_REJECTS.add(1, &[KeyValue::new("reason", "empty_content")]);
         return StageOutcome::Reject("Content is empty".into());
     }
 

--- a/src/infrastructure/downloader/hybrid_router.rs
+++ b/src/infrastructure/downloader/hybrid_router.rs
@@ -20,6 +20,13 @@ use super::resource_governor::ResourceGovernor;
 use super::spa_detector::{detect_spa, SpaSignal};
 use super::{DownloadError, Downloader, FetchedPage};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    DOWNLOADER_ESCALATIONS, DOWNLOADER_LAYER_LATENCY, DOWNLOADER_WAF_BLOCKS,
+};
+#[cfg(feature = "otel-metrics")]
+use std::time::Instant;
+
 /// Three-layer hybrid downloader.
 ///
 /// Type parameters correspond to the three fetch layers:
@@ -76,16 +83,37 @@ impl<L1: Downloader, L2: Downloader, L3: Downloader> Downloader for HybridRouter
     async fn fetch(&self, url: &Url) -> Result<FetchedPage, DownloadError> {
         // --- Layer 1: fast static HTTP ---
         debug!("Layer 1 (wreq): fetching {url}");
+        #[cfg(feature = "otel-metrics")]
+        let l1_start = Instant::now();
         let page = match self.layer1.fetch(url).await {
             Ok(p) => p,
             Err(DownloadError::WafChallenge(msg)) => {
+                #[cfg(feature = "otel-metrics")]
+                {
+                    DOWNLOADER_WAF_BLOCKS.add(1, &[opentelemetry::KeyValue::new("layer", "1")]);
+                    DOWNLOADER_LAYER_LATENCY.record(
+                        l1_start.elapsed().as_secs_f64(),
+                        &[opentelemetry::KeyValue::new("layer", "1")],
+                    );
+                }
                 return Err(DownloadError::WafChallenge(msg));
             },
             Err(e) => {
                 debug!("Layer 1 failed ({e}) — aborting");
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOADER_LAYER_LATENCY.record(
+                    l1_start.elapsed().as_secs_f64(),
+                    &[opentelemetry::KeyValue::new("layer", "1")],
+                );
                 return Err(e);
             },
         };
+
+        #[cfg(feature = "otel-metrics")]
+        DOWNLOADER_LAYER_LATENCY.record(
+            l1_start.elapsed().as_secs_f64(),
+            &[opentelemetry::KeyValue::new("layer", "1")],
+        );
 
         // SPA detected — continue escalation; static content — return early
         if let Some(page) = self.evaluate_fetch(page)? {
@@ -94,6 +122,14 @@ impl<L1: Downloader, L2: Downloader, L3: Downloader> Downloader for HybridRouter
 
         // --- Layer 2: Obscura subprocess ---
         debug!("Layer 2 (Obscura): attempting fetch for {url}");
+        #[cfg(feature = "otel-metrics")]
+        DOWNLOADER_ESCALATIONS.add(
+            1,
+            &[
+                opentelemetry::KeyValue::new("from", "1"),
+                opentelemetry::KeyValue::new("to", "2"),
+            ],
+        );
 
         // Check resources before spawning a subprocess
         if let Err(e) = self.governor.check_resources() {
@@ -103,24 +139,57 @@ impl<L1: Downloader, L2: Downloader, L3: Downloader> Downloader for HybridRouter
             )));
         }
 
+        #[cfg(feature = "otel-metrics")]
+        let l2_start = Instant::now();
         match self.layer2.fetch(url).await {
             Ok(page) if !page.html.is_empty() => {
                 debug!("Layer 2 returned {} bytes", page.html.len());
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOADER_LAYER_LATENCY.record(
+                    l2_start.elapsed().as_secs_f64(),
+                    &[opentelemetry::KeyValue::new("layer", "2")],
+                );
                 return Ok(page);
             },
             Ok(_) => {
                 debug!("Layer 2 returned empty content — will try Layer 3");
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOADER_LAYER_LATENCY.record(
+                    l2_start.elapsed().as_secs_f64(),
+                    &[opentelemetry::KeyValue::new("layer", "2")],
+                );
             },
             Err(DownloadError::WafChallenge(msg)) => {
+                #[cfg(feature = "otel-metrics")]
+                {
+                    DOWNLOADER_WAF_BLOCKS.add(1, &[opentelemetry::KeyValue::new("layer", "2")]);
+                    DOWNLOADER_LAYER_LATENCY.record(
+                        l2_start.elapsed().as_secs_f64(),
+                        &[opentelemetry::KeyValue::new("layer", "2")],
+                    );
+                }
                 return Err(DownloadError::WafChallenge(msg));
             },
             Err(e) => {
                 debug!("Layer 2 failed ({e}) — will try Layer 3");
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOADER_LAYER_LATENCY.record(
+                    l2_start.elapsed().as_secs_f64(),
+                    &[opentelemetry::KeyValue::new("layer", "2")],
+                );
             },
         }
 
         // --- Layer 3: Chromiumoxide CDP ---
         debug!("Layer 3 (Chromiumoxide): attempting fetch for {url}");
+        #[cfg(feature = "otel-metrics")]
+        DOWNLOADER_ESCALATIONS.add(
+            1,
+            &[
+                opentelemetry::KeyValue::new("from", "2"),
+                opentelemetry::KeyValue::new("to", "3"),
+            ],
+        );
 
         if let Err(e) = self.governor.check_resources() {
             warn!("ResourceGovernor denied Layer 3: {e}");
@@ -129,16 +198,36 @@ impl<L1: Downloader, L2: Downloader, L3: Downloader> Downloader for HybridRouter
             )));
         }
 
+        #[cfg(feature = "otel-metrics")]
+        let l3_start = Instant::now();
         match self.layer3.fetch(url).await {
             Ok(page) => {
                 debug!("Layer 3 returned {} bytes", page.html.len());
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOADER_LAYER_LATENCY.record(
+                    l3_start.elapsed().as_secs_f64(),
+                    &[opentelemetry::KeyValue::new("layer", "3")],
+                );
                 return Ok(page);
             },
             Err(DownloadError::WafChallenge(msg)) => {
+                #[cfg(feature = "otel-metrics")]
+                {
+                    DOWNLOADER_WAF_BLOCKS.add(1, &[opentelemetry::KeyValue::new("layer", "3")]);
+                    DOWNLOADER_LAYER_LATENCY.record(
+                        l3_start.elapsed().as_secs_f64(),
+                        &[opentelemetry::KeyValue::new("layer", "3")],
+                    );
+                }
                 return Err(DownloadError::WafChallenge(msg));
             },
             Err(e) => {
                 warn!("All layers exhausted for {url}: {e}");
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOADER_LAYER_LATENCY.record(
+                    l3_start.elapsed().as_secs_f64(),
+                    &[opentelemetry::KeyValue::new("layer", "3")],
+                );
                 return Err(e);
             },
         }
@@ -337,5 +426,16 @@ mod tests {
             StubDownloader::static_page(),
         );
         assert!(!router.supports_interactions());
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    #[test]
+    fn test_hybrid_router_instruments_init() {
+        let _ = &*super::DOWNLOADER_ESCALATIONS;
+        let _ = &*super::DOWNLOADER_LAYER_LATENCY;
+        let _ = &*super::DOWNLOADER_WAF_BLOCKS;
     }
 }

--- a/src/infrastructure/downloader/obscura_downloader.rs
+++ b/src/infrastructure/downloader/obscura_downloader.rs
@@ -13,6 +13,13 @@ use url::Url;
 
 use super::{DownloadError, Downloader, FetchedPage};
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    DOWNLOAD_OBSCURA_LATENCY, DOWNLOAD_OBSCURA_TIMEOUT,
+};
+#[cfg(feature = "otel-metrics")]
+use std::time::Instant;
+
 /// Memory budget for one Obscura subprocess (~30 MB).
 const OBSCURA_MEMORY_COST: usize = 30_000_000;
 
@@ -41,6 +48,9 @@ impl Downloader for ObscuraDownloader {
     async fn fetch(&self, url: &Url) -> Result<FetchedPage, DownloadError> {
         debug!("Obscura fetch: {}", url);
 
+        #[cfg(feature = "otel-metrics")]
+        let start = Instant::now();
+
         let url_string = url.to_string();
 
         let result = timeout(
@@ -67,6 +77,9 @@ impl Downloader for ObscuraDownloader {
 
                 debug!("Obscura returned {} bytes", markdown.len());
 
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOAD_OBSCURA_LATENCY.record(start.elapsed().as_secs_f64(), &[]);
+
                 Ok(FetchedPage {
                     url: url.clone(),
                     html: markdown,
@@ -74,11 +87,29 @@ impl Downloader for ObscuraDownloader {
                     cookies: vec![],
                 })
             },
-            Ok(Ok(Err(e))) => Err(DownloadError::Internal(format!(
-                "obscura process failed to start: {e}"
-            ))),
-            Ok(Err(_)) => Err(DownloadError::Timeout(OBSCURA_TIMEOUT.as_secs())),
-            Err(_) => Err(DownloadError::Timeout(OBSCURA_TIMEOUT.as_secs())),
+            Ok(Ok(Err(e))) => {
+                #[cfg(feature = "otel-metrics")]
+                DOWNLOAD_OBSCURA_LATENCY.record(start.elapsed().as_secs_f64(), &[]);
+                Err(DownloadError::Internal(format!(
+                    "obscura process failed to start: {e}"
+                )))
+            },
+            Ok(Err(_)) => {
+                #[cfg(feature = "otel-metrics")]
+                {
+                    DOWNLOAD_OBSCURA_LATENCY.record(start.elapsed().as_secs_f64(), &[]);
+                    DOWNLOAD_OBSCURA_TIMEOUT.add(1, &[]);
+                }
+                Err(DownloadError::Timeout(OBSCURA_TIMEOUT.as_secs()))
+            },
+            Err(_) => {
+                #[cfg(feature = "otel-metrics")]
+                {
+                    DOWNLOAD_OBSCURA_LATENCY.record(start.elapsed().as_secs_f64(), &[]);
+                    DOWNLOAD_OBSCURA_TIMEOUT.add(1, &[]);
+                }
+                Err(DownloadError::Timeout(OBSCURA_TIMEOUT.as_secs()))
+            },
         }
     }
 
@@ -106,5 +137,15 @@ mod tests {
     fn test_obscura_default() {
         let dl = ObscuraDownloader;
         assert_eq!(dl.memory_cost(), OBSCURA_MEMORY_COST);
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    #[test]
+    fn test_obscura_instruments_init() {
+        let _ = &*super::DOWNLOAD_OBSCURA_LATENCY;
+        let _ = &*super::DOWNLOAD_OBSCURA_TIMEOUT;
     }
 }

--- a/src/infrastructure/downloader/resource_governor.rs
+++ b/src/infrastructure/downloader/resource_governor.rs
@@ -19,6 +19,11 @@ use tracing::{debug, warn};
 
 use super::DownloadError;
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    update_chrome_instances, update_ram_usage, RESOURCE_DENIED,
+};
+
 /// Approximate RAM cost of one Chrome instance (200 MB).
 const CHROME_INSTANCE_COST: u64 = 200_000_000;
 
@@ -55,12 +60,20 @@ impl ResourceGovernor {
     pub fn check_resources(&self) -> Result<usize, ResourceError> {
         let usage = Self::ram_usage_percent();
 
+        #[cfg(feature = "otel-metrics")]
+        update_ram_usage(u64::from(usage));
+
         if usage >= CRITICAL_THRESHOLD {
             warn!("RAM usage {usage}% >= {CRITICAL_THRESHOLD}%: new Chrome instances denied");
+            #[cfg(feature = "otel-metrics")]
+            RESOURCE_DENIED.add(1, &[opentelemetry::KeyValue::new("reason", "ram_too_high")]);
             return Err(ResourceError::RamTooHigh(usage));
         }
 
         let available = self.semaphore.available_permits();
+
+        #[cfg(feature = "otel-metrics")]
+        update_chrome_instances(available as u64);
 
         if usage >= WARNING_THRESHOLD {
             let reduced = available / 2;
@@ -185,5 +198,27 @@ mod tests {
         let res_err = ResourceError::Insufficient("test".into());
         let dl_err: DownloadError = res_err.into();
         assert!(matches!(dl_err, DownloadError::Internal(_)));
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    use crate::infrastructure::observability::metrics_instruments::{
+        chrome_instances_get, ram_usage_get, update_chrome_instances, update_ram_usage,
+        RESOURCE_DENIED,
+    };
+
+    #[test]
+    fn test_resource_governor_instruments_init() {
+        let _ = &*RESOURCE_DENIED;
+    }
+
+    #[test]
+    fn test_gauge_backing_update_from_check_resources() {
+        update_ram_usage(50);
+        assert_eq!(ram_usage_get(), 50);
+        update_chrome_instances(4);
+        assert_eq!(chrome_instances_get(), 4);
     }
 }

--- a/src/infrastructure/downloader/wreq_downloader.rs
+++ b/src/infrastructure/downloader/wreq_downloader.rs
@@ -14,6 +14,11 @@ use url::Url;
 use wreq::Client;
 use wreq_util::Emulation;
 
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::DOWNLOAD_WREQ_LATENCY;
+#[cfg(feature = "otel-metrics")]
+use std::time::Instant;
+
 use super::{Cookie, DownloadError, Downloader, FetchedPage};
 
 /// Estimated memory cost of a wreq client instance in bytes.
@@ -182,6 +187,9 @@ impl Downloader for WreqDownloader {
     async fn fetch(&self, url: &Url) -> Result<FetchedPage, DownloadError> {
         debug!("Fetching URL: {}", url);
 
+        #[cfg(feature = "otel-metrics")]
+        let start = Instant::now();
+
         let response = self.client.get(url.as_str()).send().await.map_err(|e| {
             if e.is_timeout() {
                 DownloadError::Timeout(self.timeout_secs)
@@ -219,12 +227,17 @@ impl Downloader for WreqDownloader {
             cookies.len()
         );
 
-        Ok(FetchedPage {
+        let result = Ok(FetchedPage {
             url: final_url,
             html,
             status,
             cookies,
-        })
+        });
+
+        #[cfg(feature = "otel-metrics")]
+        DOWNLOAD_WREQ_LATENCY.record(start.elapsed().as_secs_f64(), &[]);
+
+        result
     }
 
     fn supports_interactions(&self) -> bool {
@@ -425,5 +438,14 @@ mod wiremock_tests {
 
         let page = result.unwrap();
         assert!(page.url.as_str().contains("/target"));
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    #[test]
+    fn test_download_wreq_latency_instrument_init() {
+        let _ = &*super::DOWNLOAD_WREQ_LATENCY;
     }
 }

--- a/src/infrastructure/network/session_pool.rs
+++ b/src/infrastructure/network/session_pool.rs
@@ -13,8 +13,16 @@
 use std::fmt;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "otel-metrics")]
+use std::hash::{Hash, Hasher};
+
 use dashmap::DashMap;
 use tracing::{debug, instrument, warn};
+
+#[cfg(feature = "otel-metrics")]
+use crate::infrastructure::observability::metrics_instruments::{
+    update_session_pool_healthy, SESSION_POOL_BACKOFF, SESSION_POOL_BANNED,
+};
 
 /// Unique identifier for a session slot within a domain pool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -118,6 +126,16 @@ pub struct DomainSessionPool {
     config: SessionPoolConfig,
 }
 
+/// Hash a domain string to a bounded bucket (0–999) for metric attributes.
+///
+/// Prevents cardinality explosion from unbounded domain strings.
+#[cfg(feature = "otel-metrics")]
+fn domain_bucket(domain: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    domain.hash(&mut hasher);
+    hasher.finish() % 1000
+}
+
 impl DomainSessionPool {
     /// Create a new session pool with the given configuration.
     #[must_use]
@@ -132,6 +150,20 @@ impl DomainSessionPool {
     #[must_use]
     pub fn default_pool() -> Self {
         Self::new(SessionPoolConfig::default())
+    }
+
+    /// Count total healthy sessions across all domains and update the gauge.
+    #[cfg(feature = "otel-metrics")]
+    fn refresh_healthy_gauge(&self) {
+        let mut count: u64 = 0;
+        for entry in self.sessions.iter() {
+            for state in entry.value().iter() {
+                if state.status == SessionStatus::Healthy {
+                    count += 1;
+                }
+            }
+        }
+        update_session_pool_healthy(count);
     }
 
     /// Calculate exponential backoff delay for a given failure count.
@@ -178,26 +210,32 @@ impl SessionManager for DomainSessionPool {
         }
 
         // Find first healthy or recoverable session
-        for (idx, state) in sessions.iter().enumerate() {
-            match state.status {
-                SessionStatus::Healthy => {
-                    debug!(domain, session_id = idx, "acquired healthy session");
-                    return Some(SessionId(idx));
-                },
-                SessionStatus::Banned => {
-                    if let Some(next_retry) = state.next_retry_time {
-                        if now >= next_retry {
-                            debug!(domain, session_id = idx, "acquired session after cooldown");
-                            return Some(SessionId(idx));
+        let result = 'find: {
+            for (idx, state) in sessions.iter().enumerate() {
+                match state.status {
+                    SessionStatus::Healthy => {
+                        debug!(domain, session_id = idx, "acquired healthy session");
+                        break 'find Some(SessionId(idx));
+                    },
+                    SessionStatus::Banned => {
+                        if let Some(next_retry) = state.next_retry_time {
+                            if now >= next_retry {
+                                debug!(domain, session_id = idx, "acquired session after cooldown");
+                                break 'find Some(SessionId(idx));
+                            }
                         }
-                    }
-                },
-                SessionStatus::Retiring => continue,
+                    },
+                    SessionStatus::Retiring => continue,
+                }
             }
-        }
+            warn!(domain, "no available sessions for domain");
+            None
+        };
 
-        warn!(domain, "no available sessions for domain");
-        None
+        #[cfg(feature = "otel-metrics")]
+        self.refresh_healthy_gauge();
+
+        result
     }
 
     #[instrument(skip(self), fields(domain = %domain, session_id = %session_id.0))]
@@ -211,6 +249,8 @@ impl SessionManager for DomainSessionPool {
                 debug!(domain, session_id = session_id.0, "session marked healthy");
             }
         }
+        #[cfg(feature = "otel-metrics")]
+        self.refresh_healthy_gauge();
     }
 
     #[instrument(skip(self), fields(domain = %domain, session_id = %session_id.0, status_code))]
@@ -227,6 +267,24 @@ impl SessionManager for DomainSessionPool {
                     let delay = self.backoff_delay(state.consecutive_failures);
                     state.next_retry_time = Some(Instant::now() + delay);
                     state.status = SessionStatus::Banned;
+                    #[cfg(feature = "otel-metrics")]
+                    {
+                        let bucket = domain_bucket(domain);
+                        SESSION_POOL_BANNED.add(
+                            1,
+                            &[opentelemetry::KeyValue::new(
+                                "domain",
+                                format!("{bucket:04}"),
+                            )],
+                        );
+                        SESSION_POOL_BACKOFF.record(
+                            delay.as_secs_f64(),
+                            &[opentelemetry::KeyValue::new(
+                                "domain",
+                                format!("{bucket:04}"),
+                            )],
+                        );
+                    }
                     warn!(
                         domain,
                         session_id = session_id.0,
@@ -249,6 +307,8 @@ impl SessionManager for DomainSessionPool {
                 }
             }
         }
+        #[cfg(feature = "otel-metrics")]
+        self.refresh_healthy_gauge();
     }
 
     #[instrument(skip(self))]
@@ -557,5 +617,38 @@ mod tests {
     fn report_success_on_nonexistent_session_no_panic() {
         let pool = DomainSessionPool::default_pool();
         pool.report_success("ghost.com", SessionId(99));
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "otel-metrics")]
+mod metrics_tests {
+    use super::*;
+
+    #[test]
+    fn test_session_pool_instruments_init() {
+        let _ = &*SESSION_POOL_BANNED;
+        let _ = &*SESSION_POOL_BACKOFF;
+    }
+
+    #[test]
+    fn test_domain_bucket_is_bounded() {
+        let b1 = domain_bucket("example.com");
+        let b2 = domain_bucket("another-domain.org");
+        let b3 = domain_bucket("a".repeat(1000).as_str());
+        assert!(b1 < 1000);
+        assert!(b2 < 1000);
+        assert!(b3 < 1000);
+    }
+
+    #[test]
+    fn test_domain_bucket_deterministic() {
+        assert_eq!(domain_bucket("test.com"), domain_bucket("test.com"));
+    }
+
+    #[test]
+    fn test_domain_bucket_different_domains_differ() {
+        // Not guaranteed, but overwhelmingly likely for 1000 buckets
+        assert_ne!(domain_bucket("a.com"), domain_bucket("b.com"));
     }
 }

--- a/src/infrastructure/observability/metrics_instruments.rs
+++ b/src/infrastructure/observability/metrics_instruments.rs
@@ -21,8 +21,18 @@ use opentelemetry::global;
 use opentelemetry::metrics::Histogram;
 use opentelemetry::metrics::ObservableGauge;
 
+// ---------------------------------------------------------------------------
+// AtomicU64 backing counters for observable gauges
+// ---------------------------------------------------------------------------
+
 /// Global in-flight request counter for the observable gauge.
 static IN_FLIGHT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+static RAM_USAGE_BACKING: AtomicU64 = AtomicU64::new(0);
+static CHROME_INSTANCES_BACKING: AtomicU64 = AtomicU64::new(0);
+static BATCH_CONCURRENCY_BACKING: AtomicU64 = AtomicU64::new(0);
+static ENGINE_CONCURRENCY_BACKING: AtomicU64 = AtomicU64::new(0);
+static SESSION_POOL_HEALTHY_BACKING: AtomicU64 = AtomicU64::new(0);
 
 fn meter() -> opentelemetry::metrics::Meter {
     global::meter_with_scope(
@@ -88,6 +98,362 @@ pub static CRAWLER_BANDWIDTH: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy:
         .build()
 });
 
+// ---------------------------------------------------------------------------
+// Downloader counters
+// ---------------------------------------------------------------------------
+
+/// Layer escalations counter.
+pub static DOWNLOADER_ESCALATIONS: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("downloader.escalations.total")
+        .with_description("Total layer escalations")
+        .build()
+});
+
+/// WAF block counter.
+pub static DOWNLOADER_WAF_BLOCKS: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("downloader.waf.blocks.total")
+        .with_description("Total WAF blocks")
+        .build()
+});
+
+/// Resource denied counter.
+pub static RESOURCE_DENIED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("downloader.resource.denied.total")
+        .with_description("Total resource-denied events")
+        .build()
+});
+
+/// Obscura timeout counter.
+pub static DOWNLOAD_OBSCURA_TIMEOUT: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("downloader.obscura.timeout.total")
+        .with_description("Total Obscura download timeouts")
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline counters
+// ---------------------------------------------------------------------------
+
+/// Pipeline items processed counter.
+pub static PIPELINE_ITEMS_TOTAL: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("pipeline.items.total")
+        .with_description("Total pipeline items processed")
+        .build()
+});
+
+/// Pipeline items rejected counter.
+pub static PIPELINE_ITEMS_REJECTED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("pipeline.items.rejected.total")
+        .with_description("Total pipeline items rejected")
+        .build()
+});
+
+/// Pipeline items skipped counter.
+pub static PIPELINE_ITEMS_SKIPPED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("pipeline.items.skipped.total")
+        .with_description("Total pipeline items skipped")
+        .build()
+});
+
+/// Validation rejects counter.
+pub static VALIDATE_REJECTS: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("pipeline.validate.rejects.total")
+        .with_description("Total validation rejects")
+        .build()
+});
+
+/// SPA detected counter.
+pub static CLEAN_SPA_DETECTED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("pipeline.clean.spa.detected.total")
+        .with_description("Total SPA detections during cleaning")
+        .build()
+});
+
+/// Output sink errors counter.
+pub static OUTPUT_SINK_ERRORS: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("pipeline.output.sink.errors.total")
+        .with_description("Total output sink errors")
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Batch counters
+// ---------------------------------------------------------------------------
+
+/// Batch jobs total counter.
+pub static BATCH_JOBS_TOTAL: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("batch.jobs.total")
+        .with_description("Total batch jobs started")
+        .build()
+});
+
+/// Batch jobs completed counter.
+pub static BATCH_JOBS_COMPLETED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("batch.jobs.completed.total")
+        .with_description("Total batch jobs completed successfully")
+        .build()
+});
+
+/// Batch jobs failed counter.
+pub static BATCH_JOBS_FAILED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("batch.jobs.failed.total")
+        .with_description("Total batch jobs that failed")
+        .build()
+});
+
+/// Batch URLs processed counter.
+pub static BATCH_URLS_PROCESSED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("batch.urls.processed.total")
+        .with_description("Total URLs processed in batches")
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Crawler counters
+// ---------------------------------------------------------------------------
+
+/// Engine pages crawled counter.
+pub static ENGINE_PAGES_CRAWLED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("crawler.engine.pages.crawled.total")
+        .with_description("Total pages crawled by engine")
+        .build()
+});
+
+/// Engine checkpoint saves counter.
+pub static ENGINE_CHECKPOINT_SAVES: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("crawler.engine.checkpoint.saves.total")
+        .with_description("Total engine checkpoint saves")
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Session pool counter
+// ---------------------------------------------------------------------------
+
+/// Session pool banned counter.
+pub static SESSION_POOL_BANNED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("crawler.session_pool.banned.total")
+        .with_description("Total sessions banned")
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency & checkpoint counters
+// ---------------------------------------------------------------------------
+
+/// Autoscale level transitions counter.
+pub static AUTOSCALE_LEVEL_TRANSITIONS: Lazy<opentelemetry::metrics::Counter<u64>> =
+    Lazy::new(|| {
+        meter()
+            .u64_counter("crawler.autoscale.transitions.total")
+            .with_description("Total autoscale level transitions")
+            .build()
+    });
+
+/// Checkpoint saves counter.
+pub static CHECKPOINT_SAVES: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("crawler.checkpoint.saves.total")
+        .with_description("Total checkpoint saves")
+        .build()
+});
+
+/// Checkpoint loads counter.
+pub static CHECKPOINT_LOADS: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("crawler.checkpoint.loads.total")
+        .with_description("Total checkpoint loads")
+        .build()
+});
+
+/// Checkpoint corrupted counter.
+pub static CHECKPOINT_CORRUPTED: Lazy<opentelemetry::metrics::Counter<u64>> = Lazy::new(|| {
+    meter()
+        .u64_counter("crawler.checkpoint.corrupted.total")
+        .with_description("Total corrupted checkpoints detected")
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Downloader histograms
+// ---------------------------------------------------------------------------
+
+/// Layer latency histogram (seconds).
+pub static DOWNLOADER_LAYER_LATENCY: Lazy<Histogram<f64>> = Lazy::new(|| {
+    meter()
+        .f64_histogram("downloader.layer.latency")
+        .with_description("Layer fetch latency in seconds")
+        .with_unit("s")
+        .build()
+});
+
+/// Obscura download latency histogram (seconds).
+pub static DOWNLOAD_OBSCURA_LATENCY: Lazy<Histogram<f64>> = Lazy::new(|| {
+    meter()
+        .f64_histogram("downloader.obscura.latency")
+        .with_description("Obscura download latency in seconds")
+        .with_unit("s")
+        .build()
+});
+
+/// Wreq download latency histogram (seconds).
+pub static DOWNLOAD_WREQ_LATENCY: Lazy<Histogram<f64>> = Lazy::new(|| {
+    meter()
+        .f64_histogram("downloader.wreq.latency")
+        .with_description("Wreq download latency in seconds")
+        .with_unit("s")
+        .build()
+});
+
+/// HTML reduction percentage histogram.
+pub static CLEAN_REDUCTION_PCT: Lazy<Histogram<f64>> = Lazy::new(|| {
+    meter()
+        .f64_histogram("pipeline.clean.reduction_pct")
+        .with_description("HTML reduction percentage after cleaning")
+        .with_unit("%")
+        .build()
+});
+
+/// Session pool backoff histogram (seconds).
+pub static SESSION_POOL_BACKOFF: Lazy<Histogram<f64>> = Lazy::new(|| {
+    meter()
+        .f64_histogram("crawler.session_pool.backoff")
+        .with_description("Session pool backoff delay in seconds")
+        .with_unit("s")
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Observable gauges (backed by AtomicU64)
+// ---------------------------------------------------------------------------
+
+/// RAM usage percentage gauge.
+pub static RAM_USAGE_PERCENT: Lazy<ObservableGauge<u64>> = Lazy::new(|| {
+    meter()
+        .u64_observable_gauge("downloader.resource.ram_usage_percent")
+        .with_description("Current RAM usage percentage")
+        .with_unit("%")
+        .with_callback(|observer| {
+            observer.observe(RAM_USAGE_BACKING.load(Ordering::Relaxed), &[]);
+        })
+        .build()
+});
+
+/// Active Chrome instances gauge.
+pub static CHROME_INSTANCES_ACTIVE: Lazy<ObservableGauge<u64>> = Lazy::new(|| {
+    meter()
+        .u64_observable_gauge("downloader.resource.chrome_instances_active")
+        .with_description("Number of active Chrome instances")
+        .with_callback(|observer| {
+            observer.observe(CHROME_INSTANCES_BACKING.load(Ordering::Relaxed), &[]);
+        })
+        .build()
+});
+
+/// Batch concurrency level gauge.
+pub static BATCH_CONCURRENCY_CURRENT: Lazy<ObservableGauge<u64>> = Lazy::new(|| {
+    meter()
+        .u64_observable_gauge("batch.concurrency.current")
+        .with_description("Current batch processing concurrency")
+        .with_callback(|observer| {
+            observer.observe(BATCH_CONCURRENCY_BACKING.load(Ordering::Relaxed), &[]);
+        })
+        .build()
+});
+
+/// Engine concurrency level gauge.
+pub static ENGINE_CONCURRENCY_LEVEL: Lazy<ObservableGauge<u64>> = Lazy::new(|| {
+    meter()
+        .u64_observable_gauge("crawler.engine.concurrency_level")
+        .with_description("Current engine concurrency level")
+        .with_callback(|observer| {
+            observer.observe(ENGINE_CONCURRENCY_BACKING.load(Ordering::Relaxed), &[]);
+        })
+        .build()
+});
+
+/// Session pool healthy sessions gauge.
+pub static SESSION_POOL_HEALTHY: Lazy<ObservableGauge<u64>> = Lazy::new(|| {
+    meter()
+        .u64_observable_gauge("crawler.session_pool.healthy")
+        .with_description("Number of healthy sessions in pool")
+        .with_callback(|observer| {
+            observer.observe(SESSION_POOL_HEALTHY_BACKING.load(Ordering::Relaxed), &[]);
+        })
+        .build()
+});
+
+// ---------------------------------------------------------------------------
+// Gauge helper functions
+// ---------------------------------------------------------------------------
+
+/// Set RAM usage percentage.
+pub fn update_ram_usage(value: u64) {
+    RAM_USAGE_BACKING.store(value, Ordering::Relaxed);
+}
+
+/// Read RAM usage percentage.
+pub fn ram_usage_get() -> u64 {
+    RAM_USAGE_BACKING.load(Ordering::Relaxed)
+}
+
+/// Set active Chrome instances count.
+pub fn update_chrome_instances(value: u64) {
+    CHROME_INSTANCES_BACKING.store(value, Ordering::Relaxed);
+}
+
+/// Read active Chrome instances count.
+pub fn chrome_instances_get() -> u64 {
+    CHROME_INSTANCES_BACKING.load(Ordering::Relaxed)
+}
+
+/// Set batch concurrency level.
+pub fn update_batch_concurrency(value: u64) {
+    BATCH_CONCURRENCY_BACKING.store(value, Ordering::Relaxed);
+}
+
+/// Read batch concurrency level.
+pub fn batch_concurrency_get() -> u64 {
+    BATCH_CONCURRENCY_BACKING.load(Ordering::Relaxed)
+}
+
+/// Set engine concurrency level.
+pub fn update_engine_concurrency(value: u64) {
+    ENGINE_CONCURRENCY_BACKING.store(value, Ordering::Relaxed);
+}
+
+/// Read engine concurrency level.
+pub fn engine_concurrency_get() -> u64 {
+    ENGINE_CONCURRENCY_BACKING.load(Ordering::Relaxed)
+}
+
+/// Set healthy session count.
+pub fn update_session_pool_healthy(value: u64) {
+    SESSION_POOL_HEALTHY_BACKING.store(value, Ordering::Relaxed);
+}
+
+/// Read healthy session count.
+pub fn session_pool_healthy_get() -> u64 {
+    SESSION_POOL_HEALTHY_BACKING.load(Ordering::Relaxed)
+}
+
 /// Increment the in-flight requests counter.
 pub fn in_flight_inc() {
     IN_FLIGHT_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -140,5 +506,68 @@ mod tests {
         assert_eq!(in_flight_count(), before + 1);
         in_flight_dec();
         assert_eq!(in_flight_count(), before);
+    }
+
+    #[test]
+    fn test_new_counters_init() {
+        let _ = &*DOWNLOADER_ESCALATIONS;
+        let _ = &*DOWNLOADER_WAF_BLOCKS;
+        let _ = &*RESOURCE_DENIED;
+        let _ = &*DOWNLOAD_OBSCURA_TIMEOUT;
+        let _ = &*PIPELINE_ITEMS_TOTAL;
+        let _ = &*PIPELINE_ITEMS_REJECTED;
+        let _ = &*PIPELINE_ITEMS_SKIPPED;
+        let _ = &*VALIDATE_REJECTS;
+        let _ = &*CLEAN_SPA_DETECTED;
+        let _ = &*OUTPUT_SINK_ERRORS;
+        let _ = &*BATCH_JOBS_TOTAL;
+        let _ = &*BATCH_JOBS_COMPLETED;
+        let _ = &*BATCH_JOBS_FAILED;
+        let _ = &*BATCH_URLS_PROCESSED;
+        let _ = &*ENGINE_PAGES_CRAWLED;
+        let _ = &*ENGINE_CHECKPOINT_SAVES;
+        let _ = &*SESSION_POOL_BANNED;
+        let _ = &*AUTOSCALE_LEVEL_TRANSITIONS;
+        let _ = &*CHECKPOINT_SAVES;
+        let _ = &*CHECKPOINT_LOADS;
+        let _ = &*CHECKPOINT_CORRUPTED;
+    }
+
+    #[test]
+    fn test_new_histograms_init() {
+        let _ = &*DOWNLOADER_LAYER_LATENCY;
+        let _ = &*DOWNLOAD_OBSCURA_LATENCY;
+        let _ = &*DOWNLOAD_WREQ_LATENCY;
+        let _ = &*CLEAN_REDUCTION_PCT;
+        let _ = &*SESSION_POOL_BACKOFF;
+    }
+
+    #[test]
+    fn test_new_gauges_init() {
+        let _ = &*RAM_USAGE_PERCENT;
+        let _ = &*CHROME_INSTANCES_ACTIVE;
+        let _ = &*BATCH_CONCURRENCY_CURRENT;
+        let _ = &*ENGINE_CONCURRENCY_LEVEL;
+        let _ = &*SESSION_POOL_HEALTHY;
+    }
+
+    #[test]
+    fn test_gauge_backing_roundtrip() {
+        update_ram_usage(42);
+        assert_eq!(ram_usage_get(), 42);
+        update_ram_usage(0);
+        assert_eq!(ram_usage_get(), 0);
+
+        update_chrome_instances(3);
+        assert_eq!(chrome_instances_get(), 3);
+
+        update_batch_concurrency(5);
+        assert_eq!(batch_concurrency_get(), 5);
+
+        update_engine_concurrency(2);
+        assert_eq!(engine_concurrency_get(), 2);
+
+        update_session_pool_healthy(10);
+        assert_eq!(session_pool_healthy_get(), 10);
     }
 }


### PR DESCRIPTION
## Summary

- Add 31 new OpenTelemetry metric instruments (21 counters, 5 histograms, 5 observable gauges) with AtomicU64 backing
- Instrument all 14 components that were operating blind: HybridRouter, ResourceGovernor, ObscuraDownloader, WreqDownloader, SessionPool, ConcurrencyLevel, PipelineExecutor, ValidateStage, CleanStage, MultiSinkOutput, BatchManager, BatchProcessor, Engine, Checkpoint
- All metrics feature-gated behind `#[cfg(feature = "otel-metrics")]` — zero cost when disabled

Closes #104

## Changes

| File | Change |
|------|--------|
| `src/infrastructure/observability/metrics_instruments.rs` | 31 new instrument definitions + AtomicU64 backing + helpers + tests |
| `src/infrastructure/downloader/hybrid_router.rs` | DOWNLOADER_ESCALATIONS, DOWNLOADER_LAYER_LATENCY, DOWNLOADER_WAF_BLOCKS |
| `src/infrastructure/downloader/resource_governor.rs` | RAM_USAGE_PERCENT, CHROME_INSTANCES_ACTIVE, RESOURCE_DENIED |
| `src/infrastructure/downloader/obscura_downloader.rs` | DOWNLOAD_OBSCURA_LATENCY, DOWNLOAD_OBSCURA_TIMEOUT |
| `src/infrastructure/downloader/wreq_downloader.rs` | DOWNLOAD_WREQ_LATENCY |
| `src/infrastructure/network/session_pool.rs` | SESSION_POOL_BANNED, SESSION_POOL_HEALTHY, SESSION_POOL_BACKOFF + domain_bucket() |
| `src/application/crawler/concurrency_level.rs` | AUTOSCALE_LEVEL_TRANSITIONS with swap() |
| `src/application/pipeline/executor.rs` | PIPELINE_ITEMS_TOTAL, REJECTED, SKIPPED (explicit match arms) |
| `src/application/pipeline/stages/validate.rs` | VALIDATE_REJECTS{reason} |
| `src/application/pipeline/stages/clean.rs` | CLEAN_REDUCTION_PCT, CLEAN_SPA_DETECTED |
| `src/application/pipeline/stages/multi_sink.rs` | OUTPUT_SINK_ERRORS{sink} |
| `src/application/batch/manager.rs` | BATCH_JOBS_TOTAL, COMPLETED, FAILED (in process_all_summary) |
| `src/application/batch/processor.rs` | BATCH_URLS_PROCESSED, BATCH_CONCURRENCY_CURRENT |
| `src/application/crawler/engine.rs` | ENGINE_PAGES_CRAWLED, ENGINE_CONCURRENCY_LEVEL, ENGINE_CHECKPOINT_SAVES |
| `src/application/crawler/checkpoint.rs` | CHECKPOINT_SAVES, CHECKPOINT_LOADS, CHECKPOINT_CORRUPTED |

## Chained Commits (stacked-to-main)

| Commit | Scope | Files |
|--------|-------|-------|
| `8099aed` | Instrument definitions | metrics_instruments.rs |
| `83b61a4` | Downloader + Network | 6 files |
| `b2914b0` | Pipeline + Batch | 6 files |
| `eaa9dd6` | Crawler (final) | 2 files |

## Design Review Fixes Applied

- **C1**: ObservableGauge uses global AtomicU64 registry (not instance capture)
- **C2**: PipelineExecutor uses explicit match arms (not catch-all)
- **C3**: SessionPool uses domain_bucket() for cardinality control
- **W1**: ConcurrencyLevel uses swap() for direction tracking
- **W2**: BatchManager metrics in process_all_summary

## Test Plan

- [x] `cargo check` — compiles without feature
- [x] `cargo check --features otel-metrics` — compiles with feature
- [x] `cargo clippy --features otel-metrics -- -D warnings` — 0 warnings
- [x] `cargo nextest run` — 1142/1142 pass
- [x] `cargo nextest run --features otel-metrics` — 32 metrics tests pass