### PR TITLE
test(audit): PR3 — Infrastructure: Clock injection + determinism

### DIFF
--- a/crates/webfang_core/src/application/deduplicator.rs
+++ b/crates/webfang_core/src/application/deduplicator.rs
@@ -187,4 +187,13 @@ mod tests {
         }
         assert_eq!(dedup.len(), 1000);
     }
+
+    #[test]
+    fn test_discovered_url_dedup_via_url_deduplicator() {
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com/page"));
+        assert!(!dedup.try_insert("https://example.com/page")); // duplicate
+        assert!(dedup.try_insert("https://example.com/other")); // different URL
+        assert_eq!(dedup.len(), 2);
+    }
 }

--- a/crates/webfang_core/src/application/rate_limiter.rs
+++ b/crates/webfang_core/src/application/rate_limiter.rs
@@ -584,7 +584,7 @@ mod tests {
     #[test]
     fn test_mock_clock_advance_tracks_elapsed() {
         let t0 = std::time::Instant::now();
-        let mut clock = MockClock::new(t0);
+        let clock = MockClock::new(t0);
 
         // Advance by 100ms
         clock.advance(std::time::Duration::from_millis(100));
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn test_mock_clock_set_now_overrides() {
         let t0 = std::time::Instant::now();
-        let mut clock = MockClock::new(t0);
+        let clock = MockClock::new(t0);
 
         clock.advance(std::time::Duration::from_secs(10));
         assert_eq!(
@@ -624,7 +624,7 @@ mod tests {
     #[test]
     fn test_mock_clock_duration_between_two_points() {
         let t0 = std::time::Instant::now();
-        let mut clock = MockClock::new(t0);
+        let clock = MockClock::new(t0);
 
         let start = clock.now();
         clock.advance(std::time::Duration::from_millis(250));

--- a/crates/webfang_core/src/domain/clock.rs
+++ b/crates/webfang_core/src/domain/clock.rs
@@ -9,6 +9,7 @@
 //! - [`UtcClock`] — For `DateTime<Utc>`-based timestamps (credentials, exports)
 
 use chrono::{DateTime, Utc};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 /// Clock port for `Instant`-based timing operations.
@@ -63,43 +64,62 @@ impl UtcClock for SystemUtcClock {
 
 /// Mock clock for deterministic `Instant`-based testing.
 ///
+/// Uses `Arc<Mutex<Instant>>` internally so the clock can be shared
+/// between the pool (via `Arc<dyn Clock>`) and the test (via `MockClock`).
+/// Advancing through the `MockClock` is visible to the pool.
+///
 /// # Example
 ///
 /// ```rust
 /// use std::time::{Duration, Instant};
 /// use webfang::domain::clock::{Clock, MockClock};
 ///
-/// let mut clock = MockClock::new(Instant::now());
+/// let clock = MockClock::new(Instant::now());
 /// let t0 = clock.now();
 ///
 /// // Advance time by 100ms
-/// clock.set_now(t0 + Duration::from_millis(100));
+/// clock.advance(Duration::from_millis(100));
 /// assert_eq!(clock.now(), t0 + Duration::from_millis(100));
 /// ```
 pub struct MockClock {
-    now: Instant,
+    now: Arc<Mutex<Instant>>,
 }
 
 impl MockClock {
     /// Create a mock clock starting at the given instant.
     pub fn new(now: Instant) -> Self {
-        Self { now }
+        Self {
+            now: Arc::new(Mutex::new(now)),
+        }
+    }
+
+    /// Get an `Arc<dyn Clock>` handle sharing this clock's time.
+    ///
+    /// Advancing this `MockClock` will be visible through the returned handle.
+    pub fn handle(&self) -> Arc<dyn Clock> {
+        Arc::clone(&self.now) as Arc<dyn Clock>
     }
 
     /// Advance the clock by the given duration.
-    pub fn advance(&mut self, duration: std::time::Duration) {
-        self.now += duration;
+    pub fn advance(&self, duration: std::time::Duration) {
+        *self.now.lock().expect("mock clock poisoned") += duration;
     }
 
     /// Set the clock to a specific instant.
-    pub fn set_now(&mut self, now: Instant) {
-        self.now = now;
+    pub fn set_now(&self, now: Instant) {
+        *self.now.lock().expect("mock clock poisoned") = now;
     }
 }
 
 impl Clock for MockClock {
     fn now(&self) -> Instant {
-        self.now
+        *self.now.lock().expect("mock clock poisoned")
+    }
+}
+
+impl Clock for Mutex<Instant> {
+    fn now(&self) -> Instant {
+        *self.lock().expect("mock clock poisoned")
     }
 }
 
@@ -178,7 +198,7 @@ mod tests {
     #[test]
     fn test_mock_clock_advance() {
         let t0 = Instant::now();
-        let mut clock = MockClock::new(t0);
+        let clock = MockClock::new(t0);
         clock.advance(Duration::from_millis(500));
         assert_eq!(clock.now(), t0 + Duration::from_millis(500));
     }
@@ -187,7 +207,7 @@ mod tests {
     fn test_mock_clock_set_now() {
         let t0 = Instant::now();
         let t1 = t0 + Duration::from_secs(10);
-        let mut clock = MockClock::new(t0);
+        let clock = MockClock::new(t0);
         clock.set_now(t1);
         assert_eq!(clock.now(), t1);
     }
@@ -219,7 +239,7 @@ mod tests {
     #[test]
     fn test_mock_clock_multiple_advances() {
         let t0 = Instant::now();
-        let mut clock = MockClock::new(t0);
+        let clock = MockClock::new(t0);
         clock.advance(Duration::from_millis(100));
         clock.advance(Duration::from_millis(200));
         clock.advance(Duration::from_millis(300));

--- a/crates/webfang_core/src/domain/clock.rs
+++ b/crates/webfang_core/src/domain/clock.rs
@@ -36,6 +36,12 @@ pub trait UtcClock: Send + Sync {
 /// System clock using real `Instant::now()`.
 pub struct SystemClock;
 
+impl Default for SystemClock {
+    fn default() -> Self {
+        Self
+    }
+}
+
 impl Clock for SystemClock {
     fn now(&self) -> Instant {
         Instant::now()

--- a/crates/webfang_core/src/domain/crawl_job/entities.rs
+++ b/crates/webfang_core/src/domain/crawl_job/entities.rs
@@ -63,17 +63,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_discovered_url_dedup_via_url_deduplicator() {
-        use crate::application::deduplicator::UrlDeduplicator;
-
-        let dedup = UrlDeduplicator::new();
-        assert!(dedup.try_insert("https://example.com/page"));
-        assert!(!dedup.try_insert("https://example.com/page")); // duplicate
-        assert!(dedup.try_insert("https://example.com/other")); // different URL
-        assert_eq!(dedup.len(), 2);
-    }
-
-    #[test]
     fn test_discovered_url_new() {
         let url = Url::parse("https://example.com/page").unwrap();
         let parent = Url::parse("https://example.com/").unwrap();

--- a/crates/webfang_core/src/domain/ports.rs
+++ b/crates/webfang_core/src/domain/ports.rs
@@ -95,7 +95,7 @@ pub trait AssetDownloaderPort: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::http_error::{HttpError, HttpResult};
+    use crate::domain::http_error::HttpError;
     use crate::domain::http_port::HttpResponse;
     use std::collections::HashMap;
 

--- a/crates/webfang_core/src/domain/ports.rs
+++ b/crates/webfang_core/src/domain/ports.rs
@@ -95,13 +95,14 @@ pub trait AssetDownloaderPort: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::application::http_client::{HttpError, HttpResponse};
+    use crate::domain::http_error::{HttpError, HttpResult};
+    use crate::domain::http_port::HttpResponse;
     use std::collections::HashMap;
 
     // --- Mock implementations for testing port traits ---
 
     struct MockHttpClientPort {
-        responses: HashMap<String, crate::application::http_client::HttpResult<HttpResponse>>,
+        responses: HashMap<String, crate::domain::http_error::HttpResult<HttpResponse>>,
     }
 
     impl MockHttpClientPort {
@@ -114,7 +115,7 @@ mod tests {
         fn with_response(
             mut self,
             url: &str,
-            result: crate::application::http_client::HttpResult<HttpResponse>,
+            result: crate::domain::http_error::HttpResult<HttpResponse>,
         ) -> Self {
             self.responses.insert(url.to_string(), result);
             self
@@ -128,7 +129,7 @@ mod tests {
         ) -> std::pin::Pin<
             Box<
                 dyn std::future::Future<
-                        Output = crate::application::http_client::HttpResult<HttpResponse>,
+                        Output = crate::domain::http_error::HttpResult<HttpResponse>,
                     > + Send
                     + '_,
             >,

--- a/crates/webfang_core/src/infrastructure/network/session_pool.rs
+++ b/crates/webfang_core/src/infrastructure/network/session_pool.rs
@@ -11,6 +11,7 @@
 //! - **Zero-cost abstraction** — `impl SessionManager` not `Box<dyn SessionManager>`
 
 use std::fmt;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "otel-metrics")]
@@ -18,6 +19,8 @@ use std::hash::{Hash, Hasher};
 
 use dashmap::DashMap;
 use tracing::{debug, instrument, warn};
+
+use crate::domain::clock::{Clock, SystemClock};
 
 #[cfg(feature = "otel-metrics")]
 use crate::infrastructure::observability::metrics_instruments::{
@@ -124,6 +127,8 @@ pub struct DomainSessionPool {
     /// Per-domain session states. Key = domain string, Value = Vec of session states.
     sessions: DashMap<String, Vec<SessionState>>,
     config: SessionPoolConfig,
+    /// Injected clock for deterministic time in tests.
+    clock: Arc<dyn Clock>,
 }
 
 /// Hash a domain string to a bounded bucket (0–999) for metric attributes.
@@ -137,19 +142,20 @@ fn domain_bucket(domain: &str) -> u64 {
 }
 
 impl DomainSessionPool {
-    /// Create a new session pool with the given configuration.
+    /// Create a new session pool with the given configuration and clock.
     #[must_use]
-    pub fn new(config: SessionPoolConfig) -> Self {
+    pub fn new(config: SessionPoolConfig, clock: Arc<dyn Clock>) -> Self {
         Self {
             sessions: DashMap::new(),
             config,
+            clock,
         }
     }
 
-    /// Create a pool with default configuration.
+    /// Create a pool with default configuration using the system clock.
     #[must_use]
     pub fn default_pool() -> Self {
-        Self::new(SessionPoolConfig::default())
+        Self::new(SessionPoolConfig::default(), Arc::new(SystemClock))
     }
 
     /// Count total healthy sessions across all domains and update the gauge.
@@ -197,7 +203,7 @@ impl SessionManager for DomainSessionPool {
             .or_insert_with(|| vec![SessionState::healthy(); self.config.pool_size]);
 
         // Evict stale sessions first
-        let now = Instant::now();
+        let now = self.clock.now();
         for state in sessions.iter_mut() {
             if let Some(last_failure) = state.last_failure_time {
                 if now.duration_since(last_failure) > self.config.ttl_duration
@@ -266,11 +272,11 @@ impl SessionManager for DomainSessionPool {
         if let Some(mut sessions) = self.sessions.get_mut(domain) {
             if let Some(state) = sessions.get_mut(session_id.0) {
                 state.consecutive_failures += 1;
-                state.last_failure_time = Some(Instant::now());
+                state.last_failure_time = Some(self.clock.now());
 
                 if should_ban {
                     let delay = self.backoff_delay(state.consecutive_failures);
-                    state.next_retry_time = Some(Instant::now() + delay);
+                    state.next_retry_time = Some(self.clock.now() + delay);
                     state.status = SessionStatus::Banned;
                     #[cfg(feature = "otel-metrics")]
                     {
@@ -318,7 +324,7 @@ impl SessionManager for DomainSessionPool {
 
     #[instrument(skip(self))]
     fn evict_stale(&self) {
-        let now = Instant::now();
+        let now = self.clock.now();
         for mut entry in self.sessions.iter_mut() {
             let domain = entry.key().clone();
             let sessions = entry.value_mut();
@@ -356,6 +362,7 @@ mod sealed {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::clock::MockClock;
     use std::thread;
 
     // ── Task 3.3: State transitions ──
@@ -435,7 +442,7 @@ mod tests {
             max_exp: 6,
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let d_large = pool.backoff_delay(100);
         assert_eq!(d_large, Duration::from_secs(10));
     }
@@ -448,7 +455,7 @@ mod tests {
             max_exp: 4,
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let d4 = pool.backoff_delay(4);
         let d5 = pool.backoff_delay(5);
         let d6 = pool.backoff_delay(6);
@@ -467,7 +474,7 @@ mod tests {
             ttl_duration: Duration::from_millis(1),
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let id = pool.acquire("example.com").unwrap();
         pool.report_failure("example.com", id, 429);
 
@@ -485,7 +492,7 @@ mod tests {
             ttl_duration: Duration::from_millis(1),
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let id = pool.acquire("example.com").unwrap();
         pool.report_failure("example.com", id, 429);
 
@@ -502,7 +509,7 @@ mod tests {
             ttl_duration: Duration::from_millis(1),
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let _id = pool.acquire("example.com").unwrap();
 
         thread::sleep(Duration::from_millis(5));
@@ -520,7 +527,7 @@ mod tests {
             pool_size: 3,
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let _id = pool.acquire("example.com").unwrap();
 
         assert_eq!(pool.domain_count("example.com"), 3);
@@ -532,7 +539,7 @@ mod tests {
             pool_size: 4,
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let id1 = pool.acquire("example.com").unwrap();
         let id2 = pool.acquire("example.com").unwrap();
 
@@ -577,7 +584,7 @@ mod tests {
             max_exp: 1,
             ..Default::default()
         };
-        let pool = DomainSessionPool::new(config);
+        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
         let id = pool.acquire("example.com").unwrap();
         pool.report_failure("example.com", id, 429);
 

--- a/crates/webfang_core/src/infrastructure/network/session_pool.rs
+++ b/crates/webfang_core/src/infrastructure/network/session_pool.rs
@@ -363,7 +363,6 @@ mod sealed {
 mod tests {
     use super::*;
     use crate::domain::clock::MockClock;
-    use std::thread;
 
     // ── Task 3.3: State transitions ──
 
@@ -470,16 +469,19 @@ mod tests {
 
     #[test]
     fn stale_sessions_evicted_on_acquire() {
-        let config = SessionPoolConfig {
-            ttl_duration: Duration::from_millis(1),
-            ..Default::default()
-        };
-        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
+        let clock = MockClock::new(Instant::now());
+        let pool = DomainSessionPool::new(
+            SessionPoolConfig {
+                ttl_duration: Duration::from_millis(10),
+                ..Default::default()
+            },
+            clock.handle(),
+        );
         let id = pool.acquire("example.com").unwrap();
         pool.report_failure("example.com", id, 429);
 
-        // Wait for TTL to expire
-        thread::sleep(Duration::from_millis(5));
+        // Advance past TTL — the shared clock updates the pool's view too
+        clock.advance(Duration::from_millis(20));
 
         // acquire should evict the stale banned session and return a healthy one
         let id2 = pool.acquire("example.com");
@@ -488,15 +490,19 @@ mod tests {
 
     #[test]
     fn evict_stale_removes_old_banned_sessions() {
-        let config = SessionPoolConfig {
-            ttl_duration: Duration::from_millis(1),
-            ..Default::default()
-        };
-        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
+        let clock = MockClock::new(Instant::now());
+        let pool = DomainSessionPool::new(
+            SessionPoolConfig {
+                ttl_duration: Duration::from_millis(10),
+                ..Default::default()
+            },
+            clock.handle(),
+        );
         let id = pool.acquire("example.com").unwrap();
         pool.report_failure("example.com", id, 429);
 
-        thread::sleep(Duration::from_millis(5));
+        // Advance past TTL
+        clock.advance(Duration::from_millis(20));
         pool.evict_stale();
 
         let sessions = pool.sessions.get("example.com").unwrap();
@@ -505,14 +511,18 @@ mod tests {
 
     #[test]
     fn healthy_sessions_not_evicted_by_ttl() {
-        let config = SessionPoolConfig {
-            ttl_duration: Duration::from_millis(1),
-            ..Default::default()
-        };
-        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
+        let clock = MockClock::new(Instant::now());
+        let pool = DomainSessionPool::new(
+            SessionPoolConfig {
+                ttl_duration: Duration::from_millis(10),
+                ..Default::default()
+            },
+            clock.handle(),
+        );
         let _id = pool.acquire("example.com").unwrap();
 
-        thread::sleep(Duration::from_millis(5));
+        // Advance past TTL — healthy sessions should NOT be evicted
+        clock.advance(Duration::from_millis(20));
         pool.evict_stale();
 
         let sessions = pool.sessions.get("example.com").unwrap();
@@ -577,14 +587,17 @@ mod tests {
 
     #[test]
     fn banned_session_available_after_cooldown() {
-        let config = SessionPoolConfig {
-            pool_size: 1,
-            base_delay: Duration::from_millis(1),
-            max_delay: Duration::from_millis(10),
-            max_exp: 1,
-            ..Default::default()
-        };
-        let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
+        let clock = MockClock::new(Instant::now());
+        let pool = DomainSessionPool::new(
+            SessionPoolConfig {
+                pool_size: 1,
+                base_delay: Duration::from_millis(1),
+                max_delay: Duration::from_millis(10),
+                max_exp: 1,
+                ..Default::default()
+            },
+            clock.handle(),
+        );
         let id = pool.acquire("example.com").unwrap();
         pool.report_failure("example.com", id, 429);
 
@@ -595,8 +608,8 @@ mod tests {
             assert!(sessions[0].next_retry_time.is_some());
         }
 
-        // Wait well past cooldown (backoff is 2^1 * 1ms = 2ms, sleep 50ms)
-        thread::sleep(Duration::from_millis(50));
+        // Advance past cooldown (backoff is 2^1 * 1ms = 2ms)
+        clock.advance(Duration::from_millis(50));
 
         let id2 = pool.acquire("example.com");
         assert!(id2.is_some(), "should be available after cooldown");

--- a/crates/webfang_core/src/infrastructure/stream/mod.rs
+++ b/crates/webfang_core/src/infrastructure/stream/mod.rs
@@ -32,12 +32,12 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::domain::clock::{SystemUtcClock, UtcClock};
 use crate::domain::repository::VectorRepository;
 use crate::error::ScraperError;
 
@@ -80,10 +80,12 @@ pub struct StreamRepository {
     /// and read by [`VectorRepository::save_chunk`] (the chunk call only receives
     /// `resource_url`, not the title).
     titles: Mutex<HashMap<String, String>>,
+    /// Injected clock for deterministic timestamps in tests.
+    clock: Arc<dyn UtcClock>,
 }
 
 impl StreamRepository {
-    /// Open the JSONL sink.
+    /// Open the JSONL sink with the system clock.
     ///
     /// * `path == "-"` → buffered stdout.
     /// * otherwise → a file created (truncated) at `path`.
@@ -92,6 +94,15 @@ impl StreamRepository {
     ///
     /// Returns [`ScraperError::Io`] if the file cannot be created.
     pub fn new(path: &str) -> Result<Self, ScraperError> {
+        Self::with_clock(path, Arc::new(SystemUtcClock))
+    }
+
+    /// Open the JSONL sink with an injected clock.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScraperError::Io`] if the file cannot be created.
+    pub fn with_clock(path: &str, clock: Arc<dyn UtcClock>) -> Result<Self, ScraperError> {
         let boxed: Box<dyn Write + Send> = if path == "-" {
             Box::new(std::io::stdout())
         } else {
@@ -113,6 +124,7 @@ impl StreamRepository {
         Ok(Self {
             writer: Mutex::new(std::io::BufWriter::new(boxed)),
             titles: Mutex::new(HashMap::new()),
+            clock,
         })
     }
 
@@ -126,6 +138,7 @@ impl StreamRepository {
         Self {
             writer: Mutex::new(std::io::BufWriter::new(w)),
             titles: Mutex::new(HashMap::new()),
+            clock: Arc::new(SystemUtcClock),
         }
     }
 }
@@ -184,7 +197,7 @@ impl VectorRepository for StreamRepository {
                 chunk_text: content.to_string(),
                 embedding,
                 metadata: Value::Null,
-                timestamp: Utc::now().to_rfc3339(),
+                timestamp: self.clock.now().to_rfc3339(),
             };
 
             let line = serde_json::to_string(&record)?;


### PR DESCRIPTION
## Summary
- Inject `Clock` into `DomainSessionPool` for deterministic TTL testing
- Replace 4 `thread::sleep`-based TTL tests with `MockClock`
- Inject `UtcClock` for deterministic timestamps in `stream/mod.rs`
- Fix domain→application layer import violations

## Changes
- `session_pool.rs` — Clock injection at construction, 4 tests use MockClock (zero thread::sleep)
- `stream/mod.rs` — UtcClock for VectorRecord timestamps
- `ports.rs` — Import paths corrected to domain layer
- `entities.rs` — Deduplicator test moved to application layer (Clean Architecture)
- `domain/clock.rs` — MockClock refined with `handle()` for Arc sharing

## Key Finding
There are TWO `DomainSessionPool` implementations: old async one in `session/pool.rs` (used by engine.rs) and new sync one in `network/session_pool.rs`. The old pool also has `Instant::now()` — candidate for future PR.

Depends on: #241 (PR2)
Part of: #239
