### PR TITLE
docs(release): use full feature set in from-source build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
             ```bash
             git clone https://github.com/XaviCode1000/rust-scraper
             cd rust-scraper
-            cargo build --release --features ai
+            cargo build --release --features "ai mcp ui"
             ```
 
             ## Verification


### PR DESCRIPTION
Cosmetic consistency fix for the release notes.

The 'From source' snippet in the release body used `cargo build --release --features ai`, which (given `required-features = ["ai", "mcp", "ui"]` on the `rust_scraper` bin) silently skips the binary. Updated to `--features "ai mcp ui"` so the documented command actually produces the binary, matching the real release build.

Purely documentation — no CI impact. Companion to #159.