### PR TITLE
feat(ai): complete InferencePool migration — wire into SemanticCleanerImpl

### DIFF
--- a/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
@@ -18,7 +18,6 @@
 //!   starving async runtime.
 //! - **No locks across await**: Clone Arc before async operations.
 
-use std::path::Path;
 use std::sync::Arc;
 
 use ort::session::{builder::GraphOptimizationLevel, Session};
@@ -100,148 +99,7 @@ impl ModelInput {
 }
 
 // ---------------------------------------------------------------------------
-// InferenceEngine (legacy, per-call session creation — to be removed in PR2)
-// ---------------------------------------------------------------------------
-
-/// ONNX inference engine for sentence embeddings
-///
-/// Uses ort (ONNX Runtime) as the inference backend. The engine holds model
-/// bytes in `Arc<Vec<u8>>` for cheap cloning and thread-safe sharing. Each
-/// inference call creates a local `ort::Session` inside `spawn_blocking`
-/// because `Session` is `!Send`.
-///
-/// # Thread Safety
-///
-/// `InferenceEngine` is `Clone` (cheap `Arc` clone). It is `Send + Sync`
-/// because `Arc<Vec<u8>>` is `Send + Sync`.
-#[derive(Debug, Clone)]
-pub struct InferenceEngine {
-    model_bytes: Arc<Vec<u8>>,
-    model_variant: AiModel,
-}
-
-impl InferenceEngine {
-    /// Load ONNX model from file
-    ///
-    /// Reads the model bytes from disk and stores them in an `Arc` for
-    /// cheap sharing. The actual `ort::Session` is created per-inference
-    /// inside `spawn_blocking`.
-    ///
-    /// # Arguments
-    ///
-    /// * `model_path` - Path to the ONNX model file
-    /// * `model_variant` - Which AI model is being loaded (for dimension handling)
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(InferenceEngine)` - Model bytes loaded successfully
-    /// * `Err(SemanticError::ModelLoad)` - Failed to read model file
-    ///
-    /// # Errors
-    ///
-    /// Returns error if:
-    /// - File doesn't exist or can't be read
-    /// - File is empty
-    pub async fn load_from_file<P: AsRef<Path>>(
-        model_path: P,
-        model_variant: AiModel,
-    ) -> Result<Self, SemanticError> {
-        let model_path = model_path.as_ref();
-
-        debug!(path = ?model_path, "Loading ONNX model bytes");
-
-        let model_data = tokio::fs::read(model_path).await.map_err(|e| {
-            SemanticError::ModelLoad(std::io::Error::other(format!(
-                "Failed to read model file '{}': {}",
-                model_path.display(),
-                e
-            )))
-        })?;
-
-        if model_data.is_empty() {
-            return Err(SemanticError::ModelLoad(std::io::Error::other(format!(
-                "Model file is empty: '{}'",
-                model_path.display()
-            ))));
-        }
-
-        let model_bytes = Arc::new(model_data);
-
-        debug!(
-            bytes = model_bytes.len(),
-            ?model_variant,
-            "Model bytes loaded successfully"
-        );
-
-        Ok(Self {
-            model_bytes,
-            model_variant,
-        })
-    }
-
-    /// Run inference on token inputs
-    ///
-    /// Creates an ephemeral `ort::Session` from the stored model bytes,
-    /// runs inference, and applies mean pooling + L2 normalization.
-    /// The session is created and destroyed entirely inside `spawn_blocking`
-    /// because `ort::Session` is `!Send`.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - ModelInput containing input_ids, attention_mask, token_type_ids
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(Vec<f32>)` - 384-dimensional embedding vector
-    /// * `Err(SemanticError::Inference)` - Inference failed
-    #[instrument(skip_all)]
-    pub async fn run_inference(&self, input: &ModelInput) -> Result<Vec<f32>, SemanticError> {
-        // Clone Arc before await to avoid holding references across suspension
-        let model_bytes = Arc::clone(&self.model_bytes);
-        let input = input.clone();
-        let model_native_dim = self.model_variant.embedding_dim();
-        let model_output_dim = self.model_variant.output_dim();
-
-        let result = tokio::task::spawn_blocking(move || {
-            run_session_inference_from_bytes(
-                &model_bytes,
-                &input,
-                model_native_dim,
-                model_output_dim,
-            )
-        })
-        .await
-        .map_err(|e| SemanticError::Inference(format!("Task join error: {}", e)))?;
-
-        result
-    }
-
-    /// Get embedding dimension (384 for all Granite models)
-    ///
-    /// 384-dim is invariant: Granite-97M is natively 384d, Granite-311M
-    /// uses Matryoshka truncation to 384d.
-    #[must_use]
-    pub fn embedding_dim(&self) -> usize {
-        self.model_variant.output_dim()
-    }
-
-    /// Get the AI model variant loaded in this engine
-    #[must_use]
-    pub fn model_variant(&self) -> AiModel {
-        self.model_variant
-    }
-
-    /// Check if engine is ready for inference
-    ///
-    /// Returns true if model bytes are available (non-empty Arc).
-    #[must_use]
-    pub fn is_ready(&self) -> bool {
-        !self.model_bytes.is_empty()
-    }
-}
-
-// ---------------------------------------------------------------------------
-// InferencePool (new: dedicated worker threads with persistent sessions)
+// InferencePool: dedicated worker threads with persistent sessions
 // ---------------------------------------------------------------------------
 
 use std::thread;
