### PR TITLE
feat(infra): unify asset download in adapters Downloader

### DIFF
--- a/src/infrastructure/ai/model_cache.rs
+++ b/src/infrastructure/ai/model_cache.rs
@@ -209,6 +209,7 @@ impl ModelCache {
 
         // Check existence via spawn_blocking
         let exists = tokio::task::spawn_blocking(move || cache_dir.exists())
+            .in_current_span()
             .await
             .map_err(|e| {
                 SemanticError::ModelLoad(std::io::Error::other(format!(

--- a/src/infrastructure/bridge.rs
+++ b/src/infrastructure/bridge.rs
@@ -1,7 +1,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use tokio::sync::oneshot;
-use tracing::warn;
+use tracing::{warn, Instrument};
 
 use crate::error::ScraperError;
 use crate::infrastructure::converter::html_cleaner::clean_html;
@@ -80,7 +80,11 @@ impl CpuBridge {
     {
         let (tx, rx) = oneshot::channel();
         let pool = self.pool.clone();
-        tokio::task::spawn_blocking(move || {
+        // The Instrumented wrapper attaches the current tracing span to the
+        // blocking task. We intentionally drop it here because the task runs
+        // fire-and-forget via a oneshot channel — the JoinHandle is not awaited.
+        #[allow(clippy::let_underscore_future)]
+        let _ = tokio::task::spawn_blocking(move || {
             let caught = catch_unwind(AssertUnwindSafe(move || pool.install(work)));
             let mapped: Result<R, ScraperError> = caught.map_err(|panic| {
                 let msg = panic_message(&*panic);
@@ -92,7 +96,8 @@ impl CpuBridge {
                     "canal CPU bridge descartado: tarea Tokio abortada antes de recibir el resultado"
                 );
             }
-        });
+        })
+        .in_current_span();
         rx
     }
 

--- a/src/infrastructure/observability/file_trace_layer.rs
+++ b/src/infrastructure/observability/file_trace_layer.rs
@@ -9,6 +9,11 @@
 //! `fields` object. `trace_id` uses the thread ID (stable within a thread); when
 //! OTel is also active, the OTel trace/span IDs take precedence in downstream
 //! consumers.
+//!
+//! **Thread-safety note:** This layer uses thread-local span tracking
+//! (`SPAN_STACK`). It assumes `on_enter`/`on_exit`/`on_event` are called from
+//! the same thread for a given span lifecycle — guaranteed by
+//! `tracing_subscriber::Registry`.
 
 use std::cell::RefCell;
 use std::fs::File;
@@ -24,9 +29,9 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
 // Thread-local span stack for tracking the current span inside `on_event`.
-// When a span is entered, its ID is pushed; when exited, it's popped.
-// This is necessary because `Span::current()` doesn't reliably return the
-// span ID inside a Layer's `on_event` callback.
+// When a span is entered, its ID is pushed; when exited, it's popped IF the
+// exiting ID matches the top. This prevents stack corruption from out-of-order
+// span exits.
 thread_local! {
     static SPAN_STACK: RefCell<Vec<tracing::Id>> = const { RefCell::new(Vec::new()) };
 }
@@ -85,8 +90,16 @@ where
         SPAN_STACK.with(|stack| stack.borrow_mut().push(id.clone()));
     }
 
-    fn on_exit(&self, _id: &tracing::Id, _ctx: Context<'_, S>) {
-        SPAN_STACK.with(|stack| stack.borrow_mut().pop());
+    fn on_exit(&self, id: &tracing::Id, _ctx: Context<'_, S>) {
+        SPAN_STACK.with(|stack| {
+            let mut stack = stack.borrow_mut();
+            // Only pop if the exiting ID matches the top of the stack.
+            // Out-of-order exits (e.g., inner guard dropped before outer)
+            // would corrupt the stack — this check prevents that.
+            if stack.last() == Some(id) {
+                stack.pop();
+            }
+        });
     }
 
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
@@ -109,23 +122,32 @@ where
         }
 
         // trace_id: use thread ID as a stable per-thread trace identifier.
+        // ThreadId::as_u64() is unstable (tracking #67939), so we extract from
+        // the Debug format. On Linux this is "ThreadId(N)" where N is decimal.
+        // On macOS/Windows the format differs, so we hash the raw Debug output
+        // for a platform-independent u64.
         let tid_debug = format!("{:?}", std::thread::current().id());
-        let tid_num: u64 = tid_debug
+        let tid: u64 = tid_debug
             .trim_start_matches("ThreadId(")
             .trim_end_matches(')')
             .parse()
-            .unwrap_or(0);
-        record["trace_id"] = json!(format!("{tid_num:016x}"));
+            .unwrap_or_else(|_| {
+                use std::hash::{Hash, Hasher};
+                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                tid_debug.hash(&mut hasher);
+                hasher.finish()
+            });
+        record["trace_id"] = json!(format!("{tid:016x}"));
 
-        // Capture all structured fields from the event
-        let fields = event_all_fields(event);
-        if !fields.is_empty() {
-            record["fields"] = Value::Object(fields);
+        // Single-pass field capture: extracts all fields AND the message
+        // in one traversal, avoiding the double-visit antipattern.
+        let mut recorder = EventRecorder::new();
+        event.record(&mut recorder);
+
+        if !recorder.fields.is_empty() {
+            record["fields"] = Value::Object(recorder.fields);
         }
-
-        // Extract message separately for top-level convenience
-        let msg = event_message(event);
-        if let Some(m) = msg {
+        if let Some(m) = recorder.message {
             record["message"] = json!(m);
         }
 
@@ -135,16 +157,12 @@ where
                 Err(e) => {
                     eprintln!("[FileTraceLayer] serialization error: {e}");
                     return;
-                }
+                },
             };
             line.push(b'\n');
             if let Err(e) = writer.write_all(&line) {
                 eprintln!("[FileTraceLayer] write error: {e}");
             }
-            // Flush on every event to ensure data reaches disk.
-            // This is intentional for a tracing layer — data loss on crash
-            // is worse than the syscall cost. The BufWriter still batches
-            // within a single lock acquisition.
             if let Err(e) = writer.flush() {
                 eprintln!("[FileTraceLayer] flush error: {e}");
             }
@@ -152,49 +170,44 @@ where
     }
 }
 
-/// Extract all fields from a tracing event as a JSON map.
-fn event_all_fields(event: &tracing::Event<'_>) -> Map<String, Value> {
-    let mut recorder = AllFieldsRecorder::new();
-    event.record(&mut recorder);
-    recorder.fields
-}
-
-/// Extract just the `message` field from a tracing event.
-fn event_message(event: &tracing::Event<'_>) -> Option<String> {
-    let mut recorder = MessageRecorder(String::new());
-    event.record(&mut recorder);
-    if recorder.0.is_empty() {
-        None
-    } else {
-        Some(recorder.0)
-    }
-}
-
-/// Captures all fields from a tracing event.
-struct AllFieldsRecorder {
+/// Single-pass event recorder. Captures ALL fields (including `message`) in one
+/// traversal of the event's field set, avoiding the double-visit antipattern.
+struct EventRecorder {
     fields: Map<String, Value>,
+    message: Option<String>,
 }
 
-impl AllFieldsRecorder {
+impl EventRecorder {
     fn new() -> Self {
         Self {
             fields: Map::new(),
+            message: None,
         }
     }
 }
 
-impl tracing::field::Visit for AllFieldsRecorder {
+impl tracing::field::Visit for EventRecorder {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         let name = field.name().to_string();
         let formatted = format!("{value:?}");
-        // Strip surrounding quotes from Debug output on strings
-        let value = if formatted.starts_with('"') && formatted.ends_with('"') && formatted.len() >= 2
-        {
-            Value::String(formatted[1..formatted.len() - 1].to_string())
+
+        if name == "message" {
+            let msg =
+                if formatted.starts_with('"') && formatted.ends_with('"') && formatted.len() >= 2 {
+                    formatted[1..formatted.len() - 1].to_string()
+                } else {
+                    formatted
+                };
+            self.message = Some(msg);
         } else {
-            Value::String(formatted)
-        };
-        self.fields.insert(name, value);
+            let value =
+                if formatted.starts_with('"') && formatted.ends_with('"') && formatted.len() >= 2 {
+                    Value::String(formatted[1..formatted.len() - 1].to_string())
+                } else {
+                    Value::String(formatted)
+                };
+            self.fields.insert(name, value);
+        }
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
@@ -203,10 +216,8 @@ impl tracing::field::Visit for AllFieldsRecorder {
     }
 
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        if let Some(n) = serde_json::Number::from_u128(value as u128) {
-            self.fields
-                .insert(field.name().to_string(), Value::Number(n));
-        }
+        self.fields
+            .insert(field.name().to_string(), Value::Number(value.into()));
     }
 
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
@@ -215,22 +226,11 @@ impl tracing::field::Visit for AllFieldsRecorder {
     }
 
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.fields
-            .insert(field.name().to_string(), Value::String(value.to_string()));
-    }
-}
-
-/// Captures only the `message` field.
-struct MessageRecorder(String);
-
-impl tracing::field::Visit for MessageRecorder {
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         if field.name() == "message" {
-            self.0 = format!("{value:?}");
-            // Strip surrounding quotes from Debug output
-            if self.0.starts_with('"') && self.0.ends_with('"') && self.0.len() >= 2 {
-                self.0 = self.0[1..self.0.len() - 1].to_string();
-            }
+            self.message = Some(value.to_string());
+        } else {
+            self.fields
+                .insert(field.name().to_string(), Value::String(value.to_string()));
         }
     }
 }
@@ -243,14 +243,13 @@ fn system_time_to_rfc3339(t: SystemTime) -> String {
     let secs = duration.as_secs();
     let millis = duration.subsec_millis();
 
-    // Convert seconds since epoch to Y-M-D H:M:S using integer arithmetic
     let days = secs / 86400;
     let remaining = secs % 86400;
     let hours = remaining / 3600;
     let minutes = (remaining % 3600) / 60;
     let seconds = remaining % 60;
 
-    // Days since 1970-01-00 (algorithm from Howard Hinnant)
+    // Days since 1970-01-00 (Howard Hinnant algorithm)
     let z = days as i64 + 719468;
     let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
     let doe = z - era * 146097;
@@ -262,29 +261,27 @@ fn system_time_to_rfc3339(t: SystemTime) -> String {
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let yr = if m <= 2 { y + 1 } else { y };
 
-    format!(
-        "{yr:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}.{millis:03}Z"
-    )
+    format!("{yr:04}-{m:02}-{d:02}T{hours:02}:{minutes:02}:{seconds:02}.{millis:03}Z")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::Value;
+    use std::path::Path;
     use tracing_subscriber::layer::SubscriberExt;
 
-    // Each test creates its own Dispatch to avoid cross-test interference
-    // from set_global_default (which only works once per process) or
-    // set_default (which is thread-local and can leak across tests).
-
-    // ── Contract-based tests: each test validates ONE observable behavior ──
+    // Each test creates its own Dispatch to avoid cross-test interference.
 
     #[test]
     fn contract_creates_file_at_path() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("trace.jsonl");
         let _layer = FileTraceLayer::new(path.clone()).unwrap();
-        assert!(path.exists(), "trace file must be created at the given path");
+        assert!(
+            path.exists(),
+            "trace file must be created at the given path"
+        );
     }
 
     #[test]
@@ -326,11 +323,18 @@ mod tests {
         });
 
         let parsed = parse_single_event(&path);
-        let ts = parsed["timestamp"].as_str().expect("timestamp must be a string");
-        // RFC3339: 2025-07-09T20:41:34.123Z
+        let ts = parsed["timestamp"]
+            .as_str()
+            .expect("timestamp must be a string");
         assert!(ts.ends_with('Z'), "timestamp must end with Z, got: {ts}");
-        assert!(ts.contains('T'), "timestamp must contain T separator, got: {ts}");
-        assert!(ts.len() >= 20, "timestamp must be full ISO format, got: {ts}");
+        assert!(
+            ts.contains('T'),
+            "timestamp must contain T separator, got: {ts}"
+        );
+        assert!(
+            ts.len() >= 20,
+            "timestamp must be full ISO format, got: {ts}"
+        );
         let parts: Vec<&str> = ts.split('T').collect();
         assert_eq!(parts.len(), 2, "must have date and time separated by T");
         let date_parts: Vec<&str> = parts[0].split('-').collect();
@@ -375,10 +379,13 @@ mod tests {
             .as_str()
             .expect("trace_id must be present");
         assert_eq!(trace_id.len(), 16, "trace_id must be 16 hex chars");
-        // span_id is only present when inside a span
-        if let Some(span_id) = parsed["span_id"].as_str() {
-            assert_eq!(span_id.len(), 16, "span_id must be 16 hex chars");
-        }
+        assert!(
+            parsed["span_id"].as_str().is_some(),
+            "span_id must be present inside a span, got: {:?}",
+            parsed["span_id"]
+        );
+        let span_id = parsed["span_id"].as_str().unwrap();
+        assert_eq!(span_id.len(), 16, "span_id must be 16 hex chars");
     }
 
     #[test]
@@ -399,6 +406,28 @@ mod tests {
             .expect("fields must be a JSON object");
         assert_eq!(fields["request_id"], json!(42));
         assert_eq!(fields["user"], json!("alice"));
+    }
+
+    #[test]
+    fn contract_message_not_duplicated() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trace.jsonl");
+        let layer = FileTraceLayer::new(path.clone()).unwrap();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = tracing::Dispatch::new(subscriber);
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!("unique_msg_12345");
+        });
+
+        let parsed = parse_single_event(&path);
+        assert_eq!(parsed["message"], "unique_msg_12345");
+        if let Some(fields) = parsed["fields"].as_object() {
+            assert!(
+                !fields.contains_key("message"),
+                "message must not be duplicated in fields"
+            );
+        }
     }
 
     #[test]
@@ -550,9 +579,23 @@ mod tests {
         );
     }
 
-    // ── Helpers ──
+    #[test]
+    fn contract_drop_flushes_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trace.jsonl");
+        let layer = FileTraceLayer::new(path.clone()).unwrap();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = tracing::Dispatch::new(subscriber);
 
-    fn read_jsonl_lines(path: &PathBuf) -> Vec<String> {
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!("buffered event");
+        });
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.is_empty(), "Drop must flush buffered data to disk");
+    }
+
+    fn read_jsonl_lines(path: &Path) -> Vec<String> {
         let content = std::fs::read_to_string(path).unwrap();
         content
             .lines()
@@ -561,13 +604,13 @@ mod tests {
             .collect()
     }
 
-    fn parse_single_event(path: &PathBuf) -> Value {
+    fn parse_single_event(path: &Path) -> Value {
         let lines = read_jsonl_lines(path);
         assert_eq!(lines.len(), 1, "expected exactly 1 JSONL line");
         serde_json::from_str(&lines[0]).unwrap()
     }
 
-    fn parse_lines(path: &PathBuf) -> Vec<Value> {
+    fn parse_lines(path: &Path) -> Vec<Value> {
         read_jsonl_lines(path)
             .iter()
             .map(|l| serde_json::from_str(l).unwrap())


### PR DESCRIPTION
## Summary

Unifies asset download infrastructure by extending the adapters `Downloader` and removing the island `asset_download.rs`.

### Changes

- **Delete** `src/infrastructure/scraper/asset_download.rs` (hardcoded 30s timeout, Chrome145 TLS, hash-only naming, zero retry)
- **Extend `DownloadConfig`** with `include_patterns`, `exclude_patterns`, `h2_profile`, `asset_naming`, `max_retries`, `backoff_base_ms`, `backoff_max_ms`
- **Retry with exponential backoff** on transient network errors
- **Naming strategies**: `Hash` (default), `Slug`, `ContentDisposition`
- **Inject `Downloader`** via `Option<&Downloader>` in `ScraperService::download_assets_if_enabled` with fallback for backward compat

### Root cause bugs fixed

- **#142** — `asset_download.rs:133` hardcodes 30s timeout, ignoring `--download-timeout`
- **#143** — h2 profile is hardcoded to Chrome145, ignoring `--h2-profile`
- **#144** — `--include-pattern` does not filter assets (only page URLs)
- **#145** — Assets saved as SHA-256 hash with no way to configure naming

### ADR

Full design: `docs/adr/0001-unify-asset-downloader.md` (Status: Proposed → Accepted)

### Issues

Closes #142, #143, #144, #145