### PR TITLE
fix(observability): make OTel flush async and add metrics export fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ CLAUDE.md
 
 # Scraper output (should never be committed)
 output/
+
+# GitNexus local config
+.gitnexusrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "2c5e60b8c8d282c86360cab651ded04ab0335a7b5390c8d34145cbeab8cacf5f"
 dependencies = [
  "bitflags",
  "btls-sys",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "openssl-macros",
 ]
@@ -824,6 +824,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1511,12 +1521,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1529,6 +1548,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2102,6 +2127,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2894,6 +2935,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3109,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3131,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3994,13 +4084,17 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -4139,6 +4233,7 @@ dependencies = [
  "ratatui-form",
  "rayon",
  "regex",
+ "reqwest 0.13.4",
  "rmcp",
  "robotstxt",
  "rusqlite",
@@ -4318,6 +4413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4372,6 +4476,29 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4875,7 +5002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -5125,6 +5252,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ otel-metrics = [
     "otel",
     "opentelemetry/metrics",
     "opentelemetry_sdk/metrics",
+    "opentelemetry_sdk/rt-tokio",
     "opentelemetry-otlp/metrics",
 ]
 
@@ -102,12 +103,15 @@ tracing-appender = "0.2"
 # OpenTelemetry (feature-gated: --features otel)
 opentelemetry = { version = "0.32", optional = true }
 opentelemetry_sdk = { version = "0.32", optional = true, features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.32", optional = true, features = ["http-proto", "reqwest-client"] }
+opentelemetry-otlp = { version = "0.32", optional = true, features = ["http-proto", "reqwest-blocking-client"] }
 tracing-opentelemetry = { version = "0.33", optional = true }
 
 # Utilities
 url = { version = "2", features = ["serde"] }
 futures = "0.3"
+# Force reqwest to use native-tls (OpenSSL) instead of rustls for OTel export.
+# Grafana Cloud TLS certificates are in the system store, not in rustls webpki.
+reqwest = { version = "0.13", optional = true, default-features = false, features = ["blocking", "native-tls"] }
 
 # HTML to Markdown conversion (preserves headings, code blocks, lists)
 # Pinned to <2.21 to avoid edition2024 requirement (needs Rust 1.85+)

--- a/src/application/crawler/engine.rs
+++ b/src/application/crawler/engine.rs
@@ -956,8 +956,8 @@ pub async fn crawl_site_with_options(
 #[cfg(feature = "otel-metrics")]
 mod metrics_tests {
     use crate::infrastructure::observability::metrics_instruments::{
-        ENGINE_CHECKPOINT_SAVES, ENGINE_CONCURRENCY_LEVEL, ENGINE_PAGES_CRAWLED,
-        engine_concurrency_get, update_engine_concurrency,
+        engine_concurrency_get, update_engine_concurrency, ENGINE_CHECKPOINT_SAVES,
+        ENGINE_CONCURRENCY_LEVEL, ENGINE_PAGES_CRAWLED,
     };
 
     #[test]

--- a/src/infrastructure/observability/otel.rs
+++ b/src/infrastructure/observability/otel.rs
@@ -39,7 +39,9 @@ use super::file_trace_exporter::FileTraceExporter;
 #[cfg(feature = "otel-metrics")]
 use opentelemetry_otlp::MetricExporter;
 #[cfg(feature = "otel-metrics")]
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+#[cfg(feature = "otel-metrics")]
+use std::time::Duration;
 
 /// OpenTelemetry configuration.
 #[derive(Debug, Clone)]
@@ -122,21 +124,32 @@ impl OtelGuard {
 
     /// Flush pending telemetry and shut down providers.
     ///
-    /// Must be called **before** the Tokio runtime shuts down. The OTel
-    /// batch processor and periodic reader threads need a live reactor to
-    /// drain their buffers. Call this explicitly rather than relying on
-    /// `Drop`, which may run after the runtime is gone.
-    pub fn flush(&self) {
-        // Force flush first — drains batch processor buffers while the
-        // Tokio runtime is still alive. Then shutdown signals termination.
+    /// Must be called **before** the Tokio runtime shuts down, and from
+    /// within a running Tokio context. The PeriodicReader's reqwest HTTP
+    /// call needs the Tokio runtime to make progress — using
+    /// `tokio::time::sleep` instead of `std::thread::sleep` ensures the
+    /// runtime stays responsive so the export can complete.
+    pub async fn flush(&self) {
         if let Some(ref provider) = self.provider {
-            let _ = provider.force_flush();
-            let _ = provider.shutdown();
+            if let Err(e) = provider.shutdown() {
+                eprintln!("Warning: OTel trace shutdown failed: {e}");
+            }
         }
         #[cfg(feature = "otel-metrics")]
         if let Some(ref meter) = self.meter_provider {
-            let _ = meter.force_flush();
-            let _ = meter.shutdown();
+            // force_flush triggers an immediate export cycle; the
+            // tokio::time::sleep yields the runtime so the PeriodicReader's
+            // background thread (which uses futures_executor::block_on for
+            // the blocking reqwest call) can complete.
+            if let Err(e) = meter.force_flush() {
+                eprintln!("Warning: OTel metrics force_flush failed: {e}");
+            }
+            // Give the PeriodicReader's background thread time to
+            // collect and send via the blocking reqwest client.
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            if let Err(e) = meter.shutdown() {
+                eprintln!("Warning: OTel metrics shutdown failed: {e}");
+            }
         }
     }
 }
@@ -244,26 +257,60 @@ pub fn init_otel_metrics(
     OtelGuard,
     OpenTelemetryLayer<Registry, opentelemetry_sdk::trace::Tracer>,
 )> {
-    use opentelemetry_otlp::WithExportConfig;
-
-    let exporter = MetricExporter::builder()
-        .with_http()
-        .with_endpoint(&config.endpoint)
-        .build()
-        .map_err(|e| anyhow::anyhow!("failed to build OTLP metric exporter: {e}"))?;
+    use opentelemetry_sdk::metrics::PeriodicReader;
 
     let resource = Resource::builder()
         .with_service_name(config.service_name.clone())
         .build();
 
-    let meter_provider = SdkMeterProvider::builder()
-        .with_periodic_exporter(exporter)
-        .with_resource(resource)
-        .build();
+    let meter_provider = if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok() || config.endpoint != "http://localhost:4318" {
+        // OTLP export to Grafana Cloud or custom collector
+        use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+        use std::collections::HashMap;
+
+        let mut headers = HashMap::new();
+        if let Ok(auth) = std::env::var("OTEL_EXPORTER_OTLP_HEADERS") {
+            if let Some(value) = auth.strip_prefix("Authorization=") {
+                headers.insert("Authorization".to_string(), value.to_string());
+            }
+        }
+
+        let exporter = MetricExporter::builder()
+            .with_http()
+            .with_endpoint(&config.endpoint)
+            .with_headers(headers)
+            .build()
+            .map_err(|e| anyhow::anyhow!("failed to build OTLP metric exporter: {e}"))?;
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(std::time::Duration::from_secs(5))
+            .build();
+
+        SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource)
+            .build()
+    } else {
+        // Console export for local development — prints metrics to stdout
+        use opentelemetry_sdk::metrics::PeriodicReader;
+        use opentelemetry_sdk::metrics::export::stdout::StdoutExporterBuilder;
+
+        let exporter = StdoutExporterBuilder::new()
+            .with_writer(std::io::stdout())
+            .build();
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(std::time::Duration::from_secs(10))
+            .build();
+
+        SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource)
+            .build()
+    };
 
     global::set_meter_provider(meter_provider.clone());
 
-    // Also initialize tracing so the guard can shut down both providers
     let (tracer_provider, layer) = build_tracer_provider(&config)?;
     let guard = OtelGuard::new(tracer_provider).with_meter_provider(meter_provider.clone());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,16 +306,16 @@ async fn __main() -> CliExit {
     let result = orchestrator::run(opts).await;
 
     // Flush OpenTelemetry while the Tokio runtime is still alive.
-    // The batch processor and periodic reader threads need a live reactor
+    // The batch processor and periodic reader tasks need a live reactor
     // to drain their buffers — if we rely on Drop, the runtime may already
     // be gone, causing "there is no reactor running" panics.
     #[cfg(feature = "otel-metrics")]
     if let Some(ref guard) = _otel_guard {
-        guard.flush();
+        guard.flush().await;
     }
     #[cfg(all(feature = "otel", not(feature = "otel-metrics")))]
     if let Some(ref guard) = _otel_guard {
-        guard.flush();
+        guard.flush().await;
     }
 
     result


### PR DESCRIPTION
## Summary
- Make `OtelGuard::flush()` async to avoid "no reactor running" panics during shutdown
- Add OTLP vs console export dual path in `init_otel_metrics` (Grafana Cloud export + local dev fallback)
- Support `OTEL_EXPORTER_OTLP_HEADERS` for Grafana Cloud authentication
- Switch `opentelemetry-otlp` to `reqwest-blocking-client` with `native-tls` for TLS compatibility
- Add `.gitnexusrc` to `.gitignore`