### PR TITLE
fix(cli): propagate ai_model through ExportConfig and use opts.ai_config in SemanticCleanerImpl

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -319,8 +319,6 @@ async fn __main() -> CliExit {
     // 6. Extract trace_file and ai_model before args is moved into CrawlOptions
     // =========================================================================
     let trace_file = args.crawler.trace_file.take();
-    #[cfg(feature = "ai")]
-    let ai_model_arg = args.ai.ai_model.take();
 
     // =========================================================================
     // 6b. Convert Args → CrawlOptions and apply config file defaults
@@ -417,23 +415,24 @@ async fn __main() -> CliExit {
     let result = {
         let ai_cleaner = if opts.ai {
             // Resolve model variant: CLI flag takes precedence over AI_MODEL_ID env var
-            let model_variant = match &ai_model_arg {
-                Some(model_str) => match model_str.parse::<webfang_ai::AiModel>() {
+            let model_variant = if opts.ai_config.model.is_empty() {
+                webfang_ai::AiModel::from_env_or_default()
+            } else {
+                match opts.ai_config.model.parse::<webfang_ai::AiModel>() {
                     Ok(variant) => variant,
                     Err(e) => {
                         tracing::warn!("Parsing error para --ai-model: {}", e);
                         webfang_ai::AiModel::from_env_or_default()
                     },
-                },
-                None => webfang_ai::AiModel::from_env_or_default(),
+                }
             };
 
             match SemanticCleanerImpl::new(
                 ModelConfig::default()
                     .with_model_variant(model_variant)
-                    .with_relevance_threshold(0.3)
-                    .with_max_tokens(32768)
-                    .with_offline_mode(false),
+                    .with_relevance_threshold(opts.ai_config.threshold)
+                    .with_max_tokens(opts.ai_config.max_tokens)
+                    .with_offline_mode(opts.ai_config.offline),
             )
             .await
             {

--- a/crates/webfang_core/src/cli/export_flow.rs
+++ b/crates/webfang_core/src/cli/export_flow.rs
@@ -37,6 +37,7 @@ pub struct ExportConfig<'a> {
     pub ai_threshold: f32,
     pub ai_max_tokens: usize,
     pub ai_offline: bool,
+    pub ai_model: String,
 }
 
 /// Run the export flow: AI-cleaned or standard export.

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -238,6 +238,7 @@ pub async fn run(
         ai_threshold: opts.ai_config.threshold,
         ai_max_tokens: opts.ai_config.max_tokens,
         ai_offline: opts.ai_config.offline,
+        ai_model: opts.ai_config.model.clone(),
     };
 
     // Save individual files (Markdown, etc.)

--- a/tests/behavioral/main.rs
+++ b/tests/behavioral/main.rs
@@ -53,10 +53,7 @@ pub(crate) fn assert_snapshot_redacted(name: &str, dir: &Path, value: impl Into<
 /// and compile profiles (CI vs local).
 pub(crate) fn assert_snapshot_plain(name: &str, value: impl Into<String>) {
     let mut settings = insta::Settings::clone_current();
-    settings.add_filter(
-        r"(?m)^Parsed using .+$",
-        "Parsed using [REDACTED]",
-    );
+    settings.add_filter(r"(?m)^Parsed using .+$", "Parsed using [REDACTED]");
     settings.bind(|| {
         assert_snapshot!(name, value.into());
     });

--- a/tests/behavioral/main.rs
+++ b/tests/behavioral/main.rs
@@ -48,6 +48,16 @@ pub(crate) fn assert_snapshot_redacted(name: &str, dir: &Path, value: impl Into<
 ///
 /// Use for deterministic outputs that never embed the temp dir (e.g. `--help`,
 /// `--version`, or stderr from a run that passed no `--output`).
+///
+/// Filters out clap's "Parsed using …" line which varies across clap versions
+/// and compile profiles (CI vs local).
 pub(crate) fn assert_snapshot_plain(name: &str, value: impl Into<String>) {
-    assert_snapshot!(name, value.into());
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(
+        r"(?m)^Parsed using .+$",
+        "Parsed using [REDACTED]",
+    );
+    settings.bind(|| {
+        assert_snapshot!(name, value.into());
+    });
 }

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -4,8 +4,6 @@ expression: value.into()
 ---
 CLI Arguments for the webfang binary.
 
-Parsed using `clap` with derive macros.
-
 # Examples
 
 ```no_run use webfang::Args; use clap::Parser;
@@ -32,6 +30,64 @@ Options:
           
           [env: WEBFANG_SELECTOR=]
           [default: body]
+
+  -o, --output <OUTPUT>
+          Output directory for scraped content
+          
+          [env: WEBFANG_OUTPUT=]
+          [default: output]
+
+  -f, --format <FORMAT>
+          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
+
+          Possible values:
+          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
+          - json:     Structured JSON with metadata
+          - text:     Plain text without formatting
+          
+          [env: WEBFANG_FORMAT=]
+          [default: markdown]
+
+      --export-format <EXPORT_FORMAT>
+          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
+
+          Possible values:
+          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
+          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
+          - auto:   Auto-detect format from existing export files
+          
+          [env: WEBFANG_EXPORT_FORMAT=]
+          [default: jsonl]
+
+      --obsidian-wiki-links
+          Convert same-domain links to Obsidian [[wiki-link]] syntax
+          
+          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
+
+      --obsidian-tags <OBSIDIAN_TAGS>
+          Tags to include in YAML frontmatter (comma-separated)
+          
+          [env: WEBFANG_OBSIDIAN_TAGS=]
+
+      --obsidian-relative-assets
+          Rewrite downloaded asset paths as relative to the .md file
+          
+          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
+
+      --vault <VAULT>
+          Path to Obsidian vault (auto-detects if not provided)
+          
+          [env: WEBFANG_OBSIDIAN_VAULT=]
+
+      --quick-save
+          Quick-save mode: save directly to vault _inbox folder
+          
+          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
+
+      --obsidian-rich-metadata
+          Add rich metadata to frontmatter
+          
+          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
@@ -90,6 +146,11 @@ Options:
           Download all assets (images + documents) from the page
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
+
+      --tui
+          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
+          
+          [env: WEBFANG_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
@@ -197,6 +258,31 @@ Options:
           [env: WEBFANG_SITEMAP_DEPTH=]
           [default: 3]
 
+      --cpu-cores <CPU_CORES>
+          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
+          
+          [env: WEBFANG_CPU_CORES=]
+
+      --ram-budget <RAM_BUDGET>
+          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
+          
+          [env: WEBFANG_RAM_BUDGET=]
+
+      --db-path <DB_PATH>
+          SQLite database path override for persisted resources/chunks
+          
+          [env: WEBFANG_DB_PATH=]
+
+      --elastic
+          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
+          
+          [env: WEBFANG_ELASTIC=]
+
+      --output-vectors <OUTPUT_VECTORS>
+          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
+          
+          [env: WEBFANG_OUTPUT_VECTORS=]
+
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
@@ -246,59 +332,6 @@ Options:
           [env: WEBFANG_OBSCURA_BINARY=]
           [default: obscura]
 
-  -o, --output <OUTPUT>
-          Output directory for scraped content
-          
-          [env: WEBFANG_OUTPUT=]
-          [default: output]
-
-  -f, --format <FORMAT>
-          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
-
-          Possible values:
-          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
-          - json:     Structured JSON with metadata
-          - text:     Plain text without formatting
-          
-          [env: WEBFANG_FORMAT=]
-          [default: markdown]
-
-      --export-format <EXPORT_FORMAT>
-          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
-
-          Possible values:
-          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
-          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
-          - auto:   Auto-detect format from existing export files
-          
-          [env: WEBFANG_EXPORT_FORMAT=]
-          [default: jsonl]
-
-      --cpu-cores <CPU_CORES>
-          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
-          
-          [env: WEBFANG_CPU_CORES=]
-
-      --ram-budget <RAM_BUDGET>
-          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
-          
-          [env: WEBFANG_RAM_BUDGET=]
-
-      --db-path <DB_PATH>
-          SQLite database path override for persisted resources/chunks
-          
-          [env: WEBFANG_DB_PATH=]
-
-      --elastic
-          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
-          
-          [env: WEBFANG_ELASTIC=]
-
-      --output-vectors <OUTPUT_VECTORS>
-          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
-          
-          [env: WEBFANG_OUTPUT_VECTORS=]
-
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
@@ -329,41 +362,6 @@ Options:
           
           [env: WEBFANG_PIPELINE_OUTPUT=]
           [default: jsonl]
-
-      --obsidian-wiki-links
-          Convert same-domain links to Obsidian [[wiki-link]] syntax
-          
-          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
-
-      --obsidian-tags <OBSIDIAN_TAGS>
-          Tags to include in YAML frontmatter (comma-separated)
-          
-          [env: WEBFANG_OBSIDIAN_TAGS=]
-
-      --obsidian-relative-assets
-          Rewrite downloaded asset paths as relative to the .md file
-          
-          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
-
-      --vault <VAULT>
-          Path to Obsidian vault (auto-detects if not provided)
-          
-          [env: WEBFANG_OBSIDIAN_VAULT=]
-
-      --quick-save
-          Quick-save mode: save directly to vault _inbox folder
-          
-          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
-
-      --obsidian-rich-metadata
-          Add rich metadata to frontmatter
-          
-          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
-
-      --tui
-          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
-          
-          [env: WEBFANG_TUI=]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -4,6 +4,8 @@ expression: value.into()
 ---
 CLI Arguments for the webfang binary.
 
+Parsed using [REDACTED]
+
 # Examples
 
 ```no_run use webfang::Args; use clap::Parser;
@@ -30,64 +32,6 @@ Options:
           
           [env: WEBFANG_SELECTOR=]
           [default: body]
-
-  -o, --output <OUTPUT>
-          Output directory for scraped content
-          
-          [env: WEBFANG_OUTPUT=]
-          [default: output]
-
-  -f, --format <FORMAT>
-          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
-
-          Possible values:
-          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
-          - json:     Structured JSON with metadata
-          - text:     Plain text without formatting
-          
-          [env: WEBFANG_FORMAT=]
-          [default: markdown]
-
-      --export-format <EXPORT_FORMAT>
-          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
-
-          Possible values:
-          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
-          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
-          - auto:   Auto-detect format from existing export files
-          
-          [env: WEBFANG_EXPORT_FORMAT=]
-          [default: jsonl]
-
-      --obsidian-wiki-links
-          Convert same-domain links to Obsidian [[wiki-link]] syntax
-          
-          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
-
-      --obsidian-tags <OBSIDIAN_TAGS>
-          Tags to include in YAML frontmatter (comma-separated)
-          
-          [env: WEBFANG_OBSIDIAN_TAGS=]
-
-      --obsidian-relative-assets
-          Rewrite downloaded asset paths as relative to the .md file
-          
-          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
-
-      --vault <VAULT>
-          Path to Obsidian vault (auto-detects if not provided)
-          
-          [env: WEBFANG_OBSIDIAN_VAULT=]
-
-      --quick-save
-          Quick-save mode: save directly to vault _inbox folder
-          
-          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
-
-      --obsidian-rich-metadata
-          Add rich metadata to frontmatter
-          
-          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
@@ -146,11 +90,6 @@ Options:
           Download all assets (images + documents) from the page
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
-
-      --tui
-          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
-          
-          [env: WEBFANG_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
@@ -258,31 +197,6 @@ Options:
           [env: WEBFANG_SITEMAP_DEPTH=]
           [default: 3]
 
-      --cpu-cores <CPU_CORES>
-          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
-          
-          [env: WEBFANG_CPU_CORES=]
-
-      --ram-budget <RAM_BUDGET>
-          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
-          
-          [env: WEBFANG_RAM_BUDGET=]
-
-      --db-path <DB_PATH>
-          SQLite database path override for persisted resources/chunks
-          
-          [env: WEBFANG_DB_PATH=]
-
-      --elastic
-          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
-          
-          [env: WEBFANG_ELASTIC=]
-
-      --output-vectors <OUTPUT_VECTORS>
-          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
-          
-          [env: WEBFANG_OUTPUT_VECTORS=]
-
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
@@ -332,6 +246,59 @@ Options:
           [env: WEBFANG_OBSCURA_BINARY=]
           [default: obscura]
 
+  -o, --output <OUTPUT>
+          Output directory for scraped content
+          
+          [env: WEBFANG_OUTPUT=]
+          [default: output]
+
+  -f, --format <FORMAT>
+          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
+
+          Possible values:
+          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
+          - json:     Structured JSON with metadata
+          - text:     Plain text without formatting
+          
+          [env: WEBFANG_FORMAT=]
+          [default: markdown]
+
+      --export-format <EXPORT_FORMAT>
+          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
+
+          Possible values:
+          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
+          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
+          - auto:   Auto-detect format from existing export files
+          
+          [env: WEBFANG_EXPORT_FORMAT=]
+          [default: jsonl]
+
+      --cpu-cores <CPU_CORES>
+          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
+          
+          [env: WEBFANG_CPU_CORES=]
+
+      --ram-budget <RAM_BUDGET>
+          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
+          
+          [env: WEBFANG_RAM_BUDGET=]
+
+      --db-path <DB_PATH>
+          SQLite database path override for persisted resources/chunks
+          
+          [env: WEBFANG_DB_PATH=]
+
+      --elastic
+          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
+          
+          [env: WEBFANG_ELASTIC=]
+
+      --output-vectors <OUTPUT_VECTORS>
+          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
+          
+          [env: WEBFANG_OUTPUT_VECTORS=]
+
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
@@ -362,6 +329,41 @@ Options:
           
           [env: WEBFANG_PIPELINE_OUTPUT=]
           [default: jsonl]
+
+      --obsidian-wiki-links
+          Convert same-domain links to Obsidian [[wiki-link]] syntax
+          
+          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
+
+      --obsidian-tags <OBSIDIAN_TAGS>
+          Tags to include in YAML frontmatter (comma-separated)
+          
+          [env: WEBFANG_OBSIDIAN_TAGS=]
+
+      --obsidian-relative-assets
+          Rewrite downloaded asset paths as relative to the .md file
+          
+          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
+
+      --vault <VAULT>
+          Path to Obsidian vault (auto-detects if not provided)
+          
+          [env: WEBFANG_OBSIDIAN_VAULT=]
+
+      --quick-save
+          Quick-save mode: save directly to vault _inbox folder
+          
+          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
+
+      --obsidian-rich-metadata
+          Add rich metadata to frontmatter
+          
+          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
+
+      --tui
+          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
+          
+          [env: WEBFANG_TUI=]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -61,10 +61,7 @@ fn test_help_contains_scraper() {
     assert!(output.status.success(), "expected success");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut settings = insta::Settings::clone_current();
-    settings.add_filter(
-        r"(?m)^Parsed using .+$",
-        "Parsed using [REDACTED]",
-    );
+    settings.add_filter(r"(?m)^Parsed using .+$", "Parsed using [REDACTED]");
     settings.bind(|| {
         insta::assert_snapshot!(
             "test_help_contains_scraper",

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -60,10 +60,17 @@ fn test_help_contains_scraper() {
     let output = cmd().arg("--help").output().expect("run binary");
     assert!(output.status.success(), "expected success");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    insta::assert_snapshot!(
-        "test_help_contains_scraper",
-        redact_nondeterministic(Path::new("__no_temp__"), &stdout)
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(
+        r"(?m)^Parsed using .+$",
+        "Parsed using [REDACTED]",
     );
+    settings.bind(|| {
+        insta::assert_snapshot!(
+            "test_help_contains_scraper",
+            redact_nondeterministic(Path::new("__no_temp__"), &stdout)
+        );
+    });
 }
 
 /// Test that --version outputs version and exits with code 0.

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -4,6 +4,8 @@ expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stdout)"
 ---
 CLI Arguments for the webfang binary.
 
+Parsed using [REDACTED]
+
 # Examples
 
 ```no_run use webfang::Args; use clap::Parser;
@@ -30,64 +32,6 @@ Options:
           
           [env: WEBFANG_SELECTOR=]
           [default: body]
-
-  -o, --output <OUTPUT>
-          Output directory for scraped content
-          
-          [env: WEBFANG_OUTPUT=]
-          [default: output]
-
-  -f, --format <FORMAT>
-          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
-
-          Possible values:
-          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
-          - json:     Structured JSON with metadata
-          - text:     Plain text without formatting
-          
-          [env: WEBFANG_FORMAT=]
-          [default: markdown]
-
-      --export-format <EXPORT_FORMAT>
-          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
-
-          Possible values:
-          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
-          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
-          - auto:   Auto-detect format from existing export files
-          
-          [env: WEBFANG_EXPORT_FORMAT=]
-          [default: jsonl]
-
-      --obsidian-wiki-links
-          Convert same-domain links to Obsidian [[wiki-link]] syntax
-          
-          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
-
-      --obsidian-tags <OBSIDIAN_TAGS>
-          Tags to include in YAML frontmatter (comma-separated)
-          
-          [env: WEBFANG_OBSIDIAN_TAGS=]
-
-      --obsidian-relative-assets
-          Rewrite downloaded asset paths as relative to the .md file
-          
-          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
-
-      --vault <VAULT>
-          Path to Obsidian vault (auto-detects if not provided)
-          
-          [env: WEBFANG_OBSIDIAN_VAULT=]
-
-      --quick-save
-          Quick-save mode: save directly to vault _inbox folder
-          
-          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
-
-      --obsidian-rich-metadata
-          Add rich metadata to frontmatter
-          
-          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
@@ -146,11 +90,6 @@ Options:
           Download all assets (images + documents) from the page
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
-
-      --tui
-          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
-          
-          [env: WEBFANG_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
@@ -258,31 +197,6 @@ Options:
           [env: WEBFANG_SITEMAP_DEPTH=]
           [default: 3]
 
-      --cpu-cores <CPU_CORES>
-          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
-          
-          [env: WEBFANG_CPU_CORES=]
-
-      --ram-budget <RAM_BUDGET>
-          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
-          
-          [env: WEBFANG_RAM_BUDGET=]
-
-      --db-path <DB_PATH>
-          SQLite database path override for persisted resources/chunks
-          
-          [env: WEBFANG_DB_PATH=]
-
-      --elastic
-          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
-          
-          [env: WEBFANG_ELASTIC=]
-
-      --output-vectors <OUTPUT_VECTORS>
-          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
-          
-          [env: WEBFANG_OUTPUT_VECTORS=]
-
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
@@ -332,6 +246,59 @@ Options:
           [env: WEBFANG_OBSCURA_BINARY=]
           [default: obscura]
 
+  -o, --output <OUTPUT>
+          Output directory for scraped content
+          
+          [env: WEBFANG_OUTPUT=]
+          [default: output]
+
+  -f, --format <FORMAT>
+          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
+
+          Possible values:
+          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
+          - json:     Structured JSON with metadata
+          - text:     Plain text without formatting
+          
+          [env: WEBFANG_FORMAT=]
+          [default: markdown]
+
+      --export-format <EXPORT_FORMAT>
+          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
+
+          Possible values:
+          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
+          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
+          - auto:   Auto-detect format from existing export files
+          
+          [env: WEBFANG_EXPORT_FORMAT=]
+          [default: jsonl]
+
+      --cpu-cores <CPU_CORES>
+          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
+          
+          [env: WEBFANG_CPU_CORES=]
+
+      --ram-budget <RAM_BUDGET>
+          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
+          
+          [env: WEBFANG_RAM_BUDGET=]
+
+      --db-path <DB_PATH>
+          SQLite database path override for persisted resources/chunks
+          
+          [env: WEBFANG_DB_PATH=]
+
+      --elastic
+          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
+          
+          [env: WEBFANG_ELASTIC=]
+
+      --output-vectors <OUTPUT_VECTORS>
+          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
+          
+          [env: WEBFANG_OUTPUT_VECTORS=]
+
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
@@ -362,6 +329,41 @@ Options:
           
           [env: WEBFANG_PIPELINE_OUTPUT=]
           [default: jsonl]
+
+      --obsidian-wiki-links
+          Convert same-domain links to Obsidian [[wiki-link]] syntax
+          
+          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
+
+      --obsidian-tags <OBSIDIAN_TAGS>
+          Tags to include in YAML frontmatter (comma-separated)
+          
+          [env: WEBFANG_OBSIDIAN_TAGS=]
+
+      --obsidian-relative-assets
+          Rewrite downloaded asset paths as relative to the .md file
+          
+          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
+
+      --vault <VAULT>
+          Path to Obsidian vault (auto-detects if not provided)
+          
+          [env: WEBFANG_OBSIDIAN_VAULT=]
+
+      --quick-save
+          Quick-save mode: save directly to vault _inbox folder
+          
+          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
+
+      --obsidian-rich-metadata
+          Add rich metadata to frontmatter
+          
+          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
+
+      --tui
+          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
+          
+          [env: WEBFANG_TUI=]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -4,8 +4,6 @@ expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stdout)"
 ---
 CLI Arguments for the webfang binary.
 
-Parsed using `clap` with derive macros.
-
 # Examples
 
 ```no_run use webfang::Args; use clap::Parser;
@@ -32,6 +30,64 @@ Options:
           
           [env: WEBFANG_SELECTOR=]
           [default: body]
+
+  -o, --output <OUTPUT>
+          Output directory for scraped content
+          
+          [env: WEBFANG_OUTPUT=]
+          [default: output]
+
+  -f, --format <FORMAT>
+          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
+
+          Possible values:
+          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
+          - json:     Structured JSON with metadata
+          - text:     Plain text without formatting
+          
+          [env: WEBFANG_FORMAT=]
+          [default: markdown]
+
+      --export-format <EXPORT_FORMAT>
+          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
+
+          Possible values:
+          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
+          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
+          - auto:   Auto-detect format from existing export files
+          
+          [env: WEBFANG_EXPORT_FORMAT=]
+          [default: jsonl]
+
+      --obsidian-wiki-links
+          Convert same-domain links to Obsidian [[wiki-link]] syntax
+          
+          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
+
+      --obsidian-tags <OBSIDIAN_TAGS>
+          Tags to include in YAML frontmatter (comma-separated)
+          
+          [env: WEBFANG_OBSIDIAN_TAGS=]
+
+      --obsidian-relative-assets
+          Rewrite downloaded asset paths as relative to the .md file
+          
+          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
+
+      --vault <VAULT>
+          Path to Obsidian vault (auto-detects if not provided)
+          
+          [env: WEBFANG_OBSIDIAN_VAULT=]
+
+      --quick-save
+          Quick-save mode: save directly to vault _inbox folder
+          
+          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
+
+      --obsidian-rich-metadata
+          Add rich metadata to frontmatter
+          
+          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
 
       --delay-ms <DELAY_MS>
           Delay between requests in milliseconds
@@ -90,6 +146,11 @@ Options:
           Download all assets (images + documents) from the page
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
+
+      --tui
+          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
+          
+          [env: WEBFANG_TUI=]
 
       --force-js-render
           Force JavaScript rendering for SPA sites (not yet implemented)
@@ -197,6 +258,31 @@ Options:
           [env: WEBFANG_SITEMAP_DEPTH=]
           [default: 3]
 
+      --cpu-cores <CPU_CORES>
+          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
+          
+          [env: WEBFANG_CPU_CORES=]
+
+      --ram-budget <RAM_BUDGET>
+          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
+          
+          [env: WEBFANG_RAM_BUDGET=]
+
+      --db-path <DB_PATH>
+          SQLite database path override for persisted resources/chunks
+          
+          [env: WEBFANG_DB_PATH=]
+
+      --elastic
+          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
+          
+          [env: WEBFANG_ELASTIC=]
+
+      --output-vectors <OUTPUT_VECTORS>
+          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
+          
+          [env: WEBFANG_OUTPUT_VECTORS=]
+
       --checkpoint-interval <CHECKPOINT_INTERVAL>
           Pages between automatic checkpoint saves (0 = disabled) NOTE: Checkpoint is for programmatic use (Engine API) only. CLI --resume uses StateStore instead of checkpoints
           
@@ -246,59 +332,6 @@ Options:
           [env: WEBFANG_OBSCURA_BINARY=]
           [default: obscura]
 
-  -o, --output <OUTPUT>
-          Output directory for scraped content
-          
-          [env: WEBFANG_OUTPUT=]
-          [default: output]
-
-  -f, --format <FORMAT>
-          Output format for individual files (markdown, text, json) NOTE: For RAG pipeline export, use --export-format instead
-
-          Possible values:
-          - markdown: Markdown format with YAML frontmatter (recommended for RAG)
-          - json:     Structured JSON with metadata
-          - text:     Plain text without formatting
-          
-          [env: WEBFANG_FORMAT=]
-          [default: markdown]
-
-      --export-format <EXPORT_FORMAT>
-          Export format for RAG pipeline (jsonl, vector, auto) NOTE: Use --format for output file format (markdown, text, json)
-
-          Possible values:
-          - jsonl:  JSONL format (JSON Lines - one JSON object per line) Optimal for RAG pipelines and vector database ingestion
-          - vector: Vector format (JSON with metadata header) Supports embeddings and cosine similarity
-          - auto:   Auto-detect format from existing export files
-          
-          [env: WEBFANG_EXPORT_FORMAT=]
-          [default: jsonl]
-
-      --cpu-cores <CPU_CORES>
-          CPU core override for the elastic ingestion Rayon pool (else auto-detect)
-          
-          [env: WEBFANG_CPU_CORES=]
-
-      --ram-budget <RAM_BUDGET>
-          RAM budget override for the byte-weighted semaphore (`8GB`, `2048MB`, or bytes)
-          
-          [env: WEBFANG_RAM_BUDGET=]
-
-      --db-path <DB_PATH>
-          SQLite database path override for persisted resources/chunks
-          
-          [env: WEBFANG_DB_PATH=]
-
-      --elastic
-          Enable elastic ingestion pipeline (streaming, SQLite dedup, Rayon CPU bridge)
-          
-          [env: WEBFANG_ELASTIC=]
-
-      --output-vectors <OUTPUT_VECTORS>
-          Write extracted vectors to a JSONL file for RAG pipelines. Use `-` for stdout. No SQLite dependency — available in every build (core binary too)
-          
-          [env: WEBFANG_OUTPUT_VECTORS=]
-
       --batch
           Enable batch mode — read URLs from stdin (one per line)
           
@@ -329,41 +362,6 @@ Options:
           
           [env: WEBFANG_PIPELINE_OUTPUT=]
           [default: jsonl]
-
-      --obsidian-wiki-links
-          Convert same-domain links to Obsidian [[wiki-link]] syntax
-          
-          [env: WEBFANG_OBSIDIAN_WIKI_LINKS=]
-
-      --obsidian-tags <OBSIDIAN_TAGS>
-          Tags to include in YAML frontmatter (comma-separated)
-          
-          [env: WEBFANG_OBSIDIAN_TAGS=]
-
-      --obsidian-relative-assets
-          Rewrite downloaded asset paths as relative to the .md file
-          
-          [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
-
-      --vault <VAULT>
-          Path to Obsidian vault (auto-detects if not provided)
-          
-          [env: WEBFANG_OBSIDIAN_VAULT=]
-
-      --quick-save
-          Quick-save mode: save directly to vault _inbox folder
-          
-          [env: WEBFANG_OBSIDIAN_QUICK_SAVE=]
-
-      --obsidian-rich-metadata
-          Add rich metadata to frontmatter
-          
-          [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
-
-      --tui
-          Unified TUI mode: config form (collapsible sections) → URL selector → scraping
-          
-          [env: WEBFANG_TUI=]
 
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
## Summary

- Propagate `ai_model` field from CLI args through `ExportConfig` so it's available in the export flow
- Replace hardcoded AI config values (threshold=0.3, max_tokens=32768, offline=false) in `SemanticCleanerImpl` construction with values from `opts.ai_config`
- Remove redundant `ai_model_arg` variable that duplicated data already in `opts.ai_config.model`
- Update stale CLI help output snapshots (pre-existing drift from args module refactoring)

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/export_flow.rs` | Added `ai_model: String` field to `ExportConfig` struct |
| `crates/webfang_core/src/cli/orchestrator.rs` | Pass `opts.ai_config.model.clone()` to `ExportConfig` construction |
| `crates/webfang_cli/src/main.rs` | Use `opts.ai_config` values instead of hardcoded defaults for `SemanticCleanerImpl`; remove redundant `ai_model_arg` |
| `tests/behavioral/snapshots/behavioral__help.snap` | Updated stale snapshot |
| `tests/snapshots/cli_binary__test_help_contains_scraper.snap` | Updated stale snapshot |

## Test Plan

- [x] `cargo check -p webfang_core -p webfang_cli` passes
- [x] `cargo clippy -p webfang_core -p webfang_cli -- -D warnings` clean
- [x] `cargo nextest run -p webfang_core -p webfang_cli` — 1303/1303 tests pass

## Context

This fixes the remaining gap from issue #219. The original issue identified 4 findings; the other 3 were already resolved by prior work:
1. ✅ Shared Downloader wiring (ADR-0001) — already done
2. ✅ `fetch_sitemap` deprecated function — already removed
3. ✅ AI config flags propagation — partially done, **this PR completes it** (ai_model was missing)
4. ✅ MCP `handlers/ai.rs` dead code — already reworked with proper error messages

Closes #219