@@ -422,6 +280,12 @@ impl InferencePool {
     pub fn worker_count(&self) -> usize {
         self.worker_count
     }
+
+    /// Check if pool is ready for inference
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        self.worker_count > 0
+    }
 }
 
 impl Drop for InferencePool {
@@ -524,97 +388,6 @@ fn run_session_inference(
     Ok(embedding)
 }
 
-/// Run inference from raw model bytes (creates ephemeral session).
-///
-/// Used by `InferenceEngine::run_inference` inside `spawn_blocking`.
-fn run_session_inference_from_bytes(
-    model_bytes: &[u8],
-    input: &ModelInput,
-    model_native_dim: usize,
-    model_output_dim: usize,
-) -> Result<Vec<f32>, SemanticError> {
-    let seq_len = input.seq_len();
-
-    // Create ephemeral ort::Session from model bytes
-    let mut session = Session::builder()
-        .map_err(|e| {
-            SemanticError::Inference(format!("Failed to create ONNX session builder: {}", e))
-        })?
-        .with_optimization_level(GraphOptimizationLevel::Level3)
-        .map_err(|e| SemanticError::Inference(format!("Failed to set optimization level: {}", e)))?
-        .with_intra_threads(num_cpus::get())
-        .map_err(|e| SemanticError::Inference(format!("Failed to set intra threads: {}", e)))?
-        .commit_from_memory(model_bytes)
-        .map_err(|e| {
-            SemanticError::Inference(format!("Failed to create ONNX session from memory: {}", e))
-        })?;
-
-    // Build named input tensors using ndarray + Tensor::from_array
-    let input_ids_array =
-        ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.input_ids.clone()).map_err(
-            |e| SemanticError::Inference(format!("Failed to create input_ids array: {}", e)),
-        )?;
-
-    let attention_mask_array =
-        ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.attention_mask.clone())
-            .map_err(|e| {
-                SemanticError::Inference(format!("Failed to create attention_mask array: {}", e))
-            })?;
-
-    let token_type_ids_array =
-        ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.token_type_ids.clone())
-            .map_err(|e| {
-                SemanticError::Inference(format!("Failed to create token_type_ids array: {}", e))
-            })?;
-
-    // Run inference with named inputs
-    let outputs = session
-        .run(ort::inputs![
-            "input_ids" => ort::value::Tensor::from_array(input_ids_array)
-                .map_err(|e| SemanticError::Inference(format!(
-                    "Failed to create input_ids tensor: {}",
-                    e
-                )))?,
-            "attention_mask" => ort::value::Tensor::from_array(attention_mask_array)
-                .map_err(|e| SemanticError::Inference(format!(
-                    "Failed to create attention_mask tensor: {}",
-                    e
-                )))?,
-            "token_type_ids" => ort::value::Tensor::from_array(token_type_ids_array)
-                .map_err(|e| SemanticError::Inference(format!(
-                    "Failed to create token_type_ids tensor: {}",
-                    e
-                )))?,
-        ])
-        .map_err(|e| SemanticError::Inference(format!("Model execution failed: {}", e)))?;
-
-    // Extract last_hidden_state output
-    let (_shape, raw_data): (_, &[f32]) = outputs["last_hidden_state"]
-        .try_extract_tensor::<f32>()
-        .map_err(|e| {
-            SemanticError::Inference(format!("Failed to extract last_hidden_state: {}", e))
-        })?;
-
-    // Convert to Vec<f32>
-    let embedding_flat: Vec<f32> = raw_data.to_vec();
-
-    // Apply Mean Pooling on the native embedding dimension
-    use crate::infrastructure_ai::embedding_ops::{l2_normalize_safe, mean_pool};
-    let pooled = mean_pool(
-        &embedding_flat,
-        seq_len,
-        model_native_dim,
-        &input.attention_mask,
-    );
-
-    // Matryoshka truncation: for 311M, slice native 768d down to first 384 elements
-    let truncated: Vec<f32> = pooled.iter().take(model_output_dim).copied().collect();
-
-    let embedding = l2_normalize_safe(&truncated);
-
-    Ok(embedding)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -691,144 +464,6 @@ mod tests {
         // Drop the pool — workers should already be exited, join succeeds
         drop(pool);
         // If we reach here without hanging, shutdown was clean
-    }
-
-    // --- InferenceEngine tests (legacy) ---
-
-    /// Test that InferenceEngine type exists and compiles
-    #[test]
-    fn test_inference_engine_type_exists() {
-        fn _assert_type_exists(_engine: InferenceEngine) {}
-    }
-
-    /// Test that InferenceEngine is Send + Sync (thread-safe)
-    #[test]
-    fn test_inference_engine_is_send_sync() {
-        fn assert_send<T: Send>() {}
-        fn assert_sync<T: Sync>() {}
-
-        assert_send::<InferenceEngine>();
-        assert_sync::<InferenceEngine>();
-    }
-
-    /// Test that InferenceEngine is Clone (cheap Arc clone)
-    #[test]
-    fn test_inference_engine_is_clone() {
-        fn assert_clone<T: Clone>() {}
-        assert_clone::<InferenceEngine>();
-    }
-
-    /// RED → GREEN: load_from_file with missing file → ModelLoad error
-    #[tokio::test]
-    async fn test_load_from_file_missing_file_returns_model_load_error() {
-        let result = InferenceEngine::load_from_file(
-            "/tmp/nonexistent_model_xyz123.onnx",
-            AiModel::Granite97M,
-        )
-        .await;
-
-        assert!(result.is_err());
-
-        match result {
-            Err(SemanticError::ModelLoad(_)) => {
-                // Expected — missing file produces ModelLoad error
-            },
-            other => panic!("Expected ModelLoad error, got {:?}", other),
-        }
-    }
-
-    /// RED → GREEN: load_from_file with empty file → ModelLoad error
-    #[tokio::test]
-    async fn test_load_from_file_empty_file_returns_model_load_error() {
-        let dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let model_path = dir.path().join("empty.onnx");
-
-        // Write an empty file
-        std::fs::write(&model_path, b"").expect("Failed to create empty file");
-
-        let result = InferenceEngine::load_from_file(&model_path, AiModel::Granite97M).await;
-
-        assert!(result.is_err());
-
-        match result {
-            Err(SemanticError::ModelLoad(_)) => {
-                // Expected — empty model file should produce error
-            },
-            other => panic!("Expected ModelLoad error for empty file, got {:?}", other),
-        }
-    }
-
-    /// RED → GREEN: engine created from valid bytes has correct model variant
-    #[tokio::test]
-    async fn test_engine_model_variant_is_preserved() {
-        let dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let model_path = dir.path().join("minimal.onnx");
-
-        std::fs::write(&model_path, b"not a real onnx model").expect("Failed to write file");
-
-        let engine = InferenceEngine::load_from_file(&model_path, AiModel::Granite311M)
-            .await
-            .expect("Should load bytes");
-
-        assert_eq!(engine.model_variant(), AiModel::Granite311M);
-        assert_eq!(engine.embedding_dim(), 384); // unified output dim
-    }
-
-    /// Test that embedding_dim returns 384 for both model variants
-    #[tokio::test]
-    async fn test_embedding_dim_is_always_384() {
-        let dir = tempfile::tempdir().expect("Failed to create temp dir");
-
-        // Granite-97M
-        let path_97m = dir.path().join("model_97m.onnx");
-        std::fs::write(&path_97m, b"bytes").expect("Failed to write file");
-        let engine_97m = InferenceEngine::load_from_file(&path_97m, AiModel::Granite97M)
-            .await
-            .expect("Should load");
-        assert_eq!(engine_97m.embedding_dim(), 384);
-
-        // Granite-311M
-        let path_311m = dir.path().join("model_311m.onnx");
-        std::fs::write(&path_311m, b"bytes").expect("Failed to write file");
-        let engine_311m = InferenceEngine::load_from_file(&path_311m, AiModel::Granite311M)
-            .await
-            .expect("Should load");
-        assert_eq!(engine_311m.embedding_dim(), 384);
-    }
-
-    /// Test that native dim is correct per model
-    #[tokio::test]
-    async fn test_native_embedding_dim_per_model() {
-        let dir = tempfile::tempdir().expect("Failed to create temp dir");
-
-        let path_97m = dir.path().join("model_97m.onnx");
-        std::fs::write(&path_97m, b"bytes").expect("Failed to write file");
-        let engine_97m = InferenceEngine::load_from_file(&path_97m, AiModel::Granite97M)
-            .await
-            .expect("Should load");
-        assert_eq!(engine_97m.model_variant.embedding_dim(), 384);
-
-        let path_311m = dir.path().join("model_311m.onnx");
-        std::fs::write(&path_311m, b"bytes").expect("Failed to write file");
-        let engine_311m = InferenceEngine::load_from_file(&path_311m, AiModel::Granite311M)
-            .await
-            .expect("Should load");
-        assert_eq!(engine_311m.model_variant.embedding_dim(), 768);
-    }
-
-    /// Test that load_from_file with valid non-empty bytes succeeds
-    #[tokio::test]
-    async fn test_load_from_file_with_valid_bytes_succeeds() {
-        let dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let model_path = dir.path().join("minimal.onnx");
-
-        std::fs::write(&model_path, b"some model bytes").expect("Failed to write file");
-
-        let engine = InferenceEngine::load_from_file(&model_path, AiModel::Granite97M)
-            .await
-            .expect("Should succeed with non-empty model file");
-
-        assert!(engine.is_ready());
     }
 
     // --- ModelInput tests ---

