### PR TITLE
feat: rename to webfang v2.0.0 — final closing of issue #165

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,11 +142,11 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          name: "Rust Scraper ${{ github.event.inputs.tag || github.ref_name }}"
+          name: "WebFang ${{ github.event.inputs.tag || github.ref_name }}"
           body: |
             ## What's Changed
 
-            See [CHANGELOG](https://github.com/XaviCode1000/rust-scraper/blob/main/CHANGELOG.md) for details.
+            See [CHANGELOG](https://github.com/XaviCode1000/webfang/blob/main/CHANGELOG.md) for details.
 
             ## Installation
 
@@ -155,13 +155,13 @@ jobs:
 
             ### Cargo
             ```bash
-            cargo install rust_scraper --version ${{ github.event.inputs.tag || github.ref_name }}
+            cargo install webfang --version ${{ github.event.inputs.tag || github.ref_name }}
             ```
 
             ### From source
             ```bash
-            git clone https://github.com/XaviCode1000/rust-scraper
-            cd rust-scraper
+            git clone https://github.com/XaviCode1000/webfang
+            cd webfang
             cargo build --release --features "ai mcp ui"
             ```
 
@@ -171,7 +171,7 @@ jobs:
             sha256sum -c SHA256SUMS.txt --ignore-missing
             ```
           files: |
-            artifacts/rust_scraper-*
+            artifacts/webfang-*
             artifacts/SHA256SUMS.txt
           draft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **--export-format alias**: `--export` as shorthand for `--export-format`
 - **Exit codes documented** in `--help` output
 - **Error messages in Spanish**: User-facing errors now display in Spanish
-- **Binary renamed**: `rust_scraper` → `rust-scraper` (kebab-case convention)
+- **Product renamed**: `rust_scraper` → `webfang` (short, professional, no language reference)
+- **Binary renamed**: `rust_scraper` → `webfang` (kebab-case convention)
+- **Version bump**: v1.1.1 → v2.0.0 (breaking changes: exit codes, binary name)
 
 ### 🏗️ Architecture Improvements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scraper_ai"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scraper_cli"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4369,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scraper_core"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scraper_mcp"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "rust_scraper_tui"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.1"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 authors = ["GazaDev"]
-repository = "https://github.com/XaviCode1000/rust-scraper"
-homepage = "https://github.com/XaviCode1000/rust-scraper"
+repository = "https://github.com/XaviCode1000/webfang"
+homepage = "https://github.com/XaviCode1000/webfang"
 
 [workspace.dependencies]
 # Internal crates

--- a/crates/rust_scraper_cli/Cargo.toml
+++ b/crates/rust_scraper_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_scraper_cli"
-description = "CLI entry point for rust_scraper"
+description = "CLI entry point for webfang"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ otel = ["rust_scraper_core/otel"]
 otel-metrics = ["rust_scraper_core/otel-metrics"]
 
 [[bin]]
-name = "rust_scraper"
+name = "webfang"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/rust_scraper_core/src/application/scraper_service.rs
+++ b/crates/rust_scraper_core/src/application/scraper_service.rs
@@ -287,12 +287,12 @@ pub async fn scrape_with_config(
             if let Some(spa_info) = detect_spa_content(url.as_str(), &article.text_content, &html) {
                 if spa_info.has_spa_markers {
                     warn!(
-                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 } else {
                     warn!(
-                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 }
@@ -336,12 +336,12 @@ pub async fn scrape_with_config(
             if let Some(spa_info) = detect_spa_content(url.as_str(), &fallback_content, &html) {
                 if spa_info.has_spa_markers {
                     warn!(
-                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 } else {
                     warn!(
-                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 }

--- a/crates/rust_scraper_core/src/cli/args.rs
+++ b/crates/rust_scraper_core/src/cli/args.rs
@@ -41,10 +41,10 @@ fn parse_download_concurrency(s: &str) -> Result<usize, String> {
 /// assert_eq!(args.url, "https://example.com");
 /// ```
 #[derive(Parser, Debug, Default)]
-#[command(name = "rust-scraper", version)]
+#[command(name = "webfang", version)]
 #[command(
-    about = "Scraper web industrial con Clean Architecture y evasión de WAF",
-    after_help = "CÓDIGOS DE SALIDA:\n  0    Éxito\n  2    Sin URLs descubiertas\n  69   Bloqueo por WAF o error de red\n  74   Error de E/S\n  76   Error de protocolo\n  78   Error de configuración\n\nEJEMPLOS:\n  rust-scraper -u https://example.com\n  rust-scraper -u https://example.com --ai\n  rust-scraper -u https://example.com -f jsonl\n  rust-scraper -u https://example.com -v\n  rust-scraper -u https://example.com -vv  # DEBUG\n  rust-scraper --url-list urls.txt --resume"
+    about = "High-performance web scraper with WAF evasion and AI-powered content cleaning",
+    after_help = "EXIT CODES:\n  0    Success\n  2    No URLs discovered\n  69   WAF block or network error\n  74   I/O error\n  76   Protocol error\n  78   Configuration error\n\nEXAMPLES:\n  webfang -u https://example.com\n  webfang -u https://example.com --ai\n  webfang -u https://example.com -f jsonl\n  webfang -u https://example.com -v\n  webfang -u https://example.com -vv  # DEBUG\n  webfang --url-list urls.txt --resume"
 )]
 #[command(args_conflicts_with_subcommands = true)]
 pub struct Args {

--- a/crates/rust_scraper_core/src/domain/js_renderer.rs
+++ b/crates/rust_scraper_core/src/domain/js_renderer.rs
@@ -19,7 +19,7 @@
 //! Application:  ScraperService selects renderer based on content detection
 //! ```
 //!
-//! See: <https://github.com/XaviCode1000/rust-scraper/issues/16>
+//! See: <https://github.com/XaviCode1000/webfang/issues/16>
 
 use thiserror::Error;
 

--- a/crates/rust_scraper_core/src/domain/site/crawler_config.rs
+++ b/crates/rust_scraper_core/src/domain/site/crawler_config.rs
@@ -57,7 +57,7 @@ impl CrawlerConfig {
             exclude_patterns: Vec::new(),
             concurrency: 3, // Hardware-aware: nproc - 1 for 4C CPU
             delay_ms: 500,  // Hardware-aware: 500ms for HDD
-            user_agent: "rust_scraper/0.3.0 (Web Crawler)".to_string(),
+            user_agent: "webfang/2.0.0 (High-Performance Extraction)".to_string(),
             timeout_secs: 30,
             use_sitemap: false,
             sitemap_url: None,
@@ -118,7 +118,7 @@ impl CrawlerConfigBuilder {
             exclude_patterns: Vec::new(),
             concurrency: 3,
             delay_ms: 500,
-            user_agent: "rust_scraper/0.3.0 (Web Crawler)".to_string(),
+            user_agent: "webfang/2.0.0 (High-Performance Extraction)".to_string(),
             timeout_secs: 30,
             use_sitemap: false,
             sitemap_url: None,
@@ -258,7 +258,10 @@ mod tests {
         assert_eq!(config.max_pages, 100);
         assert_eq!(config.concurrency, 3);
         assert_eq!(config.delay_ms, 500);
-        assert_eq!(config.user_agent, "rust_scraper/0.3.0 (Web Crawler)");
+        assert_eq!(
+            config.user_agent,
+            "webfang/2.0.0 (High-Performance Extraction)"
+        );
         assert_eq!(config.timeout_secs, 30);
         assert!(!config.use_sitemap);
         assert!(config.sitemap_url.is_none());

--- a/crates/rust_scraper_core/src/infrastructure/crawler/http_client.rs
+++ b/crates/rust_scraper_core/src/infrastructure/crawler/http_client.rs
@@ -48,7 +48,7 @@ pub fn create_rate_limited_client(delay_ms: u64) -> Result<Client> {
         .connect_timeout(Duration::from_secs(10))
         .gzip(true)
         .brotli(true)
-        .user_agent("rust_scraper/0.3.0 (Web Crawler)")
+        .user_agent("webfang/2.0.0 (High-Performance Extraction)")
         .build()?;
 
     debug!(

--- a/src/application/scraper_service.rs
+++ b/src/application/scraper_service.rs
@@ -268,12 +268,12 @@ pub async fn scrape_with_config(
             if let Some(spa_info) = detect_spa_content(url.as_str(), &article.text_content, &html) {
                 if spa_info.has_spa_markers {
                     warn!(
-                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 } else {
                     warn!(
-                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 }
@@ -306,12 +306,12 @@ pub async fn scrape_with_config(
             if let Some(spa_info) = detect_spa_content(url.as_str(), &fallback_content, &html) {
                 if spa_info.has_spa_markers {
                     warn!(
-                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 } else {
                     warn!(
-                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/rust-scraper/issues/16",
+                        "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
                         spa_info.url, spa_info.char_count
                     );
                 }

--- a/src/bin/rust_scraper_core.rs
+++ b/src/bin/rust_scraper_core.rs
@@ -1,4 +1,4 @@
-//! Lightweight binary: the full `rust_scraper` pipeline WITHOUT the `ai` feature.
+//! Lightweight binary: the full `webfang` pipeline WITHOUT the `ai` feature.
 //!
 //! This target reuses the exact same entry point as the main binary
 //! (`src/main.rs`) but is compiled with default features only, so the ONNX

--- a/src/domain/js_renderer.rs
+++ b/src/domain/js_renderer.rs
@@ -19,7 +19,7 @@
 //! Application:  ScraperService selects renderer based on content detection
 //! ```
 //!
-//! See: <https://github.com/XaviCode1000/rust-scraper/issues/16>
+//! See: <https://github.com/XaviCode1000/webfang/issues/16>
 
 use thiserror::Error;
 

--- a/src/infrastructure/crawler/http_client.rs
+++ b/src/infrastructure/crawler/http_client.rs
@@ -48,7 +48,7 @@ pub fn create_rate_limited_client(delay_ms: u64) -> Result<Client> {
         .connect_timeout(Duration::from_secs(10))
         .gzip(true)
         .brotli(true)
-        .user_agent("rust_scraper/0.3.0 (Web Crawler)")
+        .user_agent("webfang/2.0.0 (High-Performance Extraction)")
         .build()?;
 
     debug!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub fn version_string() -> String {
     let commit = built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown");
     let build = built_info::BUILT_TIME_UTC;
     format!(
-        "rust_scraper {} (commit: {}, build: {})",
+        "webfang {} (commit: {}, build: {})",
         env!("CARGO_PKG_VERSION"),
         commit,
         build

--- a/tests/behavioral/main.rs
+++ b/tests/behavioral/main.rs
@@ -1,4 +1,4 @@
-//! Adapter-layer behavioral tests for the `rust_scraper` binary.
+//! Adapter-layer behavioral tests for the `webfang` binary.
 //!
 //! Every test uses wiremock (no real network) and TempDir (auto-cleanup).
 //! Run with: `cargo nextest run --test behavioral`
@@ -8,11 +8,11 @@ mod cli;
 use assert_cmd::Command;
 
 /// Returns the binary name to test, based on active features.
-/// The full `rust_scraper` binary requires both `ai` and `mcp`; the
+/// The full `webfang` binary requires both `ai` and `mcp`; the
 /// `rust_scraper_core` binary is always built (default features).
 fn cli_bin() -> &'static str {
     if cfg!(all(feature = "ai", feature = "mcp")) {
-        "rust_scraper"
+        "webfang"
     } else {
         "rust_scraper_core"
     }
@@ -38,7 +38,7 @@ impl BehavioralTest {
         }
     }
 
-    /// Build a `Command` for the `rust_scraper` binary with `--url` and
+    /// Build a `Command` for the `webfang` binary with `--url` and
     /// `--output` pre-filled to this harness's server and temp dir.
     pub fn scraper_cmd(&self) -> assert_cmd::Command {
         let mut cmd = assert_cmd::Command::cargo_bin(cli_bin()).expect("binary exists");

--- a/tests/cli_behavioral_test.rs
+++ b/tests/cli_behavioral_test.rs
@@ -1,12 +1,12 @@
 //! CLI adapter behavioral tests
 //!
-//! End-to-end tests that invoke the actual `rust_scraper` binary via `assert_cmd`.
+//! End-to-end tests that invoke the actual `webfang` binary via `assert_cmd`.
 //! Mock HTTP servers (wiremock) simulate target websites; TempDir captures output.
 //!
 //! Run with: cargo nextest run --test cli_behavioral_test
 
 // Gate the entire test file behind the default feature pair. These tests
-// invoke the full `rust_scraper` binary which requires `images` + `documents`
+// invoke the full `webfang` binary which requires `images` + `documents`
 // for --download-images/--download-documents. When building with
 // --no-default-features (headless/persistence-off CI matrix) the file is
 // skipped entirely instead of triggering a hard compile_error!.
@@ -21,11 +21,11 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Returns the binary name to test, based on active features.
-/// The full `rust_scraper` binary requires both `ai` and `mcp`; the
+/// The full `webfang` binary requires both `ai` and `mcp`; the
 /// `rust_scraper_core` binary is always built (default features).
 fn cli_bin() -> &'static str {
     if cfg!(all(feature = "ai", feature = "mcp")) {
-        "rust_scraper"
+        "webfang"
     } else {
         "rust_scraper_core"
     }

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -14,11 +14,11 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Returns the binary name to test, based on active features.
-/// The full `rust_scraper` binary requires both `ai` and `mcp`; the
+/// The full `webfang` binary requires both `ai` and `mcp`; the
 /// `rust_scraper_core` binary is always built (default features).
 fn cli_bin() -> &'static str {
     if cfg!(all(feature = "ai", feature = "mcp")) {
-        "rust_scraper"
+        "webfang"
     } else {
         "rust_scraper_core"
     }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -44,7 +44,7 @@ where
 
 #[test]
 fn test_args_defaults() {
-    let args = Args::parse_from(["rust_scraper"]);
+    let args = Args::parse_from(["webfang"]);
     assert!(args.url.is_none());
     assert_eq!(args.selector, "body");
     assert_eq!(args.output, std::path::PathBuf::from("output"));
@@ -87,26 +87,26 @@ fn test_args_defaults() {
 
 #[test]
 fn test_args_url_short_flag() {
-    let args = Args::parse_from(["rust_scraper", "-u", "https://example.com"]);
+    let args = Args::parse_from(["webfang", "-u", "https://example.com"]);
     assert_eq!(args.url, Some("https://example.com".to_string()));
 }
 
 #[test]
 fn test_args_url_long_flag() {
-    let args = Args::parse_from(["rust_scraper", "--url", "https://example.com/page"]);
+    let args = Args::parse_from(["webfang", "--url", "https://example.com/page"]);
     assert_eq!(args.url, Some("https://example.com/page".to_string()));
 }
 
 #[test]
 fn test_args_url_with_trailing_slash() {
-    let args = Args::parse_from(["rust_scraper", "-u", "https://example.com/"]);
+    let args = Args::parse_from(["webfang", "-u", "https://example.com/"]);
     assert_eq!(args.url, Some("https://example.com/".to_string()));
 }
 
 #[test]
 fn test_args_url_with_query_params() {
     let args = Args::parse_from([
-        "rust_scraper",
+        "webfang",
         "-u",
         "https://example.com/search?q=test&page=1",
     ]);
@@ -119,14 +119,14 @@ fn test_args_url_with_query_params() {
 #[test]
 fn test_args_single_page_defaults_to_false() {
     let args =
-        parse_args_with_single_page_env(["rust_scraper", "--url", "https://example.com"], None);
+        parse_args_with_single_page_env(["webfang", "--url", "https://example.com"], None);
     assert!(!args.single_page);
 }
 
 #[test]
 fn test_args_single_page_env_true_enables_flag() {
     let args = parse_args_with_single_page_env(
-        ["rust_scraper", "--url", "https://example.com"],
+        ["webfang", "--url", "https://example.com"],
         Some("true"),
     );
     assert!(args.single_page);
@@ -136,7 +136,7 @@ fn test_args_single_page_env_true_enables_flag() {
 fn test_args_single_page_flag_wins_over_env_false() {
     let args = parse_args_with_single_page_env(
         [
-            "rust_scraper",
+            "webfang",
             "--url",
             "https://example.com",
             "--single-page",
@@ -150,7 +150,7 @@ fn test_args_single_page_flag_wins_over_env_false() {
 fn test_args_single_page_with_crawl_limits() {
     let args = parse_args_with_single_page_env(
         [
-            "rust_scraper",
+            "webfang",
             "--url",
             "https://example.com",
             "--single-page",
@@ -173,14 +173,14 @@ fn test_args_single_page_with_crawl_limits() {
 
 #[test]
 fn test_args_selector_short_flag() {
-    let args = Args::parse_from(["rust_scraper", "-s", "article.content"]);
+    let args = Args::parse_from(["webfang", "-s", "article.content"]);
     assert_eq!(args.selector, "article.content");
 }
 
 #[test]
 fn test_args_selector_complex_css() {
     let args = Args::parse_from([
-        "rust_scraper",
+        "webfang",
         "-s",
         "main > article.post h1, main > article.post h2",
     ]);
@@ -196,25 +196,25 @@ fn test_args_selector_complex_css() {
 
 #[test]
 fn test_args_format_markdown() {
-    let args = Args::parse_from(["rust_scraper", "-f", "markdown"]);
+    let args = Args::parse_from(["webfang", "-f", "markdown"]);
     assert_eq!(args.format, OutputFormat::Markdown);
 }
 
 #[test]
 fn test_args_format_text() {
-    let args = Args::parse_from(["rust_scraper", "-f", "text"]);
+    let args = Args::parse_from(["webfang", "-f", "text"]);
     assert_eq!(args.format, OutputFormat::Text);
 }
 
 #[test]
 fn test_args_format_json() {
-    let args = Args::parse_from(["rust_scraper", "-f", "json"]);
+    let args = Args::parse_from(["webfang", "-f", "json"]);
     assert_eq!(args.format, OutputFormat::Json);
 }
 
 #[test]
 fn test_args_format_json_lower() {
-    let args = Args::parse_from(["rust_scraper", "-f", "json"]);
+    let args = Args::parse_from(["webfang", "-f", "json"]);
     assert_eq!(args.format, OutputFormat::Json);
 }
 
@@ -224,13 +224,13 @@ fn test_args_format_json_lower() {
 
 #[test]
 fn test_args_export_format_jsonl() {
-    let args = Args::parse_from(["rust_scraper", "--export-format", "jsonl"]);
+    let args = Args::parse_from(["webfang", "--export-format", "jsonl"]);
     assert_eq!(args.export_format, ExportFormat::Jsonl);
 }
 
 #[test]
 fn test_args_export_format_vector() {
-    let args = Args::parse_from(["rust_scraper", "--export-format", "vector"]);
+    let args = Args::parse_from(["webfang", "--export-format", "vector"]);
     assert_eq!(args.export_format, ExportFormat::Vector);
 }
 
@@ -240,7 +240,7 @@ fn test_args_export_format_vector() {
 
 #[test]
 fn test_args_output_nested_path() {
-    let args = Args::parse_from(["rust_scraper", "-o", "data/scraped/2026"]);
+    let args = Args::parse_from(["webfang", "-o", "data/scraped/2026"]);
     assert_eq!(args.output, std::path::PathBuf::from("data/scraped/2026"));
 }
 
@@ -250,13 +250,13 @@ fn test_args_output_nested_path() {
 
 #[test]
 fn test_args_concurrency_numeric() {
-    let args = Args::parse_from(["rust_scraper", "--concurrency", "8"]);
+    let args = Args::parse_from(["webfang", "--concurrency", "8"]);
     assert!(!args.concurrency.is_auto());
 }
 
 #[test]
 fn test_args_concurrency_auto() {
-    let args = Args::parse_from(["rust_scraper", "--concurrency", "auto"]);
+    let args = Args::parse_from(["webfang", "--concurrency", "auto"]);
     assert!(args.concurrency.is_auto());
 }
 
@@ -266,19 +266,19 @@ fn test_args_concurrency_auto() {
 
 #[test]
 fn test_args_verbose_single() {
-    let args = Args::parse_from(["rust_scraper", "-v"]);
+    let args = Args::parse_from(["webfang", "-v"]);
     assert_eq!(args.verbose, 1);
 }
 
 #[test]
 fn test_args_verbose_double() {
-    let args = Args::parse_from(["rust_scraper", "-vv"]);
+    let args = Args::parse_from(["webfang", "-vv"]);
     assert_eq!(args.verbose, 2);
 }
 
 #[test]
 fn test_args_verbose_triple() {
-    let args = Args::parse_from(["rust_scraper", "-vvv"]);
+    let args = Args::parse_from(["webfang", "-vvv"]);
     assert_eq!(args.verbose, 3);
 }
 
@@ -288,20 +288,20 @@ fn test_args_verbose_triple() {
 
 #[test]
 fn test_args_max_depth() {
-    let args = Args::parse_from(["rust_scraper", "--max-depth", "5"]);
+    let args = Args::parse_from(["webfang", "--max-depth", "5"]);
     assert_eq!(args.max_depth, 5);
 }
 
 #[test]
 fn test_args_max_pages() {
-    let args = Args::parse_from(["rust_scraper", "--max-pages", "500"]);
+    let args = Args::parse_from(["webfang", "--max-pages", "500"]);
     assert_eq!(args.max_pages, 500);
 }
 
 #[test]
 fn test_args_include_patterns() {
     let args = Args::parse_from([
-        "rust_scraper",
+        "webfang",
         "--include-pattern",
         "*.example.com",
         "--include-pattern",
@@ -316,7 +316,7 @@ fn test_args_include_patterns() {
 
 #[test]
 fn test_args_exclude_patterns() {
-    let args = Args::parse_from(["rust_scraper", "--exclude-pattern", "*.admin.com"]);
+    let args = Args::parse_from(["webfang", "--exclude-pattern", "*.admin.com"]);
     assert_eq!(args.exclude_patterns.len(), 1);
     assert!(args.exclude_patterns.contains(&"*.admin.com".to_string()));
 }
@@ -327,13 +327,13 @@ fn test_args_exclude_patterns() {
 
 #[test]
 fn test_args_max_retries() {
-    let args = Args::parse_from(["rust_scraper", "--max-retries", "5"]);
+    let args = Args::parse_from(["webfang", "--max-retries", "5"]);
     assert_eq!(args.max_retries, 5);
 }
 
 #[test]
 fn test_args_accept_language() {
-    let args = Args::parse_from(["rust_scraper", "--accept-language", "es-AR,es;q=0.9"]);
+    let args = Args::parse_from(["webfang", "--accept-language", "es-AR,es;q=0.9"]);
     assert_eq!(args.accept_language, "es-AR,es;q=0.9");
 }
 
@@ -343,7 +343,7 @@ fn test_args_accept_language() {
 
 #[test]
 fn test_completions_subcommand_fish() {
-    let args = Args::parse_from(["rust_scraper", "completions", "fish"]);
+    let args = Args::parse_from(["webfang", "completions", "fish"]);
     assert!(matches!(
         args.subcommand,
         Some(Commands::Completions { shell: Shell::Fish })
@@ -352,7 +352,7 @@ fn test_completions_subcommand_fish() {
 
 #[test]
 fn test_completions_subcommand_zsh() {
-    let args = Args::parse_from(["rust_scraper", "completions", "zsh"]);
+    let args = Args::parse_from(["webfang", "completions", "zsh"]);
     assert!(matches!(
         args.subcommand,
         Some(Commands::Completions { shell: Shell::Zsh })
@@ -361,7 +361,7 @@ fn test_completions_subcommand_zsh() {
 
 #[test]
 fn test_completions_subcommand_bash() {
-    let args = Args::parse_from(["rust_scraper", "completions", "bash"]);
+    let args = Args::parse_from(["webfang", "completions", "bash"]);
     assert!(matches!(
         args.subcommand,
         Some(Commands::Completions { shell: Shell::Bash })
@@ -370,7 +370,7 @@ fn test_completions_subcommand_bash() {
 
 #[test]
 fn test_completions_subcommand_powershell() {
-    let args = Args::parse_from(["rust_scraper", "completions", "power-shell"]);
+    let args = Args::parse_from(["webfang", "completions", "power-shell"]);
     assert!(matches!(
         args.subcommand,
         Some(Commands::Completions {
@@ -385,7 +385,7 @@ fn test_completions_subcommand_powershell() {
 
 #[test]
 fn test_args_boolean_flags_default_false() {
-    let args = Args::parse_from(["rust_scraper"]);
+    let args = Args::parse_from(["webfang"]);
     assert!(!args.download_images);
     assert!(!args.download_documents);
     assert!(!args.use_sitemap);
@@ -400,13 +400,13 @@ fn test_args_boolean_flags_default_false() {
 
 #[test]
 fn test_args_dry_run_flag() {
-    let args = Args::parse_from(["rust_scraper", "--dry-run"]);
+    let args = Args::parse_from(["webfang", "--dry-run"]);
     assert!(args.dry_run);
 }
 
 #[test]
 fn test_args_quiet_flag() {
-    let args = Args::parse_from(["rust_scraper", "--quiet"]);
+    let args = Args::parse_from(["webfang", "--quiet"]);
     assert!(args.quiet);
 }
 
@@ -416,13 +416,13 @@ fn test_args_quiet_flag() {
 
 #[test]
 fn test_args_obsidian_wiki_links() {
-    let args = Args::parse_from(["rust_scraper", "--obsidian-wiki-links"]);
+    let args = Args::parse_from(["webfang", "--obsidian-wiki-links"]);
     assert!(args.obsidian_wiki_links);
 }
 
 #[test]
 fn test_args_obsidian_tags_parsing() {
-    let args = Args::parse_from(["rust_scraper", "--obsidian-tags", "scraped,rust,web"]);
+    let args = Args::parse_from(["webfang", "--obsidian-tags", "scraped,rust,web"]);
     let tags = args.obsidian_tags.expect("Tags should be set");
     assert_eq!(tags.len(), 3);
     assert_eq!(tags[0], "scraped");
@@ -467,7 +467,7 @@ fn test_shell_to_clap_complete() {
 #[test]
 fn test_args_combined_flags() {
     let args = Args::parse_from([
-        "rust_scraper",
+        "webfang",
         "-u",
         "https://example.com",
         "-s",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-//! Integration tests for rust_scraper
+//! Integration tests for webfang
 //!
 //! These tests verify end-to-end functionality of the scraper.
 //!

--- a/tests/tui_integration.rs
+++ b/tests/tui_integration.rs
@@ -1003,160 +1003,160 @@ fn apply_tui_config_all_fields_at_once() {
 
 #[test]
 fn args_tui_flag_parsed() {
-    let args = Args::try_parse_from(["rust_scraper", "--tui"]).expect("--tui must parse");
+    let args = Args::try_parse_from(["webfang", "--tui"]).expect("--tui must parse");
     assert!(args.tui);
 }
 
 #[test]
 fn args_tui_flag_default_false() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert!(!args.tui);
 }
 
 #[test]
 fn args_interactive_flag_hidden_but_parseable() {
     let args =
-        Args::try_parse_from(["rust_scraper", "--interactive"]).expect("--interactive must parse");
+        Args::try_parse_from(["webfang", "--interactive"]).expect("--interactive must parse");
     assert!(args.interactive);
 }
 
 #[test]
 fn args_config_tui_flag_hidden_but_parseable() {
     let args =
-        Args::try_parse_from(["rust_scraper", "--config-tui"]).expect("--config-tui must parse");
+        Args::try_parse_from(["webfang", "--config-tui"]).expect("--config-tui must parse");
     assert!(args.config_tui);
 }
 
 #[test]
 fn args_selector_default_is_body() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert_eq!(args.selector, "body");
 }
 
 #[test]
 fn args_selector_custom() {
-    let args = Args::try_parse_from(["rust_scraper", "--selector", "article"])
+    let args = Args::try_parse_from(["webfang", "--selector", "article"])
         .expect("--selector must parse");
     assert_eq!(args.selector, "article");
 }
 
 #[test]
 fn args_format_markdown_default() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert_eq!(args.format, OutputFormat::Markdown);
 }
 
 #[test]
 fn args_format_json() {
     let args =
-        Args::try_parse_from(["rust_scraper", "--format", "json"]).expect("--format must parse");
+        Args::try_parse_from(["webfang", "--format", "json"]).expect("--format must parse");
     assert_eq!(args.format, OutputFormat::Json);
 }
 
 #[test]
 fn args_export_format_jsonl_default() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert_eq!(args.export_format, ExportFormat::Jsonl);
 }
 
 #[test]
 fn args_export_format_vector() {
-    let args = Args::try_parse_from(["rust_scraper", "--export-format", "vector"])
+    let args = Args::try_parse_from(["webfang", "--export-format", "vector"])
         .expect("--export-format must parse");
     assert_eq!(args.export_format, ExportFormat::Vector);
 }
 
 #[test]
 fn args_js_strategy_static_default() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert_eq!(args.js_strategy, JsStrategy::Static);
 }
 
 #[test]
 fn args_js_strategy_hybrid() {
-    let args = Args::try_parse_from(["rust_scraper", "--js-strategy", "hybrid"])
+    let args = Args::try_parse_from(["webfang", "--js-strategy", "hybrid"])
         .expect("--js-strategy must parse");
     assert_eq!(args.js_strategy, JsStrategy::Hybrid);
 }
 
 #[test]
 fn args_max_pages_default() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert_eq!(args.max_pages, 10);
 }
 
 #[test]
 fn args_max_pages_custom() {
-    let args = Args::try_parse_from(["rust_scraper", "--max-pages", "50"])
+    let args = Args::try_parse_from(["webfang", "--max-pages", "50"])
         .expect("--max-pages must parse");
     assert_eq!(args.max_pages, 50);
 }
 
 #[test]
 fn args_timeout_secs_default() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert_eq!(args.timeout_secs, 30);
 }
 
 #[test]
 fn args_max_depth_default() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert_eq!(args.max_depth, 2);
 }
 
 #[test]
 fn args_verbose_count() {
-    let args = Args::try_parse_from(["rust_scraper", "-vv"]).expect("-vv must parse");
+    let args = Args::try_parse_from(["webfang", "-vv"]).expect("-vv must parse");
     assert_eq!(args.verbose, 2);
 }
 
 #[test]
 fn args_quiet_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--quiet"]).expect("--quiet must parse");
+    let args = Args::try_parse_from(["webfang", "--quiet"]).expect("--quiet must parse");
     assert!(args.quiet);
 }
 
 #[test]
 fn args_dry_run_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--dry-run"]).expect("--dry-run must parse");
+    let args = Args::try_parse_from(["webfang", "--dry-run"]).expect("--dry-run must parse");
     assert!(args.dry_run);
 }
 
 #[test]
 fn args_obsidian_wiki_links_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--obsidian-wiki-links"])
+    let args = Args::try_parse_from(["webfang", "--obsidian-wiki-links"])
         .expect("--obsidian-wiki-links must parse");
     assert!(args.obsidian_wiki_links);
 }
 
 #[test]
 fn args_elastic_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--elastic"]).expect("--elastic must parse");
+    let args = Args::try_parse_from(["webfang", "--elastic"]).expect("--elastic must parse");
     assert!(args.elastic);
 }
 
 #[test]
 fn args_pipeline_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--pipeline"]).expect("--pipeline must parse");
+    let args = Args::try_parse_from(["webfang", "--pipeline"]).expect("--pipeline must parse");
     assert!(args.pipeline);
 }
 
 #[test]
 fn args_use_sitemap_flag() {
     let args =
-        Args::try_parse_from(["rust_scraper", "--use-sitemap"]).expect("--use-sitemap must parse");
+        Args::try_parse_from(["webfang", "--use-sitemap"]).expect("--use-sitemap must parse");
     assert!(args.use_sitemap);
 }
 
 #[test]
 fn args_concurrency_default_auto() {
-    let args = Args::try_parse_from(["rust_scraper"]).expect("minimal parse");
+    let args = Args::try_parse_from(["webfang"]).expect("minimal parse");
     assert!(args.concurrency.is_auto());
 }
 
 #[test]
 fn args_concurrency_fixed() {
-    let args = Args::try_parse_from(["rust_scraper", "--concurrency", "8"])
+    let args = Args::try_parse_from(["webfang", "--concurrency", "8"])
         .expect("--concurrency must parse");
     assert!(!args.concurrency.is_auto());
     assert_eq!(args.concurrency.get(), Some(8));
@@ -1164,14 +1164,14 @@ fn args_concurrency_fixed() {
 
 #[test]
 fn args_download_images_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--download-images"])
+    let args = Args::try_parse_from(["webfang", "--download-images"])
         .expect("--download-images must parse");
     assert!(args.download_images);
 }
 
 #[test]
 fn args_download_documents_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--download-documents"])
+    let args = Args::try_parse_from(["webfang", "--download-documents"])
         .expect("--download-documents must parse");
     assert!(args.download_documents);
 }
@@ -1179,20 +1179,20 @@ fn args_download_documents_flag() {
 #[test]
 fn args_quick_save_flag() {
     let args =
-        Args::try_parse_from(["rust_scraper", "--quick-save"]).expect("--quick-save must parse");
+        Args::try_parse_from(["webfang", "--quick-save"]).expect("--quick-save must parse");
     assert!(args.quick_save);
 }
 
 #[test]
 fn args_autoscale_flag() {
     let args =
-        Args::try_parse_from(["rust_scraper", "--autoscale"]).expect("--autoscale must parse");
+        Args::try_parse_from(["webfang", "--autoscale"]).expect("--autoscale must parse");
     assert!(args.autoscale);
 }
 
 #[test]
 fn args_obsidian_tags_comma_separated() {
-    let args = Args::try_parse_from(["rust_scraper", "--obsidian-tags", "ai,scraping,web"])
+    let args = Args::try_parse_from(["webfang", "--obsidian-tags", "ai,scraping,web"])
         .expect("--obsidian-tags must parse");
     let tags = args.obsidian_tags.unwrap();
     assert_eq!(tags, vec!["ai", "scraping", "web"]);
@@ -1200,28 +1200,28 @@ fn args_obsidian_tags_comma_separated() {
 
 #[test]
 fn args_vault_path() {
-    let args = Args::try_parse_from(["rust_scraper", "--vault", "/home/user/MyVault"])
+    let args = Args::try_parse_from(["webfang", "--vault", "/home/user/MyVault"])
         .expect("--vault must parse");
     assert_eq!(args.vault, Some(PathBuf::from("/home/user/MyVault")));
 }
 
 #[test]
 fn args_include_patterns_comma_separated() {
-    let args = Args::try_parse_from(["rust_scraper", "--include-pattern", "*/blog/*,*/docs/*"])
+    let args = Args::try_parse_from(["webfang", "--include-pattern", "*/blog/*,*/docs/*"])
         .expect("--include-pattern must parse");
     assert_eq!(args.include_patterns, vec!["*/blog/*", "*/docs/*"]);
 }
 
 #[test]
 fn args_exclude_patterns_comma_separated() {
-    let args = Args::try_parse_from(["rust_scraper", "--exclude-pattern", "*/admin/*"])
+    let args = Args::try_parse_from(["webfang", "--exclude-pattern", "*/admin/*"])
         .expect("--exclude-pattern must parse");
     assert_eq!(args.exclude_patterns, vec!["*/admin/*"]);
 }
 
 #[test]
 fn args_force_js_render_flag() {
-    let args = Args::try_parse_from(["rust_scraper", "--force-js-render"])
+    let args = Args::try_parse_from(["webfang", "--force-js-render"])
         .expect("--force-js-render must parse");
     assert!(args.force_js_render);
 }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Product renamed from `rust_scraper` to `webfang` with major version bump to v2.0.0.

This PR closes the final items from issue #165 (CLI audit with 21 bugs).

## Changes

| Category | What Changed |
|----------|-------------|
| **Rename** | Binary: `rust_scraper` → `webfang` |
| **Version** | v1.1.1 → v2.0.0 |
| **User-agent** | `webfang/2.0.0 (High-Performance Extraction)` |
| **GitHub URLs** | Updated to webfang repo |
| **Release workflow** | Updated artifact names and install commands |
| **CLI help** | Updated about text and examples |

## Breaking Changes

1. **Binary name**: `rust_scraper` → `webfang`
2. **Exit codes**: 0 on empty discovery → exit 2 (from PR #166)
3. **Verbose default**: Now WARN level (was INFO)
4. **Error messages**: Now in Spanish (user-facing)

## Migration Guide

```bash
# Old
rust_scraper -u https://example.com

# New
webfang -u https://example.com
```

## Test Evidence

- All tests pass (0 failures)
- `cargo clippy -- -D warnings` clean
- `cargo fmt` clean
- 21 files changed, 126 insertions, 121 deletions

## Issue #165 Status

| Severity | Total | Resolved | Remaining |
|----------|-------|----------|-----------|
| CRITICAL | 2 | 2 ✅ | 0 |
| HIGH | 7 | 7 ✅ | 0 |
| MEDIUM | 7 | 3 ✅ | 4 |
| LOW | 5 | 3 ✅ | 2 |
| **Total** | **21** | **15** | **6** |

Remaining items (L4, L5, M4, M5) deferred to future PRs as they require design decisions.

Refs: #165