### PR TITLE
test(audit): PR5 — AI pipeline tests + fuzz targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/webfang_mcp",
     "crates/webfang_cli",
 ]
+exclude = ["fuzz"]
 
 [workspace.package]
 version = "2.0.0"

--- a/crates/webfang_ai/tests/semantic_cleaner_pipeline.rs
+++ b/crates/webfang_ai/tests/semantic_cleaner_pipeline.rs
@@ -4,8 +4,8 @@
 //! `SemanticCleanerImpl::clean()`, without requiring the ONNX model.
 //! Covers the audit gap: zero tests for the main cleaning pipeline.
 
-use webfang_ai::infrastructure_ai::content_pruner::{ContentPruner, LegibleContentPruner};
 use webfang_ai::infrastructure_ai::chunker::HtmlChunker;
+use webfang_ai::infrastructure_ai::content_pruner::{ContentPruner, LegibleContentPruner};
 
 /// Exercise the full pruner → chunker pipeline on simple HTML.
 #[test]
@@ -77,7 +77,9 @@ fn pipeline_empty_input_returns_empty() {
     let pruned = pruner.prune("");
     assert!(pruned.is_empty());
 
-    let chunks = chunker.chunk("").expect("chunking empty string should not fail");
+    let chunks = chunker
+        .chunk("")
+        .expect("chunking empty string should not fail");
     assert!(chunks.is_empty());
 }
 
@@ -118,7 +120,11 @@ fn pipeline_deeply_nested_html() {
     }
 
     let pruned = pruner.prune(&html);
-    let effective = if pruned.is_empty() { html.as_str() } else { &pruned };
+    let effective = if pruned.is_empty() {
+        html.as_str()
+    } else {
+        &pruned
+    };
     let _ = chunker.chunk(effective);
 }
 
@@ -138,9 +144,15 @@ fn pipeline_large_html_does_not_oom() {
     html.push_str("</article></body></html>");
 
     let pruned = pruner.prune(&html);
-    let effective = if pruned.is_empty() { html.as_str() } else { &pruned };
+    let effective = if pruned.is_empty() {
+        html.as_str()
+    } else {
+        &pruned
+    };
     // Should complete without panic or OOM — chunk count depends on pruner behavior
-    let _chunks = chunker.chunk(effective).expect("chunking large HTML should not fail");
+    let _chunks = chunker
+        .chunk(effective)
+        .expect("chunking large HTML should not fail");
 }
 
 /// Unicode content should survive the pipeline intact.
