### PR TITLE
fix(cli): resolve obsidian pipeline and glob matching inconsistencies (closes #134)

### DIFF
--- a/src/cli/orchestrator.rs
+++ b/src/cli/orchestrator.rs
@@ -171,7 +171,10 @@ pub async fn run(opts: CrawlOptions) -> CliExit {
 
     // Determine output directory for individual files
     let output_dir = if opts.export.quick_save {
-        let base = opts.export.obsidian_vault.as_deref()
+        let base = opts
+            .export
+            .obsidian_vault
+            .as_deref()
             .unwrap_or(&opts.export.output_dir);
         let inbox = base.join("_inbox");
         if !inbox.exists() {

--- a/src/cli/orchestrator.rs
+++ b/src/cli/orchestrator.rs
@@ -171,15 +171,13 @@ pub async fn run(opts: CrawlOptions) -> CliExit {
 
     // Determine output directory for individual files
     let output_dir = if opts.export.quick_save {
-        if let Some(v) = &opts.export.obsidian_vault {
-            let inbox = v.join("_inbox");
-            if !inbox.exists() {
-                let _ = std::fs::create_dir_all(&inbox);
-            }
-            inbox
-        } else {
-            opts.export.output_dir.clone()
+        let base = opts.export.obsidian_vault.as_deref()
+            .unwrap_or(&opts.export.output_dir);
+        let inbox = base.join("_inbox");
+        if !inbox.exists() {
+            let _ = std::fs::create_dir_all(&inbox);
         }
+        inbox
     } else {
         opts.export.output_dir.clone()
     };

--- a/src/domain/pattern_matching/mod.rs
+++ b/src/domain/pattern_matching/mod.rs
@@ -25,11 +25,13 @@ use url::Url;
 
 /// Check if a URL matches a glob-style pattern (dual-mode)
 ///
-/// Two modes depending on whether the pattern starts with `/`:
+/// Three modes depending on pattern shape:
 ///
 /// - **Path pattern** (starts with `/`): matched against the URL path component.
 ///   Examples: `/pricing`, `/admin/*`, `/api/v2/*`
-/// - **Host pattern** (no leading `/`): matched against the parsed hostname
+/// - **Path glob** (starts with `*/`): matched against the URL path component.
+///   Examples: `*/pricing*`, `*/cloud*`
+/// - **Host pattern** (no leading `/` or `*/`): matched against the parsed hostname
 ///   for backward-compatible behavior.
 ///   Examples: `example.com`, `*.example.com`, `*.example.com/*`
 ///
@@ -73,6 +75,15 @@ pub fn matches_pattern(url_str: &str, pattern: &str) -> bool {
             Err(_) => return false,
         };
         return glob.is_match(path);
+    }
+
+    // Path glob: pattern starts with '*/' → match against URL path
+    if pattern.starts_with("*/") {
+        let glob = match Glob::new(pattern) {
+            Ok(g) => g.compile_matcher(),
+            Err(_) => return false,
+        };
+        return glob.is_match(url.path());
     }
 
     // Host pattern: backward-compatible host-only matching
@@ -266,6 +277,46 @@ mod tests {
         ));
         assert!(matches_pattern(
             "https://sub.example.com/page",
+            "*.example.com"
+        ));
+    }
+
+    #[test]
+    fn test_matches_pattern_path_glob_with_leading_wildcard() {
+        // Patterns with '/' (but not starting with '/') match against URL path
+        assert!(matches_pattern(
+            "https://example.com/pricing",
+            "*/pricing*"
+        ));
+        assert!(matches_pattern(
+            "https://example.com/cloud-scraper",
+            "*/cloud*"
+        ));
+        assert!(!matches_pattern(
+            "https://example.com/about",
+            "*/pricing*"
+        ));
+    }
+
+    #[test]
+    fn test_matches_pattern_path_glob_preserves_existing_behavior() {
+        // Path patterns starting with '/' still work
+        assert!(matches_pattern(
+            "https://example.com/admin/settings",
+            "/admin/*"
+        ));
+        assert!(!matches_pattern(
+            "https://example.com/page",
+            "/admin/*"
+        ));
+
+        // Host patterns without '/' still work
+        assert!(matches_pattern(
+            "https://example.com/page",
+            "example.com"
+        ));
+        assert!(matches_pattern(
+            "https://blog.example.com/page",
             "*.example.com"
         ));
     }

--- a/src/domain/pattern_matching/mod.rs
+++ b/src/domain/pattern_matching/mod.rs
@@ -284,18 +284,12 @@ mod tests {
     #[test]
     fn test_matches_pattern_path_glob_with_leading_wildcard() {
         // Patterns with '/' (but not starting with '/') match against URL path
-        assert!(matches_pattern(
-            "https://example.com/pricing",
-            "*/pricing*"
-        ));
+        assert!(matches_pattern("https://example.com/pricing", "*/pricing*"));
         assert!(matches_pattern(
             "https://example.com/cloud-scraper",
             "*/cloud*"
         ));
-        assert!(!matches_pattern(
-            "https://example.com/about",
-            "*/pricing*"
-        ));
+        assert!(!matches_pattern("https://example.com/about", "*/pricing*"));
     }
 
     #[test]
@@ -305,16 +299,10 @@ mod tests {
             "https://example.com/admin/settings",
             "/admin/*"
         ));
-        assert!(!matches_pattern(
-            "https://example.com/page",
-            "/admin/*"
-        ));
+        assert!(!matches_pattern("https://example.com/page", "/admin/*"));
 
         // Host patterns without '/' still work
-        assert!(matches_pattern(
-            "https://example.com/page",
-            "example.com"
-        ));
+        assert!(matches_pattern("https://example.com/page", "example.com"));
         assert!(matches_pattern(
             "https://blog.example.com/page",
             "*.example.com"

--- a/src/infrastructure/converter/wikilinks.rs
+++ b/src/infrastructure/converter/wikilinks.rs
@@ -64,7 +64,7 @@ pub fn slug_from_url(url_path: &str) -> String {
             let parent = decode_and_normalize(segments[len - 2]).to_kebab_case();
             let current = decode_and_normalize(segments[len - 1]).to_kebab_case();
             format!("{parent}-{current}")
-        }
+        },
     }
 }
 

--- a/src/infrastructure/converter/wikilinks.rs
+++ b/src/infrastructure/converter/wikilinks.rs
@@ -70,19 +70,24 @@ pub fn slug_from_url(url_path: &str) -> String {
 
 /// Determines if a URL should be converted to a wiki-link.
 /// Returns Some(slug) if conversion is possible, None otherwise.
+///
+/// Relative paths (e.g. `/about`, `/product/1`) are treated as same-domain
+/// links and converted to wiki-links when they match `base_domain`.
 fn should_convert_wikilink(url_str: &str, base_domain: &str) -> Option<String> {
     // Skip anchor links
     if url_str.starts_with('#') {
         return None;
     }
 
-    // Skip relative paths
-    if url_str.starts_with('/') && !url_str.contains("://") {
-        return None;
-    }
+    // Convert relative paths to absolute URLs for domain comparison
+    let resolved_url = if url_str.starts_with('/') && !url_str.contains("://") {
+        format!("https://{base_domain}{url_str}")
+    } else {
+        url_str.to_string()
+    };
 
     // Try to parse the URL
-    let parsed = match url::Url::parse(url_str) {
+    let parsed = match url::Url::parse(&resolved_url) {
         Ok(p) => p,
         Err(_) => return None,
     };
@@ -386,8 +391,29 @@ mod tests {
     }
 
     #[test]
-    fn test_relative_links_unchanged() {
+    fn test_relative_single_segment_converts() {
         let md = "[About](/about)";
+        let result = convert_wiki_links(md, "example.com");
+        assert_eq!(result, "[[about]]");
+    }
+
+    #[test]
+    fn test_relative_multi_segment_converts() {
+        let md = "[Product](/product/1)";
+        let result = convert_wiki_links(md, "example.com");
+        assert_eq!(result, "[[product-1|Product]]");
+    }
+
+    #[test]
+    fn test_relative_external_not_converted() {
+        let md = "[External](https://other.com/page)";
+        let result = convert_wiki_links(md, "example.com");
+        assert_eq!(result, md);
+    }
+
+    #[test]
+    fn test_relative_anchor_not_converted() {
+        let md = "[Anchor](#section)";
         let result = convert_wiki_links(md, "example.com");
         assert_eq!(result, md);
     }

--- a/src/infrastructure/output/file_saver.rs
+++ b/src/infrastructure/output/file_saver.rs
@@ -194,7 +194,11 @@ fn rewrite_image_urls_to_relative(content: &str, _md_file_dir: &Path) -> String 
             // For simplicity, use the last 2 segments as the relative path
             let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
             let rel_path = if segments.len() >= 2 {
-                format!("./{}/{}", segments[segments.len() - 2], segments[segments.len() - 1])
+                format!(
+                    "./{}/{}",
+                    segments[segments.len() - 2],
+                    segments[segments.len() - 1]
+                )
             } else if segments.len() == 1 {
                 format!("./{}", segments[0])
             } else {
@@ -385,10 +389,7 @@ mod tests {
         let content = "First ![a](https://example.com/x.png) then ![b](https://example.com/y.jpg)";
         let dir = Path::new("/output/example.com");
         let result = rewrite_image_urls_to_relative(content, dir);
-        assert_eq!(
-            result,
-            "First ![a](./x.png) then ![b](./y.jpg)"
-        );
+        assert_eq!(result, "First ![a](./x.png) then ![b](./y.jpg)");
     }
 
     #[test]

--- a/src/infrastructure/output/file_saver.rs
+++ b/src/infrastructure/output/file_saver.rs
@@ -139,8 +139,12 @@ fn save_as_markdown(
         }
 
         // Apply relative asset paths if enabled
-        if obsidian.relative_assets && !item.assets.is_empty() {
-            processed = obsidian::resolve_asset_paths(&processed, md_file_dir, &item.assets);
+        if obsidian.relative_assets {
+            if !item.assets.is_empty() {
+                processed = obsidian::resolve_asset_paths(&processed, md_file_dir, &item.assets);
+            } else {
+                processed = rewrite_image_urls_to_relative(&processed, md_file_dir);
+            }
         }
 
         // Generate rich metadata if enabled
@@ -166,6 +170,42 @@ fn save_as_markdown(
     }
 
     Ok(())
+}
+
+/// Rewrite absolute image URLs in markdown to relative paths.
+///
+/// Scans for `![alt](https://...)` patterns and rewrites to `![alt](./relative/path)`.
+/// Used as a fallback when `--download-images` is not enabled and `item.assets` is empty.
+fn rewrite_image_urls_to_relative(content: &str, _md_file_dir: &Path) -> String {
+    use regex::Regex;
+
+    // Match ![alt text](url) where url is absolute
+    static RE: std::sync::LazyLock<Regex> =
+        std::sync::LazyLock::new(|| Regex::new(r"!\[([^\]]*)\]\((https?://[^)]+)\)").unwrap());
+
+    RE.replace_all(content, |caps: &regex::Captures| {
+        let alt = &caps[1];
+        let url = &caps[2];
+
+        // Parse the URL to extract the path
+        if let Ok(parsed) = url::Url::parse(url) {
+            let path = parsed.path();
+            // Create a relative path from md_file_dir to the image
+            // For simplicity, use the last 2 segments as the relative path
+            let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+            let rel_path = if segments.len() >= 2 {
+                format!("./{}/{}", segments[segments.len() - 2], segments[segments.len() - 1])
+            } else if segments.len() == 1 {
+                format!("./{}", segments[0])
+            } else {
+                url.to_string()
+            };
+            format!("![{alt}]({rel_path})")
+        } else {
+            caps[0].to_string()
+        }
+    })
+    .to_string()
 }
 
 /// Save results as plain text files with structured format
@@ -304,5 +344,58 @@ mod tests {
 
         let json_path = output_dir.join("results.json");
         assert!(json_path.exists());
+    }
+
+    // === rewrite_image_urls_to_relative tests ===
+
+    #[test]
+    fn test_rewrite_single_image_url_to_relative() {
+        let content = "![alt](https://example.com/img/photo.png)";
+        let dir = Path::new("/output/example.com");
+        let result = rewrite_image_urls_to_relative(content, dir);
+        assert_eq!(result, "![alt](./img/photo.png)");
+    }
+
+    #[test]
+    fn test_rewrite_deeply_nested_image_url() {
+        let content = "![alt](https://example.com/a/b/c.png)";
+        let dir = Path::new("/output/example.com");
+        let result = rewrite_image_urls_to_relative(content, dir);
+        assert_eq!(result, "![alt](./b/c.png)");
+    }
+
+    #[test]
+    fn test_rewrite_non_url_images_unchanged() {
+        let content = "![alt](./local/image.png)";
+        let dir = Path::new("/output/example.com");
+        let result = rewrite_image_urls_to_relative(content, dir);
+        assert_eq!(result, "![alt](./local/image.png)");
+    }
+
+    #[test]
+    fn test_rewrite_empty_content_returns_empty() {
+        let content = "";
+        let dir = Path::new("/output");
+        let result = rewrite_image_urls_to_relative(content, dir);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_rewrite_multiple_images() {
+        let content = "First ![a](https://example.com/x.png) then ![b](https://example.com/y.jpg)";
+        let dir = Path::new("/output/example.com");
+        let result = rewrite_image_urls_to_relative(content, dir);
+        assert_eq!(
+            result,
+            "First ![a](./x.png) then ![b](./y.jpg)"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_single_segment_path() {
+        let content = "![alt](https://example.com/photo.png)";
+        let dir = Path::new("/output/example.com");
+        let result = rewrite_image_urls_to_relative(content, dir);
+        assert_eq!(result, "![alt](./photo.png)");
     }
 }


### PR DESCRIPTION
Closes #134

## Summary

- Fix --exclude-pattern so glob patterns with */ prefix match URL paths
- Fix --obsidian-wiki-links to convert relative paths by resolving against base domain
- Fix --obsidian-relative-assets to work without --download-images via regex fallback
- Fix --quick-save to create _inbox directory without requiring --vault

## Changes

| File | Change |
|------|--------|
| src/domain/pattern_matching/mod.rs | Added starts_with('*/') check for path glob matching, 2 new tests |
| src/infrastructure/converter/wikilinks.rs | Fixed should_convert_wikilink() to handle relative paths, 4 tests updated |
| src/infrastructure/output/file_saver.rs | Added rewrite_image_urls_to_relative() with LazyLock, 6 new tests |
| src/cli/orchestrator.rs | Fixed quick-save to use unwrap_or fallback for _inbox creation

## Test Plan

- [x] cargo check passes
- [x] cargo clippy -- -D warnings clean
- [x] All 18 pattern_matching tests pass
- [x] All 22 wikilinks tests pass
- [x] All 8 file_saver tests pass
- [x] 12 new tests added across 3 modules