### PR TITLE
fix(mcp): replace .contains() with glob matching in match_url_pattern

### DIFF
--- a/src/infrastructure/mcp_server/mod.rs
+++ b/src/infrastructure/mcp_server/mod.rs
@@ -1053,7 +1053,7 @@ impl McpHandler {
 
     /// Match a URL against a glob pattern
     #[tool(
-        description = "Check if a URL matches a glob-style pattern. SSRF-safe, host-only comparison."
+        description = "Check if a URL matches a glob-style pattern. Supports path patterns (start with '/') and host patterns."
     )]
     #[instrument(skip(self), fields(url = %params.url, pattern = %params.pattern))]
     async fn match_url_pattern(
@@ -1068,7 +1068,7 @@ impl McpHandler {
             .await
             .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
 
-        let matches = params.url.contains(&params.pattern) || params.pattern == "*";
+        let matches = crate::domain::matches_pattern(&params.url, &params.pattern);
         Ok(CallToolResult::success(vec![Content::text(
             matches.to_string(),
         )]))


### PR DESCRIPTION
Closes #125

## Summary

- MCP tool `match_url_pattern` used raw `.contains()` for pattern matching — only did substring matching, not glob patterns
- Now delegates to `domain::matches_pattern()` which provides proper glob-style matching
- When #125 merges, the MCP tool automatically gains path pattern support

## Changes

| File | Change |
|------|--------|
| `src/infrastructure/mcp_server/mod.rs` | Replace `params.url.contains(&params.pattern)` with `crate::domain::matches_pattern()` |

## Test Plan

- [x] `cargo check` — compiles clean
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo test --test mcp_proptest` — 19 passed, 0 failed

## Note

This fix depends on #125 being merged for full path pattern support. On current main, `matches_pattern` is host-only — the MCP tool will match that behavior. After #125 merges, the MCP tool automatically gains `/admin/*` style path patterns.