### PR TITLE
refactor(url): Centralizar normalize_url — unificar strip_www, semaphore macro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ webfang/                          # virtual workspace root (no [package])
 │   ├── webfang_core/             # domain + application + infrastructure
 │   ├── webfang_ai/               # ONNX embeddings, semantic cleaning
 │   ├── webfang_tui/              # ratatui TUI selector
-│   ├── webfang_mcp/              # MCP server (34 tools)
+│   ├── webfang_mcp/              # MCP server (35 tools)
 │   └── webfang_cli/              # CLI binary (webfang)
 ```
 
@@ -187,7 +187,7 @@ Dual wrapping pattern: infra errors wrap into domain errors via `From` impls.
 **`crates/webfang_mcp/src/mcp_server/`** is the ONLY canonical location.
 The root `src/` was deleted (PR #163 cleanup). Never create code in `src/`.
 
-MCP tools: 34 tools across 8 categories (scraping, content, export, URL utils, security, Obsidian, assets, AI).
+MCP tools: 35 tools across 8 categories (scraping, content, export, URL utils, security, Obsidian, assets, AI).
 Transport: Streamable HTTP (`rmcp`) at `127.0.0.1:8080/mcp`, also stdio via `mcp_server_stdio` example.
 
 ### HTTP client

--- a/benches/link_extraction.rs
+++ b/benches/link_extraction.rs
@@ -66,7 +66,7 @@ fn bench_extract_links_large(c: &mut Criterion) {
 fn bench_normalize_url_simple(c: &mut Criterion) {
     c.bench_function("normalize_url_simple", |b| {
         b.iter(|| {
-            let result = normalize_url(black_box("https://example.com/page"));
+            let result = normalize_url(black_box("https://example.com/page"), true);
             assert!(!result.is_empty());
             black_box(result)
         })
@@ -76,7 +76,7 @@ fn bench_normalize_url_simple(c: &mut Criterion) {
 fn bench_normalize_url_relative(c: &mut Criterion) {
     c.bench_function("normalize_url_relative", |b| {
         b.iter(|| {
-            let result = normalize_url(black_box("/page?id=1&sort=name"));
+            let result = normalize_url(black_box("/page?id=1&sort=name"), true);
             assert!(!result.is_empty());
             black_box(result)
         })
@@ -86,7 +86,7 @@ fn bench_normalize_url_relative(c: &mut Criterion) {
 fn bench_normalize_url_with_fragment(c: &mut Criterion) {
     c.bench_function("normalize_url_with_fragment", |b| {
         b.iter(|| {
-            let result = normalize_url(black_box("https://example.com/page#section"));
+            let result = normalize_url(black_box("https://example.com/page#section"), true);
             assert!(!result.contains('#'));
             black_box(result)
         })

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -134,7 +134,7 @@ pub async fn discover_urls_for_tui(
         // Filter and normalize URLs
         let mut urls = Vec::new();
         for link in links {
-            let normalized = normalize_url(&link);
+            let normalized = normalize_url(&link, true);
             if let Ok(parsed_url) = Url::parse(&normalized) {
                 // Check if internal link
                 if let Some(seed_domain) = base.host_str() {

--- a/crates/webfang_core/src/infrastructure/crawler/batch_processor.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/batch_processor.rs
@@ -83,7 +83,7 @@ impl BatchProcessor {
         let mut result = Vec::new();
 
         for url in urls {
-            let normalized_str = normalize_url(url.as_str());
+            let normalized_str = normalize_url(url.as_str(), true);
 
             if seen.insert(normalized_str) {
                 result.push(url);

--- a/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
@@ -58,7 +58,7 @@ pub fn extract_links(html: &str, base_url: &str) -> Result<Vec<String>, crate::d
             // Resolve relative URLs
             match base.join(href) {
                 Ok(absolute_url) => {
-                    let normalized = normalize_url(absolute_url.as_str());
+                    let normalized = normalize_url(absolute_url.as_str(), true);
                     if !links.contains(&normalized) {
                         links.push(normalized);
                     }
@@ -114,18 +114,19 @@ pub fn is_internal_link(url: &str, domain: &str) -> bool {
 ///
 /// Options:
 /// - `strip_hash: true` — removes URL fragments (`#section`)
-/// - `strip_www: true` — removes `www.` prefix for better dedup
+/// - `strip_www` — removes `www.` prefix when `true` (caller controls behavior)
 /// - `remove_trailing_slash: false` — preserves trailing slashes
 /// - `remove_query_parameters: All` — strips query strings for dedup
 /// - `sort_query_parameters: true` — consistent ordering
 ///
