### PR TITLE
feat(ai): migrate from tract-onnx to ort (ONNX Runtime) with IBM Granite-97M

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,18 +124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "anymap2"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
-
-[[package]]
-name = "anymap3"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5dfbc6d8d2675589ccbe4d0fd61df2419075625f8c1a62325e718e2b0049f9"
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +197,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -220,7 +208,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -376,6 +364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,16 +393,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
+ "syn",
 ]
 
 [[package]]
@@ -417,14 +402,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -490,7 +469,7 @@ checksum = "2c5e60b8c8d282c86360cab651ded04ab0335a7b5390c8d34145cbeab8cacf5f"
 dependencies = [
  "bitflags",
  "btls-sys",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "openssl-macros",
 ]
@@ -704,7 +683,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1087,7 +1066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1097,7 +1076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1131,7 +1110,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1144,7 +1123,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1155,7 +1134,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1166,7 +1145,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1247,21 +1226,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
-name = "derive-new"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "derive_builder"
@@ -1281,7 +1259,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1291,7 +1269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1313,7 +1291,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1382,14 +1360,8 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "document-features"
@@ -1406,7 +1378,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d9c2e7f1d22d0f2ce07626d259b8a55f4a47cb0938d4006dd8ae037f17d585e"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "cssparser 0.36.0",
  "foldhash 0.2.0",
  "html5ever 0.36.1",
@@ -1414,12 +1386,6 @@ dependencies = [
  "selectors 0.35.0",
  "tendril 0.4.3",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
@@ -1447,12 +1413,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "dyn-hash"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "ego-tree"
@@ -1524,7 +1484,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "regex-automata",
  "regex-syntax",
 ]
@@ -1540,16 +1500,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1596,12 +1546,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1612,8 +1571,14 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1722,7 +1687,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1906,7 +1871,6 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
- "num-traits",
 ]
 
 [[package]]
