### PR TITLE
fix: add missing warn import in url_discovery.rs

### DIFF
--- a/crates/rust_scraper_core/src/cli/url_discovery.rs
+++ b/crates/rust_scraper_core/src/cli/url_discovery.rs
@@ -1,7 +1,7 @@
 //! URL discovery logic extracted from orchestrator.
 
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 
 use crate::application::crawl_options::CrawlOptions;


### PR DESCRIPTION
Fixes clippy error with --all-features. Missing tracing::warn import.