### PR TITLE
test: migrate single_page + obsidian + cli_binary to insta snapshots (PR-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console 0.16.4",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4395,6 +4410,7 @@ dependencies = [
  "htmd",
  "html-to-markdown-rs",
  "indicatif 0.17.11",
+ "insta",
  "jzon-rs-serde",
  "legible",
  "lol_html",
@@ -5013,6 +5029,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,8 +2429,10 @@ dependencies = [
  "once_cell",
  "pest",
  "pest_derive",
+ "regex",
  "serde",
  "similar",
+ "strip-ansi-escapes",
  "tempfile",
 ]
 
@@ -5163,6 +5165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6191,6 +6202,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ predicates = "3"
 tempfile = "3"
 wiremock = "0.6"
 proptest = "1.6"
-insta = { version = "1", features = ["redactions"] }
+insta = { version = "1", features = ["redactions", "filters"] }
 
 [profile.dev]
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ predicates = "3"
 tempfile = "3"
 wiremock = "0.6"
 proptest = "1.6"
+insta = { version = "1", features = ["redactions"] }
 
 [profile.dev]
 opt-level = 0

--- a/crates/rust_scraper_core/Cargo.toml
+++ b/crates/rust_scraper_core/Cargo.toml
@@ -156,6 +156,8 @@ tempfile = { workspace = true }
 wiremock = { workspace = true }
 proptest = { workspace = true }
 criterion = { version = "0.5", features = ["html_reports"] }
+insta = { workspace = true }
+regex = { workspace = true }
 
 # ---------------------------------------------------------------------------
 # Wiring for the previously-orphaned root `tests/` suite.

--- a/crates/rust_scraper_core/src/application/rate_limiter.rs
+++ b/crates/rust_scraper_core/src/application/rate_limiter.rs
@@ -516,24 +516,30 @@ mod tests {
     }
 
     // ============================================================================
-    // M5: Deterministic Rate Limiting Tests (tokio::time::pause)
+    // M5: Deterministic Rate Limiting Tests
+    //
+    // NOTE: governor uses QuantaClock (real time), so its `until_ready()`
+    // enforces delays against the wall clock, not tokio's mockable clock.
+    // `tokio::time::pause()` therefore freezes our measurement clock while
+    // governor may decide the wait has already elapsed in real time, making
+    // these assertions report 0ns and flake under load. We measure with
+    // `std::time::Instant` instead: governor guarantees it will not return
+    // before the real delay has elapsed, so this is deterministic.
     // ============================================================================
 
     #[tokio::test]
     async fn test_rate_limiting_precision() {
-        // M5 FIX: Use tokio::time::pause() for deterministic timing
-        tokio::time::pause();
         let config = RateLimiterConfig::new(500, 1);
         let limiter = RateLimiter::new(&config).await.unwrap();
 
         limiter.until_ready().await;
-        let start = tokio::time::Instant::now();
+        let start = std::time::Instant::now();
 
         limiter.until_ready().await;
 
         let elapsed = start.elapsed();
         assert!(
-            elapsed >= tokio::time::Duration::from_millis(500),
+            elapsed >= std::time::Duration::from_millis(500),
             "Rate limiter should enforce 500ms delay, got {:?}",
             elapsed
         );
@@ -541,8 +547,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limiting_burst_protection() {
-        // M5 FIX: Verify burst protection with multiple concurrent acquires
-        tokio::time::pause();
         let config = RateLimiterConfig::new(100, 2); // 100ms delay, burst=2
         let limiter = RateLimiter::new(&config).await.unwrap();
 
@@ -551,12 +555,12 @@ mod tests {
         limiter.until_ready().await;
 
         // Third should be delayed
-        let start = tokio::time::Instant::now();
+        let start = std::time::Instant::now();
         limiter.until_ready().await;
         let elapsed = start.elapsed();
 
         assert!(
-            elapsed >= tokio::time::Duration::from_millis(100),
+            elapsed >= std::time::Duration::from_millis(100),
             "Third request should be delayed by 100ms, got {:?}",
             elapsed
         );

--- a/crates/rust_scraper_core/src/cli/error.rs
+++ b/crates/rust_scraper_core/src/cli/error.rs
@@ -163,7 +163,8 @@ mod tests {
             suggestion: "Check syntax".into(),
         };
         let formatted = format_cli_error(&err, false);
-        assert!(formatted.contains("Configuration"));
+        // CliError::ConfigFile renders its category in Spanish (user-facing).
+        assert!(formatted.contains("Configuración"));
         assert!(formatted.contains("invalid TOML"));
         assert!(formatted.contains("Check syntax"));
     }
@@ -188,7 +189,8 @@ mod tests {
             suggestion: "Check your network".into(),
         };
         let formatted = format_cli_error(&err, false);
-        assert!(formatted.contains("Network"));
+        // CliError::NetworkError renders its category in Spanish (user-facing).
+        assert!(formatted.contains("Red"));
         assert!(formatted.contains("connection refused"));
     }
 

--- a/tests/behavioral/cli/core_test.rs
+++ b/tests/behavioral/cli/core_test.rs
@@ -1,5 +1,6 @@
 //! Core CLI behavior: version, help, missing/invalid URL.
 
+use crate::assert_snapshot_plain;
 use crate::cmd;
 use predicates::prelude::*;
 
@@ -189,4 +190,15 @@ fn invalid_url_stderr_mentions_invalid() {
 #[test]
 fn invalid_url_exit_code_64() {
     cmd().arg("--url").arg("not-a-url").assert().code(64);
+}
+
+// ---------------------------------------------------------------------------
+// --help output snapshot (deterministic, network-free)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn help_output_snapshot() {
+    let output = cmd().arg("--help").output().expect("run binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_snapshot_plain("help", stdout);
 }

--- a/tests/behavioral/cli/error_path_test.rs
+++ b/tests/behavioral/cli/error_path_test.rs
@@ -1,7 +1,8 @@
 //! Error paths: unreachable host, 404, 500 responses.
 
+use crate::assert_snapshot_redacted;
 use crate::cmd;
-use predicates::prelude::*;
+use std::path::Path;
 use std::time::Duration;
 use tempfile::TempDir;
 use wiremock::matchers::{method, path};
@@ -43,7 +44,7 @@ fn unreachable_host_exit_code_69() {
 
 #[test]
 fn unreachable_host_stderr_mentions_failure() {
-    cmd()
+    let output = cmd()
         .arg("--url")
         .arg("http://127.0.0.1:1")
         .arg("--single-page")
@@ -52,10 +53,10 @@ fn unreachable_host_stderr_mentions_failure() {
         .arg("--max-retries")
         .arg("0")
         .arg("--quiet")
-        .assert()
-        .stderr(predicate::str::contains(
-            "No pages were successfully scraped",
-        ));
+        .output()
+        .expect("run binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_snapshot_redacted("unreachable_host_stderr", Path::new("__no_temp__"), stderr);
 }
 
 // ---------------------------------------------------------------------------
@@ -78,7 +79,7 @@ async fn slow_server_timeout_exits_error() {
         .mount(&server)
         .await;
 
-    cmd()
+    let result = cmd()
         .arg("--url")
         .arg(format!("{}/slow", server.uri()))
         .arg("--single-page")
@@ -89,11 +90,16 @@ async fn slow_server_timeout_exits_error() {
         .arg("--output")
         .arg(output.path())
         .arg("--quiet")
-        .assert()
-        .code(69)
-        .stderr(predicate::str::contains(
-            "No pages were successfully scraped",
-        ));
+        .output()
+        .expect("run binary");
+
+    assert_eq!(
+        result.status.code(),
+        Some(69),
+        "slow server should time out with exit code 69"
+    );
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert_snapshot_redacted("slow_server_timeout_stderr", output.path(), stderr);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/behavioral/cli/obsidian_test.rs
+++ b/tests/behavioral/cli/obsidian_test.rs
@@ -1,9 +1,33 @@
 //! Obsidian-specific behavior: wiki-links, tags, quick-save.
 
 use crate::BehavioralTest;
+use std::path::Path;
 use walkdir::WalkDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
+
+/// Snapshot Obsidian markdown output with deterministic redactions.
+///
+/// `crate::redact_nondeterministic` collapses the temp-dir path, ANSI codes,
+/// dynamic wiremock ports, and ISO-8601 `-Z` timestamps. The frontmatter
+/// `date:` field is a bare `YYYY-MM-DD` (no time) and `scrape_date:` is
+/// `YYYY-MM-DDThh:mm:ss+0000`; neither is caught by that helper. insta's
+/// `add_filter` applies a regex onto the final snapshot string (the correct
+/// insta-native mechanism for free-text snapshots — `redactions` uses path
+/// selectors and cannot match raw lines), collapsing those fields to stable
+/// markers before snapshotting.
+fn assert_obsidian_snapshot(name: &str, dir: &Path, content: &str) {
+    let redacted = crate::redact_nondeterministic(dir, content);
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(r"date: \d{4}-\d{2}-\d{2}", "date: [DATE]");
+    settings.add_filter(
+        r"scrape_date: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}",
+        "scrape_date: [SCRAPE_DATE]",
+    );
+    settings.bind(|| {
+        insta::assert_snapshot!(name, redacted);
+    });
+}
 
 const PAGE_WITH_LINKS: &str = r#"
 <html><head><title>Wiki Links Test</title></head>
@@ -47,11 +71,7 @@ async fn obsidian_wiki_links_produces_wiki_syntax() {
         .success();
 
     let content = t.read_md_content();
-    assert!(
-        content.contains("[["),
-        "output should contain [[wiki-link]] syntax: {}",
-        &content[..content.len().min(500)]
-    );
+    assert_obsidian_snapshot("obsidian_wiki_links_produces_wiki_syntax", t.out.path(), &content);
 }
 
 #[tokio::test]
@@ -75,21 +95,7 @@ async fn obsidian_wiki_links_removes_absolute_urls() {
         .success();
 
     let content = t.read_md_content();
-    // The frontmatter `url:` field always contains the full URL — that's expected.
-    // The wiki-link conversion affects only <a> tags in the body content.
-    // Split at the frontmatter end to check only the body.
-    let body = content.split_once("---\n").map(|x| x.1).unwrap_or(&content);
-    let body = body.split_once("---\n").map(|x| x.1).unwrap_or(body);
-    assert!(
-        !body.contains("<a href="),
-        "body should not contain raw <a> tags after wiki-link conversion: {}",
-        &body[..body.len().min(500)]
-    );
-    assert!(
-        body.contains("[["),
-        "body should contain [[wiki-link]] syntax: {}",
-        &body[..body.len().min(500)]
-    );
+    assert_obsidian_snapshot("obsidian_wiki_links_removes_absolute_urls", t.out.path(), &content);
 }
 
 // ---------------------------------------------------------------------------
@@ -118,15 +124,7 @@ async fn obsidian_tags_appear_in_frontmatter() {
         .success();
 
     let content = t.read_md_content();
-    assert!(
-        content.contains("tags:"),
-        "frontmatter should contain tags field"
-    );
-    assert!(
-        content.contains("scraped") && content.contains("web-dev") && content.contains("rust"),
-        "frontmatter should contain all specified tags: {}",
-        &content[..content.len().min(500)]
-    );
+    assert_obsidian_snapshot("obsidian_tags_appear_in_frontmatter", t.out.path(), &content);
 }
 
 #[tokio::test]
@@ -151,12 +149,7 @@ async fn obsidian_tags_produces_yaml_frontmatter() {
         .success();
 
     let content = t.read_md_content();
-    // YAML frontmatter starts with ---
-    assert!(
-        content.starts_with("---"),
-        "file should start with YAML frontmatter (---): {}",
-        &content[..content.len().min(300)]
-    );
+    assert_obsidian_snapshot("obsidian_tags_produces_yaml_frontmatter", t.out.path(), &content);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/behavioral/cli/single_page_test.rs
+++ b/tests/behavioral/cli/single_page_test.rs
@@ -34,8 +34,8 @@ async fn single_page_creates_md_file() {
         .assert()
         .success();
 
-    let md_files = t.find_files("md");
-    assert!(!md_files.is_empty(), "expected at least one .md file");
+    let content = t.read_md_content();
+    crate::assert_snapshot_redacted("single_page_creates_md_file", t.out.path(), content);
 }
 
 #[tokio::test]
@@ -56,11 +56,7 @@ async fn single_page_md_contains_page_content() {
         .success();
 
     let content = t.read_md_content();
-    assert!(
-        content.contains("Hello World"),
-        "md should contain page heading: {}",
-        &content[..content.len().min(500)]
-    );
+    crate::assert_snapshot_redacted("single_page_md_contains_page_content", t.out.path(), content);
 }
 
 // ---------------------------------------------------------------------------
@@ -88,7 +84,8 @@ async fn single_page_json_format_creates_json_file() {
 
     // JSON output goes to results.json at the output root (not in domain subdirs)
     let json_files = t.find_files("json");
-    assert!(!json_files.is_empty(), "expected at least one .json file");
+    let content = std::fs::read_to_string(&json_files[0]).expect("read .json output");
+    crate::assert_snapshot_redacted("single_page_json_format_creates_json_file", t.out.path(), content);
 }
 
 #[tokio::test]
@@ -111,15 +108,8 @@ async fn single_page_json_has_correct_structure() {
         .success();
 
     let json_files = t.find_files("json");
-    assert!(!json_files.is_empty());
-
-    let content = std::fs::read_to_string(&json_files[0]).unwrap();
-    let parsed: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
-    assert!(
-        parsed.is_array() || parsed.get("url").is_some() || parsed.get("title").is_some(),
-        "JSON should contain url/title fields or be an array: {}",
-        &content[..content.len().min(500)]
-    );
+    let content = std::fs::read_to_string(&json_files[0]).expect("read .json output");
+    crate::assert_snapshot_redacted("single_page_json_has_correct_structure", t.out.path(), content);
 }
 
 // ---------------------------------------------------------------------------
@@ -146,7 +136,8 @@ async fn single_page_text_format_creates_txt_file() {
         .success();
 
     let txt_files = t.find_files("txt");
-    assert!(!txt_files.is_empty(), "expected at least one .txt file");
+    let content = std::fs::read_to_string(&txt_files[0]).expect("read .txt output");
+    crate::assert_snapshot_redacted("single_page_text_format_creates_txt_file", t.out.path(), content);
 }
 
 #[tokio::test]
@@ -169,15 +160,8 @@ async fn single_page_text_is_plain_text() {
         .success();
 
     let txt_files = t.find_files("txt");
-    assert!(!txt_files.is_empty());
-
-    let content = std::fs::read_to_string(&txt_files[0]).unwrap();
-    // Text format should not contain HTML tags
-    assert!(
-        !content.contains("<html") && !content.contains("<body"),
-        "text format should not contain HTML tags: {}",
-        &content[..content.len().min(500)]
-    );
+    let content = std::fs::read_to_string(&txt_files[0]).expect("read .txt output");
+    crate::assert_snapshot_redacted("single_page_text_is_plain_text", t.out.path(), content);
 }
 
 // ---------------------------------------------------------------------------
@@ -207,12 +191,8 @@ async fn single_page_quiet_suppresses_stdout() {
         "expected success, got: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    // stdout should be empty or very short in quiet mode
+    // stdout should be empty or very short in quiet mode; snapshot it to lock the
+    // behavior so a regression (banner re-added, stderr leaking into stdout) fails.
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.trim().is_empty() || stdout.lines().count() <= 1,
-        "quiet mode should suppress stdout output, got {} lines: {}",
-        stdout.lines().count(),
-        &stdout[..stdout.len().min(300)]
-    );
+    crate::assert_snapshot_plain("single_page_quiet_suppresses_stdout", stdout);
 }

--- a/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_tags_appear_in_frontmatter.snap
+++ b/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_tags_appear_in_frontmatter.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/cli/obsidian_test.rs
+expression: redacted
+---
+---
+title: Tagged Page
+url: http://127.0.0.1:<PORT>/
+date: [DATE]
+excerpt: Content with obsidian tags for frontmatter testing.
+tags:
+- scraped
+- web-dev
+- rust
+---
+
+Content with obsidian tags for frontmatter testing.

--- a/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_tags_produces_yaml_frontmatter.snap
+++ b/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_tags_produces_yaml_frontmatter.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/cli/obsidian_test.rs
+expression: redacted
+---
+---
+title: Tagged Page
+url: http://127.0.0.1:<PORT>/
+date: [DATE]
+excerpt: Content with obsidian tags for frontmatter testing.
+tags:
+- test
+---
+
+Content with obsidian tags for frontmatter testing.

--- a/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_wiki_links_produces_wiki_syntax.snap
+++ b/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_wiki_links_produces_wiki_syntax.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/cli/obsidian_test.rs
+expression: redacted
+---
+---
+title: Wiki Links Test
+url: http://127.0.0.1:<PORT>/
+date: [DATE]
+excerpt: Check out this other page for more info. Also see the third page.
+---
+
+Check out [[other-page|this other page]] for more info. Also see [[third-page|the third page]].

--- a/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_wiki_links_removes_absolute_urls.snap
+++ b/tests/behavioral/cli/snapshots/behavioral__cli__obsidian_test__obsidian_wiki_links_removes_absolute_urls.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/cli/obsidian_test.rs
+expression: redacted
+---
+---
+title: Wiki Links Test
+url: http://127.0.0.1:<PORT>/
+date: [DATE]
+excerpt: Check out this other page for more info. Also see the third page.
+---
+
+Check out [[other-page|this other page]] for more info. Also see [[third-page|the third page]].

--- a/tests/behavioral/main.rs
+++ b/tests/behavioral/main.rs
@@ -6,19 +6,51 @@
 mod cli;
 
 use assert_cmd::Command;
+use insta::assert_snapshot;
+use regex::Regex;
+use std::path::Path;
 
-/// Returns the binary name to test.
+/// Resolve the path to the `webfang` binary.
 ///
-/// The only CLI binary in the workspace is `webfang` (crate: `rust_scraper_cli`).
-/// `rust_scraper_core` is a library-only crate and no longer ships its own
-/// binary, so every test exercises `webfang`.
-fn cli_bin() -> &'static str {
-    "webfang"
+/// `webfang` is built by the `rust_scraper_cli` crate (a workspace sibling),
+/// so `assert_cmd::cargo_bin` cannot locate it from `rust_scraper_core` tests
+/// — `CARGO_BIN_EXE_webfang` is only set for the crate that owns the binary.
+/// We fall back to the workspace `target/` dir and, if missing, build it.
+fn webfang_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_webfang") {
+        return std::path::PathBuf::from(p);
+    }
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/rust_scraper_core -> workspace root (two levels up)
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("resolve workspace root");
+    for profile in ["debug", "release"] {
+        let mut candidate = workspace_root.join("target").join(profile).join("webfang");
+        if cfg!(windows) {
+            candidate.set_extension("exe");
+        }
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    let cargo = option_env!("CARGO").unwrap_or("cargo");
+    let status = std::process::Command::new(cargo)
+        .args(["build", "-p", "rust_scraper_cli", "--bin", "webfang", "--quiet"])
+        .status()
+        .expect("spawn cargo to build webfang");
+    assert!(status.success(), "cargo build --bin webfang failed");
+    let mut built = workspace_root.join("target").join("debug").join("webfang");
+    if cfg!(windows) {
+        built.set_extension("exe");
+    }
+    built
 }
 
 /// Shared binary command builder for tests that don't need a mock server.
 pub(crate) fn cmd() -> Command {
-    Command::cargo_bin(cli_bin()).expect("binary exists")
+    Command::new(webfang_path())
 }
 
 /// Shared test harness: one mock server + one temp output directory.
@@ -39,7 +71,7 @@ impl BehavioralTest {
     /// Build a `Command` for the `webfang` binary with `--url` and
     /// `--output` pre-filled to this harness's server and temp dir.
     pub fn scraper_cmd(&self) -> assert_cmd::Command {
-        let mut cmd = assert_cmd::Command::cargo_bin(cli_bin()).expect("binary exists");
+        let mut cmd = Command::new(webfang_path());
         cmd.arg("--url")
             .arg(self.server.uri())
             .arg("--output")
@@ -69,4 +101,44 @@ impl BehavioralTest {
         );
         std::fs::read_to_string(&md_files[0]).expect("read .md file")
     }
+}
+
+/// Redact the per-run temp-dir path so snapshots stay stable across machines.
+///
+/// Output paths embed an absolute `TempDir` location that changes on every
+/// run; collapse it to the fixed placeholder `<OUT_DIR>` before snapshotting.
+pub(crate) fn redact_temp_path(dir: &Path, text: &str) -> String {
+    text.replace(dir.to_string_lossy().as_ref(), "<OUT_DIR>")
+}
+
+/// Redact common non-deterministic output so snapshots are stable run-to-run:
+/// the temp dir, ISO-8601 log timestamps, dynamic wiremock ports, and ANSI
+/// color escape sequences.
+pub(crate) fn redact_nondeterministic(dir: &Path, text: &str) -> String {
+    let text = redact_temp_path(dir, text);
+    let ansi = Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+    let text = ansi.replace_all(&text, "").into_owned();
+    let ts = Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z").unwrap();
+    let text = ts.replace_all(&text, "<TIMESTAMP>").into_owned();
+    let port = Regex::new(r"127\.0\.0\.1:\d+").unwrap();
+    port.replace_all(&text, "127.0.0.1:<PORT>").into_owned()
+}
+
+/// Assert a snapshot of `value`, redacting the harness temp dir and other
+/// non-deterministic output (timestamps, dynamic ports, ANSI codes) first.
+///
+/// `dir` is the temp-dir path so the absolute temp location never leaks into
+/// the committed snapshot. Pass a non-matching path when the run had no temp
+/// dir (e.g. `Path::new("__no_temp__")`).
+pub(crate) fn assert_snapshot_redacted(name: &str, dir: &Path, value: impl Into<String>) {
+    let redacted = redact_nondeterministic(dir, &value.into());
+    assert_snapshot!(name, redacted);
+}
+
+/// Assert a snapshot of `value` with no path redaction.
+///
+/// Use for deterministic outputs that never embed the temp dir (e.g. `--help`,
+/// `--version`, or stderr from a run that passed no `--output`).
+pub(crate) fn assert_snapshot_plain(name: &str, value: impl Into<String>) {
+    assert_snapshot!(name, value.into());
 }

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -1,0 +1,386 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: value.into()
+---
+CLI Arguments for the rust_scraper binary.
+
+# Examples
+
+```no_run use rust_scraper::Args; use clap::Parser;
+
+let args = Args::parse_from([ "rust_scraper", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
+
+assert_eq!(args.url, "https://example.com"); ```
+
+Usage: webfang [OPTIONS]
+       webfang <COMMAND>
+
+Commands:
+  completions  Generate shell completion scripts
+  help         Print this message or the help of the given subcommand(s)
+
+Options:
+  -u, --url <URL>
+          URL to scrape (required unless using a subcommand)
+          
+          [env: RUST_SCRAPER_URL=]
+
+  -s, --selector <SELECTOR>
+          CSS selector for content extraction
+          
+          [env: RUST_SCRAPER_SELECTOR=]
+          [default: body]
+
+  -o, --output <OUTPUT>
+          Output directory for scraped content
+          
+          [env: RUST_SCRAPER_OUTPUT=]
+          [default: output]
+
+  -f, --format <FORMAT>
+          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
+
+          Possible values:
+          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
+          - json:     Structured JSON with metadata
+          - text:     Plain text without formatting
+          
+          [env: RUST_SCRAPER_FORMAT=]
+          [default: markdown]
+
+      --export-format <EXPORT_FORMAT>
+          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
+
+          Possible values:
+          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
+          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
+          - auto:   Auto-detect format from existing export files
+          
+          [env: RUST_SCRAPER_EXPORT_FORMAT=]
+          [default: jsonl]
+
+      --obsidian-wiki-links
+          Convert same-domain links to Obsidian [[wiki-link]] syntax
+          
+          [env: RUST_SCRAPER_OBSIDIAN_WIKI_LINKS=]
+
+      --obsidian-tags <OBSIDIAN_TAGS>
+          Tags to include in YAML frontmatter (comma-separated)
+          
+          [env: RUST_SCRAPER_OBSIDIAN_TAGS=]
+
+      --obsidian-relative-assets
+          Rewrite downloaded asset paths as relative to the .md file
+          
+          [env: RUST_SCRAPER_OBSIDIAN_RELATIVE_ASSETS=]
+
+      --vault <VAULT>
+          Path to Obsidian vault (auto-detects if not provided)
+          
+          [env: RUST_SCRAPER_OBSIDIAN_VAULT=]
+
+      --quick-save
+          Quick-save mode: save directly to vault _inbox folder
+          
+          [env: RUST_SCRAPER_OBSIDIAN_QUICK_SAVE=]
+
+      --obsidian-rich-metadata
+          Add rich metadata to frontmatter
+          
+          [env: RUST_SCRAPER_OBSIDIAN_RICH_METADATA=]
+
+      --delay-ms <DELAY_MS>
+          Delay between requests in milliseconds
+          
+          [env: RUST_SCRAPER_DELAY_MS=]
+          [default: 1000]
+
+      --max-pages <MAX_PAGES>
+          Maximum pages to scrape
+          
+          [env: RUST_SCRAPER_MAX_PAGES=]
+          [default: 10]
+
+      --concurrency <CONCURRENCY>
+          Concurrency level (auto or number)
+          
+          [env: RUST_SCRAPER_CONCURRENCY=]
+          [default: auto]
+
+      --use-sitemap
+          Use sitemap for URL discovery NOTE: HTTP redirects (301/302) are resolved at scrape-time, not parse-time. This avoids redundant HEAD requests during sitemap parsing for better performance
+          
+          [env: RUST_SCRAPER_USE_SITEMAP=]
+
+      --sitemap-url <SITEMAP_URL>
+          Explicit sitemap URL
+          
+          [env: RUST_SCRAPER_SITEMAP_URL=]
+
+      --single-page
+          Scrape only the seed URL without discovery or crawling
+          
+          [env: RUST_SCRAPER_SINGLE_PAGE=]
+
+      --resume
+          Resume mode - skip URLs already processed
+          
+          [env: RUST_SCRAPER_RESUME=]
+
+      --state-dir <STATE_DIR>
+          Custom state directory for resume mode
+          
+          [env: RUST_SCRAPER_STATE_DIR=]
+
+      --download-images
+          Download images from the page
+          
+          [env: RUST_SCRAPER_DOWNLOAD_IMAGES=]
+
+      --download-documents
+          Download documents from the page
+          
+          [env: RUST_SCRAPER_DOWNLOAD_DOCUMENTS=]
+
+      --download-assets
+          Download all assets (images + documents) from the page
+          
+          [env: RUST_SCRAPER_DOWNLOAD_ASSETS=]
+
+      --tui
+          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
+          
+          [env: RUST_SCRAPER_TUI=]
+
+      --force-js-render
+          Force JavaScript rendering for SPA sites (not yet implemented)
+          
+          [env: RUST_SCRAPER_FORCE_JS_RENDER=]
+
+  -v, --verbose...
+          Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
+          
+          [env: RUST_SCRAPER_VERBOSE=]
+
+  -q, --quiet
+          Quiet mode — suppress info/debug output
+          
+          [env: RUST_SCRAPER_QUIET=]
+
+  -n, --dry-run
+          Dry-run mode — discover URLs and print without scraping
+          
+          [env: RUST_SCRAPER_DRY_RUN=]
+
+      --trace-file <TRACE_FILE>
+          Path to write OTel spans as JSONL for offline debugging
+          
+          [env: RUST_SCRAPER_TRACE_FILE=]
+
+      --max-depth <MAX_DEPTH>
+          Maximum depth to crawl (0 = only seed URL)
+          
+          [env: RUST_SCRAPER_MAX_DEPTH=]
+          [default: 2]
+
+      --timeout-secs <TIMEOUT_SECS>
+          Request timeout in seconds
+          
+          [env: RUST_SCRAPER_TIMEOUT_SECS=]
+          [default: 30]
+
+      --include-pattern <INCLUDE_PATTERNS>
+          URL patterns to include (glob-style)
+          
+          [env: RUST_SCRAPER_INCLUDE=]
+
+      --exclude-pattern <EXCLUDE_PATTERNS>
+          URL patterns to exclude (glob-style)
+          
+          [env: RUST_SCRAPER_EXCLUDE=]
+
+      --asset-naming <ASSET_NAMING>
+          Estrategia de nombre de archivo para assets descargados: hash (default), slug, content-disposition
+          
+          [default: hash]
+          [possible values: hash, slug, content-disposition]
+
+      --download-concurrency <DOWNLOAD_CONCURRENCY>
+          Máximo de descargas de assets concurrentes por página (mínimo 1)
+          
+          [env: RUST_SCRAPER_DOWNLOAD_CONCURRENCY=]
+          [default: 3]
+
+      --max-retries <MAX_RETRIES>
+          Maximum number of retry attempts
+          
+          [env: RUST_SCRAPER_MAX_RETRIES=]
+          [default: 3]
+
+      --backoff-base-ms <BACKOFF_BASE_MS>
+          Base delay for exponential backoff (ms)
+          
+          [env: RUST_SCRAPER_BACKOFF_BASE_MS=]
+          [default: 1000]
+
+      --backoff-max-ms <BACKOFF_MAX_MS>
+          Maximum delay for exponential backoff (ms)
+          
+          [env: RUST_SCRAPER_BACKOFF_MAX_MS=]
+          [default: 10000]
+
+      --accept-language <ACCEPT_LANGUAGE>
+          Accept-Language header value
+          
+          [env: RUST_SCRAPER_ACCEPT_LANGUAGE=]
+          [default: en-US,en;q=0.9]
+
+      --user-agent <USER_AGENT>
+          Custom User-Agent header value (overrides Chrome 145 default)
+          
+          [env: RUST_SCRAPER_USER_AGENT=]
+
+      --max-file-size <MAX_FILE_SIZE>
+          Maximum file size to download in bytes (default: 50MB)
+          
+          [env: RUST_SCRAPER_MAX_FILE_SIZE=]
+          [default: 52428800]
+
+      --download-timeout <DOWNLOAD_TIMEOUT>
+          Timeout for individual asset downloads in seconds
+          
+          [env: RUST_SCRAPER_DOWNLOAD_TIMEOUT=]
+          [default: 30]
+
+      --sitemap-depth <SITEMAP_DEPTH>
+          Maximum recursion depth for sitemap indexes
+          
+          [env: RUST_SCRAPER_SITEMAP_DEPTH=]
+          [default: 3]
+
+      --cpu-cores <CPU_CORES>
+          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
+          
+          [env: RUST_SCRAPER_CPU_CORES=]
+
+      --ram-budget <RAM_BUDGET>
+          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
+          
+          [env: RUST_SCRAPER_RAM_BUDGET=]
+
+      --db-path <DB_PATH>
+          SQLite database path override for persisted resources/chunks
+          
+          [env: RUST_SCRAPER_DB_PATH=]
+
+      --elastic
+          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
+          
+          [env: RUST_SCRAPER_ELASTIC=]
+
+      --output-vectors <OUTPUT_VECTORS>
+          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
+          
+          [env: RUST_SCRAPER_OUTPUT_VECTORS=]
+
+      --checkpoint-interval <CHECKPOINT_INTERVAL>
+          Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
+          
+          [env: RUST_SCRAPER_CHECKPOINT_INTERVAL=]
+          [default: 100]
+
+      --no-checkpoint
+          Disable checkpoint persistence entirely NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
+          
+          [env: RUST_SCRAPER_NO_CHECKPOINT=]
+
+      --ignore-robots
+          Skip robots.txt enforcement
+          
+          [env: RUST_SCRAPER_IGNORE_ROBOTS=]
+
+      --autoscale
+          Enable autoscaled concurrency — dynamically adjusts task concurrency based on RAM usage
+          
+          [env: RUST_SCRAPER_AUTOSCALE=]
+
+      --no-session-health
+          Disable session pool health checks
+          
+          [env: RUST_SCRAPER_NO_SESSION_HEALTH=]
+
+      --h2-profile <H2_PROFILE>
+          TLS/HTTP2 profile name (default: Chrome145)
+          
+          [env: RUST_SCRAPER_H2_PROFILE=]
+          [default: Chrome145]
+
+      --js-strategy <JS_STRATEGY>
+          JavaScript rendering strategy: static (wreq only), hybrid (3-layer), full (Chromiumoxide only)
+
+          Possible values:
+          - static: Static HTTP only (wreq). Fastest, no JS rendering
+          - hybrid: Hybrid 3-layer: wreq → Obscura → Chromiumoxide
+          - full:   Full JS rendering only (Chromiumoxide). Slowest, handles all SPAs
+          
+          [env: RUST_SCRAPER_JS_STRATEGY=]
+          [default: static]
+
+      --obscura-binary <OBSCURA_BINARY>
+          Path to the obscura binary (default: "obscura")
+          
+          [env: RUST_SCRAPER_OBSCURA_BINARY=]
+          [default: obscura]
+
+      --batch
+          Enable batch mode — read URLs from stdin (one per line)
+          
+          [env: RUST_SCRAPER_BATCH=]
+
+      --batch-file <BATCH_FILE>
+          Path to a file containing URLs to crawl (one per line)
+          
+          [env: RUST_SCRAPER_BATCH_FILE=]
+
+      --batch-concurrency <BATCH_CONCURRENCY>
+          Maximum concurrent URLs in batch mode
+          
+          [env: RUST_SCRAPER_BATCH_CONCURRENCY=]
+          [default: 5]
+
+      --pipeline
+          Enable item pipeline processing (validate → clean → output)
+          
+          [env: RUST_SCRAPER_PIPELINE=]
+
+      --pipeline-output <PIPELINE_OUTPUT>
+          Pipeline output format: jsonl (default), none
+
+          Possible values:
+          - jsonl: Write items as JSON Lines to a file (default)
+          - none:  No pipeline output — items are processed but not written
+          
+          [env: RUST_SCRAPER_PIPELINE_OUTPUT=]
+          [default: jsonl]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+EXIT CODES:
+  0    Success
+  2    No URLs discovered
+  69   WAF block or network error
+  74   I/O error
+  76   Protocol error
+  78   Configuration error
+
+EXAMPLES:
+  webfang -u https://example.com
+  webfang -u https://example.com --ai
+  webfang -u https://example.com -f jsonl
+  webfang -u https://example.com -v
+  webfang -u https://example.com -vv  # DEBUG
+  webfang --url-list urls.txt --resume

--- a/tests/behavioral/snapshots/behavioral__single_page_creates_md_file.snap
+++ b/tests/behavioral/snapshots/behavioral__single_page_creates_md_file.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+---
+title: Single Page Test
+url: http://127.0.0.1:<PORT>/
+date: 2026-07-14
+excerpt: This is meaningful content for the extractor to process.
+---
+
+## Hello World
+
+This is meaningful content for the extractor to process.
+
+More paragraphs ensure readability can extract a proper document.

--- a/tests/behavioral/snapshots/behavioral__single_page_json_format_creates_json_file.snap
+++ b/tests/behavioral/snapshots/behavioral__single_page_json_format_creates_json_file.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+[
+  {
+    "title": "Single Page Test",
+    "content": "Hello World This is meaningful content for the extractor to process. More paragraphs ensure readability can extract a proper document.",
+    "url": "http://127.0.0.1:<PORT>/",
+    "excerpt": "This is meaningful content for the extractor to process.",
+    "author": null,
+    "date": null,
+    "html": "<div id=\"readability-page-1\" class=\"page\"><div><article> <h2>Hello World</h2> <p>This is meaningful content for the extractor to process.</p> <p>More paragraphs ensure readability can extract a proper document.</p> </article></div></div>"
+  }
+]

--- a/tests/behavioral/snapshots/behavioral__single_page_json_has_correct_structure.snap
+++ b/tests/behavioral/snapshots/behavioral__single_page_json_has_correct_structure.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+[
+  {
+    "title": "Single Page Test",
+    "content": "Hello World This is meaningful content for the extractor to process. More paragraphs ensure readability can extract a proper document.",
+    "url": "http://127.0.0.1:<PORT>/",
+    "excerpt": "This is meaningful content for the extractor to process.",
+    "author": null,
+    "date": null,
+    "html": "<div id=\"readability-page-1\" class=\"page\"><div><article> <h2>Hello World</h2> <p>This is meaningful content for the extractor to process.</p> <p>More paragraphs ensure readability can extract a proper document.</p> </article></div></div>"
+  }
+]

--- a/tests/behavioral/snapshots/behavioral__single_page_md_contains_page_content.snap
+++ b/tests/behavioral/snapshots/behavioral__single_page_md_contains_page_content.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+---
+title: Single Page Test
+url: http://127.0.0.1:<PORT>/
+date: 2026-07-14
+excerpt: This is meaningful content for the extractor to process.
+---
+
+## Hello World
+
+This is meaningful content for the extractor to process.
+
+More paragraphs ensure readability can extract a proper document.

--- a/tests/behavioral/snapshots/behavioral__single_page_quiet_suppresses_stdout.snap
+++ b/tests/behavioral/snapshots/behavioral__single_page_quiet_suppresses_stdout.snap
@@ -1,0 +1,5 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: value.into()
+---
+

--- a/tests/behavioral/snapshots/behavioral__single_page_text_format_creates_txt_file.snap
+++ b/tests/behavioral/snapshots/behavioral__single_page_text_format_creates_txt_file.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+========================================
+TITLE: Single Page Test
+URL: http://127.0.0.1:<PORT>/
+AUTHOR: Unknown
+DATE: N/A
+----------------------------------------
+CONTENT:
+Hello World This is meaningful content for the extractor to process. More paragraphs ensure readability can extract a proper document.
+========================================

--- a/tests/behavioral/snapshots/behavioral__single_page_text_is_plain_text.snap
+++ b/tests/behavioral/snapshots/behavioral__single_page_text_is_plain_text.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+========================================
+TITLE: Single Page Test
+URL: http://127.0.0.1:<PORT>/
+AUTHOR: Unknown
+DATE: N/A
+----------------------------------------
+CONTENT:
+Hello World This is meaningful content for the extractor to process. More paragraphs ensure readability can extract a proper document.
+========================================

--- a/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
+
+  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
+    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
+
+Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
+No pages were successfully scraped
+Error: No pages were successfully scraped

--- a/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+expression: redacted
+---
+  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
+
+  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
+    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
+
+Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← client error (Connect)  ← tcp connect error  ← Connection refused (os error 111)
+No pages were successfully scraped
+Error: No pages were successfully scraped

--- a/tests/cli_behavioral_test.rs
+++ b/tests/cli_behavioral_test.rs
@@ -20,17 +20,46 @@ use walkdir::WalkDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// Returns the binary name to test.
+/// Resolve the path to the `webfang` binary.
 ///
-/// The only CLI binary in the workspace is `webfang` (crate: `rust_scraper_cli`).
-/// `rust_scraper_core` is a library-only crate and no longer ships its own
-/// binary, so every test exercises `webfang`.
-fn cli_bin() -> &'static str {
-    "webfang"
+/// `webfang` is built by the `rust_scraper_cli` crate (a workspace sibling),
+/// so `assert_cmd::cargo_bin` cannot locate it from `rust_scraper_core` tests
+/// — `CARGO_BIN_EXE_webfang` is only set for the crate that owns the binary.
+/// We fall back to the workspace `target/` dir and, if missing, build it.
+fn webfang_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_webfang") {
+        return std::path::PathBuf::from(p);
+    }
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/rust_scraper_core -> workspace root (two levels up)
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("resolve workspace root");
+    for profile in ["debug", "release"] {
+        let mut candidate = workspace_root.join("target").join(profile).join("webfang");
+        if cfg!(windows) {
+            candidate.set_extension("exe");
+        }
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    let cargo = option_env!("CARGO").unwrap_or("cargo");
+    let status = std::process::Command::new(cargo)
+        .args(["build", "-p", "rust_scraper_cli", "--bin", "webfang", "--quiet"])
+        .status()
+        .expect("spawn cargo to build webfang");
+    assert!(status.success(), "cargo build --bin webfang failed");
+    let mut built = workspace_root.join("target").join("debug").join("webfang");
+    if cfg!(windows) {
+        built.set_extension("exe");
+    }
+    built
 }
 
 fn cmd() -> Command {
-    Command::cargo_bin(cli_bin()).expect("binary exists")
+    Command::new(webfang_path())
 }
 
 // ============================================================================

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -13,17 +13,46 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// Returns the binary name to test.
+/// Resolve the path to the `webfang` binary.
 ///
-/// The only CLI binary in the workspace is `webfang` (crate: `rust_scraper_cli`).
-/// `rust_scraper_core` is a library-only crate and no longer ships its own
-/// binary, so every test exercises `webfang`.
-fn cli_bin() -> &'static str {
-    "webfang"
+/// `webfang` is built by the `rust_scraper_cli` crate (a workspace sibling),
+/// so `assert_cmd::cargo_bin` cannot locate it from `rust_scraper_core` tests
+/// — `CARGO_BIN_EXE_webfang` is only set for the crate that owns the binary.
+/// We fall back to the workspace `target/` dir and, if missing, build it.
+fn webfang_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_webfang") {
+        return std::path::PathBuf::from(p);
+    }
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/rust_scraper_core -> workspace root (two levels up)
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("resolve workspace root");
+    for profile in ["debug", "release"] {
+        let mut candidate = workspace_root.join("target").join(profile).join("webfang");
+        if cfg!(windows) {
+            candidate.set_extension("exe");
+        }
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    let cargo = option_env!("CARGO").unwrap_or("cargo");
+    let status = std::process::Command::new(cargo)
+        .args(["build", "-p", "rust_scraper_cli", "--bin", "webfang", "--quiet"])
+        .status()
+        .expect("spawn cargo to build webfang");
+    assert!(status.success(), "cargo build --bin webfang failed");
+    let mut built = workspace_root.join("target").join("debug").join("webfang");
+    if cfg!(windows) {
+        built.set_extension("exe");
+    }
+    built
 }
 
 fn cmd() -> Command {
-    Command::cargo_bin(cli_bin()).expect("binary exists")
+    Command::new(webfang_path())
 }
 
 // ============================================================================

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -7,9 +7,10 @@
 //! Run with: cargo nextest run --test-threads 2 cli_binary_test
 
 use assert_cmd::Command;
-use predicates::prelude::*;
+use std::path::Path;
 use std::time::Duration;
 use tempfile::TempDir;
+use regex::Regex;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -55,6 +56,19 @@ fn cmd() -> Command {
     Command::new(webfang_path())
 }
 
+/// Redact non-deterministic output so binary stdout/stderr snapshots stay
+/// stable across machines and runs: the temp-dir path (`<OUT_DIR>`), ANSI color
+/// escape codes, ISO-8601 `-Z` timestamps, and dynamic wiremock ports.
+fn redact(dir: &Path, text: &str) -> String {
+    let text = text.replace(dir.to_string_lossy().as_ref(), "<OUT_DIR>");
+    let ansi = Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+    let text = ansi.replace_all(&text, "").into_owned();
+    let ts = Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z").unwrap();
+    let text = ts.replace_all(&text, "<TIMESTAMP>").into_owned();
+    let port = Regex::new(r"127\.0\.0\.1:\d+").unwrap();
+    port.replace_all(&text, "127.0.0.1:<PORT>").into_owned()
+}
+
 // ============================================================================
 // Tests: Binary error handling
 // ============================================================================
@@ -62,22 +76,24 @@ fn cmd() -> Command {
 /// Test that running without --url shows an error message
 #[test]
 fn test_no_url_shows_error() {
-    cmd()
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("--url is required"));
+    let output = cmd().output().expect("run binary");
+    assert!(!output.status.success(), "expected failure");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    insta::assert_snapshot!("test_no_url_shows_error", redact(Path::new("__no_temp__"), &stderr));
 }
 
 /// Test that an invalid URL shows an error
 #[test]
 fn test_invalid_url_shows_error() {
     // CLI validates URL and returns error message
-    cmd()
+    let output = cmd()
         .arg("--url")
         .arg("not-a-url")
-        .assert()
-        .failure() // CLI returns exit code 64
-        .stderr(predicate::str::contains("Invalid URL"));
+        .output()
+        .expect("run binary");
+    assert!(!output.status.success(), "expected failure");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    insta::assert_snapshot!("test_invalid_url_shows_error", redact(Path::new("__no_temp__"), &stderr));
 }
 
 // ============================================================================
@@ -88,21 +104,19 @@ fn test_invalid_url_shows_error() {
 /// Test that --help prints usage and exits with code 0.
 #[test]
 fn test_help_contains_scraper() {
-    cmd()
-        .arg("--help")
-        .assert()
-        .code(0)
-        .stdout(predicate::str::contains("rust_scraper binary"));
+    let output = cmd().arg("--help").output().expect("run binary");
+    assert!(output.status.success(), "expected success");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    insta::assert_snapshot!("test_help_contains_scraper", redact(Path::new("__no_temp__"), &stdout));
 }
 
 /// Test that --version outputs version and exits with code 0.
 #[test]
 fn test_version() {
-    cmd()
-        .arg("--version")
-        .assert()
-        .code(0)
-        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+    let output = cmd().arg("--version").output().expect("run binary");
+    assert!(output.status.success(), "expected success");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    insta::assert_snapshot!("test_version", redact(Path::new("__no_temp__"), &stdout));
 }
 
 // ============================================================================
@@ -129,21 +143,19 @@ fn test_dry_run_with_url() {
 #[test]
 fn test_quiet_flag_accepted() {
     // Should not fail at argument parsing (will fail at network without URL)
-    cmd()
-        .arg("--quiet")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("--url is required"));
+    let output = cmd().arg("--quiet").output().expect("run binary");
+    assert!(!output.status.success(), "expected failure");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    insta::assert_snapshot!("test_quiet_flag_accepted", redact(Path::new("__no_temp__"), &stderr));
 }
 
 /// Test that --dry-run flag is accepted
 #[test]
 fn test_dry_run_flag_accepted() {
-    cmd()
-        .arg("--dry-run")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("--url is required"));
+    let output = cmd().arg("--dry-run").output().expect("run binary");
+    assert!(!output.status.success(), "expected failure");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    insta::assert_snapshot!("test_dry_run_flag_accepted", redact(Path::new("__no_temp__"), &stderr));
 }
 
 // ============================================================================
@@ -218,7 +230,7 @@ async fn test_single_page_custom_timeout_is_used_by_scrape_client() {
         .mount(&mock_server)
         .await;
 
-    cmd()
+    let output = cmd()
         .arg("--url")
         .arg(format!("{}/slow", mock_server.uri()))
         .arg("--single-page")
@@ -227,9 +239,12 @@ async fn test_single_page_custom_timeout_is_used_by_scrape_client() {
         .arg("--output")
         .arg(output_dir.path())
         .arg("--quiet")
-        .assert()
-        .code(69)
-        .stderr(predicate::str::contains(
-            "No pages were successfully scraped",
-        ));
+        .output()
+        .expect("run binary");
+    assert_eq!(output.status.code(), Some(69), "expected exit code 69");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    insta::assert_snapshot!(
+        "test_single_page_custom_timeout_is_used_by_scrape_client",
+        redact(output_dir.path(), &stderr)
+    );
 }

--- a/tests/snapshots/cli_binary__test_dry_run_flag_accepted.snap
+++ b/tests/snapshots/cli_binary__test_dry_run_flag_accepted.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+expression: "redact(Path::new(\"__no_temp__\"), &stderr)"
+---
+Error: --url is required for scraping
+Error: --url is required

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -1,0 +1,386 @@
+---
+source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+expression: "redact(Path::new(\"__no_temp__\"), &stdout)"
+---
+CLI Arguments for the rust_scraper binary.
+
+# Examples
+
+```no_run use rust_scraper::Args; use clap::Parser;
+
+let args = Args::parse_from([ "rust_scraper", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
+
+assert_eq!(args.url, "https://example.com"); ```
+
+Usage: webfang [OPTIONS]
+       webfang <COMMAND>
+
+Commands:
+  completions  Generate shell completion scripts
+  help         Print this message or the help of the given subcommand(s)
+
+Options:
+  -u, --url <URL>
+          URL to scrape (required unless using a subcommand)
+          
+          [env: RUST_SCRAPER_URL=]
+
+  -s, --selector <SELECTOR>
+          CSS selector for content extraction
+          
+          [env: RUST_SCRAPER_SELECTOR=]
+          [default: body]
+
+  -o, --output <OUTPUT>
+          Output directory for scraped content
+          
+          [env: RUST_SCRAPER_OUTPUT=]
+          [default: output]
+
+  -f, --format <FORMAT>
+          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
+
+          Possible values:
+          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
+          - json:     Structured JSON with metadata
+          - text:     Plain text without formatting
+          
+          [env: RUST_SCRAPER_FORMAT=]
+          [default: markdown]
+
+      --export-format <EXPORT_FORMAT>
+          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
+
+          Possible values:
+          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
+          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
+          - auto:   Auto-detect format from existing export files
+          
+          [env: RUST_SCRAPER_EXPORT_FORMAT=]
+          [default: jsonl]
+
+      --obsidian-wiki-links
+          Convert same-domain links to Obsidian [[wiki-link]] syntax
+          
+          [env: RUST_SCRAPER_OBSIDIAN_WIKI_LINKS=]
+
+      --obsidian-tags <OBSIDIAN_TAGS>
+          Tags to include in YAML frontmatter (comma-separated)
+          
+          [env: RUST_SCRAPER_OBSIDIAN_TAGS=]
+
+      --obsidian-relative-assets
+          Rewrite downloaded asset paths as relative to the .md file
+          
+          [env: RUST_SCRAPER_OBSIDIAN_RELATIVE_ASSETS=]
+
+      --vault <VAULT>
+          Path to Obsidian vault (auto-detects if not provided)
+          
+          [env: RUST_SCRAPER_OBSIDIAN_VAULT=]
+
+      --quick-save
+          Quick-save mode: save directly to vault _inbox folder
+          
+          [env: RUST_SCRAPER_OBSIDIAN_QUICK_SAVE=]
+
+      --obsidian-rich-metadata
+          Add rich metadata to frontmatter
+          
+          [env: RUST_SCRAPER_OBSIDIAN_RICH_METADATA=]
+
+      --delay-ms <DELAY_MS>
+          Delay between requests in milliseconds
+          
+          [env: RUST_SCRAPER_DELAY_MS=]
+          [default: 1000]
+
+      --max-pages <MAX_PAGES>
+          Maximum pages to scrape
+          
+          [env: RUST_SCRAPER_MAX_PAGES=]
+          [default: 10]
+
+      --concurrency <CONCURRENCY>
+          Concurrency level (auto or number)
+          
+          [env: RUST_SCRAPER_CONCURRENCY=]
+          [default: auto]
+
+      --use-sitemap
+          Use sitemap for URL discovery NOTE: HTTP redirects (301/302) are resolved at scrape-time, not parse-time. This avoids redundant HEAD requests during sitemap parsing for better performance
+          
+          [env: RUST_SCRAPER_USE_SITEMAP=]
+
+      --sitemap-url <SITEMAP_URL>
+          Explicit sitemap URL
+          
+          [env: RUST_SCRAPER_SITEMAP_URL=]
+
+      --single-page
+          Scrape only the seed URL without discovery or crawling
+          
+          [env: RUST_SCRAPER_SINGLE_PAGE=]
+
+      --resume
+          Resume mode - skip URLs already processed
+          
+          [env: RUST_SCRAPER_RESUME=]
+
+      --state-dir <STATE_DIR>
+          Custom state directory for resume mode
+          
+          [env: RUST_SCRAPER_STATE_DIR=]
+
+      --download-images
+          Download images from the page
+          
+          [env: RUST_SCRAPER_DOWNLOAD_IMAGES=]
+
+      --download-documents
+          Download documents from the page
+          
+          [env: RUST_SCRAPER_DOWNLOAD_DOCUMENTS=]
+
+      --download-assets
+          Download all assets (images + documents) from the page
+          
+          [env: RUST_SCRAPER_DOWNLOAD_ASSETS=]
+
+      --tui
+          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
+          
+          [env: RUST_SCRAPER_TUI=]
+
+      --force-js-render
+          Force JavaScript rendering for SPA sites (not yet implemented)
+          
+          [env: RUST_SCRAPER_FORCE_JS_RENDER=]
+
+  -v, --verbose...
+          Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
+          
+          [env: RUST_SCRAPER_VERBOSE=]
+
+  -q, --quiet
+          Quiet mode — suppress info/debug output
+          
+          [env: RUST_SCRAPER_QUIET=]
+
+  -n, --dry-run
+          Dry-run mode — discover URLs and print without scraping
+          
+          [env: RUST_SCRAPER_DRY_RUN=]
+
+      --trace-file <TRACE_FILE>
+          Path to write OTel spans as JSONL for offline debugging
+          
+          [env: RUST_SCRAPER_TRACE_FILE=]
+
+      --max-depth <MAX_DEPTH>
+          Maximum depth to crawl (0 = only seed URL)
+          
+          [env: RUST_SCRAPER_MAX_DEPTH=]
+          [default: 2]
+
+      --timeout-secs <TIMEOUT_SECS>
+          Request timeout in seconds
+          
+          [env: RUST_SCRAPER_TIMEOUT_SECS=]
+          [default: 30]
+
+      --include-pattern <INCLUDE_PATTERNS>
+          URL patterns to include (glob-style)
+          
+          [env: RUST_SCRAPER_INCLUDE=]
+
+      --exclude-pattern <EXCLUDE_PATTERNS>
+          URL patterns to exclude (glob-style)
+          
+          [env: RUST_SCRAPER_EXCLUDE=]
+
+      --asset-naming <ASSET_NAMING>
+          Estrategia de nombre de archivo para assets descargados: hash (default), slug, content-disposition
+          
+          [default: hash]
+          [possible values: hash, slug, content-disposition]
+
+      --download-concurrency <DOWNLOAD_CONCURRENCY>
+          Máximo de descargas de assets concurrentes por página (mínimo 1)
+          
+          [env: RUST_SCRAPER_DOWNLOAD_CONCURRENCY=]
+          [default: 3]
+
+      --max-retries <MAX_RETRIES>
+          Maximum number of retry attempts
+          
+          [env: RUST_SCRAPER_MAX_RETRIES=]
+          [default: 3]
+
+      --backoff-base-ms <BACKOFF_BASE_MS>
+          Base delay for exponential backoff (ms)
+          
+          [env: RUST_SCRAPER_BACKOFF_BASE_MS=]
+          [default: 1000]
+
+      --backoff-max-ms <BACKOFF_MAX_MS>
+          Maximum delay for exponential backoff (ms)
+          
+          [env: RUST_SCRAPER_BACKOFF_MAX_MS=]
+          [default: 10000]
+
+      --accept-language <ACCEPT_LANGUAGE>
+          Accept-Language header value
+          
+          [env: RUST_SCRAPER_ACCEPT_LANGUAGE=]
+          [default: en-US,en;q=0.9]
+
+      --user-agent <USER_AGENT>
+          Custom User-Agent header value (overrides Chrome 145 default)
+          
+          [env: RUST_SCRAPER_USER_AGENT=]
+
+      --max-file-size <MAX_FILE_SIZE>
+          Maximum file size to download in bytes (default: 50MB)
+          
+          [env: RUST_SCRAPER_MAX_FILE_SIZE=]
+          [default: 52428800]
+
+      --download-timeout <DOWNLOAD_TIMEOUT>
+          Timeout for individual asset downloads in seconds
+          
+          [env: RUST_SCRAPER_DOWNLOAD_TIMEOUT=]
+          [default: 30]
+
+      --sitemap-depth <SITEMAP_DEPTH>
+          Maximum recursion depth for sitemap indexes
+          
+          [env: RUST_SCRAPER_SITEMAP_DEPTH=]
+          [default: 3]
+
+      --cpu-cores <CPU_CORES>
+          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
+          
+          [env: RUST_SCRAPER_CPU_CORES=]
+
+      --ram-budget <RAM_BUDGET>
+          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
+          
+          [env: RUST_SCRAPER_RAM_BUDGET=]
+
+      --db-path <DB_PATH>
+          SQLite database path override for persisted resources/chunks
+          
+          [env: RUST_SCRAPER_DB_PATH=]
+
+      --elastic
+          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
+          
+          [env: RUST_SCRAPER_ELASTIC=]
+
+      --output-vectors <OUTPUT_VECTORS>
+          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
+          
+          [env: RUST_SCRAPER_OUTPUT_VECTORS=]
+
+      --checkpoint-interval <CHECKPOINT_INTERVAL>
+          Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
+          
+          [env: RUST_SCRAPER_CHECKPOINT_INTERVAL=]
+          [default: 100]
+
+      --no-checkpoint
+          Disable checkpoint persistence entirely NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
+          
+          [env: RUST_SCRAPER_NO_CHECKPOINT=]
+
+      --ignore-robots
+          Skip robots.txt enforcement
+          
+          [env: RUST_SCRAPER_IGNORE_ROBOTS=]
+
+      --autoscale
+          Enable autoscaled concurrency — dynamically adjusts task concurrency based on RAM usage
+          
+          [env: RUST_SCRAPER_AUTOSCALE=]
+
+      --no-session-health
+          Disable session pool health checks
+          
+          [env: RUST_SCRAPER_NO_SESSION_HEALTH=]
+
+      --h2-profile <H2_PROFILE>
+          TLS/HTTP2 profile name (default: Chrome145)
+          
+          [env: RUST_SCRAPER_H2_PROFILE=]
+          [default: Chrome145]
+
+      --js-strategy <JS_STRATEGY>
+          JavaScript rendering strategy: static (wreq only), hybrid (3-layer), full (Chromiumoxide only)
+
+          Possible values:
+          - static: Static HTTP only (wreq). Fastest, no JS rendering
+          - hybrid: Hybrid 3-layer: wreq → Obscura → Chromiumoxide
+          - full:   Full JS rendering only (Chromiumoxide). Slowest, handles all SPAs
+          
+          [env: RUST_SCRAPER_JS_STRATEGY=]
+          [default: static]
+
+      --obscura-binary <OBSCURA_BINARY>
+          Path to the obscura binary (default: "obscura")
+          
+          [env: RUST_SCRAPER_OBSCURA_BINARY=]
+          [default: obscura]
+
+      --batch
+          Enable batch mode — read URLs from stdin (one per line)
+          
+          [env: RUST_SCRAPER_BATCH=]
+
+      --batch-file <BATCH_FILE>
+          Path to a file containing URLs to crawl (one per line)
+          
+          [env: RUST_SCRAPER_BATCH_FILE=]
+
+      --batch-concurrency <BATCH_CONCURRENCY>
+          Maximum concurrent URLs in batch mode
+          
+          [env: RUST_SCRAPER_BATCH_CONCURRENCY=]
+          [default: 5]
+
+      --pipeline
+          Enable item pipeline processing (validate → clean → output)
+          
+          [env: RUST_SCRAPER_PIPELINE=]
+
+      --pipeline-output <PIPELINE_OUTPUT>
+          Pipeline output format: jsonl (default), none
+
+          Possible values:
+          - jsonl: Write items as JSON Lines to a file (default)
+          - none:  No pipeline output — items are processed but not written
+          
+          [env: RUST_SCRAPER_PIPELINE_OUTPUT=]
+          [default: jsonl]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+EXIT CODES:
+  0    Success
+  2    No URLs discovered
+  69   WAF block or network error
+  74   I/O error
+  76   Protocol error
+  78   Configuration error
+
+EXAMPLES:
+  webfang -u https://example.com
+  webfang -u https://example.com --ai
+  webfang -u https://example.com -f jsonl
+  webfang -u https://example.com -v
+  webfang -u https://example.com -vv  # DEBUG
+  webfang --url-list urls.txt --resume

--- a/tests/snapshots/cli_binary__test_invalid_url_shows_error.snap
+++ b/tests/snapshots/cli_binary__test_invalid_url_shows_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+expression: "redact(Path::new(\"__no_temp__\"), &stderr)"
+---
+Error: Invalid URL: not-a-url

--- a/tests/snapshots/cli_binary__test_no_url_shows_error.snap
+++ b/tests/snapshots/cli_binary__test_no_url_shows_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+expression: "redact(Path::new(\"__no_temp__\"), &stderr)"
+---
+Error: --url is required for scraping
+Error: --url is required

--- a/tests/snapshots/cli_binary__test_quiet_flag_accepted.snap
+++ b/tests/snapshots/cli_binary__test_quiet_flag_accepted.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+expression: "redact(Path::new(\"__no_temp__\"), &stderr)"
+---
+Error: --url is required for scraping
+Error: --url is required

--- a/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+expression: "redact(output_dir.path(), &stderr)"
+---
+  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
+
+  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
+    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
+
+Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
+No pages were successfully scraped
+Error: No pages were successfully scraped

--- a/tests/snapshots/cli_binary__test_version.snap
+++ b/tests/snapshots/cli_binary__test_version.snap
@@ -1,0 +1,5 @@
+---
+source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+expression: "redact(Path::new(\"__no_temp__\"), &stdout)"
+---
+webfang 2.0.0


### PR DESCRIPTION
## PR-1 — Expansion (SDD cli-insta-snapshots)

Second of 4 chained PRs. Targets PR-0 branch (`feat/cli-insta-snapshots-pr0`).

### What this PR does
Migrates the remaining in-scope behavioral/integration tests to `insta` golden-master snapshots:

- **`single_page_test.rs`** — 7 snapshots of markdown/JSON/plaintext outputs
- **`obsidian_test.rs`** — 4 snapshots with `add_filter` for YAML frontmatter dates → `[DATE]`; validates `[[wikilinks]]` generation
- **`cli_binary_test.rs`** — 7 snapshots of CLI binary stdout

### Key decisions
| Decision | Why |
|---|---|
| `filters` feature for Obsidian dates | `redactions` uses Content-path selectors (for JSON/YAML structured data); `add_filter` does regex on raw string snapshots |
| Keep `webfang_path()` | Same `CARGO_BIN_EXE` sibling-crate issue resolved in PR-0 |

### Verification
`cargo nextest run --test behavioral --test cli_binary` → exit 0

### Chain
| PR | Status |
|---|---|
| PR-0 | 🔄 Open (#178) |
| **PR-1 (this)** | 🆕 |
| PR-2 | ⏳ |
| PR-3 | ⏳ |