### PR TITLE
fix(crawler): drop task_ctx before collector.collect() to prevent batch hang

### DIFF
--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -523,10 +523,16 @@ impl Engine {
             handle_crawl_result(result, &self.error_count);
         }
 
+        // Drop task_ctx so all cloned Senders inside CrawlTaskCtx are released.
+        // Without this, collect() hangs forever — the mpsc channel stays open
+        // because a Sender clone inside the Arc<CrawlTaskCtx> is still alive.
+        drop(task_ctx);
+
         // Final checkpoint save
         self.save_checkpoint().await;
 
-        // Collect results via mpsc channel (shutdown limpio)
+        // Collect results via mpsc channel — now all Senders are dropped,
+        // so the receiver worker will drain and terminate.
         let collected_urls = self.collector.take().unwrap().collect().await;
         let total_pages = collected_urls.len();
         let errors = self.error_count.load(std::sync::atomic::Ordering::SeqCst);

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -405,7 +405,12 @@ async fn run_batch(opts: CrawlOptions) -> CliExit {
         BatchManager::from_file(path, crawler_config, opts.batch.concurrency)
     } else {
         info!("Reading URLs from stdin");
-        BatchManager::from_stdin(crawler_config, opts.batch.concurrency)
+        // spawn_blocking: stdin read is blocking I/O that must not run on the
+        // Tokio async runtime thread pool — it would block other tasks.
+        let concurrency = opts.batch.concurrency;
+        tokio::task::spawn_blocking(move || BatchManager::from_stdin(crawler_config, concurrency))
+            .await
+            .expect("spawn_blocking panicked")
     };
 
     let manager = match manager_result {


### PR DESCRIPTION
## Summary
- Fix infinite hang in `--batch` and `--batch-file` modes caused by `ResultsCollector::collect()` never completing
- Wrap `BatchManager::from_stdin()` in `spawn_blocking` to avoid blocking the Tokio runtime

## Root cause
`Engine::run()` held an `Arc<CrawlTaskCtx>` that contained a cloned `ResultsCollector` (and its `mpsc::Sender`). After all crawl tasks joined, the `Arc` was never dropped, so the `Sender` clone kept the mpsc channel open. `collect()` dropped the original `Sender` but the clone prevented channel closure → infinite hang.

## Fix
Add `drop(task_ctx)` after all tasks complete and before `collect()` is called, ensuring all `Sender` clones are released and the channel can close.

## Test results
- `batch_stdin_processes_urls`: **0.014s** (was: 30s timeout)
- `batch_file_processes_urls`: **0.014s** (was: 30s timeout)
- `batch_empty_stdin_exits_64`: pass
- `batch_empty_file_exits_64`: pass

## Verification
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo nextest run -- cli::batch_test` (4/4 pass)