### PR TITLE
fix(error): remove duplicate NetworkFailure variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -124,10 +124,6 @@ pub enum ScraperError {
     #[error("recurso superó límite de 25 MB")]
     PayloadTooLarge,
 
-    /// Network error (connection failed, timeout, etc.)
-    #[error("error de red: {0}")]
-    NetworkFailure(#[from] WreqError),
-
     /// Semaphore exhausted (backpressure)
     #[error("semáforo agotado: no hay permisos disponibles")]
     SemaphoreInanition,
@@ -351,6 +347,15 @@ impl ScraperError {
     #[must_use]
     pub fn ingestion(err: impl std::fmt::Display) -> Self {
         Self::Ingestion(err.to_string())
+    }
+}
+
+impl From<WreqError> for ScraperError {
+    /// Convert a `wreq::Error` into the single network variant, preserving the
+    /// underlying cause chain (D4). Consolidates the former duplicate
+    /// `NetworkFailure` variant (#153).
+    fn from(e: WreqError) -> Self {
+        ScraperError::Network(Box::new(e))
     }
 }
 

--- a/src/infrastructure/crawler/resource_downloader.rs
+++ b/src/infrastructure/crawler/resource_downloader.rs
@@ -145,7 +145,7 @@ impl ResourceDownloader {
     /// - Global timeout exceeded (`GlobalTimeout`)
     /// - Per-chunk timeout exceeded — Anti-Slowloris (`SlowlorisTimeout`)
     /// - `Content-Length` or accumulated size exceeds the limit (`PayloadTooLarge`)
-    /// - Network error occurs (`NetworkFailure`)
+    /// - Network error occurs (`Network`)
     /// - Semaphore acquisition fails (`SemaphoreInanition`)
     pub async fn download(&self, url: &str) -> Result<Vec<u8>, ScraperError> {
         // Global timeout wraps the request (headers). Permits are acquired only


### PR DESCRIPTION
## Resumen

Consolidación de las dos variantes de error de red en `ScraperError`.

`NetworkFailure(#[from] WreqError)` duplicaba la variante genérica `Network(Box<dyn Error + Send + Sync>)`. `Network` es la única usada en código (`scraper_service.rs:29`) y preserva la cadena de causa (D4), por lo que `NetworkFailure` se elimina y las conversiones desde `wreq::Error` se enrutan mediante un `impl From<WreqError> -> Network` explícito. Ningún call site cambia.

## Verificación
- `cargo check` + `cargo clippy -- -D warnings`: limpio
- `cargo nextest run --lib error`: 76/76 ok
- Sin referencias restantes a `NetworkFailure` (doc comment de `resource_downloader.rs` actualizado)

Fixes #153