### PR TITLE
fix(cli): 3 bugs found during comprehensive CLI testing — sitemap, vector export, batch hang

### DIFF
--- a/crates/rust_scraper_core/Cargo.toml
+++ b/crates/rust_scraper_core/Cargo.toml
@@ -181,6 +181,10 @@ path = "../../tests/cli_binary_test.rs"
 name = "cli_behavioral"
 path = "../../tests/cli_behavioral_test.rs"
 
+[[test]]
+name = "stream_repository_jsonl"
+path = "../../tests/stream_repository_jsonl.rs"
+
 [lints.clippy]
 doc_markdown = "allow"
 uninlined_format_args = "allow"

--- a/crates/rust_scraper_core/src/application/crawler/discovery.rs
+++ b/crates/rust_scraper_core/src/application/crawler/discovery.rs
@@ -543,9 +543,8 @@ async fn crawl_with_sitemap_internal(
                     tracing::info!("Discovered sitemap URL: {}", url);
                     url
                 },
-                Err(CrawlError::SitemapNotFound(_)) => {
-                    tracing::warn!("no sitemap found, switching to standard crawling");
-                    return Ok(Vec::new());
+                Err(CrawlError::SitemapNotFound(url)) => {
+                    return Err(CrawlError::SitemapNotFound(url));
                 },
                 Err(e) => return Err(e),
             }

--- a/crates/rust_scraper_core/src/application/crawler/engine.rs
+++ b/crates/rust_scraper_core/src/application/crawler/engine.rs
@@ -123,6 +123,9 @@ pub struct Engine {
     output_stages: Vec<Arc<Box<dyn OutputStage>>>,
     /// Optional autoscale level for RAM-aware concurrency adjustment.
     autoscale_level: Option<Arc<SharedConcurrencyLevel>>,
+    /// Handle for the signal handler task — aborted on shutdown
+    /// to prevent the tokio runtime from hanging waiting for it.
+    signal_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Engine {
@@ -175,6 +178,7 @@ impl Engine {
             pipeline: None,
             output_stages: Vec::new(),
             autoscale_level: None,
+            signal_handle: None,
         })
     }
 
@@ -326,7 +330,11 @@ impl Engine {
     }
 
     /// Spawn a signal handler that sets the shutdown flag on SIGINT/SIGTERM.
-    fn spawn_signal_handler(shutdown: ShutdownSignal) {
+    ///
+    /// Returns the [`JoinHandle`] so the caller can abort it on shutdown.
+    /// Without this, the tokio runtime hangs waiting for a task that never
+    /// completes (e.g. in batch mode where no signal is sent).
+    fn spawn_signal_handler(shutdown: ShutdownSignal) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let ctrl_c = tokio::signal::ctrl_c();
             #[cfg(unix)]
@@ -349,7 +357,7 @@ impl Engine {
                 info!("Received interrupt — initiating graceful shutdown");
             }
             shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
-        });
+        })
     }
 
     /// Record a URL as visited (both hash dedup and string tracking).
