### PR TITLE
fix(ci): include ui feature in release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
       - name: Build optimized binary
-        run: cargo build --release --locked --features "ai mcp"
+        run: cargo build --release --locked --features "ai mcp ui"
       - name: Strip binary
         run: |
           strip target/release/rust_scraper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build release binary
-        run: cargo build --release --locked --features "ai mcp" --target ${{ matrix.target }}
+        run: cargo build --release --locked --features "ai mcp ui" --target ${{ matrix.target }}
 
       - name: Strip binary (Linux/macOS)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Resumen

El job `Build Release` de CI fallaba en `Strip binary` con `strip: 'target/release/rust_scraper': No such file`.

Causa: el binario `rust_scraper` declara `required-features = ["ai", "mcp", "ui"]` (Cargo.toml:371), pero los jobs de release buildaban con `--features "ai mcp"`. Cargo saltea el binario cuando sus `required-features` no se cumplen, así que el binario nunca se compilaba y el `strip` lo encontraba ausente.

Fix: agregar `ui` a las features del build de release en `ci.yml` (job `release`) y `release.yml` (job de build por target).

## Alcance
- `.github/workflows/ci.yml`: `cargo build --release --locked --features "ai mcp ui"`
- `.github/workflows/release.yml`: `cargo build --release --locked --features "ai mcp ui" --target ${{ matrix.target }}`

Nota: `release.yml:165` es texto de documentación en el release body (no un build), por eso no se tocó.

## Atribución
Regresión introducida por PR #155 (gating de feature `ui`). Sin este fix, el CI de main seguirá fallando en el job release.

Fixes el fallo de CI run 29172768051