### PR TITLE
chore(deps): remove unused workspace deps reqwest, rustls-webpki, time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,10 +90,6 @@ crossbeam-channel = "0.5"
 # Observability
 indicatif = { version = "0.17", features = ["improved_unicode"] }
 
-# Security
-rustls-webpki = ">=0.103.12"
-time = ">=0.3.47"
-
 # tokio-console
 console-subscriber = "0.4"
 
@@ -108,7 +104,6 @@ opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.32", features = ["http-proto", "reqwest-blocking-client"] }
 tracing-opentelemetry = "0.33"
-reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 
 # MIME detection
 mimetype-detector = "0.3"


### PR DESCRIPTION
## Linked Issue

Closes #232

## Summary

- Remove 3 unused workspace dependencies: `reqwest v0.13`, `rustls-webpki`, `time`
- All three had zero direct imports confirmed by exhaustive grep
- Transitive dependencies remain unaffected (reqwest v0.12.28 via hf-hub, time via cookie/syntect/tracing-appender)

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Remove `reqwest`, `rustls-webpki`, `time` from workspace dependencies (-5 lines) |

## Context

These dependencies were introduced in earlier iterations and never cleaned up. The workspace `reqwest v0.13` was the old HTTP client before the wreq migration. The transitivo `reqwest v0.12.28` via `hf-hub → webfang_ai` is a separate version and is NOT affected by this removal.

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo nextest run` passes 3/3 consecutive runs (1715/1715 tests)
- [x] `cargo tree -d` confirms only expected duplicates (dashmap, selectors)

## Contributor Checklist

- [x] Linked an approved issue (#232)
- [x] Added `type:chore` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers