### PR TITLE
feat(mcp): add CSS selector param, DomInspectorPort DI, selector_service, and integration tests

### DIFF
--- a/crates/rust_scraper_core/src/domain/dom_inspector.rs
+++ b/crates/rust_scraper_core/src/domain/dom_inspector.rs
@@ -7,8 +7,10 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 /// Error kind for CSS selector diagnostics.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SelectorErrorKind {
     /// Selector matched 0 elements in the DOM.
     ZeroMatches,
@@ -19,7 +21,7 @@ pub enum SelectorErrorKind {
 }
 
 /// A closest-match selector suggestion computed via Jaro-Winkler similarity.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SelectorSuggestion {
     /// The suggested selector text (e.g. `.main-content`, `#article`, `article`).
     pub selector: String,
@@ -28,7 +30,7 @@ pub struct SelectorSuggestion {
 }
 
 /// Structural report of a DOM, used for selector diagnostics.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DomStructureReport {
     /// Total element count (capped at the inspector's node-count cap).
     pub element_count: usize,
@@ -45,7 +47,7 @@ pub struct DomStructureReport {
 }
 
 /// Diagnostic information for a failed CSS selector.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SelectorDiagnostic {
     /// What went wrong.
     pub error_kind: SelectorErrorKind,
@@ -56,7 +58,7 @@ pub struct SelectorDiagnostic {
 }
 
 /// Result of CSS selector extraction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExtractResult {
     /// Selector matched one or more elements.
     Matched(String),

--- a/crates/rust_scraper_core/src/infrastructure/scraper/dom_inspector.rs
+++ b/crates/rust_scraper_core/src/infrastructure/scraper/dom_inspector.rs
@@ -171,14 +171,15 @@ impl DomInspectorPort for DefaultDomInspector {
             }
         }
 
-        // Sort common_classes descending by frequency, top 10.
+        // Sort common_classes descending by frequency, then alphabetically for
+        // deterministic output when frequencies are tied. Top 10.
         let mut common_classes: Vec<(String, usize)> = class_counts.into_iter().collect();
-        common_classes.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        common_classes.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         common_classes.truncate(10);
 
-        // Sort common_ids descending by frequency, top 5.
+        // Sort common_ids descending by frequency, then alphabetically. Top 5.
         let mut common_ids: Vec<(String, usize)> = id_counts.into_iter().collect();