@@ -158,7 +170,9 @@ fn pipeline_unicode_content_preserved() {
 
     let pruned = pruner.prune(html);
     let effective = if pruned.is_empty() { html } else { &pruned };
-    let chunks = chunker.chunk(effective).expect("unicode HTML should chunk fine");
+    let chunks = chunker
+        .chunk(effective)
+        .expect("unicode HTML should chunk fine");
 
     let all_content: String = chunks.iter().map(|c| c.content.as_str()).collect();
     assert!(

--- a/crates/webfang_ai/tests/semantic_cleaner_pipeline.rs
+++ b/crates/webfang_ai/tests/semantic_cleaner_pipeline.rs
@@ -1,0 +1,214 @@
+//! Integration tests for SemanticCleaner pipeline components.
+//!
+//! Tests the pipeline stages (pruner → chunker) in the same order as
+//! `SemanticCleanerImpl::clean()`, without requiring the ONNX model.
+//! Covers the audit gap: zero tests for the main cleaning pipeline.
+
+use webfang_ai::infrastructure_ai::content_pruner::{ContentPruner, LegibleContentPruner};
+use webfang_ai::infrastructure_ai::chunker::HtmlChunker;
+
+/// Exercise the full pruner → chunker pipeline on simple HTML.
+#[test]
+fn pipeline_simple_html_produces_chunks() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let html = r#"
+        <html><body>
+        <article>
+            <h1>Hello World</h1>
+            <p>This is a substantial test paragraph with enough content to pass chunking thresholds. It contains multiple sentences to ensure proper chunking behavior.</p>
+        </article>
+        </body></html>
+    "#;
+
+    let pruned = pruner.prune(html);
+    let effective = if pruned.is_empty() { html } else { &pruned };
+
+    let chunks = chunker.chunk(effective).expect("chunking should not fail");
+    assert!(
+        !chunks.is_empty(),
+        "pipeline should produce at least one chunk from valid HTML"
+    );
+}
+
+/// Complex HTML with scripts and styles should still produce clean output.
+#[test]
+fn pipeline_strips_scripts_and_styles() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let html = r#"
+        <html><head>
+            <script>var evil = document.createElement('xss');</script>
+            <style>body { display: none; }</style>
+        </head><body>
+        <article>
+            <p>The actual content that should survive the pipeline processing with enough text to meet chunking thresholds.</p>
+        </article>
+        </body></html>
+    "#;
+
+    let pruned = pruner.prune(html);
+    let effective = if pruned.is_empty() { html } else { &pruned };
+
+    let chunks = chunker.chunk(effective).expect("chunking should not fail");
+    // Chunks should contain article content, not script/style
+    for chunk in &chunks {
+        assert!(
+            !chunk.content.contains("var evil"),
+            "script content should be stripped: {}",
+            chunk.content
+        );
+        assert!(
+            !chunk.content.contains("display: none"),
+            "style content should be stripped: {}",
+            chunk.content
+        );
+    }
+}
+
+/// Empty input returns empty pipeline output.
+#[test]
+fn pipeline_empty_input_returns_empty() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let pruned = pruner.prune("");
+    assert!(pruned.is_empty());
+
+    let chunks = chunker.chunk("").expect("chunking empty string should not fail");
+    assert!(chunks.is_empty());
+}
+
+/// Malformed HTML should not panic the pipeline.
+#[test]
+fn pipeline_malformed_html_does_not_panic() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let malformed_inputs = vec![
+        "<<<not valid html>>>><<<",
+        "<div><p>Unclosed tags everywhere",
+        "</div></div></div>",
+        "\0\0\0\x00\x01\x02",
+        "<script>alert('xss')</script>",
+    ];
+
+    for input in malformed_inputs {
+        let pruned = pruner.prune(input);
+        let effective = if pruned.is_empty() { input } else { &pruned };
+        let _ = chunker.chunk(effective);
+    }
+}
+
+/// Deeply nested HTML should still produce output.
+#[test]
+fn pipeline_deeply_nested_html() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let mut html = String::new();
+    for _ in 0..50 {
+        html.push_str("<div>");
+    }
+    html.push_str("Deep content that must survive 50 levels of nesting for testing.");
+    for _ in 0..50 {
+        html.push_str("</div>");
+    }
+
+    let pruned = pruner.prune(&html);
+    let effective = if pruned.is_empty() { html.as_str() } else { &pruned };
+    let _ = chunker.chunk(effective);
+}
+
+/// Pipeline handles very large HTML without panicking or OOM.
+#[test]
+fn pipeline_large_html_does_not_oom() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let mut html = String::with_capacity(500_000);
+    html.push_str("<html><body><article>");
+    for i in 0..1000 {
+        html.push_str(&format!(
+            "<p>Paragraph {i} with enough content to test chunking at scale across many iterations.</p>"
+        ));
+    }
+    html.push_str("</article></body></html>");
+
+    let pruned = pruner.prune(&html);
+    let effective = if pruned.is_empty() { html.as_str() } else { &pruned };
+    // Should complete without panic or OOM — chunk count depends on pruner behavior
+    let _chunks = chunker.chunk(effective).expect("chunking large HTML should not fail");
+}
+
+/// Unicode content should survive the pipeline intact.
+#[test]
+fn pipeline_unicode_content_preserved() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let html = r#"
+        <article>
+            <p>日本語のテストコンテンツです。これは十分な長さのテキストで、チャンク分割の閾値を超えるべきです。</p>
+            <p>Contenido en español con acentos: áéíóú ñü. This paragraph has enough text for chunking.</p>
+        </article>
+    "#;
+
+    let pruned = pruner.prune(html);
+    let effective = if pruned.is_empty() { html } else { &pruned };
+    let chunks = chunker.chunk(effective).expect("unicode HTML should chunk fine");
+
+    let all_content: String = chunks.iter().map(|c| c.content.as_str()).collect();
+    assert!(
+        all_content.contains("日本語") || all_content.contains("español"),
+        "unicode characters should be preserved in pipeline output"
+    );
+}
+
+/// HTML with only whitespace and no real content should produce zero chunks.
+#[test]
+fn pipeline_whitespace_only_produces_no_chunks() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let pruned = pruner.prune("   \n\t  \n   ");
+    let effective = if pruned.is_empty() {
+        "   \n\t  \n   "
+    } else {
+        &pruned
+    };
+    let chunks = chunker.chunk(effective).expect("chunking should not fail");
+    assert!(chunks.is_empty());
+}
+
+/// Verify pruned output feeds correctly into chunker (pipeline integration).
+#[test]
+fn pipeline_pruned_to_chunker_handoff() {
+    let pruner = LegibleContentPruner::standard();
+    let chunker = HtmlChunker::new();
+
+    let html = r#"
+        <html>
+        <nav>Navigation that should be pruned away</nav>
+        <main>
+            <h1>Important Article Title</h1>
+            <p>This is the main article content with enough text to produce meaningful chunks through the pipeline.</p>
+            <p>Second paragraph with additional content that adds substance to the article body.</p>
+        </main>
+        <aside>Sidebar that should also be removed by the pruner.</aside>
+        </html>
+    "#;
+
+    let pruned = pruner.prune(html);
+    let effective = if pruned.is_empty() { html } else { &pruned };
+    let chunks = chunker.chunk(effective).expect("pipeline should not fail");
+
+    let all_content: String = chunks.iter().map(|c| c.content.as_str()).collect();
+    // Main content should be present
+    assert!(
+        all_content.contains("Important Article") || all_content.contains("article"),
+        "main article content should survive pruning: {all_content}"
+    );
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,10 +10,12 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 arbitrary = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["rt"] }
 url = "2"
 
 [dependencies.webfang]