@@ -370,8 +378,8 @@ impl Engine {
     pub async fn run(&mut self) -> Result<CrawlResult, CrawlError> {
         let config_clone = Arc::clone(&self.config);
 
-        // Spawn signal handler for graceful shutdown
-        Self::spawn_signal_handler(Arc::clone(&self.shutdown));
+        // Spawn signal handler for graceful shutdown — store handle to abort on drop
+        self.signal_handle = Some(Self::spawn_signal_handler(Arc::clone(&self.shutdown)));
 
         // Load checkpoint state if resuming
         if let Some(ref cp) = self.checkpoint {
@@ -751,6 +759,13 @@ impl Engine {
 
     /// Graceful shutdown — drop the collector sender, receiver drains remaining items
     pub async fn shutdown(mut self) {
+        // Abort the signal handler to prevent the runtime from hanging
+        // waiting for a task that never completes (e.g. batch mode exits
+        // without a signal ever being sent).
+        if let Some(handle) = self.signal_handle.take() {
+            handle.abort();
+        }
+
         // Save checkpoint before shutting down
         self.save_checkpoint().await;
 

--- a/crates/rust_scraper_core/src/infrastructure/stream/mod.rs
+++ b/crates/rust_scraper_core/src/infrastructure/stream/mod.rs
@@ -95,6 +95,14 @@ impl StreamRepository {
         let boxed: Box<dyn Write + Send> = if path == "-" {
             Box::new(std::io::stdout())
         } else {
+            if let Some(parent) = std::path::Path::new(path).parent() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    ScraperError::Io(std::io::Error::new(
+                        e.kind(),
+                        format!("no se pudo crear el directorio '{}': {e}", parent.display()),
+                    ))
+                })?;
+            }
             Box::new(std::fs::File::create(path).map_err(|e| {
                 ScraperError::Io(std::io::Error::new(
                     e.kind(),

--- a/crates/rust_scraper_core/tests/exit_code_integration.rs
+++ b/crates/rust_scraper_core/tests/exit_code_integration.rs
@@ -233,3 +233,67 @@ async fn test_sitemap_not_found_propagates_error() {
         },
     }
 }
+
+// ============================================================================
+// Tests: Engine signal handler abort — no hang on shutdown (Bug #191 fix)
+// ============================================================================
+
+/// Exercise crawl_site_with_options with a small crawl that completes
+/// naturally. The fix ensures the signal handler's JoinHandle is aborted
+/// in engine.shutdown(), preventing the runtime from hanging.
+///
+/// Before the fix: tokio runtime hangs waiting for the orphaned signal
+/// handler task to complete (which never happens since no signal is sent).
+/// After the fix: shutdown aborts the signal handler, runtime exits cleanly.
+#[tokio::test]
+async fn test_crawl_completes_without_signal_handler_hang() {
+    let mock_server = MockServer::start().await;
+    let server_uri = mock_server.uri();
+
+    Mock::given(method("GET"))
+        .and(path("/index.html"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><h1>Single Page</h1></body></html>"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let seed = url::Url::parse(&format!("{server_uri}/index.html")).expect("valid URL");
+    let config = rust_scraper_core::domain::CrawlerConfig::builder(seed)
+        .max_depth(0)
+        .max_pages(1)
+        .delay_ms(1)
+        .concurrency(1)
+        .timeout_secs(5)
+        .build();
+
+    let options = rust_scraper_core::application::crawler::engine::EngineOptions {
+        checkpoint_path: None,
+        session_pool_enabled: false,
+        ignore_robots: true,
+        js_strategy: rust_scraper_core::domain::JsStrategy::Static,
+        autoscale_enabled: false,
+    };
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        rust_scraper_core::crawl_site_with_options(config, options),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(crawl_result)) => {
+            assert!(
+                crawl_result.total_pages > 0,
+                "crawl should have completed at least 1 page"
+            );
+        },
+        Ok(Err(e)) => {
+            panic!("crawl should succeed, got error: {e:?}");
+        },
+        Err(_elapsed) => {
+            panic!("crawl timed out after 10s — possible signal handler hang");
+        },
+    }
+}

--- a/crates/rust_scraper_core/tests/exit_code_integration.rs
+++ b/crates/rust_scraper_core/tests/exit_code_integration.rs
@@ -185,3 +185,51 @@ async fn test_valid_sitemap_returns_exit_0() {
         .assert()
         .code(0);
 }
+
+// ============================================================================
+// Tests: SitemapNotFound propagation (Bug #191 fix)
+// ============================================================================
+
+/// When no sitemap is found at any location, crawl_with_sitemap must return
+/// Err(CrawlError::SitemapNotFound) — NOT Ok(vec![]) as pre-fix behavior did.
+///
+/// wiremock returns 404 for all unregistered paths, so discover_sitemap_url
+/// exhausts robots.txt + fallback locations and returns SitemapNotFound.
+/// crawl_with_sitemap must propagate this instead of silently returning empty.
+#[tokio::test]
+async fn test_sitemap_not_found_propagates_error() {
+    let mock_server = MockServer::start().await;
+    let base_url = format!("{}/", mock_server.uri());
+
+    let seed = url::Url::parse(&format!("{base_url}index.html")).expect("valid seed URL");
+    let config = rust_scraper_core::domain::CrawlerConfig::builder(seed)
+        .max_pages(5)
+        .delay_ms(1)
+        .timeout_secs(5)
+        .build();
+
+    let result = rust_scraper_core::application::crawler::discovery::crawl_with_sitemap(
+        &base_url, None, &config,
+    )
+    .await;
+
+    match result {
+        Err(rust_scraper_core::domain::CrawlError::SitemapNotFound(url)) => {
+            assert!(url.contains(
+                &mock_server
+                    .uri()
+                    .replace("http://", "")
+                    .replace("https://", "")
+            ));
+        },
+        Ok(urls) => {
+            panic!(
+                "expected SitemapNotFound error, got Ok with {} URLs",
+                urls.len()
+            );
+        },
+        Err(e) => {
+            panic!("expected SitemapNotFound error, got {:?}", e);
+        },
+    }
+}

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -2,13 +2,13 @@
 source: crates/rust_scraper_core/../../tests/behavioral/main.rs
 expression: value.into()
 ---
-CLI Arguments for the rust_scraper binary.
+CLI Arguments for the webfang binary.
 
 # Examples
 
-```no_run use rust_scraper::Args; use clap::Parser;
+```no_run use webfang::Args; use clap::Parser;
 
-let args = Args::parse_from([ "rust_scraper", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
+let args = Args::parse_from([ "webfang", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
 
 assert_eq!(args.url, "https://example.com"); ```
 
@@ -23,18 +23,18 @@ Options:
   -u, --url <URL>
           URL to scrape (required unless using a subcommand)
           
-          [env: RUST_SCRAPER_URL=]
+          [env: WEBFANG_URL=]
 
   -s, --selector <SELECTOR>
           CSS selector for content extraction
           
-          [env: RUST_SCRAPER_SELECTOR=]
+          [env: WEBFANG_SELECTOR=]
           [default: body]
 
   -o, --output <OUTPUT>
           Output directory for scraped content
           
-          [env: RUST_SCRAPER_OUTPUT=]
+          [env: WEBFANG_OUTPUT=]
           [default: output]
 
   -f, --format <FORMAT>
@@ -45,7 +45,7 @@ Options:
           - json:     Structured JSON with metadata
           - text:     Plain text without formatting
           
-          [env: RUST_SCRAPER_FORMAT=]
+          [env: WEBFANG_FORMAT=]
           [default: markdown]
 
       --export-format <EXPORT_FORMAT>
@@ -56,148 +56,148 @@ Options:
           - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
           - auto:   Auto-detect format from existing export files
           
-          [env: RUST_SCRAPER_EXPORT_FORMAT=]
+          [env: WEBFANG_EXPORT_FORMAT=]
           [default: jsonl]
 
       --obsidian-wiki-links
           Convert same-domain links to Obsidian [[wiki-link]] syntax
           
-          [env: RUST_SCRAPER_OBSIDIAN_WIKI_LINKS=]
+          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
 
       --obsidian-tags <OBSIDIAN_TAGS>
           Tags to include in YAML frontmatter (comma-separated)
           
-          [env: RUST_SCRAPER_OBSIDIAN_TAGS=]
+          [env: WEBFANG_OBSIDIAN_TAGS=]
 
       --obsidian-relative-assets
           Rewrite downloaded asset paths as relative to the .md file
           
-          [env: RUST_SCRAPER_OBSIDIAN_RELATIVE_ASSETS=]
+          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
 
       --vault <VAULT>
           Path to Obsidian vault (auto-detects if not provided)
           
-          [env: RUST_SCRAPER_OBSIDIAN_VAULT=]
+          [env: WEBFANG_OBSIDIAN_VAULT=]
 
       --quick-save
           Quick-save mode: save directly to vault _inbox folder
           
-          [env: RUST_SCRAPER_OBSIDIAN_QUICK_SAVE=]
+          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
 
       --obsidian-rich-metadata
           Add rich metadata to frontmatter
           
-          [env: RUST_SCRAPER_OBSIDIAN_RICH_METADATA=]
+          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
           
-          [env: RUST_SCRAPER_DELAY_MS=]
+          [env: WEBFANG_DELAY_MS=]
           [default: 1000]
 
       --max-pages <MAX_PAGES>
           Maximum pages to scrape
           
-          [env: RUST_SCRAPER_MAX_PAGES=]
+          [env: WEBFANG_MAX_PAGES=]
           [default: 10]
 
       --concurrency <CONCURRENCY>
           Concurrency level (auto or number)
           
-          [env: RUST_SCRAPER_CONCURRENCY=]
+          [env: WEBFANG_CONCURRENCY=]
           [default: auto]
 
       --use-sitemap
           Use sitemap for URL discovery NOTE: HTTP redirects (301/302) are resolved at scrape-time, not parse-time. This avoids redundant HEAD requests during sitemap parsing for better performance
           
-          [env: RUST_SCRAPER_USE_SITEMAP=]
+          [env: WEBFANG_USE_SITEMAP=]
 
       --sitemap-url <SITEMAP_URL>
           Explicit sitemap URL
           
-          [env: RUST_SCRAPER_SITEMAP_URL=]
+          [env: WEBFANG_SITEMAP_URL=]
 
       --single-page
           Scrape only the seed URL without discovery or crawling
           
-          [env: RUST_SCRAPER_SINGLE_PAGE=]
+          [env: WEBFANG_SINGLE_PAGE=]
 
       --resume
           Resume mode - skip URLs already processed
           
-          [env: RUST_SCRAPER_RESUME=]
+          [env: WEBFANG_RESUME=]
 
       --state-dir <STATE_DIR>
           Custom state directory for resume mode
           
-          [env: RUST_SCRAPER_STATE_DIR=]
+          [env: WEBFANG_STATE_DIR=]
 
       --download-images
           Download images from the page
           
-          [env: RUST_SCRAPER_DOWNLOAD_IMAGES=]
+          [env: WEBFANG_DOWNLOAD_IMAGES=]
 
       --download-documents
           Download documents from the page
           
-          [env: RUST_SCRAPER_DOWNLOAD_DOCUMENTS=]
+          [env: WEBFANG_DOWNLOAD_DOCUMENTS=]
 
       --download-assets
           Download all assets (images + documents) from the page
           
-          [env: RUST_SCRAPER_DOWNLOAD_ASSETS=]
+          [env: WEBFANG_DOWNLOAD_ASSETS=]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping
           
-          [env: RUST_SCRAPER_TUI=]
+          [env: WEBFANG_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
           
-          [env: RUST_SCRAPER_FORCE_JS_RENDER=]
+          [env: WEBFANG_FORCE_JS_RENDER=]
 
   -v, --verbose...
           Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
           
-          [env: RUST_SCRAPER_VERBOSE=]
+          [env: WEBFANG_VERBOSE=]
 
   -q, --quiet
           Quiet mode — suppress info/debug output
           
-          [env: RUST_SCRAPER_QUIET=]
+          [env: WEBFANG_QUIET=]
 
   -n, --dry-run
           Dry-run mode — discover URLs and print without scraping
           
-          [env: RUST_SCRAPER_DRY_RUN=]
+          [env: WEBFANG_DRY_RUN=]
 
       --trace-file <TRACE_FILE>
           Path to write OTel spans as JSONL for offline debugging
           
-          [env: RUST_SCRAPER_TRACE_FILE=]
+          [env: WEBFANG_TRACE_FILE=]
 
       --max-depth <MAX_DEPTH>
           Maximum depth to crawl (0 = only seed URL)
           
-          [env: RUST_SCRAPER_MAX_DEPTH=]
+          [env: WEBFANG_MAX_DEPTH=]
           [default: 2]
 
       --timeout-secs <TIMEOUT_SECS>
           Request timeout in seconds
           
-          [env: RUST_SCRAPER_TIMEOUT_SECS=]
+          [env: WEBFANG_TIMEOUT_SECS=]
           [default: 30]
 
       --include-pattern <INCLUDE_PATTERNS>
           URL patterns to include (glob-style)
           
-          [env: RUST_SCRAPER_INCLUDE=]
+          [env: WEBFANG_INCLUDE=]
 
       --exclude-pattern <EXCLUDE_PATTERNS>
           URL patterns to exclude (glob-style)
           
-          [env: RUST_SCRAPER_EXCLUDE=]
+          [env: WEBFANG_EXCLUDE=]
 
       --asset-naming <ASSET_NAMING>
           Estrategia de nombre de archivo para assets descargados: hash (default), slug, content-disposition
@@ -208,111 +208,111 @@ Options:
       --download-concurrency <DOWNLOAD_CONCURRENCY>
           Máximo de descargas de assets concurrentes por página (mínimo 1)
           
-          [env: RUST_SCRAPER_DOWNLOAD_CONCURRENCY=]
+          [env: WEBFANG_DOWNLOAD_CONCURRENCY=]
           [default: 3]
 
       --max-retries <MAX_RETRIES>
           Maximum number of retry attempts
           
-          [env: RUST_SCRAPER_MAX_RETRIES=]
+          [env: WEBFANG_MAX_RETRIES=]
           [default: 3]
 
       --backoff-base-ms <BACKOFF_BASE_MS>
           Base delay for exponential backoff (ms)
           
-          [env: RUST_SCRAPER_BACKOFF_BASE_MS=]
+          [env: WEBFANG_BACKOFF_BASE_MS=]
           [default: 1000]
 
       --backoff-max-ms <BACKOFF_MAX_MS>
           Maximum delay for exponential backoff (ms)
           
-          [env: RUST_SCRAPER_BACKOFF_MAX_MS=]
+          [env: WEBFANG_BACKOFF_MAX_MS=]
           [default: 10000]
 
       --accept-language <ACCEPT_LANGUAGE>
           Accept-Language header value
           
-          [env: RUST_SCRAPER_ACCEPT_LANGUAGE=]
+          [env: WEBFANG_ACCEPT_LANGUAGE=]
           [default: en-US,en;q=0.9]
 
       --user-agent <USER_AGENT>
           Custom User-Agent header value (overrides Chrome 145 default)
           
-          [env: RUST_SCRAPER_USER_AGENT=]
+          [env: WEBFANG_USER_AGENT=]
 
       --max-file-size <MAX_FILE_SIZE>
           Maximum file size to download in bytes (default: 50MB)
           
-          [env: RUST_SCRAPER_MAX_FILE_SIZE=]
+          [env: WEBFANG_MAX_FILE_SIZE=]
           [default: 52428800]
 
       --download-timeout <DOWNLOAD_TIMEOUT>
           Timeout for individual asset downloads in seconds
           
-          [env: RUST_SCRAPER_DOWNLOAD_TIMEOUT=]
+          [env: WEBFANG_DOWNLOAD_TIMEOUT=]
           [default: 30]
 
       --sitemap-depth <SITEMAP_DEPTH>
           Maximum recursion depth for sitemap indexes
           
-          [env: RUST_SCRAPER_SITEMAP_DEPTH=]
+          [env: WEBFANG_SITEMAP_DEPTH=]
           [default: 3]
 
       --cpu-cores <CPU_CORES>
           CPU core override for the elastic ingestion Rayon pool (else auto-detect)
           
-          [env: RUST_SCRAPER_CPU_CORES=]
+          [env: WEBFANG_CPU_CORES=]
 
       --ram-budget <RAM_BUDGET>
           RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
           
-          [env: RUST_SCRAPER_RAM_BUDGET=]
+          [env: WEBFANG_RAM_BUDGET=]
 
       --db-path <DB_PATH>
           SQLite database path override for persisted resources/chunks
           
-          [env: RUST_SCRAPER_DB_PATH=]
+          [env: WEBFANG_DB_PATH=]
 
       --elastic
           Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
           
-          [env: RUST_SCRAPER_ELASTIC=]
+          [env: WEBFANG_ELASTIC=]
 
       --output-vectors <OUTPUT_VECTORS>
           Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
           
-          [env: RUST_SCRAPER_OUTPUT_VECTORS=]
+          [env: WEBFANG_OUTPUT_VECTORS=]
 
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: RUST_SCRAPER_CHECKPOINT_INTERVAL=]
+          [env: WEBFANG_CHECKPOINT_INTERVAL=]
           [default: 100]
 
       --no-checkpoint
           Disable checkpoint persistence entirely NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: RUST_SCRAPER_NO_CHECKPOINT=]
+          [env: WEBFANG_NO_CHECKPOINT=]
 
       --ignore-robots
           Skip robots.txt enforcement
           
-          [env: RUST_SCRAPER_IGNORE_ROBOTS=]
+          [env: WEBFANG_IGNORE_ROBOTS=]
 
       --autoscale
           Enable autoscaled concurrency — dynamically adjusts task concurrency based on RAM usage
           
-          [env: RUST_SCRAPER_AUTOSCALE=]
+          [env: WEBFANG_AUTOSCALE=]
 
       --no-session-health
           Disable session pool health checks
           
-          [env: RUST_SCRAPER_NO_SESSION_HEALTH=]
+          [env: WEBFANG_NO_SESSION_HEALTH=]
 
       --h2-profile <H2_PROFILE>
           TLS/HTTP2 profile name (default: Chrome145)
           
-          [env: RUST_SCRAPER_H2_PROFILE=]
+          [env: WEBFANG_H2_PROFILE=]
           [default: Chrome145]
 
       --js-strategy <JS_STRATEGY>
@@ -323,35 +323,35 @@ Options:
           - hybrid: Hybrid 3-layer: wreq → Obscura → Chromiumoxide
           - full:   Full JS rendering only (Chromiumoxide). Slowest, handles all SPAs
           
-          [env: RUST_SCRAPER_JS_STRATEGY=]
+          [env: WEBFANG_JS_STRATEGY=]
           [default: static]
 
       --obscura-binary <OBSCURA_BINARY>
           Path to the obscura binary (default: "obscura")
           
-          [env: RUST_SCRAPER_OBSCURA_BINARY=]
+          [env: WEBFANG_OBSCURA_BINARY=]
           [default: obscura]
 
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
-          [env: RUST_SCRAPER_BATCH=]
+          [env: WEBFANG_BATCH=]
 
       --batch-file <BATCH_FILE>
           Path to a file containing URLs to crawl (one per line)
           
-          [env: RUST_SCRAPER_BATCH_FILE=]
+          [env: WEBFANG_BATCH_FILE=]
 
       --batch-concurrency <BATCH_CONCURRENCY>
           Maximum concurrent URLs in batch mode
           
-          [env: RUST_SCRAPER_BATCH_CONCURRENCY=]
+          [env: WEBFANG_BATCH_CONCURRENCY=]
           [default: 5]
 
       --pipeline
           Enable item pipeline processing (validate → clean → output)
           
-          [env: RUST_SCRAPER_PIPELINE=]
+          [env: WEBFANG_PIPELINE=]
 
       --pipeline-output <PIPELINE_OUTPUT>
           Pipeline output format: jsonl (default), none
@@ -360,7 +360,7 @@ Options:
           - jsonl: Write items as JSON Lines to a file (default)
           - none:  No pipeline output — items are processed but not written
           
-          [env: RUST_SCRAPER_PIPELINE_OUTPUT=]
+          [env: WEBFANG_PIPELINE_OUTPUT=]
           [default: jsonl]
 
   -h, --help

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+assertion_line: 52
 expression: value.into()
 ---
-CLI Arguments for the webfang binary.
+CLI Arguments for the rust_scraper binary.
 
 # Examples
 
-```no_run use webfang::Args; use clap::Parser;
+```no_run use rust_scraper::Args; use clap::Parser;
 
-let args = Args::parse_from([ "webfang", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
+let args = Args::parse_from([ "rust_scraper", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
 
 assert_eq!(args.url, "https://example.com"); ```
 
@@ -23,18 +24,18 @@ Options:
   -u, --url <URL>
           URL to scrape (required unless using a subcommand)
           
-          [env: WEBFANG_URL=]
+          [env: RUST_SCRAPER_URL=]
 
   -s, --selector <SELECTOR>
           CSS selector for content extraction
           
-          [env: WEBFANG_SELECTOR=]
+          [env: RUST_SCRAPER_SELECTOR=]
           [default: body]
 
   -o, --output <OUTPUT>
           Output directory for scraped content
           
-          [env: WEBFANG_OUTPUT=]
+          [env: RUST_SCRAPER_OUTPUT=]
           [default: output]
 
   -f, --format <FORMAT>
@@ -45,7 +46,7 @@ Options:
           - json:     Structured JSON with metadata
           - text:     Plain text without formatting
           
-          [env: WEBFANG_FORMAT=]
+          [env: RUST_SCRAPER_FORMAT=]
           [default: markdown]
 
       --export-format <EXPORT_FORMAT>
@@ -56,148 +57,148 @@ Options:
           - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
           - auto:   Auto-detect format from existing export files
           
-          [env: WEBFANG_EXPORT_FORMAT=]
+          [env: RUST_SCRAPER_EXPORT_FORMAT=]
           [default: jsonl]
 
       --obsidian-wiki-links
           Convert same-domain links to Obsidian [[wiki-link]] syntax
           
-          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
+          [env: RUST_SCRAPER_OBSIDIAN_WIKI_LINKS=]
 
       --obsidian-tags <OBSIDIAN_TAGS>
           Tags to include in YAML frontmatter (comma-separated)
           
-          [env: WEBFANG_OBSIDIAN_TAGS=]
+          [env: RUST_SCRAPER_OBSIDIAN_TAGS=]
 
       --obsidian-relative-assets
           Rewrite downloaded asset paths as relative to the .md file
           
-          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
+          [env: RUST_SCRAPER_OBSIDIAN_RELATIVE_ASSETS=]
 
       --vault <VAULT>
           Path to Obsidian vault (auto-detects if not provided)
           
-          [env: WEBFANG_OBSIDIAN_VAULT=]
+          [env: RUST_SCRAPER_OBSIDIAN_VAULT=]
 
       --quick-save
           Quick-save mode: save directly to vault _inbox folder
           
-          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
+          [env: RUST_SCRAPER_OBSIDIAN_QUICK_SAVE=]
 
       --obsidian-rich-metadata
           Add rich metadata to frontmatter
           
-          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
+          [env: RUST_SCRAPER_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
           
-          [env: WEBFANG_DELAY_MS=]
+          [env: RUST_SCRAPER_DELAY_MS=]
           [default: 1000]
 
       --max-pages <MAX_PAGES>
           Maximum pages to scrape
           
-          [env: WEBFANG_MAX_PAGES=]
+          [env: RUST_SCRAPER_MAX_PAGES=]
           [default: 10]
 
       --concurrency <CONCURRENCY>
           Concurrency level (auto or number)
           
-          [env: WEBFANG_CONCURRENCY=]
+          [env: RUST_SCRAPER_CONCURRENCY=]
           [default: auto]
 
       --use-sitemap
           Use sitemap for URL discovery NOTE: HTTP redirects (301/302) are resolved at scrape-time, not parse-time. This avoids redundant HEAD requests during sitemap parsing for better performance
           
-          [env: WEBFANG_USE_SITEMAP=]
+          [env: RUST_SCRAPER_USE_SITEMAP=]
 
       --sitemap-url <SITEMAP_URL>
           Explicit sitemap URL
           
-          [env: WEBFANG_SITEMAP_URL=]
+          [env: RUST_SCRAPER_SITEMAP_URL=]
 
       --single-page
           Scrape only the seed URL without discovery or crawling
           
-          [env: WEBFANG_SINGLE_PAGE=]
+          [env: RUST_SCRAPER_SINGLE_PAGE=]
 
       --resume
           Resume mode - skip URLs already processed
           
-          [env: WEBFANG_RESUME=]
+          [env: RUST_SCRAPER_RESUME=]
 
       --state-dir <STATE_DIR>
           Custom state directory for resume mode
           
-          [env: WEBFANG_STATE_DIR=]
+          [env: RUST_SCRAPER_STATE_DIR=]
 
       --download-images
           Download images from the page
           
-          [env: WEBFANG_DOWNLOAD_IMAGES=]
+          [env: RUST_SCRAPER_DOWNLOAD_IMAGES=]
 
       --download-documents
           Download documents from the page
           
-          [env: WEBFANG_DOWNLOAD_DOCUMENTS=]
+          [env: RUST_SCRAPER_DOWNLOAD_DOCUMENTS=]
 
       --download-assets
           Download all assets (images + documents) from the page
           
-          [env: WEBFANG_DOWNLOAD_ASSETS=]
+          [env: RUST_SCRAPER_DOWNLOAD_ASSETS=]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping
           
-          [env: WEBFANG_TUI=]
+          [env: RUST_SCRAPER_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
           
-          [env: WEBFANG_FORCE_JS_RENDER=]
+          [env: RUST_SCRAPER_FORCE_JS_RENDER=]
 
   -v, --verbose...
           Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
           
-          [env: WEBFANG_VERBOSE=]
+          [env: RUST_SCRAPER_VERBOSE=]
 
   -q, --quiet
           Quiet mode — suppress info/debug output
           
-          [env: WEBFANG_QUIET=]
+          [env: RUST_SCRAPER_QUIET=]
 
   -n, --dry-run
           Dry-run mode — discover URLs and print without scraping
           
-          [env: WEBFANG_DRY_RUN=]
+          [env: RUST_SCRAPER_DRY_RUN=]
 
       --trace-file <TRACE_FILE>
           Path to write OTel spans as JSONL for offline debugging
           
-          [env: WEBFANG_TRACE_FILE=]
+          [env: RUST_SCRAPER_TRACE_FILE=]
 
       --max-depth <MAX_DEPTH>
           Maximum depth to crawl (0 = only seed URL)
           
-          [env: WEBFANG_MAX_DEPTH=]
+          [env: RUST_SCRAPER_MAX_DEPTH=]
           [default: 2]
 
       --timeout-secs <TIMEOUT_SECS>
           Request timeout in seconds
           
-          [env: WEBFANG_TIMEOUT_SECS=]
+          [env: RUST_SCRAPER_TIMEOUT_SECS=]
           [default: 30]
 
       --include-pattern <INCLUDE_PATTERNS>
           URL patterns to include (glob-style)
           
-          [env: WEBFANG_INCLUDE=]
+          [env: RUST_SCRAPER_INCLUDE=]
 
       --exclude-pattern <EXCLUDE_PATTERNS>
           URL patterns to exclude (glob-style)
           
-          [env: WEBFANG_EXCLUDE=]
+          [env: RUST_SCRAPER_EXCLUDE=]
 
       --asset-naming <ASSET_NAMING>
           Estrategia de nombre de archivo para assets descargados: hash (default), slug, content-disposition
@@ -208,111 +209,111 @@ Options:
       --download-concurrency <DOWNLOAD_CONCURRENCY>
           Máximo de descargas de assets concurrentes por página (mínimo 1)
           
-          [env: WEBFANG_DOWNLOAD_CONCURRENCY=]
+          [env: RUST_SCRAPER_DOWNLOAD_CONCURRENCY=]
           [default: 3]
 
       --max-retries <MAX_RETRIES>
           Maximum number of retry attempts
           
-          [env: WEBFANG_MAX_RETRIES=]
+          [env: RUST_SCRAPER_MAX_RETRIES=]
           [default: 3]
 
       --backoff-base-ms <BACKOFF_BASE_MS>
           Base delay for exponential backoff (ms)
           
-          [env: WEBFANG_BACKOFF_BASE_MS=]
+          [env: RUST_SCRAPER_BACKOFF_BASE_MS=]
           [default: 1000]
 
       --backoff-max-ms <BACKOFF_MAX_MS>
           Maximum delay for exponential backoff (ms)
           
-          [env: WEBFANG_BACKOFF_MAX_MS=]
+          [env: RUST_SCRAPER_BACKOFF_MAX_MS=]
           [default: 10000]
 
       --accept-language <ACCEPT_LANGUAGE>
           Accept-Language header value
           
-          [env: WEBFANG_ACCEPT_LANGUAGE=]
+          [env: RUST_SCRAPER_ACCEPT_LANGUAGE=]
           [default: en-US,en;q=0.9]
 
       --user-agent <USER_AGENT>
           Custom User-Agent header value (overrides Chrome 145 default)
           
-          [env: WEBFANG_USER_AGENT=]
+          [env: RUST_SCRAPER_USER_AGENT=]
 
       --max-file-size <MAX_FILE_SIZE>
           Maximum file size to download in bytes (default: 50MB)
           
-          [env: WEBFANG_MAX_FILE_SIZE=]
+          [env: RUST_SCRAPER_MAX_FILE_SIZE=]
           [default: 52428800]
 
       --download-timeout <DOWNLOAD_TIMEOUT>
           Timeout for individual asset downloads in seconds
           
-          [env: WEBFANG_DOWNLOAD_TIMEOUT=]
+          [env: RUST_SCRAPER_DOWNLOAD_TIMEOUT=]
           [default: 30]
 
       --sitemap-depth <SITEMAP_DEPTH>
           Maximum recursion depth for sitemap indexes
           
-          [env: WEBFANG_SITEMAP_DEPTH=]
+          [env: RUST_SCRAPER_SITEMAP_DEPTH=]
           [default: 3]
 
       --cpu-cores <CPU_CORES>
           CPU core override for the elastic ingestion Rayon pool (else auto-detect)
           
-          [env: WEBFANG_CPU_CORES=]
+          [env: RUST_SCRAPER_CPU_CORES=]
 
       --ram-budget <RAM_BUDGET>
           RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
           
-          [env: WEBFANG_RAM_BUDGET=]
+          [env: RUST_SCRAPER_RAM_BUDGET=]
 
       --db-path <DB_PATH>
           SQLite database path override for persisted resources/chunks
           
-          [env: WEBFANG_DB_PATH=]
+          [env: RUST_SCRAPER_DB_PATH=]
 
       --elastic
           Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
           
-          [env: WEBFANG_ELASTIC=]
+          [env: RUST_SCRAPER_ELASTIC=]
 
       --output-vectors <OUTPUT_VECTORS>
           Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
           
-          [env: WEBFANG_OUTPUT_VECTORS=]
+          [env: RUST_SCRAPER_OUTPUT_VECTORS=]
 
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: WEBFANG_CHECKPOINT_INTERVAL=]
+          [env: RUST_SCRAPER_CHECKPOINT_INTERVAL=]
           [default: 100]
 
       --no-checkpoint
           Disable checkpoint persistence entirely NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: WEBFANG_NO_CHECKPOINT=]
+          [env: RUST_SCRAPER_NO_CHECKPOINT=]
 
       --ignore-robots
           Skip robots.txt enforcement
           
-          [env: WEBFANG_IGNORE_ROBOTS=]
+          [env: RUST_SCRAPER_IGNORE_ROBOTS=]
 
       --autoscale
           Enable autoscaled concurrency — dynamically adjusts task concurrency based on RAM usage
           
-          [env: WEBFANG_AUTOSCALE=]
+          [env: RUST_SCRAPER_AUTOSCALE=]
 
       --no-session-health
           Disable session pool health checks
           
-          [env: WEBFANG_NO_SESSION_HEALTH=]
+          [env: RUST_SCRAPER_NO_SESSION_HEALTH=]
 
       --h2-profile <H2_PROFILE>
           TLS/HTTP2 profile name (default: Chrome145)
           
-          [env: WEBFANG_H2_PROFILE=]
+          [env: RUST_SCRAPER_H2_PROFILE=]
           [default: Chrome145]
 
       --js-strategy <JS_STRATEGY>
@@ -323,35 +324,35 @@ Options:
           - hybrid: Hybrid 3-layer: wreq → Obscura → Chromiumoxide
           - full:   Full JS rendering only (Chromiumoxide). Slowest, handles all SPAs
           
-          [env: WEBFANG_JS_STRATEGY=]
+          [env: RUST_SCRAPER_JS_STRATEGY=]
           [default: static]
 
       --obscura-binary <OBSCURA_BINARY>
           Path to the obscura binary (default: "obscura")
           
-          [env: WEBFANG_OBSCURA_BINARY=]
+          [env: RUST_SCRAPER_OBSCURA_BINARY=]
           [default: obscura]
 
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
-          [env: WEBFANG_BATCH=]
+          [env: RUST_SCRAPER_BATCH=]
 
       --batch-file <BATCH_FILE>
           Path to a file containing URLs to crawl (one per line)
           
-          [env: WEBFANG_BATCH_FILE=]
+          [env: RUST_SCRAPER_BATCH_FILE=]
 
       --batch-concurrency <BATCH_CONCURRENCY>
           Maximum concurrent URLs in batch mode
           
-          [env: WEBFANG_BATCH_CONCURRENCY=]
+          [env: RUST_SCRAPER_BATCH_CONCURRENCY=]
           [default: 5]
 
       --pipeline
           Enable item pipeline processing (validate → clean → output)
           
-          [env: WEBFANG_PIPELINE=]
+          [env: RUST_SCRAPER_PIPELINE=]
 
       --pipeline-output <PIPELINE_OUTPUT>
           Pipeline output format: jsonl (default), none
@@ -360,7 +361,7 @@ Options:
           - jsonl: Write items as JSON Lines to a file (default)
           - none:  No pipeline output — items are processed but not written
           
-          [env: WEBFANG_PIPELINE_OUTPUT=]
+          [env: RUST_SCRAPER_PIPELINE_OUTPUT=]
           [default: jsonl]
 
   -h, --help

--- a/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -2,11 +2,11 @@
 source: crates/rust_scraper_core/../../tests/behavioral/main.rs
 expression: redacted
 ---
-  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
 
-  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
+  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
+    at crates/webfang_core/src/cli/scrape_flow.rs:229
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped

--- a/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+assertion_line: 43
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
 
-  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:229
+  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
+    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped

--- a/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -2,11 +2,11 @@
 source: crates/rust_scraper_core/../../tests/behavioral/main.rs
 expression: redacted
 ---
-  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
 
-  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
-    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
+  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
+    at crates/webfang_core/src/cli/scrape_flow.rs:229
 
 Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← client error (Connect)  ← tcp connect error  ← Connection refused (os error 111)
 No pages were successfully scraped

--- a/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/rust_scraper_core/../../tests/behavioral/main.rs
+assertion_line: 43
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
 
-  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
-    at crates/webfang_core/src/cli/scrape_flow.rs:229
+  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
+    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
 
 Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← client error (Connect)  ← tcp connect error  ← Connection refused (os error 111)
 No pages were successfully scraped

--- a/tests/cli_behavioral_test.rs
+++ b/tests/cli_behavioral_test.rs
@@ -50,7 +50,7 @@ fn test_help_exits_zero() {
         .arg("--help")
         .assert()
         .code(0)
-        .stdout(predicate::str::contains("webfang binary"));
+        .stdout(predicate::str::contains("rust_scraper binary"));
 }
 
 /// --version prints version and exits with code 0.

--- a/tests/cli_behavioral_test.rs
+++ b/tests/cli_behavioral_test.rs
@@ -50,7 +50,7 @@ fn test_help_exits_zero() {
         .arg("--help")
         .assert()
         .code(0)
-        .stdout(predicate::str::contains("rust_scraper binary"));
+        .stdout(predicate::str::contains("webfang binary"));
 }
 
 /// --version prints version and exits with code 0.

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+assertion_line: 63
 expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stdout)"
 ---
-CLI Arguments for the webfang binary.
+CLI Arguments for the rust_scraper binary.
 
 # Examples
 
-```no_run use webfang::Args; use clap::Parser;
+```no_run use rust_scraper::Args; use clap::Parser;
 
-let args = Args::parse_from([ "webfang", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
+let args = Args::parse_from([ "rust_scraper", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
 
 assert_eq!(args.url, "https://example.com"); ```
 
@@ -23,18 +24,18 @@ Options:
   -u, --url <URL>
           URL to scrape (required unless using a subcommand)
           
-          [env: WEBFANG_URL=]
+          [env: RUST_SCRAPER_URL=]
 
   -s, --selector <SELECTOR>
           CSS selector for content extraction
           
-          [env: WEBFANG_SELECTOR=]
+          [env: RUST_SCRAPER_SELECTOR=]
           [default: body]
 
   -o, --output <OUTPUT>
           Output directory for scraped content
           
-          [env: WEBFANG_OUTPUT=]
+          [env: RUST_SCRAPER_OUTPUT=]
           [default: output]
 
   -f, --format <FORMAT>
@@ -45,7 +46,7 @@ Options:
           - json:     Structured JSON with metadata
           - text:     Plain text without formatting
           
-          [env: WEBFANG_FORMAT=]
+          [env: RUST_SCRAPER_FORMAT=]
           [default: markdown]
 
       --export-format <EXPORT_FORMAT>
@@ -56,148 +57,148 @@ Options:
           - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
           - auto:   Auto-detect format from existing export files
           
-          [env: WEBFANG_EXPORT_FORMAT=]
+          [env: RUST_SCRAPER_EXPORT_FORMAT=]
           [default: jsonl]
 
       --obsidian-wiki-links
           Convert same-domain links to Obsidian [[wiki-link]] syntax
           
-          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
+          [env: RUST_SCRAPER_OBSIDIAN_WIKI_LINKS=]
 
       --obsidian-tags <OBSIDIAN_TAGS>
           Tags to include in YAML frontmatter (comma-separated)
           
-          [env: WEBFANG_OBSIDIAN_TAGS=]
+          [env: RUST_SCRAPER_OBSIDIAN_TAGS=]
 
       --obsidian-relative-assets
           Rewrite downloaded asset paths as relative to the .md file
           
-          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
+          [env: RUST_SCRAPER_OBSIDIAN_RELATIVE_ASSETS=]
 
       --vault <VAULT>
           Path to Obsidian vault (auto-detects if not provided)
           
-          [env: WEBFANG_OBSIDIAN_VAULT=]
+          [env: RUST_SCRAPER_OBSIDIAN_VAULT=]
 
       --quick-save
           Quick-save mode: save directly to vault _inbox folder
           
-          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
+          [env: RUST_SCRAPER_OBSIDIAN_QUICK_SAVE=]
 
       --obsidian-rich-metadata
           Add rich metadata to frontmatter
           
-          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
+          [env: RUST_SCRAPER_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
           
-          [env: WEBFANG_DELAY_MS=]
+          [env: RUST_SCRAPER_DELAY_MS=]
           [default: 1000]
 
       --max-pages <MAX_PAGES>
           Maximum pages to scrape
           
-          [env: WEBFANG_MAX_PAGES=]
+          [env: RUST_SCRAPER_MAX_PAGES=]
           [default: 10]
 
       --concurrency <CONCURRENCY>
           Concurrency level (auto or number)
           
-          [env: WEBFANG_CONCURRENCY=]
+          [env: RUST_SCRAPER_CONCURRENCY=]
           [default: auto]
 
       --use-sitemap
           Use sitemap for URL discovery NOTE: HTTP redirects (301/302) are resolved at scrape-time, not parse-time. This avoids redundant HEAD requests during sitemap parsing for better performance
           
-          [env: WEBFANG_USE_SITEMAP=]
+          [env: RUST_SCRAPER_USE_SITEMAP=]
 
       --sitemap-url <SITEMAP_URL>
           Explicit sitemap URL
           
-          [env: WEBFANG_SITEMAP_URL=]
+          [env: RUST_SCRAPER_SITEMAP_URL=]
 
       --single-page
           Scrape only the seed URL without discovery or crawling
           
-          [env: WEBFANG_SINGLE_PAGE=]
+          [env: RUST_SCRAPER_SINGLE_PAGE=]
 
       --resume
           Resume mode - skip URLs already processed
           
-          [env: WEBFANG_RESUME=]
+          [env: RUST_SCRAPER_RESUME=]
 
       --state-dir <STATE_DIR>
           Custom state directory for resume mode
           
-          [env: WEBFANG_STATE_DIR=]
+          [env: RUST_SCRAPER_STATE_DIR=]
 
       --download-images
           Download images from the page
           
-          [env: WEBFANG_DOWNLOAD_IMAGES=]
+          [env: RUST_SCRAPER_DOWNLOAD_IMAGES=]
 
       --download-documents
           Download documents from the page
           
-          [env: WEBFANG_DOWNLOAD_DOCUMENTS=]
+          [env: RUST_SCRAPER_DOWNLOAD_DOCUMENTS=]
 
       --download-assets
           Download all assets (images + documents) from the page
           
-          [env: WEBFANG_DOWNLOAD_ASSETS=]
+          [env: RUST_SCRAPER_DOWNLOAD_ASSETS=]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping
           
-          [env: WEBFANG_TUI=]
+          [env: RUST_SCRAPER_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
           
-          [env: WEBFANG_FORCE_JS_RENDER=]
+          [env: RUST_SCRAPER_FORCE_JS_RENDER=]
 
   -v, --verbose...
           Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
           
-          [env: WEBFANG_VERBOSE=]
+          [env: RUST_SCRAPER_VERBOSE=]
 
   -q, --quiet
           Quiet mode — suppress info/debug output
           
-          [env: WEBFANG_QUIET=]
+          [env: RUST_SCRAPER_QUIET=]
 
   -n, --dry-run
           Dry-run mode — discover URLs and print without scraping
           
-          [env: WEBFANG_DRY_RUN=]
+          [env: RUST_SCRAPER_DRY_RUN=]
 
       --trace-file <TRACE_FILE>
           Path to write OTel spans as JSONL for offline debugging
           
-          [env: WEBFANG_TRACE_FILE=]
+          [env: RUST_SCRAPER_TRACE_FILE=]
 
       --max-depth <MAX_DEPTH>
           Maximum depth to crawl (0 = only seed URL)
           
-          [env: WEBFANG_MAX_DEPTH=]
+          [env: RUST_SCRAPER_MAX_DEPTH=]
           [default: 2]
 
       --timeout-secs <TIMEOUT_SECS>
           Request timeout in seconds
           
-          [env: WEBFANG_TIMEOUT_SECS=]
+          [env: RUST_SCRAPER_TIMEOUT_SECS=]
           [default: 30]
 
       --include-pattern <INCLUDE_PATTERNS>
           URL patterns to include (glob-style)
           
-          [env: WEBFANG_INCLUDE=]
+          [env: RUST_SCRAPER_INCLUDE=]
 
       --exclude-pattern <EXCLUDE_PATTERNS>
           URL patterns to exclude (glob-style)
           
-          [env: WEBFANG_EXCLUDE=]
+          [env: RUST_SCRAPER_EXCLUDE=]
 
       --asset-naming <ASSET_NAMING>
           Estrategia de nombre de archivo para assets descargados: hash (default), slug, content-disposition
@@ -208,111 +209,111 @@ Options:
       --download-concurrency <DOWNLOAD_CONCURRENCY>
           Máximo de descargas de assets concurrentes por página (mínimo 1)
           
-          [env: WEBFANG_DOWNLOAD_CONCURRENCY=]
+          [env: RUST_SCRAPER_DOWNLOAD_CONCURRENCY=]
           [default: 3]
 
       --max-retries <MAX_RETRIES>
           Maximum number of retry attempts
           
-          [env: WEBFANG_MAX_RETRIES=]
+          [env: RUST_SCRAPER_MAX_RETRIES=]
           [default: 3]
 
       --backoff-base-ms <BACKOFF_BASE_MS>
           Base delay for exponential backoff (ms)
           
-          [env: WEBFANG_BACKOFF_BASE_MS=]
+          [env: RUST_SCRAPER_BACKOFF_BASE_MS=]
           [default: 1000]
 
       --backoff-max-ms <BACKOFF_MAX_MS>
           Maximum delay for exponential backoff (ms)
           
-          [env: WEBFANG_BACKOFF_MAX_MS=]
+          [env: RUST_SCRAPER_BACKOFF_MAX_MS=]
           [default: 10000]
 
       --accept-language <ACCEPT_LANGUAGE>
           Accept-Language header value
           
-          [env: WEBFANG_ACCEPT_LANGUAGE=]
+          [env: RUST_SCRAPER_ACCEPT_LANGUAGE=]
           [default: en-US,en;q=0.9]
 
       --user-agent <USER_AGENT>
           Custom User-Agent header value (overrides Chrome 145 default)
           
-          [env: WEBFANG_USER_AGENT=]
+          [env: RUST_SCRAPER_USER_AGENT=]
 
       --max-file-size <MAX_FILE_SIZE>
           Maximum file size to download in bytes (default: 50MB)
           
-          [env: WEBFANG_MAX_FILE_SIZE=]
+          [env: RUST_SCRAPER_MAX_FILE_SIZE=]
           [default: 52428800]
 
       --download-timeout <DOWNLOAD_TIMEOUT>
           Timeout for individual asset downloads in seconds
           
-          [env: WEBFANG_DOWNLOAD_TIMEOUT=]
+          [env: RUST_SCRAPER_DOWNLOAD_TIMEOUT=]
           [default: 30]
 
       --sitemap-depth <SITEMAP_DEPTH>
           Maximum recursion depth for sitemap indexes
           
-          [env: WEBFANG_SITEMAP_DEPTH=]
+          [env: RUST_SCRAPER_SITEMAP_DEPTH=]
           [default: 3]
 
       --cpu-cores <CPU_CORES>
           CPU core override for the elastic ingestion Rayon pool (else auto-detect)
           
-          [env: WEBFANG_CPU_CORES=]
+          [env: RUST_SCRAPER_CPU_CORES=]
 
       --ram-budget <RAM_BUDGET>
           RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
           
-          [env: WEBFANG_RAM_BUDGET=]
+          [env: RUST_SCRAPER_RAM_BUDGET=]
 
       --db-path <DB_PATH>
           SQLite database path override for persisted resources/chunks
           
-          [env: WEBFANG_DB_PATH=]
+          [env: RUST_SCRAPER_DB_PATH=]
 
       --elastic
           Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
           
-          [env: WEBFANG_ELASTIC=]
+          [env: RUST_SCRAPER_ELASTIC=]
 
       --output-vectors <OUTPUT_VECTORS>
           Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
           
-          [env: WEBFANG_OUTPUT_VECTORS=]
+          [env: RUST_SCRAPER_OUTPUT_VECTORS=]
 
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: WEBFANG_CHECKPOINT_INTERVAL=]
+          [env: RUST_SCRAPER_CHECKPOINT_INTERVAL=]
           [default: 100]
 
       --no-checkpoint
           Disable checkpoint persistence entirely NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: WEBFANG_NO_CHECKPOINT=]
+          [env: RUST_SCRAPER_NO_CHECKPOINT=]
 
       --ignore-robots
           Skip robots.txt enforcement
           
-          [env: WEBFANG_IGNORE_ROBOTS=]
+          [env: RUST_SCRAPER_IGNORE_ROBOTS=]
 
       --autoscale
           Enable autoscaled concurrency — dynamically adjusts task concurrency based on RAM usage
           
-          [env: WEBFANG_AUTOSCALE=]
+          [env: RUST_SCRAPER_AUTOSCALE=]
 
       --no-session-health
           Disable session pool health checks
           
-          [env: WEBFANG_NO_SESSION_HEALTH=]
+          [env: RUST_SCRAPER_NO_SESSION_HEALTH=]
 
       --h2-profile <H2_PROFILE>
           TLS/HTTP2 profile name (default: Chrome145)
           
-          [env: WEBFANG_H2_PROFILE=]
+          [env: RUST_SCRAPER_H2_PROFILE=]
           [default: Chrome145]
 
       --js-strategy <JS_STRATEGY>
@@ -323,35 +324,35 @@ Options:
           - hybrid: Hybrid 3-layer: wreq → Obscura → Chromiumoxide
           - full:   Full JS rendering only (Chromiumoxide). Slowest, handles all SPAs
           
-          [env: WEBFANG_JS_STRATEGY=]
+          [env: RUST_SCRAPER_JS_STRATEGY=]
           [default: static]
 
       --obscura-binary <OBSCURA_BINARY>
           Path to the obscura binary (default: "obscura")
           
-          [env: WEBFANG_OBSCURA_BINARY=]
+          [env: RUST_SCRAPER_OBSCURA_BINARY=]
           [default: obscura]
 
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
-          [env: WEBFANG_BATCH=]
+          [env: RUST_SCRAPER_BATCH=]
 
       --batch-file <BATCH_FILE>
           Path to a file containing URLs to crawl (one per line)
           
-          [env: WEBFANG_BATCH_FILE=]
+          [env: RUST_SCRAPER_BATCH_FILE=]
 
       --batch-concurrency <BATCH_CONCURRENCY>
           Maximum concurrent URLs in batch mode
           
-          [env: WEBFANG_BATCH_CONCURRENCY=]
+          [env: RUST_SCRAPER_BATCH_CONCURRENCY=]
           [default: 5]
 
       --pipeline
           Enable item pipeline processing (validate → clean → output)
           
-          [env: WEBFANG_PIPELINE=]
+          [env: RUST_SCRAPER_PIPELINE=]
 
       --pipeline-output <PIPELINE_OUTPUT>
           Pipeline output format: jsonl (default), none
@@ -360,7 +361,7 @@ Options:
           - jsonl: Write items as JSON Lines to a file (default)
           - none:  No pipeline output — items are processed but not written
           
-          [env: WEBFANG_PIPELINE_OUTPUT=]
+          [env: RUST_SCRAPER_PIPELINE_OUTPUT=]
           [default: jsonl]
 
   -h, --help

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
-expression: "redact(Path::new(\"__no_temp__\"), &stdout)"
+expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stdout)"
 ---
-CLI Arguments for the rust_scraper binary.
+CLI Arguments for the webfang binary.
 
 # Examples
 
-```no_run use rust_scraper::Args; use clap::Parser;
+```no_run use webfang::Args; use clap::Parser;
 
-let args = Args::parse_from([ "rust_scraper", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
+let args = Args::parse_from([ "webfang", "--url", "https://example.com", "--output", "./output", "--export-format", "jsonl", "--resume", ]);
 
 assert_eq!(args.url, "https://example.com"); ```
 
@@ -23,18 +23,18 @@ Options:
   -u, --url <URL>
           URL to scrape (required unless using a subcommand)
           
-          [env: RUST_SCRAPER_URL=]
+          [env: WEBFANG_URL=]
 
   -s, --selector <SELECTOR>
           CSS selector for content extraction
           
-          [env: RUST_SCRAPER_SELECTOR=]
+          [env: WEBFANG_SELECTOR=]
           [default: body]
 
   -o, --output <OUTPUT>
           Output directory for scraped content
           
-          [env: RUST_SCRAPER_OUTPUT=]
+          [env: WEBFANG_OUTPUT=]
           [default: output]
 
   -f, --format <FORMAT>
@@ -45,7 +45,7 @@ Options:
           - json:     Structured JSON with metadata
           - text:     Plain text without formatting
           
-          [env: RUST_SCRAPER_FORMAT=]
+          [env: WEBFANG_FORMAT=]
           [default: markdown]
 
       --export-format <EXPORT_FORMAT>
@@ -56,148 +56,148 @@ Options:
           - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
           - auto:   Auto-detect format from existing export files
           
-          [env: RUST_SCRAPER_EXPORT_FORMAT=]
+          [env: WEBFANG_EXPORT_FORMAT=]
           [default: jsonl]
 
       --obsidian-wiki-links
           Convert same-domain links to Obsidian [[wiki-link]] syntax
           
-          [env: RUST_SCRAPER_OBSIDIAN_WIKI_LINKS=]
+          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
 
       --obsidian-tags <OBSIDIAN_TAGS>
           Tags to include in YAML frontmatter (comma-separated)
           
-          [env: RUST_SCRAPER_OBSIDIAN_TAGS=]
+          [env: WEBFANG_OBSIDIAN_TAGS=]
 
       --obsidian-relative-assets
           Rewrite downloaded asset paths as relative to the .md file
           
-          [env: RUST_SCRAPER_OBSIDIAN_RELATIVE_ASSETS=]
+          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
 
       --vault <VAULT>
           Path to Obsidian vault (auto-detects if not provided)
           
-          [env: RUST_SCRAPER_OBSIDIAN_VAULT=]
+          [env: WEBFANG_OBSIDIAN_VAULT=]
 
       --quick-save
           Quick-save mode: save directly to vault _inbox folder
           
-          [env: RUST_SCRAPER_OBSIDIAN_QUICK_SAVE=]
+          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
 
       --obsidian-rich-metadata
           Add rich metadata to frontmatter
           
-          [env: RUST_SCRAPER_OBSIDIAN_RICH_METADATA=]
+          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
           
-          [env: RUST_SCRAPER_DELAY_MS=]
+          [env: WEBFANG_DELAY_MS=]
           [default: 1000]
 
       --max-pages <MAX_PAGES>
           Maximum pages to scrape
           
-          [env: RUST_SCRAPER_MAX_PAGES=]
+          [env: WEBFANG_MAX_PAGES=]
           [default: 10]
 
       --concurrency <CONCURRENCY>
           Concurrency level (auto or number)
           
-          [env: RUST_SCRAPER_CONCURRENCY=]
+          [env: WEBFANG_CONCURRENCY=]
           [default: auto]
 
       --use-sitemap
           Use sitemap for URL discovery NOTE: HTTP redirects (301/302) are resolved at scrape-time, not parse-time. This avoids redundant HEAD requests during sitemap parsing for better performance
           
-          [env: RUST_SCRAPER_USE_SITEMAP=]
+          [env: WEBFANG_USE_SITEMAP=]
 
       --sitemap-url <SITEMAP_URL>
           Explicit sitemap URL
           
-          [env: RUST_SCRAPER_SITEMAP_URL=]
+          [env: WEBFANG_SITEMAP_URL=]
 
       --single-page
           Scrape only the seed URL without discovery or crawling
           
-          [env: RUST_SCRAPER_SINGLE_PAGE=]
+          [env: WEBFANG_SINGLE_PAGE=]
 
       --resume
           Resume mode - skip URLs already processed
           
-          [env: RUST_SCRAPER_RESUME=]
+          [env: WEBFANG_RESUME=]
 
       --state-dir <STATE_DIR>
           Custom state directory for resume mode
           
-          [env: RUST_SCRAPER_STATE_DIR=]
+          [env: WEBFANG_STATE_DIR=]
 
       --download-images
           Download images from the page
           
-          [env: RUST_SCRAPER_DOWNLOAD_IMAGES=]
+          [env: WEBFANG_DOWNLOAD_IMAGES=]
 
       --download-documents
           Download documents from the page
           
-          [env: RUST_SCRAPER_DOWNLOAD_DOCUMENTS=]
+          [env: WEBFANG_DOWNLOAD_DOCUMENTS=]
 
       --download-assets
           Download all assets (images + documents) from the page
           
-          [env: RUST_SCRAPER_DOWNLOAD_ASSETS=]
+          [env: WEBFANG_DOWNLOAD_ASSETS=]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping
           
-          [env: RUST_SCRAPER_TUI=]
+          [env: WEBFANG_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
           
-          [env: RUST_SCRAPER_FORCE_JS_RENDER=]
+          [env: WEBFANG_FORCE_JS_RENDER=]
 
   -v, --verbose...
           Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
           
-          [env: RUST_SCRAPER_VERBOSE=]
+          [env: WEBFANG_VERBOSE=]
 
   -q, --quiet
           Quiet mode — suppress info/debug output
           
-          [env: RUST_SCRAPER_QUIET=]
+          [env: WEBFANG_QUIET=]
 
   -n, --dry-run
           Dry-run mode — discover URLs and print without scraping
           
-          [env: RUST_SCRAPER_DRY_RUN=]
+          [env: WEBFANG_DRY_RUN=]
 
       --trace-file <TRACE_FILE>
           Path to write OTel spans as JSONL for offline debugging
           
-          [env: RUST_SCRAPER_TRACE_FILE=]
+          [env: WEBFANG_TRACE_FILE=]
 
       --max-depth <MAX_DEPTH>
           Maximum depth to crawl (0 = only seed URL)
           
-          [env: RUST_SCRAPER_MAX_DEPTH=]
+          [env: WEBFANG_MAX_DEPTH=]
           [default: 2]
 
       --timeout-secs <TIMEOUT_SECS>
           Request timeout in seconds
           
-          [env: RUST_SCRAPER_TIMEOUT_SECS=]
+          [env: WEBFANG_TIMEOUT_SECS=]
           [default: 30]
 
       --include-pattern <INCLUDE_PATTERNS>
           URL patterns to include (glob-style)
           
-          [env: RUST_SCRAPER_INCLUDE=]
+          [env: WEBFANG_INCLUDE=]
 
       --exclude-pattern <EXCLUDE_PATTERNS>
           URL patterns to exclude (glob-style)
           
-          [env: RUST_SCRAPER_EXCLUDE=]
+          [env: WEBFANG_EXCLUDE=]
 
       --asset-naming <ASSET_NAMING>
           Estrategia de nombre de archivo para assets descargados: hash (default), slug, content-disposition
@@ -208,111 +208,111 @@ Options:
       --download-concurrency <DOWNLOAD_CONCURRENCY>
           Máximo de descargas de assets concurrentes por página (mínimo 1)
           
-          [env: RUST_SCRAPER_DOWNLOAD_CONCURRENCY=]
+          [env: WEBFANG_DOWNLOAD_CONCURRENCY=]
           [default: 3]
 
       --max-retries <MAX_RETRIES>
           Maximum number of retry attempts
           
-          [env: RUST_SCRAPER_MAX_RETRIES=]
+          [env: WEBFANG_MAX_RETRIES=]
           [default: 3]
 
       --backoff-base-ms <BACKOFF_BASE_MS>
           Base delay for exponential backoff (ms)
           
-          [env: RUST_SCRAPER_BACKOFF_BASE_MS=]
+          [env: WEBFANG_BACKOFF_BASE_MS=]
           [default: 1000]
 
       --backoff-max-ms <BACKOFF_MAX_MS>
           Maximum delay for exponential backoff (ms)
           
-          [env: RUST_SCRAPER_BACKOFF_MAX_MS=]
+          [env: WEBFANG_BACKOFF_MAX_MS=]
           [default: 10000]
 
       --accept-language <ACCEPT_LANGUAGE>
           Accept-Language header value
           
-          [env: RUST_SCRAPER_ACCEPT_LANGUAGE=]
+          [env: WEBFANG_ACCEPT_LANGUAGE=]
           [default: en-US,en;q=0.9]
 
       --user-agent <USER_AGENT>
           Custom User-Agent header value (overrides Chrome 145 default)
           
-          [env: RUST_SCRAPER_USER_AGENT=]
+          [env: WEBFANG_USER_AGENT=]
 
       --max-file-size <MAX_FILE_SIZE>
           Maximum file size to download in bytes (default: 50MB)
           
-          [env: RUST_SCRAPER_MAX_FILE_SIZE=]
+          [env: WEBFANG_MAX_FILE_SIZE=]
           [default: 52428800]
 
       --download-timeout <DOWNLOAD_TIMEOUT>
           Timeout for individual asset downloads in seconds
           
-          [env: RUST_SCRAPER_DOWNLOAD_TIMEOUT=]
+          [env: WEBFANG_DOWNLOAD_TIMEOUT=]
           [default: 30]
 
       --sitemap-depth <SITEMAP_DEPTH>
           Maximum recursion depth for sitemap indexes
           
-          [env: RUST_SCRAPER_SITEMAP_DEPTH=]
+          [env: WEBFANG_SITEMAP_DEPTH=]
           [default: 3]
 
       --cpu-cores <CPU_CORES>
           CPU core override for the elastic ingestion Rayon pool (else auto-detect)
           
-          [env: RUST_SCRAPER_CPU_CORES=]
+          [env: WEBFANG_CPU_CORES=]
 
       --ram-budget <RAM_BUDGET>
           RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
           
-          [env: RUST_SCRAPER_RAM_BUDGET=]
+          [env: WEBFANG_RAM_BUDGET=]
 
       --db-path <DB_PATH>
           SQLite database path override for persisted resources/chunks
           
-          [env: RUST_SCRAPER_DB_PATH=]
+          [env: WEBFANG_DB_PATH=]
 
       --elastic
           Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
           
-          [env: RUST_SCRAPER_ELASTIC=]
+          [env: WEBFANG_ELASTIC=]
 
       --output-vectors <OUTPUT_VECTORS>
           Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
           
-          [env: RUST_SCRAPER_OUTPUT_VECTORS=]
+          [env: WEBFANG_OUTPUT_VECTORS=]
 
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: RUST_SCRAPER_CHECKPOINT_INTERVAL=]
+          [env: WEBFANG_CHECKPOINT_INTERVAL=]
           [default: 100]
 
       --no-checkpoint
           Disable checkpoint persistence entirely NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
-          [env: RUST_SCRAPER_NO_CHECKPOINT=]
+          [env: WEBFANG_NO_CHECKPOINT=]
 
       --ignore-robots
           Skip robots.txt enforcement
           
-          [env: RUST_SCRAPER_IGNORE_ROBOTS=]
+          [env: WEBFANG_IGNORE_ROBOTS=]
 
       --autoscale
           Enable autoscaled concurrency — dynamically adjusts task concurrency based on RAM usage
           
-          [env: RUST_SCRAPER_AUTOSCALE=]
+          [env: WEBFANG_AUTOSCALE=]
 
       --no-session-health
           Disable session pool health checks
           
-          [env: RUST_SCRAPER_NO_SESSION_HEALTH=]
+          [env: WEBFANG_NO_SESSION_HEALTH=]
 
       --h2-profile <H2_PROFILE>
           TLS/HTTP2 profile name (default: Chrome145)
           
-          [env: RUST_SCRAPER_H2_PROFILE=]
+          [env: WEBFANG_H2_PROFILE=]
           [default: Chrome145]
 
       --js-strategy <JS_STRATEGY>
@@ -323,35 +323,35 @@ Options:
           - hybrid: Hybrid 3-layer: wreq → Obscura → Chromiumoxide
           - full:   Full JS rendering only (Chromiumoxide). Slowest, handles all SPAs
           
-          [env: RUST_SCRAPER_JS_STRATEGY=]
+          [env: WEBFANG_JS_STRATEGY=]
           [default: static]
 
       --obscura-binary <OBSCURA_BINARY>
           Path to the obscura binary (default: "obscura")
           
-          [env: RUST_SCRAPER_OBSCURA_BINARY=]
+          [env: WEBFANG_OBSCURA_BINARY=]
           [default: obscura]
 
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
-          [env: RUST_SCRAPER_BATCH=]
+          [env: WEBFANG_BATCH=]
 
       --batch-file <BATCH_FILE>
           Path to a file containing URLs to crawl (one per line)
           
-          [env: RUST_SCRAPER_BATCH_FILE=]
+          [env: WEBFANG_BATCH_FILE=]
 
       --batch-concurrency <BATCH_CONCURRENCY>
           Maximum concurrent URLs in batch mode
           
-          [env: RUST_SCRAPER_BATCH_CONCURRENCY=]
+          [env: WEBFANG_BATCH_CONCURRENCY=]
           [default: 5]
 
       --pipeline
           Enable item pipeline processing (validate → clean → output)
           
-          [env: RUST_SCRAPER_PIPELINE=]
+          [env: WEBFANG_PIPELINE=]
 
       --pipeline-output <PIPELINE_OUTPUT>
           Pipeline output format: jsonl (default), none
@@ -360,7 +360,7 @@ Options:
           - jsonl: Write items as JSON Lines to a file (default)
           - none:  No pipeline output — items are processed but not written
           
-          [env: RUST_SCRAPER_PIPELINE_OUTPUT=]
+          [env: WEBFANG_PIPELINE_OUTPUT=]
           [default: jsonl]
 
   -h, --help

--- a/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
+assertion_line: 211
 expression: "redact_nondeterministic(output_dir.path(), &stderr)"
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
 
-  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:229
+  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
+    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped

--- a/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/rust_scraper_core/../../tests/cli_binary_test.rs
-expression: "redact(output_dir.path(), &stderr)"
+expression: "redact_nondeterministic(output_dir.path(), &stderr)"
 ---
-  <TIMESTAMP>  WARN rust_scraper_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/rust_scraper_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
+    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
 
-  <TIMESTAMP>  WARN rust_scraper_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/rust_scraper_core/src/cli/scrape_flow.rs:229
+  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
+    at crates/webfang_core/src/cli/scrape_flow.rs:229
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped

--- a/tests/stream_repository_jsonl.rs
+++ b/tests/stream_repository_jsonl.rs
@@ -10,11 +10,12 @@
 //! `StreamRepository` has no SQLite dependency, so this test runs under the
 //! default (core) build.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use rust_scraper::domain::repository::VectorRepository;
-use rust_scraper::infrastructure::stream::{StreamRepository, VectorRecord};
-use tempfile::NamedTempFile;
+use rust_scraper_core::domain::repository::VectorRepository;
+use rust_scraper_core::infrastructure::stream::{StreamRepository, VectorRecord};
+use tempfile::{NamedTempFile, TempDir};
 
 #[tokio::test]
 async fn stream_repository_writes_jsonl_with_384_dim_embedding() {
@@ -76,4 +77,31 @@ async fn stream_repository_stdout_dash_is_valid_sink_path() {
         repo.is_ok(),
         "`StreamRepository::new(\"-\")` must construct without error"
     );
+}
+
+#[tokio::test]
+async fn stream_repository_creates_parent_directories() {
+    let tmp = TempDir::new().expect("temp dir");
+    let nested_path: PathBuf = tmp
+        .path()
+        .join("subdir")
+        .join("nested")
+        .join("output.jsonl");
+
+    assert!(
+        !nested_path.parent().unwrap().exists(),
+        "parent dir must not exist before StreamRepository::new"
+    );
+
+    let repo = StreamRepository::new(&nested_path.to_string_lossy());
+    assert!(
+        repo.is_ok(),
+        "StreamRepository::new must succeed for nested path"
+    );
+
+    assert!(
+        nested_path.parent().unwrap().exists(),
+        "parent directories must be created by StreamRepository::new"
+    );
+    assert!(nested_path.exists(), "output file must be created");
 }


### PR DESCRIPTION
Closes #191

## Summary

3 real bugs found during comprehensive CLI testing against real websites (books.toscrape.com, quotes.toscrape.com).

### Bug 1: Sitemap crawl produces 0 output files 🔴

crawl_with_sitemap_internal() was swallowing SitemapNotFound by returning Ok(Vec::new()) instead of propagating the error. The orchestrator saw 0 URLs and exited silently.

**Fix:** Propagate Err(CrawlError::SitemapNotFound(url)) so callers can decide whether to fall back to DOM crawling.

### Bug 2: --output-vectors fails with No such file or directory 🟡

StreamRepository::new() called File::create(path) without creating parent directories first.

**Fix:** Add create_dir_all() before File::create() with Spanish user-facing error message.

### Bug 3: Batch processing hangs after succeeded message 🔴

spawn_signal_handler() discarded the tokio JoinHandle, leaving an orphaned task waiting forever for SIGINT/SIGTERM.

**Fix:** Store the JoinHandle in Engine.signal_handle and abort it in shutdown().

## Verification

- cargo check — clean
- cargo clippy -- -D warnings — clean
- cargo fmt — applied
- cargo nextest run — 1272/1273 pass (1 pre-existing failure)
- 3 new tests for each fix
- 317 lines changed