-        common_ids.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        common_ids.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         common_ids.truncate(5);
 
         DomStructureReport {

--- a/crates/rust_scraper_mcp/Cargo.toml
+++ b/crates/rust_scraper_mcp/Cargo.toml
@@ -42,6 +42,8 @@ bytes = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 schemars = { workspace = true }
+insta = { workspace = true }
+scraper = { workspace = true }
 
 [lints.clippy]
 doc_markdown = "allow"

--- a/crates/rust_scraper_mcp/src/mcp_server/mod.rs
+++ b/crates/rust_scraper_mcp/src/mcp_server/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod handlers;
 pub mod params;
+pub mod selector_service;
 pub mod server;
 pub mod state;
 

--- a/crates/rust_scraper_mcp/src/mcp_server/mod.rs
+++ b/crates/rust_scraper_mcp/src/mcp_server/mod.rs
@@ -139,16 +139,26 @@ impl McpHandler {
         if params.download_documents == Some(true) {
             config.download_documents = true;
         }
+        // Wire CSS selector (defaults to "body" when not provided)
+        if let Some(ref sel) = params.selector {
+            config.selector = sel.clone();
+        }
 
         let client = self.state.container.http_client().as_ref();
         let dl = self.state.downloader.as_deref();
+        let inspector = self.state.inspector.as_deref();
         match rust_scraper_core::application::scraper_service::scrape_with_config(
-            client, &url, &config, dl, None,
+            client, &url, &config, dl, inspector,
         )
         .await
         {
             Ok(outcome) => {
-                let content = serde_json::to_string_pretty(&outcome.results)
+                let response = selector_service::build_scrape_response(
+                    outcome.results,
+                    &outcome.extract_result,
+                    &params.selector,
+                );
+                let content = serde_json::to_string_pretty(&response)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },

--- a/crates/rust_scraper_mcp/src/mcp_server/params.rs
+++ b/crates/rust_scraper_mcp/src/mcp_server/params.rs
@@ -21,6 +21,13 @@ pub struct ScrapeWithOptionsParams {
     pub download_images: Option<bool>,
     /// Download documents if found (default: false)
     pub download_documents: Option<bool>,
+    /// CSS selector for content extraction (default: "body").
+    ///
+    /// When provided, the scraper extracts only the HTML matching this
+    /// selector. If the selector matches zero elements or is invalid, the
+    /// full page HTML is returned with a diagnostic explaining the failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema, Debug)]

--- a/crates/rust_scraper_mcp/src/mcp_server/selector_service.rs
+++ b/crates/rust_scraper_mcp/src/mcp_server/selector_service.rs
@@ -1,0 +1,282 @@
+//! Selector service — builds MCP JSON responses with selector diagnostics.
+//!
+//! Keeps [`super::mod`] from growing past 1197 lines by delegating the
+//! response-building logic for CSS selector scraping to this module.
+//!
+//! The [`build_scrape_response`] function takes the scrape results, the
+//! [`ExtractResult`] from the selector extraction, and the original selector
+//! parameter, and produces a [`serde_json::Value`] with:
+//! - `results`: the scraped content
+//! - `selector_applied`: whether a CSS selector was provided
+//! - `selector_matched`: whether the selector matched elements
+//! - `diagnostic`: optional diagnostic info (DOM structure + suggestions)
+
+use rust_scraper_core::domain::{ExtractResult, ScrapedContent};
+
+/// Build the MCP scrape response JSON with selector metadata.
+///
+/// # Arguments
+///
+/// * `results` — The scraped content from `scrape_with_config`
+/// * `extract_result` — The selector extraction result (Matched or Fallback)
+/// * `selector` — The original CSS selector parameter (None if not provided)
+///
+/// # Returns
+///
+/// A JSON object with:
+/// - `results`: array of scraped content
+/// - `selector_applied`: `true` if a selector was provided
+/// - `selector_matched`: `true` if the selector matched elements
+/// - `diagnostic`: `null` when matched or no inspector; object on failure
+#[must_use]
+pub fn build_scrape_response(
+    results: Vec<ScrapedContent>,
+    extract_result: &ExtractResult,
+    selector: &Option<String>,
+) -> serde_json::Value {
+    let selector_applied = selector.is_some();
+    let selector_matched = extract_result.is_matched();
+
+    let diagnostic = match extract_result {
+        ExtractResult::Matched(_) => None,
+        ExtractResult::Fallback { diagnostic, .. } => diagnostic.as_ref(),
+    };
+
+    serde_json::json!({
+        "results": results,
+        "selector_applied": selector_applied,
+        "selector_matched": selector_matched,
+        "diagnostic": diagnostic,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_scraper_core::domain::{
+        DomStructureReport, SelectorDiagnostic, SelectorErrorKind, SelectorSuggestion, ValidUrl,
+    };
+    use std::collections::HashMap;
+
+    /// Create a minimal ScrapedContent for testing.
+    fn test_content(title: &str) -> ScrapedContent {
+        ScrapedContent {
+            title: title.to_owned(),
+            content: String::new(),
+            url: ValidUrl::parse("https://example.com").unwrap(),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: Vec::new(),
+            correlation_id: None,
+        }
+    }
+
+    // ── Test 1: Selector matches elements ──────────────────────────
+
+    #[test]
+    fn test_matched_with_selector() {
+        let results = vec![test_content("Article Title")];
+        let extract_result = ExtractResult::Matched("<article>Content</article>".to_owned());
+        let selector = Some("main article".to_owned());
+
+        let json = build_scrape_response(results, &extract_result, &selector);
+
+        assert_eq!(
+            json["selector_applied"], true,
+            "selector_applied must be true"
+        );
+        assert_eq!(
+            json["selector_matched"], true,
+            "selector_matched must be true"
+        );
+        assert!(
+            json["diagnostic"].is_null(),
+            "diagnostic must be null on match"
+        );
+        assert_eq!(
+            json["results"][0]["title"], "Article Title",
+            "results must contain scraped content"
+        );
+    }
+
+    // ── Test 2: Selector zero matches with diagnostic ─────────────
+
+    #[test]
+    fn test_fallback_with_diagnostic() {
+        let results = vec![test_content("Full Page")];
+        let report = DomStructureReport {
+            element_count: 15,
+            truncated: false,
+            tag_counts: HashMap::from([("div".to_owned(), 5), ("p".to_owned(), 8)]),
+            max_depth: 4,
+            common_classes: vec![("main-content".to_owned(), 3)],
+            common_ids: vec![("header".to_owned(), 1)],
+        };
+        let suggestions = vec![SelectorSuggestion {
+            selector: ".main-content".to_owned(),
+            score: 0.85,
+        }];
+        let diagnostic = SelectorDiagnostic {
+            error_kind: SelectorErrorKind::ZeroMatches,
+            report,
+            suggestions,
+        };
+        let extract_result = ExtractResult::Fallback {
+            html: "<html>full page</html>".to_owned(),
+            diagnostic: Some(diagnostic),
+        };
+        let selector = Some(".nonexistent".to_owned());
+
+        let json = build_scrape_response(results, &extract_result, &selector);
+
+        assert_eq!(json["selector_applied"], true);
+        assert_eq!(json["selector_matched"], false);
+        // serde serializes ZeroMatches as the string "ZeroMatches"
+        assert_eq!(
+            json["diagnostic"]["error_kind"], "ZeroMatches",
+            "error_kind must be ZeroMatches"
+        );
+        assert_eq!(
+            json["diagnostic"]["report"]["element_count"], 15,
+            "report must contain element_count"
+        );
+        assert_eq!(
+            json["diagnostic"]["report"]["tag_counts"]["div"], 5,
+            "report must contain tag_counts"
+        );
+        assert_eq!(
+            json["diagnostic"]["suggestions"][0]["selector"], ".main-content",
+            "suggestions must contain closest match"
+        );
+        assert_eq!(
+            json["diagnostic"]["suggestions"][0]["score"], 0.85,
+            "suggestions must contain score"
+        );
+    }
+
+    // ── Test 3: Invalid selector with diagnostic ──────────────────
+
+    #[test]
+    fn test_fallback_invalid_selector() {
+        let results = vec![test_content("Page")];
+        let diagnostic = SelectorDiagnostic {
+            error_kind: SelectorErrorKind::InvalidSelector("unexpected token".to_owned()),
+            report: DomStructureReport::default(),
+            suggestions: Vec::new(),
+        };
+        let extract_result = ExtractResult::Fallback {
+            html: "<html>full</html>".to_owned(),
+            diagnostic: Some(diagnostic),
+        };
+        let selector = Some("div >>> p".to_owned());
+
+        let json = build_scrape_response(results, &extract_result, &selector);
+
+        assert_eq!(json["selector_applied"], true);
+        assert_eq!(json["selector_matched"], false);
+        // serde serializes InvalidSelector("msg") as {"InvalidSelector": "msg"}
+        assert_eq!(
+            json["diagnostic"]["error_kind"]["InvalidSelector"], "unexpected token",
+            "error_kind must be InvalidSelector with message"
+        );
+    }
+
+    // ── Test 4: Fallback without diagnostic (no inspector) ─────────
+
+    #[test]
+    fn test_fallback_no_diagnostic() {
+        let results = vec![test_content("Page")];
+        let extract_result = ExtractResult::Fallback {
+            html: "<html>full</html>".to_owned(),
+            diagnostic: None,
+        };
+        let selector = Some(".missing".to_owned());
+
+        let json = build_scrape_response(results, &extract_result, &selector);
+
+        assert_eq!(json["selector_applied"], true);
+        assert_eq!(json["selector_matched"], false);
+        assert!(
+            json["diagnostic"].is_null(),
+            "diagnostic must be null when no inspector configured"
+        );
+    }
+
+    // ── Test 5: No selector (backward compat) ─────────────────────
+
+    #[test]
+    fn test_no_selector_backward_compat() {
+        let results = vec![test_content("Default Page")];
+        // When no selector is provided, config.selector defaults to "body"
+        // which always matches → ExtractResult::Matched
+        let extract_result = ExtractResult::Matched("<body>default content</body>".to_owned());
+        let selector: Option<String> = None;
+
+        let json = build_scrape_response(results, &extract_result, &selector);
+
+        assert_eq!(
+            json["selector_applied"], false,
+            "selector_applied must be false when no selector provided"
+        );
+        assert_eq!(
+            json["selector_matched"], true,
+            "selector_matched is true because body selector matches"
+        );
+        assert!(
+            json["diagnostic"].is_null(),
+            "diagnostic must be null on match"
+        );
+    }
+
+    // ── Test 6: Empty results with matched selector ───────────────
+
+    #[test]
+    fn test_matched_empty_results() {
+        let results: Vec<ScrapedContent> = Vec::new();
+        let extract_result = ExtractResult::Matched(String::new());
+        let selector = Some("img".to_owned());
+
+        let json = build_scrape_response(results, &extract_result, &selector);
+
+        assert_eq!(json["selector_applied"], true);
+        assert_eq!(json["selector_matched"], true);
+        assert!(
+            json["results"].is_array(),
+            "results must always be an array"
+        );
+        assert_eq!(
+            json["results"].as_array().unwrap().len(),
+            0,
+            "results must be empty array"
+        );
+    }
+
+    // ── Test 7: EmptyDocument error kind ───────────────────────────
+
+    #[test]
+    fn test_fallback_empty_document() {
+        let results: Vec<ScrapedContent> = Vec::new();
+        let diagnostic = SelectorDiagnostic {
+            error_kind: SelectorErrorKind::EmptyDocument,
+            report: DomStructureReport::default(),
+            suggestions: Vec::new(),
+        };
+        let extract_result = ExtractResult::Fallback {
+            html: String::new(),
+            diagnostic: Some(diagnostic),
+        };
+        let selector = Some("article".to_owned());
+
+        let json = build_scrape_response(results, &extract_result, &selector);
+
+        assert_eq!(json["selector_applied"], true);
+        assert_eq!(json["selector_matched"], false);
+        // serde serializes EmptyDocument as the string "EmptyDocument"
+        assert_eq!(
+            json["diagnostic"]["error_kind"], "EmptyDocument",
+            "error_kind must be EmptyDocument"
+        );
+    }
+}

--- a/crates/rust_scraper_mcp/src/mcp_server/state.rs
+++ b/crates/rust_scraper_mcp/src/mcp_server/state.rs
@@ -9,6 +9,7 @@ use tokio::sync::Semaphore;
 
 use rust_scraper_core::adapters::downloader::Downloader;
 use rust_scraper_core::di::Container;
+use rust_scraper_core::domain::DomInspectorPort;
 
 /// Per-category semaphore limits for backpressure.
 /// Tuned for Intel i5-4590 (4C), 8GB DDR3, HDD.
@@ -61,6 +62,8 @@ pub struct McpState {
     pub semaphores: Arc<CategorySemaphores>,
     /// Shared Downloader for connection pooling across MCP tool calls
     pub downloader: Option<Arc<Downloader>>,
+    /// DOM inspector for CSS selector diagnostics (None = no diagnostics)
+    pub inspector: Option<Arc<dyn DomInspectorPort>>,
 }
 
 /// Semaphore instances for each tool category.
@@ -86,6 +89,7 @@ impl McpState {
             limits,
             semaphores,
             downloader: None,
+            inspector: None,
         }
     }
 
@@ -98,6 +102,7 @@ impl McpState {
             limits,
             semaphores,
             downloader: None,
+            inspector: None,
         }
     }
 
@@ -105,6 +110,17 @@ impl McpState {
     #[must_use]
     pub fn with_downloader(mut self, downloader: Arc<Downloader>) -> Self {
         self.downloader = Some(downloader);
+        self
+    }
+
+    /// Set a DOM inspector for CSS selector diagnostics.
+    ///
+    /// When set, failed selector extractions produce a `SelectorDiagnostic`
+    /// with DOM structure analysis and closest-match suggestions.
+    /// When `None` (default), diagnostics are `null` in the response.
+    #[must_use]
+    pub fn with_inspector(mut self, inspector: Arc<dyn DomInspectorPort>) -> Self {
+        self.inspector = Some(inspector);
         self
     }
 }
@@ -129,6 +145,24 @@ impl CategorySemaphores {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_scraper_core::domain::CrawlerConfig;
+    use rust_scraper_core::infrastructure::config::ScraperConfig;
+    use rust_scraper_core::infrastructure::scraper::dom_inspector::NoOpInspector;
+    use tempfile::TempDir;
+
+    /// Build a minimal Container for testing (async, needs a temp output dir).
+    async fn test_container() -> (TempDir, Container) {
+        let tmp = TempDir::new().expect("create temp dir");
+        let crawler_config = CrawlerConfig::new(url::Url::parse("https://example.com").unwrap());
+        let scraper_config = ScraperConfig {
+            output_dir: tmp.path().to_path_buf(),
+            ..Default::default()
+        };
+        let container = Container::new(crawler_config, scraper_config)
+            .await
+            .expect("create test container");
+        (tmp, container)
+    }
 
     #[test]
     fn test_default_limits_are_reasonable() {
@@ -148,5 +182,33 @@ mod tests {
         assert_eq!(semaphores.ai.available_permits(), limits.ai);
         assert_eq!(semaphores.scraping.available_permits(), limits.scraping);
         assert_eq!(semaphores.obsidian.available_permits(), limits.obsidian);
+    }
+
+    #[tokio::test]
+    async fn test_new_state_has_no_inspector() {
+        let (_tmp, container) = test_container().await;
+        let state = McpState::new(container);
+        assert!(state.inspector.is_none(), "inspector must default to None");
+    }
+
+    #[tokio::test]
+    async fn test_with_inspector_sets_inspector() {
+        let (_tmp, container) = test_container().await;
+        let inspector: Arc<dyn DomInspectorPort> = Arc::new(NoOpInspector);
+        let state = McpState::new(container).with_inspector(inspector);
+        assert!(
+            state.inspector.is_some(),
+            "inspector must be set after with_inspector"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_with_limits_has_no_inspector() {
+        let (_tmp, container) = test_container().await;
+        let state = McpState::with_limits(container, CategoryLimits::default());
+        assert!(
+            state.inspector.is_none(),
+            "inspector must default to None in with_limits"
+        );
     }
 }

--- a/crates/rust_scraper_mcp/tests/fixtures/selector_test_page.html
+++ b/crates/rust_scraper_mcp/tests/fixtures/selector_test_page.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Selector Test Page</title>
+</head>
+<body>
+    <header id="header">
+        <h1>Test Page for CSS Selector Diagnostics</h1>
+        <nav class="navigation">
+            <a href="/home">Home</a>
+            <a href="/about">About</a>
+        </nav>
+    </header>
+    <main class="main-content">
+        <article class="post">
+            <h2>First Article</h2>
+            <p>This is the first article content.</p>
+        </article>
+        <article class="post">
+            <h2>Second Article</h2>
+            <p>This is the second article content.</p>
+        </article>
+        <aside class="sidebar">
+            <h3>Related</h3>
+            <ul>
+                <li>Link 1</li>
+                <li>Link 2</li>
+            </ul>
+        </aside>
+    </main>
+    <footer id="footer">
+        <p>&copy; 2024 Test Site</p>
+    </footer>
+</body>
+</html>

--- a/crates/rust_scraper_mcp/tests/selector_integration.rs
+++ b/crates/rust_scraper_mcp/tests/selector_integration.rs
@@ -165,3 +165,37 @@ fn test_scrape_zero_match_no_inspector() {
         "diagnostic must be null without inspector"
     );
 }
+
+// ── Test 6: Empty HTML page → EmptyDocument diagnostic ──────────
+
+#[test]
+fn test_scrape_with_empty_page() {
+    // Simulate an empty HTML page (server returns empty body).
+    // extract_with_selector would produce EmptyDocument (not ZeroMatches)
+    // because html.trim().is_empty() triggers the early return.
+    let html = "";
+    let selector = "article".to_owned();
+    let diagnostic = build_real_diagnostic(html, &selector, SelectorErrorKind::EmptyDocument);
+    let extract_result = ExtractResult::Fallback {
+        html: html.to_owned(),
+        diagnostic: Some(diagnostic),
+    };
+    let results = vec![make_content("Empty Page")];
+
+    let json = build_scrape_response(results, &extract_result, &Some(selector));
+
+    assert_eq!(
+        json["selector_applied"], true,
+        "selector_applied must be true when a selector is provided"
+    );
+    assert_eq!(
+        json["selector_matched"], false,
+        "selector_matched must be false for an empty page"
+    );
+    assert_eq!(
+        json["diagnostic"]["error_kind"], "EmptyDocument",
+        "error_kind must be EmptyDocument for empty HTML"
+    );
+
+    insta::assert_snapshot!("empty_page", pretty(json));
+}

--- a/crates/rust_scraper_mcp/tests/selector_integration.rs
+++ b/crates/rust_scraper_mcp/tests/selector_integration.rs
@@ -1,0 +1,167 @@
+//! Integration tests for CSS selector scraping with diagnostics.
+//!
+//! Tests the full pipeline: HTML fixture → DefaultDomInspector →
+//! build_scrape_response → JSON output with selector metadata.
+//!
+//! These tests verify that the MCP response includes:
+//! - `selector_applied`: whether a selector was provided
+//! - `selector_matched`: whether the selector matched elements
+//! - `diagnostic`: DOM structure report + suggestions on failure
+
+use rust_scraper_core::domain::{
+    DomInspectorPort, ExtractResult, ScrapedContent, SelectorDiagnostic, SelectorErrorKind,
+    ValidUrl,
+};
+use rust_scraper_core::infrastructure::scraper::dom_inspector::DefaultDomInspector;
+use rust_scraper_mcp::mcp_server::selector_service::build_scrape_response;
+
+/// Load the HTML fixture for testing.
+fn fixture_html() -> String {
+    std::fs::read_to_string("tests/fixtures/selector_test_page.html").expect("read fixture HTML")
+}
+
+/// Create a minimal ScrapedContent for testing.
+fn make_content(title: &str) -> ScrapedContent {
+    ScrapedContent {
+        title: title.to_owned(),
+        content: String::new(),
+        url: ValidUrl::parse("https://example.com").unwrap(),
+        excerpt: None,
+        author: None,
+        date: None,
+        html: None,
+        assets: Vec::new(),
+        correlation_id: None,
+    }
+}
+
+/// Extract elements matching a CSS selector from HTML.
+/// Returns `Ok(html)` if matched, `Err(SelectorErrorKind)` on failure.
+fn try_select(html: &str, selector: &str) -> Result<String, SelectorErrorKind> {
+    let document = scraper::Html::parse_document(html);
+    match scraper::Selector::parse(selector) {
+        Ok(sel) => {
+            let matching: Vec<String> = document.select(&sel).map(|el| el.html()).collect();
+            if matching.is_empty() {
+                Err(SelectorErrorKind::ZeroMatches)
+            } else {
+                Ok(matching.join("\n"))
+            }
+        },
+        Err(e) => Err(SelectorErrorKind::InvalidSelector(e.to_string())),
+    }
+}
+
+/// Build a real diagnostic using DefaultDomInspector on the fixture HTML.
+fn build_real_diagnostic(
+    html: &str,
+    selector: &str,
+    error_kind: SelectorErrorKind,
+) -> SelectorDiagnostic {
+    let inspector = DefaultDomInspector::new();
+    let document = scraper::Html::parse_document(html);
+    let report = inspector.inspect(&document);
+    let suggestions = inspector.suggest(&document, selector);
+    SelectorDiagnostic {
+        error_kind,
+        report,
+        suggestions,
+    }
+}
+
+/// Pretty-print a serde_json::Value for snapshot comparison.
+fn pretty(json: serde_json::Value) -> String {
+    serde_json::to_string_pretty(&json).unwrap_or_else(|_| "serialization failed".into())
+}
+
+// ── Test 1: Selector provided and matches elements ──────────────
+
+#[test]
+fn test_scrape_with_matching_selector() {
+    let html = fixture_html();
+    let selector = "main article".to_owned();
+    let matched_html = try_select(&html, &selector).expect("selector should match");
+    let extract_result = ExtractResult::Matched(matched_html);
+    let results = vec![make_content("Article Title")];
+
+    let json = build_scrape_response(results, &extract_result, &Some(selector));
+
+    insta::assert_snapshot!("matching_selector", pretty(json));
+}
+
+// ── Test 2: Selector provided but 0 matches ─────────────────────
+
+#[test]
+fn test_scrape_with_zero_match_selector() {
+    let html = fixture_html();
+    let selector = ".nonexistent".to_owned();
+    let error_kind = try_select(&html, &selector).expect_err("should be zero matches");
+    let diagnostic = build_real_diagnostic(&html, &selector, error_kind);
+    let extract_result = ExtractResult::Fallback {
+        html: html.clone(),
+        diagnostic: Some(diagnostic),
+    };
+    let results = vec![make_content("Full Page")];
+
+    let json = build_scrape_response(results, &extract_result, &Some(selector));
+
+    insta::assert_snapshot!("zero_match_selector", pretty(json));
+}
+
+// ── Test 3: Invalid CSS selector ─────────────────────────────────
+
+#[test]
+fn test_scrape_with_invalid_selector() {
+    let html = fixture_html();
+    let selector = "div >>> p".to_owned();
+    let error_kind = try_select(&html, &selector).expect_err("should be invalid selector");
+    let diagnostic = build_real_diagnostic(&html, &selector, error_kind);
+    let extract_result = ExtractResult::Fallback {
+        html: html.clone(),
+        diagnostic: Some(diagnostic),
+    };
+    let results = vec![make_content("Page")];
+
+    let json = build_scrape_response(results, &extract_result, &Some(selector));
+
+    insta::assert_snapshot!("invalid_selector", pretty(json));
+}
+
+// ── Test 4: No selector provided (backward compat) ──────────────
+
+#[test]
+fn test_scrape_without_selector_backward_compat() {
+    let html = fixture_html();
+    // When no selector is provided, config.selector defaults to "body"
+    // which always matches → ExtractResult::Matched
+    let extract_result = ExtractResult::Matched(html);
+    let results = vec![make_content("Default Page")];
+    let selector: Option<String> = None;
+
+    let json = build_scrape_response(results, &extract_result, &selector);
+
+    insta::assert_snapshot!("no_selector_backward_compat", pretty(json));
+}
+
+// ── Test 5: Zero matches without inspector (diagnostic null) ─────
+
+#[test]
+fn test_scrape_zero_match_no_inspector() {
+    let html = fixture_html();
+    let selector = ".missing-class".to_owned();
+    // No inspector configured → diagnostic: null
+    let extract_result = ExtractResult::Fallback {
+        html: html.clone(),
+        diagnostic: None,
+    };
+    let results = vec![make_content("Page")];
+
+    let json = build_scrape_response(results, &extract_result, &Some(selector));
+
+    assert_eq!(json["selector_applied"], true);
+    assert_eq!(json["selector_matched"], false);
+    assert!(
+        json["diagnostic"].is_null(),
+        "diagnostic must be null without inspector"
+    );
+}

--- a/crates/rust_scraper_mcp/tests/snapshots/selector_integration__empty_page.snap
+++ b/crates/rust_scraper_mcp/tests/snapshots/selector_integration__empty_page.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rust_scraper_mcp/tests/selector_integration.rs
+assertion_line: 200
+expression: pretty(json)
+---
+{
+  "diagnostic": {
+    "error_kind": "EmptyDocument",
+    "report": {
+      "common_classes": [],
+      "common_ids": [],
+      "element_count": 3,
+      "max_depth": 2,
+      "tag_counts": {
+        "body": 1,
+        "head": 1,
+        "html": 1
+      },
+      "truncated": false
+    },
+    "suggestions": []
+  },
+  "results": [
+    {
+      "author": null,
+      "content": "",
+      "date": null,
+      "excerpt": null,
+      "title": "Empty Page",
+      "url": "https://example.com/"
+    }
+  ],
+  "selector_applied": true,
+  "selector_matched": false
+}

--- a/crates/rust_scraper_mcp/tests/snapshots/selector_integration__invalid_selector.snap
+++ b/crates/rust_scraper_mcp/tests/snapshots/selector_integration__invalid_selector.snap
@@ -1,0 +1,77 @@
+---
+source: crates/rust_scraper_mcp/tests/selector_integration.rs
+expression: pretty(json)
+---
+{
+  "diagnostic": {
+    "error_kind": {
+      "InvalidSelector": "Unexpected error occurred. Please report this to the developer\nDanglingCombinator"
+    },
+    "report": {
+      "common_classes": [
+        [
+          "post",
+          2
+        ],
+        [
+          "main-content",
+          1
+        ],
+        [
+          "navigation",
+          1
+        ],
+        [
+          "sidebar",
+          1
+        ]
+      ],
+      "common_ids": [
+        [
+          "footer",
+          1
+        ],
+        [
+          "header",
+          1
+        ]
+      ],
+      "element_count": 25,
+      "max_depth": 6,
+      "tag_counts": {
+        "a": 2,
+        "article": 2,
+        "aside": 1,
+        "body": 1,
+        "footer": 1,
+        "h1": 1,
+        "h2": 2,
+        "h3": 1,
+        "head": 1,
+        "header": 1,
+        "html": 1,
+        "li": 2,
+        "main": 1,
+        "meta": 2,
+        "nav": 1,
+        "p": 3,
+        "title": 1,
+        "ul": 1
+      },
+      "truncated": false
+    },
+    "suggestions": []
+  },
+  "results": [
+    {
+      "author": null,
+      "content": "",
+      "date": null,
+      "excerpt": null,
+      "title": "Page",
+      "url": "https://example.com/"
+    }
+  ],
+  "selector_applied": true,
+  "selector_matched": false
+}

--- a/crates/rust_scraper_mcp/tests/snapshots/selector_integration__matching_selector.snap
+++ b/crates/rust_scraper_mcp/tests/snapshots/selector_integration__matching_selector.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rust_scraper_mcp/tests/selector_integration.rs
+expression: pretty(json)
+---
+{
+  "diagnostic": null,
+  "results": [
+    {
+      "author": null,
+      "content": "",
+      "date": null,
+      "excerpt": null,
+      "title": "Article Title",
+      "url": "https://example.com/"
+    }
+  ],
+  "selector_applied": true,
+  "selector_matched": true
+}

--- a/crates/rust_scraper_mcp/tests/snapshots/selector_integration__no_selector_backward_compat.snap
+++ b/crates/rust_scraper_mcp/tests/snapshots/selector_integration__no_selector_backward_compat.snap
@@ -1,0 +1,19 @@
+---
+source: crates/rust_scraper_mcp/tests/selector_integration.rs
+expression: pretty(json)
+---
+{
+  "diagnostic": null,
+  "results": [
+    {
+      "author": null,
+      "content": "",
+      "date": null,
+      "excerpt": null,
+      "title": "Default Page",
+      "url": "https://example.com/"
+    }
+  ],
+  "selector_applied": false,
+  "selector_matched": true
+}

--- a/crates/rust_scraper_mcp/tests/snapshots/selector_integration__zero_match_selector.snap
+++ b/crates/rust_scraper_mcp/tests/snapshots/selector_integration__zero_match_selector.snap
@@ -1,0 +1,88 @@
+---
+source: crates/rust_scraper_mcp/tests/selector_integration.rs
+expression: pretty(json)
+---
+{
+  "diagnostic": {
+    "error_kind": "ZeroMatches",
+    "report": {
+      "common_classes": [
+        [
+          "post",
+          2
+        ],
+        [
+          "main-content",
+          1
+        ],
+        [
+          "navigation",
+          1
+        ],
+        [
+          "sidebar",
+          1
+        ]
+      ],
+      "common_ids": [
+        [
+          "footer",
+          1
+        ],
+        [
+          "header",
+          1
+        ]
+      ],
+      "element_count": 25,
+      "max_depth": 6,
+      "tag_counts": {
+        "a": 2,
+        "article": 2,
+        "aside": 1,
+        "body": 1,
+        "footer": 1,
+        "h1": 1,
+        "h2": 2,
+        "h3": 1,
+        "head": 1,
+        "header": 1,
+        "html": 1,
+        "li": 2,
+        "main": 1,
+        "meta": 2,
+        "nav": 1,
+        "p": 3,
+        "title": 1,
+        "ul": 1
+      },
+      "truncated": false
+    },
+    "suggestions": [
+      {
+        "score": 0.766025641025641,
+        "selector": ".main-content"
+      },
+      {
+        "score": 0.74,
+        "selector": ".post"
+      },
+      {
+        "score": 0.6237373737373737,
+        "selector": ".navigation"
+      }
+    ]
+  },
+  "results": [
+    {
+      "author": null,
+      "content": "",
+      "date": null,
+      "excerpt": null,
+      "title": "Full Page",
+      "url": "https://example.com/"
+    }
+  ],
+  "selector_applied": true,
+  "selector_matched": false
+}


### PR DESCRIPTION
## Summary

- Add `selector: Option<String>` to `ScrapeWithOptionsParams` (backward compatible)
- Add `inspector: Option<Arc<dyn DomInspectorPort>>` to `McpState` with builder pattern
- Create `selector_service.rs` for diagnostic response building (keeps mod.rs from growing)
- Wire selector + inspector into `scrape_with_options` handler
- Add 5 integration tests with insta snapshots (match, zero-match, invalid, backward compat, empty page)

Closes #185

## Changes

| File | Change |
|------|--------|
| `crates/rust_scraper_mcp/src/mcp_server/params.rs` | Add `selector: Option<String>` |
| `crates/rust_scraper_mcp/src/mcp_server/state.rs` | Add `inspector` field + builder |
| `crates/rust_scraper_mcp/src/mcp_server/selector_service.rs` | NEW — response building |
| `crates/rust_scraper_mcp/src/mcp_server/mod.rs` | Wire selector + inspector |
| `crates/rust_scraper_mcp/tests/selector_integration.rs` | NEW — 5 integration tests |
| `crates/rust_scraper_mcp/tests/snapshots/*.snap` | NEW — insta snapshots |

## Test Plan

- [x] 15 new tests pass (3 state + 7 selector_service + 5 integration)
- [x] All 1485 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean

## Chain Context

| Field | Value |
|-------|-------|
| Chain | mcp-css-selector |
| Position | 4 of 4 (final) |
| Base | `feat/mcp-selector-app` |
| Depends on | PR1 + PR2 + PR3 |
| Follow-up | None (merge tracker to main) |
| Review budget | ~700 / 800 |

### Scope
- Includes: MCP wiring, selector_service, integration tests
- Excludes: Nothing (this is the final PR)

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit