### PR TITLE
test(audit): PR4 — Interfaces: MCP assertions + TUI dedup

### DIFF
--- a/tests/ai_integration.rs
+++ b/tests/ai_integration.rs
@@ -203,43 +203,73 @@ fn test_download_progress_calculations() {
 /// Test that SemanticError variants are properly defined
 #[test]
 fn test_semantic_error_variants() {
-    // Test ModelLoad error
+    // Test ModelLoad error — match on variant, verify inner error
     let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
     let err = SemanticError::ModelLoad(io_err);
-    assert!(err.to_string().contains("cargando modelo"));
+    match err {
+        SemanticError::ModelLoad(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
+        other => panic!("expected ModelLoad, got {other:?}"),
+    }
 
-    // Test ChunkTooLarge error
+    // Test ChunkTooLarge error — match on variant, verify fields
     let err = SemanticError::ChunkTooLarge {
         chunk_id: "chunk-1".to_string(),
         tokens: 600,
         max: 512,
     };
-    assert!(err.to_string().contains("chunk-1"));
-    assert!(err.to_string().contains("600 > 512"));
+    match err {
+        SemanticError::ChunkTooLarge {
+            chunk_id,
+            tokens,
+            max,
+        } => {
+            assert_eq!(chunk_id, "chunk-1");
+            assert_eq!(tokens, 600);
+            assert_eq!(max, 512);
+        },
+        other => panic!("expected ChunkTooLarge, got {other:?}"),
+    }
 
-    // Test Download error
+    // Test Download error — match on variant, verify fields
     let err = SemanticError::Download {
         repo: "test/repo".to_string(),
         cause: "network error".to_string(),
     };
-    assert!(err.to_string().contains("test/repo"));
-    assert!(err.to_string().contains("network error"));
+    match err {
+        SemanticError::Download { repo, cause } => {
+            assert_eq!(repo, "test/repo");
+            assert_eq!(cause, "network error");
+        },
+        other => panic!("expected Download, got {other:?}"),
+    }
 
-    // Test CacheValidation error
+    // Test CacheValidation error — match on variant, verify fields
     let err = SemanticError::CacheValidation {
         repo: "test/repo".to_string(),
         expected: "abc123".to_string(),
         actual: "def456".to_string(),
     };
-    assert!(err.to_string().contains("abc123"));
-    assert!(err.to_string().contains("def456"));
+    match err {
+        SemanticError::CacheValidation {
+            repo,
+            expected,
+            actual,
+        } => {
+            assert_eq!(repo, "test/repo");
+            assert_eq!(expected, "abc123");
+            assert_eq!(actual, "def456");
+        },
+        other => panic!("expected CacheValidation, got {other:?}"),
+    }
 
-    // Test OfflineMode error
+    // Test OfflineMode error — match on variant, verify field
     let err = SemanticError::OfflineMode {
         repo: "test/repo".to_string(),
     };
-    assert!(err.to_string().contains("test/repo"));
-    assert!(err.to_string().contains("offline"));
+    match err {
+        SemanticError::OfflineMode { repo } => assert_eq!(repo, "test/repo"),
+        other => panic!("expected OfflineMode, got {other:?}"),
+    }
 }
 
 /// Test that ScraperError can be created from SemanticError
@@ -253,7 +283,12 @@ fn test_scraper_error_from_semantic_error() {
     ));
 
     let scraper_err: ScraperError = semantic_err.into();
-    assert!(scraper_err.to_string().contains("limpieza semántica"));
+    match scraper_err {
+        ScraperError::Semantic(SemanticError::ModelLoad(e)) => {
+            assert_eq!(e.kind(), std::io::ErrorKind::NotFound);
+        },
+        other => panic!("expected ScraperError::Semantic(ModelLoad), got {other:?}"),
+    }
 }
 
 /// Test ChunkId inner value access

--- a/tests/mcp_behavioral_test.rs
+++ b/tests/mcp_behavioral_test.rs
@@ -19,6 +19,26 @@ use webfang::di::Container;
 use webfang::infrastructure::mcp_server::server::build_mcp_router;
 use webfang::infrastructure::mcp_server::state::McpState;
 