-path = ".."
+package = "webfang_core"
+path = "../crates/webfang_core"
 
 # ============================================================================
 # Fuzz Targets — ordered by risk (highest exposure to untrusted input first)
@@ -93,6 +95,20 @@ bench = false
 [[bin]]
 name = "fuzz_compression_detect"
 path = "fuzz_targets/fuzz_compression_detect.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_parse_content_disposition"
+path = "fuzz_targets/fuzz_parse_content_disposition.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_decompression"
+path = "fuzz_targets/fuzz_decompression.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz.toml
+++ b/fuzz/fuzz.toml
@@ -1,0 +1,42 @@
+# Fuzz configuration for cargo-fuzz
+# Docs: https://rust-fuzz.github.io/book/cargo-fuzz/configuration.html
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+
+# Default libfuzzer settings applied to all targets
+[libfuzzer]
+max_len = 8192
+timeout = 10
+runs = 0  # unlimited (run until Ctrl-C)
+max_total_time = 600  # 10 minutes per target
+jobs = 1
+
+# Per-target overrides
+[[target]]
+name = "fuzz_html_cleaner"
+max_len = 16384  # HTML can be large
+
+[[target]]
+name = "fuzz_parse_content_disposition"
+max_len = 4096  # HTTP headers are typically small
+
+[[target]]
+name = "fuzz_decompression"
+max_len = 32768  # compressed payloads can be larger
+timeout = 15  # decompression can be slower
+
+[[target]]
+name = "fuzz_compression_detect"
+max_len = 16384
+
+[[target]]
+name = "fuzz_waf_detection"
+max_len = 8192
+
+[[target]]
+name = "fuzz_parse_sitemap"
+max_len = 32768  # sitemaps can be large XML
+timeout = 15

--- a/fuzz/fuzz_targets/fuzz_decompression.rs
+++ b/fuzz/fuzz_targets/fuzz_decompression.rs
@@ -1,0 +1,21 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz decompression detection and decompression — processes untrusted network bytes.
+// A panic here = DoS when receiving compressed responses from hostile servers.
+fuzz_target!(|data: &[u8]| {
+    // detect_and_decompress is async and requires a CompressionHandler instance.
+    // Use a small max_decompressed_size to bound memory during fuzzing.
+    let handler = webfang::infrastructure::crawler::compression_handler::CompressionHandler::with_max_size(
+        1024 * 1024, // 1MB limit for fuzzing
+    );
+
+    // Run async decompression in a short-lived tokio runtime
+    if let Ok(rt) = tokio::runtime::Runtime::new() {
+        let _ = rt.block_on(async {
+            handler
+                .detect_and_decompress(data, "https://example.com/data.bin")
+                .await
+        });
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_parse_content_disposition.rs
+++ b/fuzz/fuzz_targets/fuzz_parse_content_disposition.rs
@@ -1,0 +1,12 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// Fuzz Content-Disposition header parsing — processes untrusted HTTP headers.
+// A panic here = DoS when receiving malformed Content-Disposition values.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        // parse_content_disposition returns Option<String> — None means unparseable.
+        // Must NEVER panic on any valid or invalid UTF-8 string.
+        let _ = webfang::infrastructure::crawler::binary_utils::parse_content_disposition(s);
+    }
+});


### PR DESCRIPTION
## Summary
- Add 9 SemanticCleaner pipeline tests (pruner→chunker, no ONNX required)
- Create 2 new fuzz targets: `parse_content_disposition` and `detect_and_decompress`
- Add seed corpus infrastructure for new fuzz targets
- Configure fuzz settings (per-target max_len, timeout)
- Fix broken fuzz dependency that made ALL 14 existing targets non-compilable

## Changes
- **NEW** `semantic_cleaner_pipeline.rs` — 9 integration tests for cleaning pipeline
- **NEW** `fuzz_parse_content_disposition.rs` — Fuzz target for RFC 5987 parsing
- **NEW** `fuzz_decompression.rs` — Fuzz target for compression detection
- `fuzz/Cargo.toml` — Fixed broken `path = ".."` dependency, added new targets
- **NEW** `fuzz/fuzz.toml` — Per-target configuration
- `fuzz/corpus/` — Seed files for new targets

## Critical Finding
🚨 `fuzz/Cargo.toml` had `path = ".."` pointing to workspace root (no package there). ALL 14 existing fuzz targets were silently non-compilable. Fixed by pointing to `crates/webfang_core`.

Depends on: #243 (PR4)
Part of: #239
