### PR TITLE
chore(release): bump to v1.1.1 (Blindaje de Fidelidad D1–D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Extensible Design:** Easy to add new validation rules and error variants
 - **Memory Safety:** Pure move semantics prevent accidental clones in hot paths
 
+## [1.1.1] - 2026-07-11
+
+### 🔧 Fixed / Observability Hardening (Blindaje de Fidelidad D1–D5)
+
+#### D4 — Error Source Integrity
+- `ScraperError::Download` / `Network` now carry `#[source] Box<dyn Error + Send + Sync>`.
+- `CrawlError::Download` and `DownloadError::Network` preserve `#[source]`.
+- `From<DownloadError> for CrawlError` keeps the full cause (`wreq::Error` → Connect/timeout) instead of `.to_string()`.
+- `scrape_flow` no longer flattens with `.to_string()`: `failures` retains the `ScraperError` and the orchestrator prints the `source()` chain (`← cause`).
+- `is_transient_error` inspects the boxed error `Display` (broadened keywords) → 5xx/connect/timeout retries preserved.
+
+#### D5 — Observable Connection Pooling
+- `client_id` (stable `{:p}` pointer of the shared `Arc<Client>`) recorded as a span field in `wreq_downloader::fetch` and `adapters::downloader::Downloader::download_once`, and as an event field on the download log.
+- Verified live: 15 asset downloads shared the same `client_id` → pool reuse confirmed (TLS handshake savings, socket-exhaustion protection).
+
+#### D1–D3 — Stability
+- D1: `--download-concurrency 0` rejected at CLI (`parse_download_concurrency`) and clamped to 1 in `with_download_concurrency` → no `buffer_unordered(0)` deadlock.
+- D2/D3: `FileTraceLayer` emits `parent_id` and a logical `trace_id` (W3C OTel / root-span / seed) → reconstructable trace tree.
+
+#### Maintenance
+- `fix(clippy)`: `parse_set_cookie` uses `?` instead of `match` (resolves `clippy::question_mark` on clippy 1.97 / CI).
+
+#### Verification
+- `cargo clippy --all-targets --all-features -- -D warnings` ✅ · unit+integration+behavioral tests ✅ · all-features tests ✅ · MCP handshake ✅ · CI `conclusion: success`.
+
 ## [1.1.0] - 2026-04-04
 
 ### 🎉 Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scraper"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "Production-ready web scraper with Clean Architecture, TUI selector, and sitemap support"
 authors = ["GazaDev"]


### PR DESCRIPTION
## Resumen

Cerrar la fase de blindaje v0.5.0 del scraper: la traza pasa de ser "ciega" a telemetría de alta resolución. Este PR agrupa D1–D5 (el trabajo de D1–D3 ya estaba en el árbol; D4 y D5 son los nuevos).

## D4 — Integridad de causa (`Error::source()`)

Antes, `ScraperError::Download(String)` / `ScraperError::Network(String)` aplanaban la causa raíz a un `String` en el borde de servicio, perdiendo la navegabilidad de la cadena.

- `ScraperError::Download` / `Network` ahora llevan `#[source] Box<dyn Error + Send + Sync>`.
- `CrawlError::Download` y `DownloadError::Network` también preservan `#[source]`.
- `From<DownloadError> for CrawlError` ya no hace `.to_string()`: conserva la causa completa (`wreq::Error` → Connect/timeout).
- `scrape_flow.rs` ya no hace `e.to_string()` en `failures`: el vector conserva el `ScraperError` completo y `orchestrator.rs` imprime la cadena `source()` (`← causa`).
- `is_transient_error` ahora inspecciona el `Display` del error boxed (keywords ampliados: `connect`/`timeout`/`refused`/`reset`) → se preserva la semántica de reintentos de 5xx/connect/timeout.

## D5 — Pooling observable

El `Arc<wreq::Client>` siempre se reusó, pero era invisible en telemetría.

- `client_id` (`{:p}` del puntero del `Client` compartido) como **span field** en `wreq_downloader::fetch` y `adapters::downloader::Downloader::download_once`, y como **event field** en el log `info!("downloaded: …")` (único nivel no filtrado por el subscriber).
- Verificado en vivo: 15 descargas de assets mostraron el **mismo** `client_id` (`0x55d2788f7e50`) → reuso de pool confirmado, 14 handshakes TLS ahorrados por página.

## D1–D3 (incluidos, ya presentes en el árbol)

- **D1:** `--download-concurrency 0` rechazado en CLI (`parse_download_concurrency`) y clampado a 1 en `with_download_concurrency` → fin del deadlock de `buffer_unordered(0)`.
- **D2/D3:** `FileTraceLayer` emite `parent_id` y un `trace_id` lógico (W3C OTel / root-span / seed) en vez del thread-ID → árbol de trazas reconstruible.

## Verificación

- `cargo check` ✅ · `cargo fmt --check` ✅ · `cargo clippy -- -D warnings` ✅ · `cargo check --features otel` ✅
- Tests: 89 `downloader` + 15 `file_trace_layer` ✅
- `gitnexus detect-changes` → sin símbolos inesperados.
- Run empírico con `--trace-file`: `client_id` constante en 15 `download_once`.

## Notas

- Sin cambios de API pública rota; los tipos de error son internos.
- La Ruta Disruptiva (zero-copy errors) se descartó: rompería el límite `Box<dyn Error>` de Clean Architecture por nanosegundos de overhead en el path de error.