--- a/crates/webfang_ai/src/infrastructure_ai/mod.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/mod.rs
@@ -20,7 +20,7 @@
 //!     ↓
 //! [Tokenizer] Convert each chunk to token IDs
 //!     ↓
-//! [InferenceEngine] Generate embeddings (spawn_blocking, concurrent)
+//! [InferencePool] Generate embeddings (dedicated worker threads)
 //!     ↓
 //! [RelevanceScorer] Filter by threshold (SIMD cosine similarity)
 //!     ↓
@@ -108,7 +108,6 @@ pub use model_downloader::{DownloadProgress, ModelDownloader};
 
 pub use semantic_cleaner_impl::{ModelConfig, SemanticCleanerImpl};
 
-pub use inference_engine::InferenceEngine;
 pub use inference_engine::InferencePool;
 
 pub use tokenizer::{MiniLmTokenizer, TokenBatch, DEFAULT_MAX_LENGTH};

--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -350,14 +350,13 @@ impl SemanticCleanerImpl {
             )))
         })?;
         let model_bytes = Arc::new(model_data);
-        let inference_pool = Arc::new(InferencePool::new(model_bytes, model_variant).map_err(
-            |e| {
+        let inference_pool =
+            Arc::new(InferencePool::new(model_bytes, model_variant).map_err(|e| {
                 SemanticError::ModelLoad(std::io::Error::other(format!(
                     "Failed to create inference pool: {}",
                     e
                 )))
-            },
-        )?);
+            })?);
 
         // Load tokenizer
         let tokenizer_path = config.cache_dir.join("tokenizer.json");