-/// # Arguments
-///
-/// * `url` - URL to normalize
-///
 /// # Returns
 ///
 /// Normalized URL string
+///
+/// # Arguments
+///
+/// * `url` - URL to normalize
+/// * `strip_www` - If `true`, removes `www.` prefix (e.g. `www.example.com` → `example.com`)
 ///
 /// # Examples
 ///
@@ -133,21 +134,25 @@ pub fn is_internal_link(url: &str, domain: &str) -> bool {
 /// use webfang::infrastructure::crawler::normalize_url;
 ///
 /// assert_eq!(
-///     normalize_url("https://example.com/page#section"),
+///     normalize_url("https://example.com/page#section", true),
 ///     "https://example.com/page"
 /// );
 /// assert_eq!(
-///     normalize_url("https://www.example.com/page"),
+///     normalize_url("https://www.example.com/page", true),
 ///     "https://example.com/page"
 /// );
 /// assert_eq!(
-///     normalize_url("https://example.com:443/page"),
+///     normalize_url("https://www.example.com/page", false),
+///     "https://www.example.com/page"
+/// );
+/// assert_eq!(
+///     normalize_url("https://example.com:443/page", true),
 ///     "https://example.com/page"
 /// );
 /// ```
 #[inline]
 #[must_use]
-pub fn normalize_url(url: &str) -> String {
+pub fn normalize_url(url: &str, strip_www: bool) -> String {
     use url_normalize::{normalize_url as normalize, Options, RemoveQueryParameters};
 
     // Non-URLs (no scheme) should not be normalized — return as-is.
@@ -161,7 +166,7 @@ pub fn normalize_url(url: &str) -> String {
         remove_trailing_slash: false,
         remove_query_parameters: RemoveQueryParameters::All,
         sort_query_parameters: true,
-        strip_www: true,
+        strip_www,
         force_https: false,
         ..Options::default()
     };
@@ -303,11 +308,11 @@ mod tests {
     #[test]
     fn test_normalize_url_remove_fragment() {
         assert_eq!(
-            normalize_url("https://example.com/page#section"),
+            normalize_url("https://example.com/page#section", true),
             "https://example.com/page"
         );
         assert_eq!(
-            normalize_url("https://example.com/page#top"),
+            normalize_url("https://example.com/page#top", true),
             "https://example.com/page"
         );
     }
@@ -315,11 +320,11 @@ mod tests {
     #[test]
     fn test_normalize_url_preserve_trailing_slash() {
         assert_eq!(
-            normalize_url("https://example.com/page/"),
+            normalize_url("https://example.com/page/", true),
             "https://example.com/page/"
         );
         assert_eq!(
-            normalize_url("https://example.com/page/#section"),
+            normalize_url("https://example.com/page/#section", true),
             "https://example.com/page/"
         );
     }
@@ -327,37 +332,45 @@ mod tests {
     #[test]
     fn test_normalize_url_no_change() {
         assert_eq!(
-            normalize_url("https://example.com/page"),
+            normalize_url("https://example.com/page", true),
             "https://example.com/page"
         );
     }
 
     #[test]
     fn test_normalize_url_invalid() {
-        let result = normalize_url("not-a-valid-url");
+        let result = normalize_url("not-a-valid-url", true);
         assert_eq!(result, "not-a-valid-url");
     }
 
     #[test]
     fn test_normalize_url_strips_www() {
         assert_eq!(
-            normalize_url("https://www.example.com/page"),
+            normalize_url("https://www.example.com/page", true),
             "https://example.com/page"
         );
         assert_eq!(
-            normalize_url("https://www.example.com/page/"),
+            normalize_url("https://www.example.com/page/", true),
             "https://example.com/page/"
+        );
+    }
+
+    #[test]
+    fn test_normalize_url_keeps_www_when_disabled() {
+        assert_eq!(
+            normalize_url("https://www.example.com/page", false),
+            "https://www.example.com/page"
         );
     }
 
     #[test]
     fn test_normalize_url_removes_default_port() {
         assert_eq!(
-            normalize_url("https://example.com:443/page"),
+            normalize_url("https://example.com:443/page", true),
             "https://example.com/page"
         );
         assert_eq!(
-            normalize_url("http://example.com:80/page"),
+            normalize_url("http://example.com:80/page", true),
             "http://example.com/page"
         );
     }

--- a/crates/webfang_mcp/examples/mcp_server.rs
+++ b/crates/webfang_mcp/examples/mcp_server.rs
@@ -20,7 +20,7 @@
 //! Axum router (/mcp)
 //!   └── StreamableHttpService (rmcp)
 //!         ├── LocalSessionManager — tracks Mcp-Session-Id per client
-//!         └── McpHandler — 34 tools across 8 categories
+//!         └── McpHandler — 35 tools across 8 categories
 //!               ├── State: Container (HTTP client, config) + semaphores
 //!               └── Tools: scraping, content, export, url_utils,
 //!                          security, obsidian, assets, ai
@@ -160,7 +160,7 @@
 //! The stdio transport reads JSON-RPC from stdin and writes to stdout.
 //! All logging goes to stderr. See `mcp_server_stdio.rs` for details.
 //!
-//! ## Complete tool catalog (34 tools)
+//! ## Complete tool catalog (35 tools)
 //!
 //! ### Category 1: Scraping Core (8 tools)
 //!

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -28,13 +28,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ScrapeUrlParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .ai
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, ai);
 
         let _url = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
@@ -57,13 +51,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<SearchObsidianParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .obsidian
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, obsidian);
 
         Ok(CallToolResult::error(vec![Content::text(
             "AI feature not available in webfang_mcp. Rebuild webfang_cli with --features ai instead.".to_string(),

--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -22,13 +22,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DownloadAssetsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .assets
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, assets);
 
         let base_url = url::Url::parse(&params.base_url).map_err(|e| {
             McpError::invalid_params(

--- a/crates/webfang_mcp/src/mcp_server/handlers/content.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/content.rs
@@ -24,13 +24,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<CleanHtmlParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .content
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, content);
 
         let cleaned =
             webfang_core::infrastructure::converter::html_cleaner::clean_html(&params.html);
@@ -46,13 +40,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<HtmlToMarkdownParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .content
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, content);
 
         let md = webfang_core::infrastructure::converter::html_to_markdown::convert_to_markdown(
             &params.html,
@@ -69,13 +57,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExtractLinksParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .content
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, content);
 
         match webfang_core::infrastructure::crawler::extract_links(&params.html, &params.base_url) {
             Ok(links) => {
@@ -96,13 +78,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<HighlightCodeParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .content
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, content);
 
         let highlighted =
             webfang_core::infrastructure::converter::syntax_highlight::highlight_code_blocks(
@@ -120,13 +96,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ConvertWikiLinksParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .content
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, content);
 
         let wikilinks = webfang_core::infrastructure::converter::wikilinks::convert_wiki_links(
             &params.markdown,
@@ -144,13 +114,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<GenerateFrontmatterParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .content
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, content);
 
         let title = params.title.as_deref().unwrap_or("Untitled");
         let url = params.url.as_deref().unwrap_or("");
@@ -175,13 +139,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<GenerateRichMetadataParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .content
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, content);
 
         let content = params.content.as_deref().unwrap_or("");
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -24,13 +24,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExportFileParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .export
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, export);
 
         let format = webfang_core::domain::entities::ExportFormat::parse_str(&params.format)
             .unwrap_or(webfang_core::domain::entities::ExportFormat::Jsonl);
@@ -59,13 +53,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExportJsonlParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .export
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, export);
 
         let output_dir = params.output_dir.as_deref().unwrap_or("./output");
         let filename = params.filename.as_deref().unwrap_or("export");
@@ -83,13 +71,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExportVectorParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .export
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, export);
 
         let output_dir = params.output_dir.as_deref().unwrap_or("./output");
         let filename = params.filename.as_deref().unwrap_or("export");
@@ -107,13 +89,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ProcessExportPipelineParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .export
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, export);
 
         let url = params.url.as_deref().unwrap_or("");
         let format = params.format.as_deref().unwrap_or("jsonl");

--- a/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
@@ -22,13 +22,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DetectVaultParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .obsidian
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, obsidian);
 
         let cli_path = params
             .vault_path
@@ -55,13 +49,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<BuildObsidianUriParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .obsidian
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, obsidian);
 
         let uri = webfang_core::infrastructure::obsidian::uri::build_obsidian_uri(
             &params.vault_name,
@@ -79,13 +67,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<BuildObsidianUriParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .obsidian
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, obsidian);
 
         let uri = webfang_core::infrastructure::obsidian::uri::build_obsidian_uri(
             &params.vault_name,

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -24,13 +24,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ScrapeUrlParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let url = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
@@ -61,13 +55,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ScrapeWithOptionsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let url = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
@@ -129,13 +117,7 @@ impl McpHandler {
         let _enter = span.enter();
 
         tracing::info!("starting batch scrape");
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let urls: Vec<url::Url> = params
             .urls
@@ -187,13 +169,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<CrawlSiteParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let seed_url = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
@@ -235,16 +211,7 @@ impl McpHandler {
         let _enter = span.enter();
 
         tracing::info!("starting sitemap crawl");
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| {
-                tracing::error!("semaphore acquire failed: {}", e);
-                McpError::internal_error(format!("semaphore error: {e}"), None)
-            })?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let seed_url = url::Url::parse(&params.url).map_err(|e| {
             tracing::error!("invalid URL: {}", e);
@@ -284,13 +251,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DiscoverUrlsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let port = self.state.container.http_client();
         match port.get(&params.url).await {
@@ -320,13 +281,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DiscoverUrlsParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let seed = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
@@ -362,13 +317,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DetectSpaParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .scraping
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, scraping);
 
         let port = self.state.container.http_client();
         match port.get(&params.url).await {

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -23,13 +23,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DetectWafParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .security
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, security);
 
         match webfang_core::infrastructure::http::waf_engine::WafInspector::detect_body(
             &params.html,
@@ -52,13 +46,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<VerifyWafIntegrityParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .security
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, security);
 
         let html = params.html.as_deref().unwrap_or("");
         let mut header_map = wreq::header::HeaderMap::new();
@@ -91,13 +79,7 @@ impl McpHandler {
     )]
     #[instrument(skip(self))]
     async fn list_waf_providers(&self) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .security
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, security);
 
         let providers =
             webfang_core::infrastructure::http::waf_engine::WafInspector::supported_providers();
@@ -112,13 +94,7 @@ impl McpHandler {
     )]
     #[instrument(skip(self))]
     async fn get_scrape_metrics(&self) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .security
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, security);
 
         let metrics = serde_json::json!({
             "message": "Metrics collection requires active scraping session",

--- a/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
@@ -97,28 +97,17 @@ impl McpHandler {
             .await
             .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
 
-        use url_normalize::{normalize_url as normalize, Options, RemoveQueryParameters};
+        // Delegate to core normalize_url with strip_www=false (MCP preserves www prefix)
+        let normalized = webfang_core::infrastructure::crawler::normalize_url(&params.url, false);
 
+        // Core returns as-is for non-URLs; MCP tool reports error for invalid input
         if !params.url.contains("://") {
             return Ok(CallToolResult::error(vec![Content::text(
                 "Invalid URL: no scheme found".to_string(),
             )]));
         }
 
-        let opts = Options {
-            strip_hash: true,
-            remove_trailing_slash: false,
-            remove_query_parameters: RemoveQueryParameters::All,
-            sort_query_parameters: true,
-            strip_www: false,
-            force_https: false,
-            ..Options::default()
-        };
-
-        match normalize(&params.url, &opts) {
-            Ok(normalized) => Ok(CallToolResult::success(vec![Content::text(normalized)])),
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
-        }
+        Ok(CallToolResult::success(vec![Content::text(normalized)]))
     }
 
     /// Match a URL against a glob pattern

--- a/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
@@ -23,13 +23,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ValidateUrlParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .url_utils
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, url_utils);
 
         match url::Url::parse(&params.url) {
             Ok(u) => {
@@ -63,13 +57,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExtractDomainParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .url_utils
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, url_utils);
 
         match url::Url::parse(&params.url) {
             Ok(u) => {
@@ -89,13 +77,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<NormalizeUrlParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .url_utils
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, url_utils);
 
         // Delegate to core normalize_url with strip_www=false (MCP preserves www prefix)
         let normalized = webfang_core::infrastructure::crawler::normalize_url(&params.url, false);
@@ -119,13 +101,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<MatchUrlPatternParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .url_utils
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, url_utils);
 
         let matches = webfang_core::domain::matches_pattern(&params.url, &params.pattern);
         Ok(CallToolResult::success(vec![Content::text(
@@ -142,13 +118,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<IsInternalLinkParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .url_utils
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, url_utils);
 
         let is_internal = match (
             url::Url::parse(&params.url),
@@ -175,13 +145,7 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ValidateUrlParams>,
     ) -> Result<CallToolResult, McpError> {
-        let _permit = self
-            .state
-            .semaphores
-            .url_utils
-            .acquire()
-            .await
-            .map_err(|e| McpError::internal_error(format!("semaphore error: {e}"), None))?;
+        let _permit = acquire_semaphore!(self, url_utils);
 
         match webfang_core::adapters::url_path::OutputPath::from_url(&params.url) {
             Ok(output_path) => {

--- a/crates/webfang_mcp/src/mcp_server/macros.rs
+++ b/crates/webfang_mcp/src/mcp_server/macros.rs
@@ -1,0 +1,18 @@
+//! Shared macros for MCP handlers
+
+/// Acquire a per-category semaphore permit with error mapping.
+///
+/// Usage: `let _permit = acquire_semaphore!(self, category_name);`
+/// Where category_name is one of: ai, scraping, export, obsidian, content, url_utils, security, assets
+#[macro_export]
+macro_rules! acquire_semaphore {
+    ($self:expr, $category:ident) => {
+        $self
+            .state
+            .semaphores
+            .$category
+            .acquire()
+            .await
+            .map_err(|e| rmcp::ErrorData::internal_error(format!("semaphore error: {e}"), None))?
+    };
+}

--- a/crates/webfang_mcp/src/mcp_server/mod.rs
+++ b/crates/webfang_mcp/src/mcp_server/mod.rs
@@ -1,6 +1,6 @@
 //! MCP Server — Model Context Protocol bridge for AI agents
 //!
-//! Exposes 34 scraper tools across 8 categories via Streamable HTTP.
+//! Exposes 35 scraper tools across 8 categories via Streamable HTTP.
 //! Architecture:
 //! - `state.rs` — McpState with embedded Container + per-category semaphores
 //! - `server.rs` — Axum router + StreamableHttpService setup
@@ -9,6 +9,8 @@
 //! Backpressure: Each category has its own tokio::sync::Semaphore
 //! to prevent resource exhaustion on constrained hardware.
 
+#[macro_use]
+pub mod macros;
 pub mod handlers;
 pub mod params;
 pub mod selector_service;
@@ -26,7 +28,7 @@ pub use state::McpState;
 /// Main MCP handler struct.
 ///
 /// Holds the application state and combined tool router.
-/// All 34 tools are registered via `#[tool_router]` macros
+/// All 35 tools are registered via `#[tool_router]` macros
 /// in the handler submodules.
 #[derive(Clone)]
 pub struct McpHandler {

--- a/crates/webfang_mcp/src/mcp_server/server.rs
+++ b/crates/webfang_mcp/src/mcp_server/server.rs
@@ -95,8 +95,8 @@ mod tests {
         let handler = test_handler().await;
         let tools = handler.tool_router.list_all();
         assert!(
-            tools.len() >= 34,
-            "Expected at least 34 tools, got {}",
+            tools.len() >= 35,
+            "Expected at least 35 tools, got {}",
             tools.len()
         );
 

--- a/fuzz/fuzz_targets/fuzz_url_normalization.rs
+++ b/fuzz/fuzz_targets/fuzz_url_normalization.rs
@@ -11,6 +11,6 @@ use libfuzzer_sys::fuzz_target;
 // Our goal: normalize_url must NEVER panic on any input.
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
-        let _ = webfang::infrastructure::crawler::link_extractor::normalize_url(s);
+        let _ = webfang::infrastructure::crawler::link_extractor::normalize_url(s, true);
     }
 });


### PR DESCRIPTION
## Summary

- **Centralize `normalize_url`**: unified two duplicate implementations into one function with `strip_www: bool` parameter. Core function now accepts the parameter; MCP handler delegates with `strip_www=false` (preserves www), crawler callers pass `strip_www=true` (strips www for dedup).
- **`acquire_semaphore!` macro**: new macro eliminates ~210 LOC of boilerplate across 35 MCP tools (7-line blocks → 1-line calls).
- **Tool count corrected**: 34 → 35 in AGENTS.md, mod.rs, server.rs, examples.

## Changes

| File | Change |
|------|--------|
| `link_extractor.rs` | `normalize_url(url, strip_www: bool)` — parameterized |
| `url_utils.rs` (MCP) | Delegates to core with `strip_www=false` |
| `macros.rs` (new) | `acquire_semaphore!(self, category)` macro |
| 8 handler files | Replaced 35 semaphore blocks with macro |
| `AGENTS.md` | Tool count 34 → 35 |
| `server.rs`, `examples` | Tool count 34 → 35 |

## Verification

- [x] `cargo check` ✅
- [x] `cargo clippy -- -D warnings` ✅ (zero warnings)
- [x] `cargo nextest run` ✅ (all tests pass)
- [x] 18 files changed, +107 -298 (net ~191 LOC eliminated)

## Fixes

Closes #231