### PR TITLE
refactor(html): unify strip_html_tags and normalize_whitespace (issue #230)

### DIFF
--- a/crates/webfang_ai/src/infrastructure_ai/chunker.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/chunker.rs
@@ -232,9 +232,15 @@ impl HtmlChunker {
     ///
     /// * `html` - HTML content
     ///
-    /// # Returns
+    /// Strip HTML tags, returning only text content.
     ///
-    /// Plain text with HTML tags removed
+    /// **NOTE**: This implementation intentionally replaces `>` with `\n` to
+    /// preserve sentence boundaries for semantic chunking. This differs from
+    /// the bridge.rs and clean.rs implementations which strip tags without
+    /// adding newlines. Merging with those implementations would break the
+    /// AI chunking pipeline's ability to detect sentence structure.
+    ///
+    /// See: https://github.com/xavi/webfang/issues/230
     #[allow(clippy::manual_strip)]
     fn strip_html_tags(&self, html: &str) -> String {
         // Simple regex-free HTML tag stripping

--- a/crates/webfang_core/src/application/pipeline/stages/clean.rs
+++ b/crates/webfang_core/src/application/pipeline/stages/clean.rs
@@ -59,11 +59,8 @@ fn clean(mut item: ScrapedItem) -> StageOutcome {
     // 1. Extract readable content via legible (Readability port)
     let extracted = extract_readability(&item.raw_html);
 
-    // 2. Strip residual HTML tags
-    let no_tags = strip_html_tags(&extracted);
-
-    // 3. Normalize whitespace
-    let text = normalize_whitespace(&no_tags);
+    // 2. Strip tags + normalize whitespace via bridge (lol_html + strip pipeline)
+    let text = crate::infrastructure::bridge::clean_html_to_text(extracted.as_bytes());
 
     let cleaned_size = text.len();
     let reduction_pct = if original_size > 0 {
@@ -114,27 +111,6 @@ fn extract_readability(html: &str) -> String {
         },
         Err(_) => html.to_string(),
     }
-}
-
-/// Strip HTML tags, returning only text content.
-fn strip_html_tags(html: &str) -> String {
-    let mut result = String::with_capacity(html.len());
-    let mut inside_tag = false;
-    for ch in html.chars() {
-        match ch {
-            '<' => inside_tag = true,
-            '>' => inside_tag = false,
-            c if !inside_tag => result.push(c),
-            _ => {},
-        }
-    }
-    result
-}
-
-/// Collapse runs of whitespace (spaces, tabs, newlines) into a single space
-/// and trim leading/trailing whitespace.
-fn normalize_whitespace(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<&str>>().join(" ")
 }
 
 #[cfg(test)]
@@ -231,21 +207,6 @@ mod tests {
             },
             _ => panic!("expected Continue"),
         }
-    }
-
-    #[test]
-    fn test_strip_html_tags() {
-        assert_eq!(strip_html_tags("<p>hello</p>"), "hello");
-        assert_eq!(strip_html_tags("<a href='x'>link</a>"), "link");
-        assert_eq!(strip_html_tags("no tags"), "no tags");
-        assert_eq!(strip_html_tags("<br><hr>"), "");
-    }
-
-    #[test]
-    fn test_normalize_whitespace() {
-        assert_eq!(normalize_whitespace("  hello  world  "), "hello world");
-        assert_eq!(normalize_whitespace("a\n\nb\t\nc"), "a b c");
-        assert_eq!(normalize_whitespace("single"), "single");
     }
 
     #[test]

--- a/crates/webfang_core/src/infrastructure/bridge.rs
+++ b/crates/webfang_core/src/infrastructure/bridge.rs
@@ -175,7 +175,7 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
 /// infallible — the work closure stays non-`Result`, reusing `dispatch`'s
 /// single `Result` wrap. (ONNX embeddings are wired in the orchestrator's async
 /// layer — see Decision 5; the bridge is sync CPU-bound text extraction only.)
-fn clean_html_to_text(bytes: &[u8]) -> String {
+pub fn clean_html_to_text(bytes: &[u8]) -> String {
     // `from_utf8_lossy` never panics on invalid UTF-8 (replaces with U+FFFD),
     // so malformed payloads do not crash the Rayon pool.
     let html = String::from_utf8_lossy(bytes);

--- a/crates/webfang_core/src/infrastructure/converter/html_cleaner.rs
+++ b/crates/webfang_core/src/infrastructure/converter/html_cleaner.rs
@@ -108,22 +108,7 @@ pub fn clean_html(html: &str) -> String {
 
 /// Collapse consecutive whitespace into single spaces.
 fn normalize_whitespace(html: &str) -> String {
-    let mut result = String::with_capacity(html.len());
-    let mut in_whitespace = false;
-
-    for ch in html.chars() {
-        if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
-            if !in_whitespace {
-                result.push(' ');
-                in_whitespace = true;
-            }
-        } else {
-            result.push(ch);
-            in_whitespace = false;
-        }
-    }
-
-    result
+    html.split_whitespace().collect::<Vec<&str>>().join(" ")
 }
 
 #[cfg(all(test, not(miri)))]


### PR DESCRIPTION
## Summary

- Consolidate 5 HTML cleaning functions into 3 by eliminating duplication across `clean.rs`, `html_cleaner.rs`, and `bridge.rs`
- `clean.rs` now delegates to `bridge::clean_html_to_text()` (lol_html + strip pipeline) instead of its own naive implementation
- `html_cleaner.rs` `normalize_whitespace` simplified from state machine to `split_whitespace().join(" ")`

Closes #230

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/infrastructure/bridge.rs` | Make `clean_html_to_text` public for cross-module use |
| `crates/webfang_core/src/application/pipeline/stages/clean.rs` | Remove local `strip_html_tags` + `normalize_whitespace`, use `bridge::clean_html_to_text()` |
| `crates/webfang_core/src/infrastructure/converter/html_cleaner.rs` | Replace state-machine `normalize_whitespace` with `split_whitespace().join(" ")` |
| `crates/webfang_ai/src/infrastructure_ai/chunker.rs` | Document why its `strip_html_tags` is intentionally different (no logic changes) |

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| `strip_html_tags` implementations | 3 (bridge, clean, chunker) | 2 (bridge, chunker) |
| `normalize_whitespace` implementations | 2 (clean, html_cleaner) | 1 (html_cleaner) |
| chunker.rs logic changes | — | None (doc-only) |

## Test Plan

- [x] `cargo check` — passes
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] `cargo nextest run` — 24/24 affected tests pass (bridge, clean, html_cleaner)
- [x] Issue criteria verified: 2 `strip_html_tags`, 1 `normalize_whitespace`, 0 chunker logic changes

## Notes

- `chunker.rs` is intentionally NOT merged — its `>` → `\n` replacement preserves sentence boundaries for AI semantic chunking
- `lol_html` was already a dependency; no new dependencies added
- `clean_html_to_text` already normalizes whitespace via `strip_html_tags` in bridge.rs, so the separate `normalize_whitespace` call in `clean.rs` was redundant