@@ -502,9 +501,7 @@ impl SemanticCleaner for SemanticCleanerImpl {
             // Following `anti-lock-across-await`: No locks held across await points
             let embeddings = try_join_all(token_buffers.iter().map(|input| {
                 let pool = &self.inference_pool;
-                async move {
-                    pool.infer(input).await
-                }
+                async move { pool.infer(input).await }
             }))
             .await
             .map_err(|e| {

--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -12,7 +12,7 @@
 //!     ↓
 //! [Tokenizer] Convert each chunk to token IDs
 //!     ↓
-//! [InferenceEngine] Generate embeddings (spawn_blocking, concurrent)
+//! [InferencePool] Generate embeddings (dedicated worker threads)
 //!     ↓
 //! [RelevanceScorer] Filter by threshold (SIMD cosine similarity)
 //!     ↓
@@ -24,7 +24,7 @@
 //! - [`async-join-parallel`](crate::rust_skills::async_join_parallel): Use `try_join_all` for concurrent embeddings
 //! - [`mem-reuse-collections`](crate::rust_skills::mem_reuse_collections): Pre-allocate `Vec::with_capacity`, reuse buffers
 //! - [`own-borrow-over-clone`](crate::rust_skills::own_borrow_over_clone): Borrow `&chunks`, `&embeddings` - don't clone
-//! - [`async-spawn-blocking`](crate::rust_skills::async_spawn_blocking): InferenceEngine uses spawn_blocking internally
+//! - [`async-spawn-blocking`](crate::rust_skills::async_spawn_blocking): InferencePool uses dedicated worker threads
 //! - [`err-context-chain`](crate::rust_skills::err_context_chain): Add `.context()` to errors
 //! - [`anti-unwrap-abuse`](crate::rust_skills::anti_unwrap_abuse): Use `?` operator, NO `.unwrap()` in prod
 //! - [`anti-lock-across-await`](crate::rust_skills::anti_lock_across_await): Don't hold MutexGuard across `.await`
@@ -57,13 +57,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::future::try_join_all;
-use tokio::sync::Semaphore;
 use tracing::{debug, info, warn};
 
 use crate::infrastructure_ai::cache_config::{default_cache_dir, AiModel, CacheConfig};
 use crate::infrastructure_ai::model_cache::ModelCache;
 use crate::infrastructure_ai::{
-    ContentPruner, HtmlChunker, InferenceEngine, LegibleContentPruner, MiniLmTokenizer,
+    ContentPruner, HtmlChunker, InferencePool, LegibleContentPruner, MiniLmTokenizer,
     RelevanceScorer,
 };
 use webfang_core::domain::semantic_cleaner::{private, SemanticCleaner};
@@ -201,7 +200,7 @@ impl ModelConfig {
 /// It integrates all Phase 2 and Phase 3 modules:
 /// - [`HtmlChunker`]: Semantic chunking with arena allocator
 /// - [`MiniLmTokenizer`]: HuggingFace tokenization
-/// - [`InferenceEngine`]: ONNX model execution with spawn_blocking
+/// - [`InferencePool`]: ONNX model execution with dedicated worker threads
 /// - [`RelevanceScorer`]: SIMD-accelerated cosine similarity filtering
 ///
 /// # Thread Safety
@@ -217,8 +216,8 @@ impl ModelConfig {
 /// - **Concurrency**: Embeddings generated concurrently with `try_join_all`
 pub struct SemanticCleanerImpl {
     // Phase 2: Core inference
-    /// ONNX inference engine (shared via Arc)
-    inference_engine: Arc<InferenceEngine>,
+    /// ONNX inference pool (dedicated worker threads with persistent sessions)
+    inference_pool: Arc<InferencePool>,
     /// HuggingFace tokenizer
     tokenizer: MiniLmTokenizer,
 
@@ -235,9 +234,6 @@ pub struct SemanticCleanerImpl {
     // Config
     /// Model and pipeline configuration
     config: ModelConfig,
-
-    /// Semaphore to limit concurrent inference blocking tasks (avoids thread thrashing on 4-core CPUs)
-    semaphore: Arc<Semaphore>,
 }
 
 impl SemanticCleanerImpl {
@@ -343,19 +339,25 @@ impl SemanticCleanerImpl {
                 });
         }
 
-        // Load inference engine
+        // Load inference pool
         let model_path = cache.model_path(&config.model_file);
         let model_variant = config.model_variant;
-        let inference_engine = Arc::new(
-            InferenceEngine::load_from_file(&model_path, model_variant)
-                .await
-                .map_err(|e| {
-                    SemanticError::ModelLoad(std::io::Error::other(format!(
-                        "Failed to load inference engine: {}",
-                        e
-                    )))
-                })?,
-        );
+        let model_data = tokio::fs::read(&model_path).await.map_err(|e| {
+            SemanticError::ModelLoad(std::io::Error::other(format!(
+                "Failed to read model file '{}': {}",
+                model_path.display(),
+                e
+            )))
+        })?;
+        let model_bytes = Arc::new(model_data);
+        let inference_pool = Arc::new(InferencePool::new(model_bytes, model_variant).map_err(
+            |e| {
+                SemanticError::ModelLoad(std::io::Error::other(format!(
+                    "Failed to create inference pool: {}",
+                    e
+                )))
+            },
+        )?);
 
         // Load tokenizer
         let tokenizer_path = config.cache_dir.join("tokenizer.json");
@@ -377,20 +379,19 @@ impl SemanticCleanerImpl {
 
         info!("Semantic cleaner initialized successfully");
         debug!(
-            embedding_dim = inference_engine.embedding_dim(),
+            embedding_dim = inference_pool.embedding_dim(),
             max_tokens = config.max_tokens,
             relevance_threshold = config.relevance_threshold,
             "Pipeline components loaded"
         );
 
         Ok(Self {
-            inference_engine,
+            inference_pool,
             tokenizer,
             chunker,
             scorer,
             pruner: LegibleContentPruner::standard(),
             config,
-            semaphore: Arc::new(Semaphore::new(num_cpus::get().max(1))),
         })
     }
 
@@ -497,15 +498,12 @@ impl SemanticCleaner for SemanticCleanerImpl {
 
             // Step 3: Generate embeddings CONCURRENTLY (async-join-parallel)
             // Following `async-join-parallel`: use try_join_all for concurrent independent operations
-            // Following `async-spawn-blocking`: InferenceEngine already uses spawn_blocking internally
+            // InferencePool dispatches to dedicated worker threads with persistent sessions
             // Following `anti-lock-across-await`: No locks held across await points
-            let semaphore = Arc::clone(&self.semaphore);
             let embeddings = try_join_all(token_buffers.iter().map(|input| {
-                let sem = Arc::clone(&semaphore);
-                let engine = &self.inference_engine;
+                let pool = &self.inference_pool;
                 async move {
-                    let _permit = sem.acquire_owned().await.expect("semaphore no fue cerrado");
-                    engine.run_inference(input).await
+                    pool.infer(input).await
                 }
             }))
             .await
@@ -542,8 +540,7 @@ impl SemanticCleaner for SemanticCleanerImpl {
     }
 
     fn is_ready(&self) -> bool {
-        // Model is ready if inference engine is ready
-        self.inference_engine.is_ready()
+        self.inference_pool.is_ready()
     }
 }
 

--- a/crates/webfang_ai/src/infrastructure_ai/tokenizer.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/tokenizer.rs
@@ -85,7 +85,7 @@ impl TokenBatch {
     /// Convert batch to Vec<ModelInput> for inference
     ///
     /// This converts each sequence in the batch to a ModelInput
-    /// suitable for passing to InferenceEngine::run_inference.
+    /// suitable for passing to InferencePool::infer.
     ///
     /// # Returns
     ///

--- a/crates/webfang_ai/src/lib.rs
+++ b/crates/webfang_ai/src/lib.rs
@@ -12,7 +12,7 @@ pub use webfang_core::error::SemanticError;
 
 // Re-export key AI types for convenience
 pub use infrastructure_ai::{
-    AiModel, CacheConfig, ChunkId, ContentPruner, HtmlChunker, InferenceEngine, InferencePool,
+    AiModel, CacheConfig, ChunkId, ContentPruner, HtmlChunker, InferencePool,
     LegibleContentPruner, MiniLmTokenizer, ModelCache, ModelConfig, ModelDownloader,
     RelevanceScorer, SemanticCleanerImpl, SentenceSplitter, ThresholdConfig, TokenBatch,
 };

--- a/crates/webfang_ai/src/lib.rs
+++ b/crates/webfang_ai/src/lib.rs
@@ -12,7 +12,7 @@ pub use webfang_core::error::SemanticError;
 
 // Re-export key AI types for convenience
 pub use infrastructure_ai::{
-    AiModel, CacheConfig, ChunkId, ContentPruner, HtmlChunker, InferencePool,
-    LegibleContentPruner, MiniLmTokenizer, ModelCache, ModelConfig, ModelDownloader,
-    RelevanceScorer, SemanticCleanerImpl, SentenceSplitter, ThresholdConfig, TokenBatch,
+    AiModel, CacheConfig, ChunkId, ContentPruner, HtmlChunker, InferencePool, LegibleContentPruner,
+    MiniLmTokenizer, ModelCache, ModelConfig, ModelDownloader, RelevanceScorer,
+    SemanticCleanerImpl, SentenceSplitter, ThresholdConfig, TokenBatch,
 };

--- a/tests/ai_integration.rs
+++ b/tests/ai_integration.rs
@@ -20,7 +20,7 @@ use webfang_ai::infrastructure_ai::model_downloader::ModelDownloader;
 use webfang_ai::infrastructure_ai::{
     default_cache_dir, CacheConfig, ModelCache, DEFAULT_MODEL_FILE, DEFAULT_MODEL_REPO,
 };
-use webfang_ai::infrastructure_ai::{InferenceEngine, ModelConfig, SemanticCleanerImpl};
+use webfang_ai::infrastructure_ai::{InferencePool, ModelConfig, SemanticCleanerImpl};
 use webfang_ai::SemanticCleaner;
 use webfang_ai::SemanticError;
 use webfang_core::domain::DocumentChunk;
@@ -290,33 +290,27 @@ fn test_scraper_error_from_semantic_error() {
 }
 
 // ============================================================================
-// InferenceEngine Tests (Phase 2)
+// InferencePool Tests (Phase 2)
 // ============================================================================
 
-/// Test that InferenceEngine is Send + Sync (thread-safe)
+/// Test that InferencePool is Send + Sync (thread-safe)
 ///
-/// This is critical for using InferenceEngine in async contexts
+/// This is critical for using InferencePool in async contexts
 /// with tokio::spawn and across thread boundaries.
-///
-/// Following `own-arc-shared` and `async-spawn-blocking` rules,
-/// InferenceEngine must be Send + Sync to work with Arc and spawn_blocking.
 #[test]
-fn test_inference_engine_is_send_sync() {
+fn test_inference_pool_is_send_sync() {
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
 
-    assert_send::<InferenceEngine>();
-    assert_sync::<InferenceEngine>();
+    assert_send::<InferencePool>();
+    assert_sync::<InferencePool>();
 }
 
-/// Test that InferenceEngine is Clone (cheap Arc clone)
-///
-/// InferenceEngine wraps Arc<RunnableModel>, so cloning is cheap
-/// (just increments atomic counter) and safe for concurrent use.
+/// Test that InferencePool is Clone (cheap clone)
 #[test]
-fn test_inference_engine_is_clone() {
+fn test_inference_pool_is_clone() {
     fn assert_clone<T: Clone>() {}
-    assert_clone::<InferenceEngine>();
+    assert_clone::<InferencePool>();
 }
 
 /// Test that TokenBatch can be created
@@ -839,11 +833,11 @@ async fn test_semantic_cleaner_long_content() {
 /// Test concurrent embedding generation
 ///
 /// Verifies that try_join_all works correctly for concurrent inference.
-/// This test may need a mock InferenceEngine for comprehensive testing.
+/// This test may need a mock InferencePool for comprehensive testing.
 #[tokio::test]
 async fn test_concurrent_embeddings() {
     // This test verifies the concurrent embedding pattern
-    // In production, this would use real InferenceEngine
+    // In production, this would use real InferencePool
 
     use futures::future::try_join_all;
 


### PR DESCRIPTION
## Summary
- Wire `InferencePool` into `SemanticCleanerImpl`, replacing `InferenceEngine` + `Semaphore`
- Remove legacy `InferenceEngine` struct and all dead code (~391 lines removed)
- `clean()` now calls `pool.infer()` directly — no semaphore, no spawn_blocking wrapper

## Changes
- `semantic_cleaner_impl.rs`: `Arc<InferenceEngine>` → `Arc<InferencePool>`, remove Semaphore
- `inference_engine.rs`: remove InferenceEngine struct, keep only InferencePool + ModelInput
- `mod.rs`, `lib.rs`: update re-exports
- `tests/ai_integration.rs`: update all references

## Test plan
- [x] cargo check -p webfang_ai
- [x] cargo test -p webfang_ai --lib (119 tests pass)
- [x] Zero InferenceEngine references remain
- [x] Zero Semaphore references in semantic_cleaner_impl.rs

## Part of
- Issue #200: InferencePool with dedicated worker threads