### PR TITLE
fix(mcp,exporter,crawler): MCP test wiring, try_send counter, Auto detection order

### DIFF
--- a/crates/webfang_core/src/application/crawler/collector.rs
+++ b/crates/webfang_core/src/application/crawler/collector.rs
@@ -179,6 +179,10 @@ impl ResultsCollector {
         &self,
         msg: CrawlMessage,
     ) -> Result<(), Box<mpsc::error::TrySendError<CrawlMessage>>> {
+        // Update counter synchronously for is_full() checks (same as send())
+        if let CrawlMessage::Success(_) = &msg {
+            self.counter.fetch_add(1, Ordering::Relaxed);
+        }
         self.tx.try_send(msg).map_err(Box::new)
     }
 

--- a/crates/webfang_core/src/application/export_factory.rs
+++ b/crates/webfang_core/src/application/export_factory.rs
@@ -39,17 +39,17 @@ pub fn create_exporter(
             let jsonl_path = output_dir.join(format!("{filename}.jsonl"));
             let vector_path = output_dir.join(format!("{filename}.json"));
 
-            if vector_path.exists() {
-                info!("Detected Vector format - {:?} exists", vector_path);
-                let config = ExporterConfig::new(output_dir, ExportFormat::Vector, filename)
-                    .with_append(true);
-                let exporter = VectorExporter::new(config);
-                Ok(Box::new(exporter))
-            } else if jsonl_path.exists() {
+            if jsonl_path.exists() {
                 info!("Detected JSONL format - {:?} exists", jsonl_path);
                 let config = ExporterConfig::new(output_dir, ExportFormat::Jsonl, filename)
                     .with_append(true);
                 let exporter = jsonl_exporter::JsonlExporter::new(config);
+                Ok(Box::new(exporter))
+            } else if vector_path.exists() {
+                info!("Detected Vector format - {:?} exists", vector_path);
+                let config = ExporterConfig::new(output_dir, ExportFormat::Vector, filename)
+                    .with_append(true);
+                let exporter = VectorExporter::new(config);
                 Ok(Box::new(exporter))
             } else {
                 // Fallback to default Jsonl

--- a/crates/webfang_mcp/Cargo.toml
+++ b/crates/webfang_mcp/Cargo.toml
@@ -9,6 +9,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[features]
+mcp = ["webfang_core/mcp"]
+
 [dependencies]
 webfang_core = { workspace = true }
 
@@ -38,6 +41,7 @@ url-normalize = { workspace = true }
 wreq = { workspace = true }
 
 [dev-dependencies]
+webfang_core = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 schemars = { workspace = true }
@@ -48,6 +52,14 @@ wiremock = { workspace = true }
 [[test]]
 name = "discover_sitemap_wiremock"
 path = "tests/discover_sitemap_wiremock.rs"
+
+[[test]]
+name = "mcp_behavioral_test"
+path = "../../tests/mcp_behavioral_test.rs"
+
+[[test]]
+name = "mcp_lifecycle_test"
+path = "../../tests/mcp_lifecycle_test.rs"
 
 [lints.clippy]
 doc_markdown = "allow"

--- a/tests/mcp_behavioral_test.rs
+++ b/tests/mcp_behavioral_test.rs
@@ -14,10 +14,10 @@ use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use wreq::Client;
 
-use webfang::config::Config;
-use webfang::di::Container;
-use webfang::infrastructure::mcp_server::server::build_mcp_router;
-use webfang::infrastructure::mcp_server::state::McpState;
+use webfang_core::config::Config;
+use webfang_core::di::Container;
+use webfang_mcp::mcp_server::server::build_mcp_router;
+use webfang_mcp::mcp_server::state::McpState;
 
 /// JSON-RPC standard error code for "Method not found" (JSON-RPC 2.0 spec).
 const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
@@ -42,7 +42,7 @@ fn parse_jsonrpc_error_code(body: &str) -> Option<i64> {
 /// Start a test MCP server on a random port and return the base URL.
 async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     let config = Config::default();
-    let container = Container::new(config)
+    let container = Container::new(config.crawler, config.scraper)
         .await
         .expect("container creation failed");
     let state = McpState::new(container);

--- a/tests/mcp_lifecycle_test.rs
+++ b/tests/mcp_lifecycle_test.rs
@@ -12,10 +12,10 @@ use std::net::SocketAddr;
 use tokio::net::TcpListener;
 use wreq::Client;
 
-use webfang::config::Config;
-use webfang::di::Container;
-use webfang::infrastructure::mcp_server::server::build_mcp_router;
-use webfang::infrastructure::mcp_server::state::McpState;
+use webfang_core::config::Config;
+use webfang_core::di::Container;
+use webfang_mcp::mcp_server::server::build_mcp_router;
+use webfang_mcp::mcp_server::state::McpState;
 
 /// Start a test MCP server on a random port and return the base URL.
 ///
@@ -25,7 +25,7 @@ use webfang::infrastructure::mcp_server::state::McpState;
 /// server works end-to-end with the actual application state.
 async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     let config = Config::default();
-    let container = Container::new(config)
+    let container = Container::new(config.crawler, config.scraper)
         .await
         .expect("container creation failed");
     let state = McpState::new(container);

--- a/tests/mcp_proptest.rs
+++ b/tests/mcp_proptest.rs
@@ -276,8 +276,8 @@ proptest! {
 #[test]
 fn test_ai_module_returns_empty_router_without_feature() {
     use rmcp::handler::server::tool::ToolRouter;
-    use webfang::infrastructure::mcp_server::handlers::ai::build_router as ai_build_router;
-    use webfang::infrastructure::mcp_server::McpHandler;
+    use webfang_mcp::mcp_server::handlers::ai::build_router as ai_build_router;
+    use webfang_mcp::mcp_server::McpHandler;
 
     let router: ToolRouter<McpHandler> = ai_build_router();
     // Empty router has no registered tools — verifies AI tools are absent
@@ -296,8 +296,8 @@ fn test_ai_module_returns_empty_router_without_feature() {
 #[test]
 fn test_ai_module_compiles_with_feature() {
     use rmcp::handler::server::tool::ToolRouter;
-    use webfang::infrastructure::mcp_server::handlers::ai::build_router as ai_build_router;
-    use webfang::infrastructure::mcp_server::McpHandler;
+    use webfang_mcp::mcp_server::handlers::ai::build_router as ai_build_router;
+    use webfang_mcp::mcp_server::McpHandler;
 
     // This test verifies the AI module compiles with --features ai
     // and returns a valid ToolRouter (even if currently empty stub)
@@ -317,13 +317,13 @@ fn test_ai_module_compiles_with_feature() {
 #[cfg(not(feature = "ai"))]
 #[tokio::test]
 async fn test_mcp_handler_construction_without_ai() {
-    use webfang::config::Config;
-    use webfang::di::Container;
-    use webfang::infrastructure::mcp_server::state::McpState;
-    use webfang::infrastructure::mcp_server::McpHandler;
+    use webfang_core::config::Config;
+    use webfang_core::di::Container;
+    use webfang_mcp::mcp_server::state::McpState;
+    use webfang_mcp::mcp_server::McpHandler;
 
     let config = Config::default();
-    let container = Container::new(config)
+    let container = Container::new(config.crawler, config.scraper)
         .await
         .expect("container creation failed");
     let state = McpState::new(container);
@@ -335,13 +335,13 @@ async fn test_mcp_handler_construction_without_ai() {
 #[cfg(feature = "ai")]
 #[tokio::test]
 async fn test_mcp_handler_construction_with_ai() {
-    use webfang::config::Config;
-    use webfang::di::Container;
-    use webfang::infrastructure::mcp_server::state::McpState;
-    use webfang::infrastructure::mcp_server::McpHandler;
+    use webfang_core::config::Config;
+    use webfang_core::di::Container;
+    use webfang_mcp::mcp_server::state::McpState;
+    use webfang_mcp::mcp_server::McpHandler;
 
     let config = Config::default();
-    let container = Container::new(config)
+    let container = Container::new(config.crawler, config.scraper)
         .await
         .expect("container creation failed");
     let state = McpState::new(container);
@@ -352,13 +352,13 @@ async fn test_mcp_handler_construction_with_ai() {
 /// Verify all non-AI tool categories are registered regardless of feature flag
 #[tokio::test]
 async fn test_non_ai_tool_categories_registered() {
-    use webfang::config::Config;
-    use webfang::di::Container;
-    use webfang::infrastructure::mcp_server::state::McpState;
-    use webfang::infrastructure::mcp_server::McpHandler;
+    use webfang_core::config::Config;
+    use webfang_core::di::Container;
+    use webfang_mcp::mcp_server::state::McpState;
+    use webfang_mcp::mcp_server::McpHandler;
 
     let config = Config::default();
-    let container = Container::new(config)
+    let container = Container::new(config.crawler, config.scraper)
         .await
         .expect("container creation failed");
     let state = McpState::new(container);


### PR DESCRIPTION
## Summary

Fixes three post-audit findings from #245 that were never actually implemented:

- **MCP tests dead code** — Added `[[test]]` entries, `mcp` feature flag, and fixed broken imports so `mcp_behavioral_test` (5 tests) and `mcp_lifecycle_test` (3 tests) now compile and run in CI
- **try_send() counter drift** — `try_send()` now updates the atomic counter like `send()` does, fixing incorrect `collector.len()`/`is_full()` when messages are sent via the non-blocking path
- **ExportFormat::Auto detection order** — Swapped priority so JSONL (the default format) is detected before Vector, preventing surprises when both `.json` and `.jsonl` files exist

## Test plan

- [x] `cargo check` + `cargo clippy -- -D warnings` + `cargo fmt`
- [x] `cargo nextest run` — all tests pass
- [x] `cargo test -p webfang_mcp --features mcp --test mcp_behavioral_test --test mcp_lifecycle_test` — 8/8 MCP tests pass

## Changes

| File | Change |
|------|--------|
| `crates/webfang_mcp/Cargo.toml` | Added `[[test]]` entries + `[features] mcp` + `webfang_core` dev-dep |
| `crates/webfang_core/src/application/crawler/collector.rs` | `try_send()` now increments atomic counter |
| `crates/webfang_core/src/application/export_factory.rs` | Auto detection: JSONL before Vector |
| `tests/mcp_behavioral_test.rs` | Fixed imports (`webfang::` → `webfang_core::` + `webfang_mcp::`) |
| `tests/mcp_lifecycle_test.rs` | Fixed imports + `Container::new()` signature |

Closes #245 (partial — findings #1, #6, #7)