+/// JSON-RPC standard error code for "Method not found" (JSON-RPC 2.0 spec).
+const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
+
+/// Parse JSON-RPC response body and extract the error code, if present.
+///
+/// Handles both direct JSON and SSE-wrapped (`data: ` prefix) responses.
+/// Returns `Some(error_code)` if the response contains a JSON-RPC error object.
+fn parse_jsonrpc_error_code(body: &str) -> Option<i64> {
+    let json_str = if body.contains("data: ") {
+        body.lines()
+            .find(|line| line.starts_with("data: "))
+            .map(|line| line.strip_prefix("data: ").unwrap_or(line))?
+    } else {
+        body
+    };
+
+    let parsed: Value = serde_json::from_str(json_str).ok()?;
+    parsed.get("error")?.get("code")?.as_i64()
+}
+
 /// Start a test MCP server on a random port and return the base URL.
 async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     let config = Config::default();
@@ -286,9 +306,10 @@ async fn test_invalid_session_returns_error() {
 
     // Should return an error (4xx) or handle gracefully
     // The MCP protocol may return 400 Bad Request or similar for invalid sessions
+    let has_jsonrpc_error = parse_jsonrpc_error_code(&body).is_some();
     assert!(
-        !status.is_success() || body.contains("error"),
-        "invalid session should return error status or error in body, got {}: {}",
+        !status.is_success() || has_jsonrpc_error,
+        "invalid session should return error status or JSON-RPC error in body, got {}: {}",
         status,
         &body[..body.len().min(500)]
     );
@@ -350,11 +371,14 @@ async fn test_unknown_method_returns_error() {
     // Should return success (200) with JSON-RPC error in body,
     // or an HTTP error status
     if status.is_success() {
-        // Check for JSON-RPC error in response
-        let has_error = body.contains("error") || body.contains("Method not found");
-        assert!(
-            has_error,
-            "unknown method should return JSON-RPC error: {}",
+        // Verify JSON-RPC error code -32601 (Method not found)
+        let error_code = parse_jsonrpc_error_code(&body);
+        assert_eq!(
+            error_code,
+            Some(JSONRPC_METHOD_NOT_FOUND),
+            "unknown method should return JSON-RPC error code {} (Method not found), got code {:?} in: {}",
+            JSONRPC_METHOD_NOT_FOUND,
+            error_code,
             &body[..body.len().min(500)]
         );
     }

--- a/tests/tui_smoke_test.rs
+++ b/tests/tui_smoke_test.rs
@@ -26,85 +26,10 @@ fn make_urls(n: usize) -> Vec<Url> {
 
 // ===========================================================================
 // Group 1: UrlSelectorState
+//
+// Core UrlSelectorState tests live in tui_unit_tests.rs (more comprehensive).
+// Only tests for behavior NOT covered there belong here.
 // ===========================================================================
-
-#[test]
-fn url_selector_new_initializes_empty_selection() {
-    let urls = make_urls(5);
-    let state = UrlSelectorState::new(&urls);
-    assert_eq!(state.selected_count(), 0);
-    assert_eq!(state.total_count(), 5);
-}
-
-#[test]
-fn url_selector_toggle_selection() {
-    let urls = make_urls(3);
-    let mut state = UrlSelectorState::new(&urls);
-    state.toggle_selection();
-    assert!(state.is_selected(0));
-    assert_eq!(state.selected_count(), 1);
-}
-
-#[test]
-fn url_selector_toggle_deselects() {
-    let urls = make_urls(3);
-    let mut state = UrlSelectorState::new(&urls);
-    state.toggle_selection();
-    state.toggle_selection();
-    assert!(!state.is_selected(0));
-    assert_eq!(state.selected_count(), 0);
-}
-
-#[test]
-fn url_selector_select_all() {
-    let urls = make_urls(5);
-    let mut state = UrlSelectorState::new(&urls);
-    state.select_all();
-    assert_eq!(state.selected_count(), 5);
-}
-
-#[test]
-fn url_selector_deselect_all() {
-    let urls = make_urls(5);
-    let mut state = UrlSelectorState::new(&urls);
-    state.select_all();
-    state.deselect_all();
-    assert_eq!(state.selected_count(), 0);
-}
-
-#[test]
-fn url_selector_cursor_movement() {
-    let urls = make_urls(5);
-    let mut state = UrlSelectorState::new(&urls);
-    state.cursor_down();
-    state.cursor_down();
-    assert_eq!(state.cursor(), 2);
-    state.cursor_up();
-    assert_eq!(state.cursor(), 1);
-}
-
-#[test]
-fn url_selector_cursor_clamps_at_bounds() {
-    let urls = make_urls(3);
-    let mut state = UrlSelectorState::new(&urls);
-    // Already at 0, going up should stay at 0
-    state.cursor_up();
-    state.cursor_up();
-    assert_eq!(state.cursor(), 0);
-    // Go to end, then try past the end
-    state.cursor_down();
-    state.cursor_down();
-    state.cursor_down();
-    state.cursor_down();
-    assert_eq!(state.cursor(), 2);
-}
-
-#[test]
-fn url_selector_empty_urls() {
-    let state = UrlSelectorState::new(&[]);
-    assert_eq!(state.selected_count(), 0);
-    assert_eq!(state.total_count(), 0);
-}
 
 #[test]
 fn url_selector_toggle_out_of_bounds() {
@@ -113,59 +38,6 @@ fn url_selector_toggle_out_of_bounds() {
     // Cursor at 0, should not panic
     state.toggle_selection();
     assert!(state.is_selected(0));
-}
-
-#[test]
-fn url_selector_get_selected_urls() {
-    let urls = make_urls(3);
-    let mut state = UrlSelectorState::new(&urls);
-    state.toggle_selection(); // index 0
-    state.cursor_down();
-    state.cursor_down();
-    state.toggle_selection(); // index 2
-    let selected = state.get_selected_urls();
-    assert_eq!(selected.len(), 2);
-    assert_eq!(selected[0].as_str(), "https://example.com/page/0");
-    assert_eq!(selected[1].as_str(), "https://example.com/page/2");
-}
-
-#[test]
-fn url_selector_confirmation_mode() {
-    let urls = make_urls(3);
-    let mut state = UrlSelectorState::new(&urls);
-    assert!(!state.is_confirming());
-    state.enter_confirm_mode();
-    assert!(state.is_confirming());
-    state.exit_confirm_mode();
-    assert!(!state.is_confirming());
-}
-
-#[test]
-fn url_selector_scroll_with_visible_height() {
-    let urls = make_urls(10);
-    let mut state = UrlSelectorState::new(&urls);
-    state.set_visible_height(3);
-
-    // Move cursor past the visible area
-    for _ in 0..5 {
-        state.cursor_down();
-    }
-    assert_eq!(state.cursor(), 5);
-    assert!(
-        state.scroll() > 0,
-        "scroll should advance when cursor goes below visible area"
-    );
-}
-
-#[test]
-fn url_selector_get_url() {
-    let urls = make_urls(3);
-    let state = UrlSelectorState::new(&urls);
-    assert_eq!(
-        state.get_url(0).unwrap().as_str(),
-        "https://example.com/page/0"
-    );
-    assert!(state.get_url(99).is_none());
 }
 
 // ===========================================================================
@@ -193,12 +65,10 @@ fn progress_widget_builder_methods() {
 
 // ===========================================================================
 // Group 3: ErrorLogWidget
+//
+// Core ErrorLogWidget::new() and rendering tests live in tui_unit_tests.rs.
+// Only tests for behavior NOT covered there belong here.
 // ===========================================================================
-
-#[test]
-fn error_log_widget_init_no_panic() {
-    let _widget = ErrorLogWidget::new();
-}
 
 #[test]
 fn error_log_widget_toggle_auto_scroll() {


### PR DESCRIPTION
## Summary
- Replace MCP string-match assertions with JSON-RPC error code validation
- Deduplicate 13 TUI tests across unit and smoke test files
- Audit all 27 `#[ignore]` tests (all valid, none stale)
- Refactor 10 Display-as-assertion patterns to variant pattern matching

## Changes
- `mcp_behavioral_test.rs` — String-match → JSON-RPC error code assertions
- `tui_unit_tests.rs`, `tui_smoke_test.rs` — 13 duplicate tests removed
- `ai_integration.rs` — 10 `error.to_string().contains(...)` → `matches!(error, Variant(...))`

## Critical Finding
🚨 MCP test files (`mcp_behavioral_test.rs`, `mcp_lifecycle_test.rs`) are **dead code** — no `[[test]]` entry in any Cargo.toml. These tests are NOT running in CI. Feature gate `#![cfg(feature = "mcp/ui/ai")]` checks features on the owning crate but those features only exist on `webfang_core`.

Depends on: #242 (PR3)
Part of: #239
