### PR TITLE
fix(mcp): resolve issue #218

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -36,7 +36,7 @@ impl McpHandler {
             .unwrap_or(webfang_core::domain::entities::ExportFormat::Jsonl);
 
         let output_dir = PathBuf::from(&params.output_dir);
-        match std::fs::create_dir_all(&output_dir) {
+        match tokio::fs::create_dir_all(&output_dir).await {
             Ok(_) => {
                 let path = output_dir.join(format!("{}.{}", params.filename, format.extension()));
                 Ok(CallToolResult::success(vec![Content::text(format!(

--- a/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
@@ -91,7 +91,7 @@ impl McpHandler {
             &params.vault_name,
             &params.file_path,
         );
-        match std::process::Command::new("open").arg(&uri).spawn() {
+        match tokio::process::Command::new("open").arg(&uri).spawn() {
             Ok(_) => Ok(CallToolResult::success(vec![Content::text(format!(
                 "Opened in Obsidian: {uri}"
             ))])),

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -61,9 +61,20 @@ impl McpHandler {
             .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
 
         let html = params.html.as_deref().unwrap_or("");
-        let headers = wreq::header::HeaderMap::new();
+        let mut header_map = wreq::header::HeaderMap::new();
+        if let Some(ref hdrs) = params.headers {
+            for (key, value) in hdrs {
+                if let (Ok(name), Ok(val)) = (
+                    wreq::header::HeaderName::from_bytes(key.as_bytes()),
+                    wreq::header::HeaderValue::from_str(value),
+                ) {
+                    header_map.insert(name, val);
+                }
+            }
+        }
         match webfang_core::infrastructure::http::waf_engine::WafInspector::verify_integrity(
-            &headers, html,
+            &header_map,
+            html,
         ) {
             Ok(_) => Ok(CallToolResult::success(vec![Content::text(
                 "WAF integrity check passed",

--- a/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
@@ -165,7 +165,11 @@ impl McpHandler {
             url::Url::parse(&params.url),
             url::Url::parse(&params.seed_domain),
         ) {
-            (Ok(u), Ok(s)) => u.host_str() == s.host_str(),
+            (Ok(u), Ok(s)) => {
+                let url_host = u.host_str().unwrap_or("");
+                let seed_host = s.host_str().unwrap_or("");
+                url_host == seed_host || url_host.ends_with(&format!(".{seed_host}"))
+            },
             _ => false,
         };
         Ok(CallToolResult::success(vec![Content::text(

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -245,4 +245,6 @@ pub(crate) struct ProcessExportPipelineParams {
 pub(crate) struct VerifyWafIntegrityParams {
     /// HTML body to inspect
     pub html: Option<String>,
+    /// Optional JSON object of HTTP headers to check (e.g. {"server": "cloudflare"})
+    pub headers: Option<std::collections::HashMap<String, String>>,
 }


### PR DESCRIPTION
Closes #218. Fixes 4 Judgment Day findings: blocking syscalls in async handlers, empty HeaderMap in WAF check, exact host match in is_internal_link. 52/52 tests pass.