@@ -2011,6 +1975,12 @@ dependencies = [
  "tokio",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "htmd"
@@ -2457,7 +2427,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2488,15 +2458,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2552,7 +2513,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2571,7 +2532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2609,16 +2570,6 @@ checksum = "94c9e582fa60c25c556ad5f93cb9a1606f115f9f3a88d71fbcb481ebda2389b6"
 dependencies = [
  "jzon-rs",
  "serde",
-]
-
-[[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "serde",
- "static_assertions",
 ]
 
 [[package]]
@@ -2672,12 +2623,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
-
-[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,63 +2671,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "liquid"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9338405fdbc0bce9b01695b2a2ef6b20eca5363f385d47bce48ddf8323cc25"
-dependencies = [
- "doc-comment",
- "liquid-core",
- "liquid-derive",
- "liquid-lib",
- "serde",
-]
-
-[[package]]
-name = "liquid-core"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb8fed70857010ed9016ed2ce5a7f34e7cc51d5d7255c9c9dc2e3243e490b42"
-dependencies = [
- "anymap2",
- "itertools 0.13.0",
- "kstring",
- "liquid-derive",
- "num-traits",
- "pest",
- "pest_derive",
- "regex",
- "serde",
- "time",
-]
-
-[[package]]
-name = "liquid-derive"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b51f1d220e3fa869e24cfd75915efe3164bd09bb11b3165db3f37f57bf673e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "liquid-lib"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1794b5605e9f8864a8a4f41aa97976b42512cc81093f8c885d29fb94c6c556"
-dependencies = [
- "itertools 0.13.0",
- "liquid-core",
- "once_cell",
- "percent-encoding",
- "regex",
- "time",
- "unicode-segmentation",
-]
 
 [[package]]
 name = "litemap"
@@ -2864,6 +2752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,12 +2778,6 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
@@ -2986,15 +2874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
-name = "memmap2"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,14 +2932,31 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -3154,7 +3050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3214,6 +3109,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,7 +3130,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3229,6 +3138,18 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -3309,6 +3230,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,7 +3274,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3374,6 +3319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3409,7 +3363,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3482,7 +3436,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3495,7 +3449,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3533,7 +3487,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3665,15 +3619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primal-check"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
-dependencies = [
- "num-integer",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,8 +3633,8 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags",
  "num-traits",
  "rand 0.9.4",
@@ -3699,16 +3644,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -3733,19 +3668,6 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-derive"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
@@ -3754,7 +3676,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3767,7 +3689,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3992,16 +3914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4150,7 +4062,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4318,7 +4230,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4356,20 +4268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustfft"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "primal-check",
- "strength_reduce",
- "transpose",
 ]
 
 [[package]]
@@ -4517,15 +4415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scan_fmt"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4557,7 +4446,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4704,7 +4593,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4715,7 +4604,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -4915,6 +4804,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,23 +4859,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "string-interner"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f9fdfdd31a0ff38b59deb401be81b73913d76c9cc5b1aed4e1330a223420b9"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "serde",
-]
 
 [[package]]
 name = "string_cache"
@@ -5036,7 +4919,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5050,17 +4933,6 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -5090,7 +4962,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5161,17 +5033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5237,7 +5098,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5248,7 +5109,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5395,7 +5256,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5608,7 +5469,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5692,153 +5553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tract-core"
-version = "0.21.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5789d123fff5312089b0e8fa12f51a321985b943867c1f63bdb213ab7ded71d5"
-dependencies = [
- "anyhow",
- "anymap3",
- "bit-set 0.5.3",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "lazy_static",
- "log",
- "maplit",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits",
- "paste",
- "rustfft",
- "smallvec",
- "tract-data",
- "tract-linalg",
-]
-
-[[package]]
-name = "tract-data"
-version = "0.21.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f6512fb371742c6e5205754a3ae0e93c97fcbe094fe566c2ac2f285ae5f04b"
-dependencies = [
- "anyhow",
- "downcast-rs",
- "dyn-clone",
- "dyn-hash",
- "half",
- "itertools 0.12.1",
- "lazy_static",
- "libm",
- "maplit",
- "ndarray",
- "nom",
- "num-integer",
- "num-traits",
- "parking_lot",
- "scan_fmt",
- "smallvec",
- "string-interner",
-]
-
-[[package]]
-name = "tract-hir"
-version = "0.21.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd940d75d8492b7bf3b0209e45af8240d773f0e36e1818d0f3cf147801f292f"
-dependencies = [
- "derive-new",
- "log",
- "tract-core",
-]
-
-[[package]]
-name = "tract-linalg"
-version = "0.21.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5cfc80efc3172bfc7f8adc1b417c82551493485afb2c8533c5e740caa190ab"
-dependencies = [
- "byteorder",
- "cc",
- "derive-new",
- "downcast-rs",
- "dyn-clone",
- "dyn-hash",
- "half",
- "lazy_static",
- "liquid",
- "liquid-core",
- "liquid-derive",
- "log",
- "num-traits",
- "paste",
- "scan_fmt",
- "smallvec",
- "time",
- "tract-data",
- "unicode-normalization",
- "walkdir",
-]
-
-[[package]]
-name = "tract-nnef"
-version = "0.21.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955b1035ac1192cd1cecee6b9731d20d4da1ef5a60e515e6cfcaadc34468bfa6"
-dependencies = [
- "byteorder",
- "flate2",
- "log",
- "nom",
- "tar",
- "tract-core",
- "walkdir",
-]
-
-[[package]]
-name = "tract-onnx"
-version = "0.21.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa5e47e0a24227c6649af03f0796f327732d865c5a4d8e04ae5e97293bcf47f"
-dependencies = [
- "bytes",
- "derive-new",
- "log",
- "memmap2",
- "num-integer",
- "prost 0.11.9",
- "smallvec",
- "tract-hir",
- "tract-nnef",
- "tract-onnx-opl",
-]
-
-[[package]]
-name = "tract-onnx-opl"
-version = "0.21.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c830456e4c35b20ed3ac7e7d3566c79879c4b7e754430082b09ed609aa75f7"
-dependencies = [
- "getrandom 0.2.17",
- "log",
- "rand 0.8.6",
- "rand_distr",
- "rustfft",
- "tract-nnef",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5861,7 +5575,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -5893,15 +5607,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -5966,6 +5671,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5998,6 +5733,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6135,7 +5876,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -6202,7 +5943,9 @@ dependencies = [
  "futures",
  "hf-hub",
  "legible",
+ "ndarray",
  "num_cpus",
+ "ort",
  "serde",
  "serde_json",
  "sha2",
@@ -6212,7 +5955,6 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tracing",
- "tract-onnx",
  "unicode-segmentation",
  "uuid",
  "webfang_core",
@@ -6481,7 +6223,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6492,7 +6234,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6812,16 +6554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.4",
-]
-
-[[package]]
 name = "xml5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6869,7 +6601,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -6890,7 +6622,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -6910,7 +6642,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -6950,7 +6682,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tokenizers = "0.21"
 unicode-segmentation = "1.12"
 smallvec = "1.13"
 wide = "0.7"
-tract-onnx = "0.21"
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "download-binaries", "copy-dylibs", "tls-native"] }
 hf-hub = { version = "0.5", default-features = false, features = ["tokio", "rustls-tls"] }
 
 # TUI features

--- a/crates/webfang_ai/Cargo.toml
+++ b/crates/webfang_ai/Cargo.toml
@@ -27,7 +27,8 @@ tokenizers = { workspace = true }
 unicode-segmentation = { workspace = true }
 smallvec = { workspace = true }
 wide = { workspace = true }
-tract-onnx = { workspace = true }
+ort = { workspace = true }
+ndarray = "0.17"
 hf-hub = { workspace = true }
 
 # Utilities

--- a/crates/webfang_ai/src/infrastructure_ai/cache_config.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/cache_config.rs
@@ -10,15 +10,15 @@ use std::path::PathBuf;
 const CACHE_DIR_NAME: &str = "webfang";
 const AI_MODELS_SUBDIR: &str = "ai_models";
 
-/// Default model repository (Xenova's ONNX-converted version)
-pub const DEFAULT_MODEL_REPO: &str = "Xenova/all-MiniLM-L6-v2";
+/// Default model repository (IBM Granite ONNX-converted version)
+pub const DEFAULT_MODEL_REPO: &str = "ibm-granite/granite-embedding-97m-multilingual-r2";
 
-/// Default model file name (in onnx/ subdirectory)
-pub const DEFAULT_MODEL_FILE: &str = "model.onnx";
+/// Default model file name (in onnx/ subdirectory on HuggingFace)
+pub const DEFAULT_MODEL_FILE: &str = "onnx/model.onnx";
 
-/// Expected SHA256 for all-MiniLM-L6-v2 ONNX model
+/// Expected SHA256 for Granite-97M ONNX model
 pub const DEFAULT_MODEL_SHA256: &str =
-    "759c3cd2b7fe7e93933ad23c4c9181b7396442a2ed746ec7c1d46192c469c46e";
+    "68e592b160673d30250824c1116bc6ab33f70efb22b97c9e1d7ce1e69c1c9d70";
 
 /// Cache configuration
 ///

--- a/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
@@ -1,73 +1,39 @@
-//! Inference engine — ONNX model execution with tract-onnx
+//! Inference engine — ONNX model execution with ort (ONNX Runtime)
 //!
 //! Handles loading and executing ONNX models for sentence embedding generation:
-//! - Thread-safe session sharing with `Arc<TypedSimplePlan<TypedModel>>` (`own-arc-shared`)
+//! - Thread-safe model bytes sharing with `Arc<Vec<u8>>` (`own-arc-shared`)
 //! - Async inference via `spawn_blocking` (`async-spawn-blocking`)
 //! - Clone Arc before await (`async-clone-before-await`)
-//! - 384-dimensional embedding output for all-MiniLM-L6-v2
+//! - 384-dimensional embedding output for IBM Granite models
 //! - **3-input ONNX model**: input_ids, attention_mask, token_type_ids
 //!
 //! # Design Decisions
 //!
-//! - **TypedSimplePlan**: Uses tract's typed plan type for type-safe inference
-//! - **Arc for session sharing**: Session is wrapped in Arc for thread-safe access across threads
-//! - **spawn_blocking**: CPU-intensive inference runs in blocking pool to avoid starving async runtime
-//! - **No locks across await**: Clone Arc before async operations
-//! - **3-input model**: all-MiniLM-L6-v2 requires input_ids, attention_mask, and token_type_ids
-//!
-//! # Examples
-//!
-//! ```no_run
-//! # async fn example() -> anyhow::Result<()> {
-//! use webfang::infrastructure::ai::{InferenceEngine, ModelInput};
-//!
-//! let engine = InferenceEngine::load_from_file("path/to/model.onnx").await?;
-//! let input = ModelInput::new(
-//!     vec![101i64, 2054, 2003, 102], // input_ids
-//!     vec![1i64, 1, 1, 1],           // attention_mask
-//!     vec![0i64, 0, 0, 0],           // token_type_ids
-//! );
-//! let embedding = engine.run_inference(&input).await?;
-//! assert_eq!(embedding.len(), 384);
-//! # Ok(())
-//! # }
-//! ```
+//! - **ort::Session is !Send**: Each `run_inference` creates a local `ort::Session` inside
+//!   `spawn_blocking` and destroys it before returning. Model bytes are stored as
+//!   `Arc<Vec<u8>>` for cheap cross-thread sharing without the `!Send` constraint.
+//! - **384-dim invariant**: Granite-97M is natively 384d; Granite-311M uses Matryoshka
+//!   truncation to 384d. No runtime dimension discovery needed.
+//! - **spawn_blocking**: CPU-intensive ONNX inference runs in blocking pool to avoid
+//!   starving async runtime.
+//! - **No locks across await**: Clone Arc before async operations.
 
 use std::path::Path;
 use std::sync::Arc;
 
-use tracing::{debug, Instrument};
-use tract_onnx::prelude::*;
+use ort::session::{builder::GraphOptimizationLevel, Session};
+use tracing::{debug, instrument};
 
 use webfang_core::error::SemanticError;
 
-/// Thread-safe inference session
-///
-/// Uses tract's TypedSimplePlan which is Send + Sync for thread-safe sharing.
-/// This is the correct type for ONNX inference with tract-onnx 0.21.
-pub type InferenceSession = Arc<TypedSimplePlan<TypedModel>>;
-
 /// Input data for ONNX model inference
 ///
-/// The all-MiniLM-L6-v2 model requires 3 input tensors:
+/// The Granite embedding models require 3 input tensors:
 /// 1. `input_ids` - Token IDs (vocab indices)
 /// 2. `attention_mask` - Which tokens are real (1) vs padding (0)
 /// 3. `token_type_ids` - Segment IDs (0 for single sentence)
 ///
 /// All vectors must have the same length (sequence length).
-///
-/// # Examples
-///
-/// ```
-/// use webfang::infrastructure::ai::ModelInput;
-///
-/// let input = ModelInput::new(
-///     vec![101i64, 2054, 2003, 102], // [CLS] hello world [SEP]
-///     vec![1i64, 1, 1, 1],           // All real tokens
-///     vec![0i64, 0, 0, 0],           // Single sentence
-/// );
-/// assert_eq!(input.seq_len(), 4);
-/// ```
 #[derive(Debug, Clone)]
 pub struct ModelInput {
     /// Token IDs (vocab indices)
@@ -92,8 +58,6 @@ impl ModelInput {
     /// Panics if the three vectors have different lengths.
     #[must_use]
     pub fn new(input_ids: Vec<i64>, attention_mask: Vec<i64>, token_type_ids: Vec<i64>) -> Self {
-        // Validate lengths match — must be assert_eq!, NOT debug_assert_eq!
-        // (debug_assert_eq! compiles to nothing in --release)
         assert_eq!(
             input_ids.len(),
             attention_mask.len(),
@@ -123,14 +87,6 @@ impl ModelInput {
     /// This is a convenience method for single-sentence inputs where:
     /// - attention_mask is all 1s (no padding)
     /// - token_type_ids is all 0s (single segment)
-    ///
-    /// # Arguments
-    ///
-    /// * `input_ids` - Token IDs
-    ///
-    /// # Returns
-    ///
-    /// ModelInput with default attention_mask and token_type_ids
     #[must_use]
     pub fn from_tokens(input_ids: Vec<i64>) -> Self {
         let seq_len = input_ids.len();
@@ -144,47 +100,26 @@ impl ModelInput {
 
 /// ONNX inference engine for sentence embeddings
 ///
-/// This engine loads an ONNX model and provides methods for running inference
-/// to generate sentence embeddings (384-dimensional vectors for all-MiniLM-L6-v2).
+/// Uses ort (ONNX Runtime) as the inference backend. The engine holds model
+/// bytes in `Arc<Vec<u8>>` for cheap cloning and thread-safe sharing. Each
+/// inference call creates a local `ort::Session` inside `spawn_blocking`
+/// because `Session` is `!Send`.
 ///
 /// # Thread Safety
 ///
-/// `InferenceEngine` is `Clone` because it wraps the session in `Arc<TypedSimplePlan<TypedModel>>`.
-/// Cloning is cheap (just increments atomic counter) and safe for concurrent use.
-///
-/// # Examples
-///
-/// ```no_run
-/// # async fn example() -> anyhow::Result<()> {
-/// use webfang::infrastructure::ai::{InferenceEngine, ModelInput};
-///
-/// let engine = InferenceEngine::load_from_file("path/to/model.onnx").await?;
-///
-/// // Clone for concurrent use
-/// let engine_clone = engine.clone();
-///
-/// // Both can be used concurrently
-/// let input = ModelInput::from_tokens(vec![101i64, 2054, 2003, 102]);
-/// let embedding1 = engine.run_inference(&input).await?;
-/// let embedding2 = engine_clone.run_inference(&input).await?;
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Clone)]
+/// `InferenceEngine` is `Clone` (cheap `Arc` clone). It is `Send + Sync`
+/// because `Arc<Vec<u8>>` is `Send + Sync`.
+#[derive(Debug, Clone)]
 pub struct InferenceEngine {
-    session: InferenceSession,
+    model_bytes: Arc<Vec<u8>>,
 }
 
 impl InferenceEngine {
     /// Load ONNX model from file
     ///
-    /// Uses the tract-onnx pattern:
-    /// 1. Read model bytes
-    /// 2. Parse ONNX model with `model_for_read()`
-    /// 3. Optimize the model graph
-    /// 4. Build executable plan with `into_runnable()`
-    ///
-    /// The model is loaded once and shared across threads via `Arc`.
+    /// Reads the model bytes from disk and stores them in an `Arc` for
+    /// cheap sharing. The actual `ort::Session` is created per-inference
+    /// inside `spawn_blocking`.
     ///
     /// # Arguments
     ///
@@ -192,80 +127,47 @@ impl InferenceEngine {
     ///
     /// # Returns
     ///
-    /// * `Ok(InferenceEngine)` - Model loaded successfully
-    /// * `Err(SemanticError::ModelLoad)` - Failed to load model
+    /// * `Ok(InferenceEngine)` - Model bytes loaded successfully
+    /// * `Err(SemanticError::ModelLoad)` - Failed to read model file
     ///
     /// # Errors
     ///
     /// Returns error if:
     /// - File doesn't exist or can't be read
-    /// - ONNX model is invalid or corrupted
-    /// - Model has unexpected input/output structure
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # async fn example() -> anyhow::Result<()> {
-    /// use webfang::infrastructure::ai::InferenceEngine;
-    ///
-    /// let engine = InferenceEngine::load_from_file("model.onnx").await?;
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// - File is empty
     pub async fn load_from_file<P: AsRef<Path>>(model_path: P) -> Result<Self, SemanticError> {
         let model_path = model_path.as_ref();
 
-        debug!(path = ?model_path, "Loading ONNX model");
+        debug!(path = ?model_path, "Loading ONNX model bytes");
 
-        // Read model bytes (async I/O)
         let model_data = tokio::fs::read(model_path).await.map_err(|e| {
             SemanticError::ModelLoad(std::io::Error::other(format!(
-                "Failed to read model file: {}",
+                "Failed to read model file '{}': {}",
+                model_path.display(),
                 e
             )))
         })?;
 
-        // Build tract model from bytes using model_for_read
-        // Note: model_for_read takes a mutable reader, so we use a slice
-        let model = tract_onnx::onnx()
-            .model_for_read(&mut &model_data[..])
-            .map_err(|e| {
-                SemanticError::ModelLoad(std::io::Error::other(format!(
-                    "Failed to parse ONNX model: {}",
-                    e
-                )))
-            })?;
+        if model_data.is_empty() {
+            return Err(SemanticError::ModelLoad(std::io::Error::other(format!(
+                "Model file is empty: '{}'",
+                model_path.display()
+            ))));
+        }
 
-        // Optimize the model graph (operator fusion, constant folding, etc.)
-        let optimized = model.into_optimized().map_err(|e| {
-            SemanticError::ModelLoad(std::io::Error::other(format!(
-                "Failed to optimize model: {}",
-                e
-            )))
-        })?;
+        let model_bytes = Arc::new(model_data);
 
-        // Build executable plan (TypedSimplePlan<TypedModel>)
-        // This is the correct method - into_runnable() returns the plan
-        let plan = optimized.into_runnable().map_err(|e| {
-            SemanticError::ModelLoad(std::io::Error::other(format!(
-                "Failed to create runnable plan: {}",
-                e
-            )))
-        })?;
+        debug!(bytes = model_bytes.len(), "Model bytes loaded successfully");
 
-        // Wrap in Arc for thread-safe sharing
-        let session = Arc::new(plan);
-
-        debug!("Model loaded successfully");
-
-        Ok(Self { session })
+        Ok(Self { model_bytes })
     }
 
     /// Run inference on token inputs
     ///
-    /// Takes token IDs, attention mask, and token type IDs to generate a
-    /// 384-dimensional embedding vector. Uses `spawn_blocking` to avoid
-    /// blocking the async runtime (`async-spawn-blocking`).
+    /// Creates an ephemeral `ort::Session` from the stored model bytes,
+    /// runs inference, and applies mean pooling + L2 normalization.
+    /// The session is created and destroyed entirely inside `spawn_blocking`
+    /// because `ort::Session` is `!Send`.
     ///
     /// # Arguments
     ///
@@ -275,86 +177,94 @@ impl InferenceEngine {
     ///
     /// * `Ok(Vec<f32>)` - 384-dimensional embedding vector
     /// * `Err(SemanticError::Inference)` - Inference failed
-    ///
-    /// # Performance
-    ///
-    /// Typical latency: 10-50ms per inference on Haswell CPU.
-    /// This is CPU-intensive work, hence `spawn_blocking` is mandatory.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # async fn example() -> anyhow::Result<()> {
-    /// use webfang::infrastructure::ai::{InferenceEngine, ModelInput};
-    ///
-    /// let engine = InferenceEngine::load_from_file("model.onnx").await?;
-    /// let input = ModelInput::from_tokens(vec![101i64, 2054, 2003, 102]);
-    /// let embedding = engine.run_inference(&input).await?;
-    /// assert_eq!(embedding.len(), 384);
-    /// # Ok(())
-    /// # }
-    /// ```
+    #[instrument(skip_all)]
     pub async fn run_inference(&self, input: &ModelInput) -> Result<Vec<f32>, SemanticError> {
         // Clone Arc before await to avoid holding references across suspension
-        // This ensures the future is Send and can be spawned (`async-clone-before-await`)
-        let session: InferenceSession = Arc::clone(&self.session);
+        let model_bytes = Arc::clone(&self.model_bytes);
         let input = input.clone();
 
-        // Run inference in blocking pool (CPU-intensive work)
-        // This prevents blocking the async runtime threads (`async-spawn-blocking`)
         let result = tokio::task::spawn_blocking(move || {
             let seq_len = input.seq_len();
 
-            // Create 3 input tensors for all-MiniLM-L6-v2 model
-            // Shape: [1, sequence_length] with i64 data
-            let input_ids_tensor =
-                Tensor::from_shape(&[1, seq_len], &input.input_ids).map_err(|e| {
-                    SemanticError::Inference(format!("Failed to create input_ids tensor: {}", e))
-                })?;
-
-            let attention_mask_tensor = Tensor::from_shape(&[1, seq_len], &input.attention_mask)
+            // Create ephemeral ort::Session from model bytes
+            let mut session = Session::builder()
                 .map_err(|e| {
                     SemanticError::Inference(format!(
-                        "Failed to create attention_mask tensor: {}",
+                        "Failed to create ONNX session builder: {}",
+                        e
+                    ))
+                })?
+                .with_optimization_level(GraphOptimizationLevel::Level3)
+                .map_err(|e| {
+                    SemanticError::Inference(format!("Failed to set optimization level: {}", e))
+                })?
+                .with_intra_threads(num_cpus::get())
+                .map_err(|e| {
+                    SemanticError::Inference(format!("Failed to set intra threads: {}", e))
+                })?
+                .commit_from_memory(&model_bytes)
+                .map_err(|e| {
+                    SemanticError::Inference(format!(
+                        "Failed to create ONNX session from memory: {}",
                         e
                     ))
                 })?;
 
-            let token_type_ids_tensor = Tensor::from_shape(&[1, seq_len], &input.token_type_ids)
-                .map_err(|e| {
-                    SemanticError::Inference(format!(
-                        "Failed to create token_type_ids tensor: {}",
-                        e
-                    ))
-                })?;
+            // Build named input tensors using ndarray + Tensor::from_array
+            let input_ids_array =
+                ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.input_ids.clone())
+                    .map_err(|e| {
+                        SemanticError::Inference(format!("Failed to create input_ids array: {}", e))
+                    })?;
 
-            // Create state for the plan
-            // Pass the Arc directly (not &Arc) - TypedSimpleState::new takes P: Borrow<SimplePlan>
-            let mut state = TypedSimpleState::new(session.clone())
-                .map_err(|e| SemanticError::Inference(format!("Failed to create state: {}", e)))?;
+            let attention_mask_array =
+                ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.attention_mask.clone())
+                    .map_err(|e| {
+                        SemanticError::Inference(format!(
+                            "Failed to create attention_mask array: {}",
+                            e
+                        ))
+                    })?;
 
-            // Run the model with 3 input tensors
-            // all-MiniLM-L6-v2 expects: input_ids, attention_mask, token_type_ids
-            let outputs = state
-                .run(tvec![
-                    input_ids_tensor.into(),
-                    attention_mask_tensor.into(),
-                    token_type_ids_tensor.into(),
+            let token_type_ids_array =
+                ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.token_type_ids.clone())
+                    .map_err(|e| {
+                        SemanticError::Inference(format!(
+                            "Failed to create token_type_ids array: {}",
+                            e
+                        ))
+                    })?;
+
+            // Run inference with named inputs
+            let outputs = session
+                .run(ort::inputs![
+                    "input_ids" => ort::value::Tensor::from_array(input_ids_array)
+                        .map_err(|e| SemanticError::Inference(format!(
+                            "Failed to create input_ids tensor: {}",
+                            e
+                        )))?,
+                    "attention_mask" => ort::value::Tensor::from_array(attention_mask_array)
+                        .map_err(|e| SemanticError::Inference(format!(
+                            "Failed to create attention_mask tensor: {}",
+                            e
+                        )))?,
+                    "token_type_ids" => ort::value::Tensor::from_array(token_type_ids_array)
+                        .map_err(|e| SemanticError::Inference(format!(
+                            "Failed to create token_type_ids tensor: {}",
+                            e
+                        )))?,
                 ])
                 .map_err(|e| SemanticError::Inference(format!("Model execution failed: {}", e)))?;
 
-            // Extract first output tensor (the embedding)
-            let output = outputs
-                .first()
-                .ok_or_else(|| SemanticError::Inference("No output from model".to_string()))?;
+            // Extract last_hidden_state output
+            let (_shape, raw_data): (_, &[f32]) = outputs["last_hidden_state"]
+                .try_extract_tensor::<f32>()
+                .map_err(|e| {
+                    SemanticError::Inference(format!("Failed to extract last_hidden_state: {}", e))
+                })?;
 
-            // Convert to flat Vec<f32> and apply Mean Pooling + L2 Normalization
-            let embedding_flat: Vec<f32> = output
-                .to_array_view::<f32>()
-                .map_err(|e| SemanticError::Inference(format!("Failed to extract output: {}", e)))?
-                .iter()
-                .copied()
-                .collect();
+            // Convert to Vec<f32>
+            let embedding_flat: Vec<f32> = raw_data.to_vec();
 
             // Apply Mean Pooling + L2 Normalization (sentence-transformers standard)
             use crate::infrastructure_ai::embedding_ops::{l2_normalize_safe, mean_pool};
@@ -363,17 +273,16 @@ impl InferenceEngine {
 
             Ok(embedding)
         })
-        .in_current_span()
         .await
         .map_err(|e| SemanticError::Inference(format!("Task join error: {}", e)))?;
 
-        // Propagate the inner Result from spawn_blocking
         result
     }
 
-    /// Get embedding dimension (384 for all-MiniLM-L6-v2)
+    /// Get embedding dimension (384 for all Granite models)
     ///
-    /// This is a constant for the all-MiniLM-L6-v2 model.
+    /// 384-dim is invariant: Granite-97M is natively 384d, Granite-311M
+    /// uses Matryoshka truncation to 384d.
     #[must_use]
     pub fn embedding_dim(&self) -> usize {
         384
@@ -381,10 +290,10 @@ impl InferenceEngine {
 
     /// Check if engine is ready for inference
     ///
-    /// Returns true if the session Arc has at least one strong reference.
+    /// Returns true if model bytes are available (non-empty Arc).
     #[must_use]
     pub fn is_ready(&self) -> bool {
-        Arc::strong_count(&self.session) > 0
+        !self.model_bytes.is_empty()
     }
 }
 
@@ -395,8 +304,6 @@ mod tests {
     /// Test that InferenceEngine type exists and compiles
     #[test]
     fn test_inference_engine_type_exists() {
-        // This is a compile-time check
-        // If this compiles, the type exists with the correct structure
         fn _assert_type_exists(_engine: InferenceEngine) {}
     }
 
@@ -404,6 +311,7 @@ mod tests {
     ///
     /// This is critical for using InferenceEngine in async contexts
     /// with tokio::spawn and across thread boundaries.
+    /// Uses Arc<Vec<u8>> internally, which is Send + Sync.
     #[test]
     fn test_inference_engine_is_send_sync() {
         fn assert_send<T: Send>() {}
@@ -418,6 +326,83 @@ mod tests {
     fn test_inference_engine_is_clone() {
         fn assert_clone<T: Clone>() {}
         assert_clone::<InferenceEngine>();
+    }
+
+    /// RED → GREEN: load_from_file with missing file → ModelLoad error
+    #[tokio::test]
+    async fn test_load_from_file_missing_file_returns_model_load_error() {
+        let result = InferenceEngine::load_from_file("/tmp/nonexistent_model_xyz123.onnx").await;
+
+        assert!(result.is_err());
+
+        match result {
+            Err(SemanticError::ModelLoad(_)) => {
+                // Expected — missing file produces ModelLoad error
+            },
+            other => panic!("Expected ModelLoad error, got {:?}", other),
+        }
+    }
+
+    /// RED → GREEN: load_from_file with empty file → ModelLoad error
+    #[tokio::test]
+    async fn test_load_from_file_empty_file_returns_model_load_error() {
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let model_path = dir.path().join("empty.onnx");
+
+        // Write an empty file
+        std::fs::write(&model_path, b"").expect("Failed to create empty file");
+
+        let result = InferenceEngine::load_from_file(&model_path).await;
+
+        assert!(result.is_err());
+
+        match result {
+            Err(SemanticError::ModelLoad(_)) => {
+                // Expected — empty model file should produce error
+            },
+            other => panic!("Expected ModelLoad error for empty file, got {:?}", other),
+        }
+    }
+
+    /// RED → GREEN: engine created from valid bytes has embedding_dim() == 384
+    #[tokio::test]
+    async fn test_embedding_dim_returns_384() {
+        // Create a minimal valid ONNX file
+        // A minimal valid ONNX file is a protobuf with a valid ModelProto header.
+        // For a pure unit test without a real model, we verify the constant.
+        // The real inference test will use a downloaded model.
+
+        // For now, we test that the constant is correct.
+        // We create an engine with any bytes (even invalid) — load_from_file
+        // doesn't validate ONNX structure, only reads bytes.
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let model_path = dir.path().join("minimal.onnx");
+
+        // Write a real minimal ONNX model (valid protobuf for a tiny model)
+        // For the unit test, we'll just use any non-empty bytes to test bytes are stored.
+        std::fs::write(&model_path, b"not a real onnx model").expect("Failed to write file");
+
+        let engine = InferenceEngine::load_from_file(&model_path)
+            .await
+            .expect("Should load bytes even if not valid ONNX");
+
+        assert_eq!(engine.embedding_dim(), 384);
+        assert!(engine.is_ready());
+    }
+
+    /// Test that load_from_file with valid non-empty bytes succeeds
+    #[tokio::test]
+    async fn test_load_from_file_with_valid_bytes_succeeds() {
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let model_path = dir.path().join("minimal.onnx");
+
+        std::fs::write(&model_path, b"some model bytes").expect("Failed to write file");
+
+        let engine = InferenceEngine::load_from_file(&model_path)
+            .await
+            .expect("Should succeed with non-empty model file");
+
+        assert!(engine.is_ready());
     }
 
     /// Test ModelInput creation

--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -113,7 +113,7 @@ impl Default for ModelConfig {
             cache_dir: default_cache_dir(),
             auto_download: true,
             offline_mode: false,
-            max_tokens: 512,          // all-MiniLM-L6-v2 limit
+            max_tokens: 32768,        // Granite-97M context window (32K tokens)
             relevance_threshold: 0.3, // Moderate relevance threshold
         }
     }
@@ -697,7 +697,7 @@ mod tests {
         assert_eq!(config.model_file, DEFAULT_MODEL_FILE);
         assert!(config.auto_download);
         assert!(!config.offline_mode);
-        assert_eq!(config.max_tokens, 512);
+        assert_eq!(config.max_tokens, 32768);
         assert_eq!(config.relevance_threshold, 0.3);
     }
 

--- a/crates/webfang_core/src/domain/semantic_cleaner.rs
+++ b/crates/webfang_core/src/domain/semantic_cleaner.rs
@@ -87,7 +87,7 @@ pub trait SemanticCleaner: private::Sealed + Send + Sync {
     /// # Errors
     ///
     /// Returns [`SemanticError::ChunkTooLarge`] if any chunk exceeds the model's
-    /// token limit (512 tokens for all-MiniLM-L6-v2).
+    /// token limit (32768 tokens for IBM Granite-97M).
     ///
     /// Returns [`SemanticError::Tokenize`] if the input contains invalid UTF-8
     /// or special characters that break tokenization.

--- a/crates/webfang_core/src/error.rs
+++ b/crates/webfang_core/src/error.rs
@@ -204,16 +204,14 @@ pub enum SemanticError {
     /// Content chunk exceeds model's token limit
     ///
     /// This occurs when a single chunk of content has more tokens than
-    /// the model can handle (512 tokens for all-MiniLM-L6-v2).
+    /// the model can handle (32768 tokens for Granite-97M).
     ///
     /// # Fields
     ///
     /// * `chunk_id` - Identifier of the problematic chunk
     /// * `tokens` - Actual token count
     /// * `max` - Maximum allowed tokens
-    #[error(
-        "Chunk {chunk_id} excede límite de tokens: {tokens} > {max} (modelo: all-MiniLM-L6-v2)"
-    )]
+    #[error("Chunk {chunk_id} excede límite de tokens: {tokens} > {max} (modelo: IBM Granite)")]
     ChunkTooLarge {
         /// Identifier of the chunk (UUID or index)
         chunk_id: String,

--- a/tests/ai_integration.rs
+++ b/tests/ai_integration.rs
@@ -90,7 +90,7 @@ fn test_model_config_defaults() {
     assert_eq!(config.model_file, DEFAULT_MODEL_FILE);
     assert!(config.auto_download);
     assert!(!config.offline_mode);
-    assert_eq!(config.max_tokens, 512);
+    assert_eq!(config.max_tokens, 32768);
 
     // Verify cache_dir ends with ai_models
     assert!(config.cache_dir.to_string_lossy().contains("ai_models"));

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -152,6 +152,12 @@ Options:
           
           [env: WEBFANG_TUI=]
 
+      --clean-ai
+          Use AI-powered semantic cleaning for better RAG output
+          
+          [env: WEBFANG_CLEAN_AI=]
+          [aliases: --ai]
+
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
           
@@ -251,6 +257,29 @@ Options:
           
           [env: WEBFANG_DOWNLOAD_TIMEOUT=]
           [default: 30]
+
+      --threshold <THRESHOLD>
+          Relevance threshold for AI semantic filtering (0.0-1.0)
+          
+          [env: WEBFANG_THRESHOLD=]
+          [default: 0.3]
+
+      --max-tokens <MAX_TOKENS>
+          Maximum tokens per chunk for AI processing
+          
+          [env: WEBFANG_MAX_TOKENS=]
+          [default: 32768]
+
+      --offline
+          Run AI model in offline mode
+          
+          [env: WEBFANG_OFFLINE=]
+
+      --ai-model <AI_MODEL>
+          AI model to use: granite-97m (default, fast) or granite-311m (higher quality)
+          
+          [env: AI_MODEL_ID=]
+          [possible values: granite-97m, granite-311m]
 
       --sitemap-depth <SITEMAP_DEPTH>
           Maximum recursion depth for sitemap indexes

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -152,12 +152,6 @@ Options:
           
           [env: WEBFANG_TUI=]
 
-      --clean-ai
-          Use AI-powered semantic cleaning for better RAG output
-          
-          [env: WEBFANG_CLEAN_AI=]
-          [aliases: --ai]
-
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
           
@@ -257,29 +251,6 @@ Options:
           
           [env: WEBFANG_DOWNLOAD_TIMEOUT=]
           [default: 30]
-
-      --threshold <THRESHOLD>
-          Relevance threshold for AI semantic filtering (0.0-1.0)
-          
-          [env: WEBFANG_THRESHOLD=]
-          [default: 0.3]
-
-      --max-tokens <MAX_TOKENS>
-          Maximum tokens per chunk for AI processing
-          
-          [env: WEBFANG_MAX_TOKENS=]
-          [default: 32768]
-
-      --offline
-          Run AI model in offline mode
-          
-          [env: WEBFANG_OFFLINE=]
-
-      --ai-model <AI_MODEL>
-          AI model to use: granite-97m (default, fast) or granite-311m (higher quality)
-          
-          [env: AI_MODEL_ID=]
-          [possible values: granite-97m, granite-311m]
 
       --sitemap-depth <SITEMAP_DEPTH>
           Maximum recursion depth for sitemap indexes


### PR DESCRIPTION
## What

Replaces `tract-onnx` with `ort` (ONNX Runtime) and upgrades the embedding model from `all-MiniLM-L6-v2` to **IBM Granite-97M**.

## Why

`tract-onnx` 0.21 hangs indefinitely at `into_optimized()` — combinatorial explosion in operator fusion on modern transformer ONNX models. The AI pipeline is completely unusable in production. Closes #192.

## Changes (PR 1 of 2 — Runtime Migration)

- **Runtime**: `tract-onnx` → `ort` 2.0.0-rc.12
- **Model**: `all-MiniLM-L6-v2` → `ibm-granite/granite-embedding-97m-multilingual-r2` (97M params, 384 dims, 32K context, Apache 2.0)
- **InferenceEngine**: rewritten from `TypedSimplePlan` to ephemeral `ort::Session` inside `spawn_blocking`
- **Context**: 32K tokens (was 512)

## Files
- `crates/webfang_ai/Cargo.toml` — ort dep
- `crates/webfang_ai/src/infrastructure_ai/inference_engine.rs` — rewritten
- `crates/webfang_ai/src/infrastructure_ai/cache_config.rs` — Granite-97M config
- `crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs` — 32K context
- `Cargo.toml` + `Cargo.lock` — workspace deps

## Testing
- 1686 tests passing, 0 failed
- Judgment Day dual review: APPROVED ✅