### PR TITLE
refactor(core): Split orchestrator run() + ProgressObserver (closes #229)

### DIFF
--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -15,6 +15,7 @@ pub mod export_factory;
 pub mod export_utils;
 pub mod http_client;
 pub mod pipeline;
+pub mod progress_observer;
 pub mod progress_types;
 pub mod rate_limiter;
 pub mod scraper_service;

--- a/crates/webfang_core/src/application/progress_observer.rs
+++ b/crates/webfang_core/src/application/progress_observer.rs
@@ -1,0 +1,328 @@
+//! Progress observer trait for decoupled progress reporting.
+//!
+//! Provides a trait abstraction over the raw `mpsc::Sender<ScrapeProgress>` channel,
+//! eliminating boilerplate `if !quiet { if let Some(tx) = ... }` patterns.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::application::progress_types::{ScrapeError, ScrapeProgress};
+
+/// Trait for observing scraping progress events.
+///
+/// Implementations handle the quiet/channel logic internally, so callers
+/// only need a single one-liner per event.
+///
+/// Methods are desugared to `Pin<Box<dyn Future<…> + Send + '_>>` so the
+/// trait is dyn-compatible without the `async_trait` crate, matching the
+/// pattern in `domain::repository::VectorRepository`.
+pub trait ProgressObserver: Send + Sync {
+    /// A page scrape has started.
+    fn on_page_started<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
+    /// A page scrape completed successfully.
+    fn on_page_completed<'a>(
+        &'a self,
+        url: &'a str,
+        chars: usize,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
+    /// A page scrape failed.
+    fn on_page_failed<'a>(
+        &'a self,
+        url: &'a str,
+        error: &'a ScrapeError,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
+    /// All URLs have been processed.
+    fn on_finished<'a>(
+        &'a self,
+        total: usize,
+        successful: usize,
+        failed: usize,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
+    /// A URL was blocked by robots.txt.
+    fn on_robots_blocked<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+}
+
+/// Live observer that forwards events through an optional `mpsc::Sender`.
+///
+/// Respects the `quiet` flag — when `true`, no events are emitted.
+pub struct LiveProgressObserver {
+    tx: Option<tokio::sync::mpsc::Sender<ScrapeProgress>>,
+    quiet: bool,
+}
+
+impl LiveProgressObserver {
+    /// Create a new live observer.
+    ///
+    /// If `tx` is `None` or `quiet` is `true`, all methods become no-ops.
+    pub fn new(tx: Option<tokio::sync::mpsc::Sender<ScrapeProgress>>, quiet: bool) -> Self {
+        Self { tx, quiet }
+    }
+}
+
+impl ProgressObserver for LiveProgressObserver {
+    fn on_page_started<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if self.quiet {
+                return;
+            }
+            if let Some(ref tx) = self.tx {
+                let _ = tx
+                    .send(ScrapeProgress::Started {
+                        url: url.to_string(),
+                    })
+                    .await;
+            }
+        })
+    }
+
+    fn on_page_completed<'a>(
+        &'a self,
+        url: &'a str,
+        chars: usize,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if self.quiet {
+                return;
+            }
+            if let Some(ref tx) = self.tx {
+                let _ = tx
+                    .send(ScrapeProgress::Completed {
+                        url: url.to_string(),
+                        chars,
+                    })
+                    .await;
+            }
+        })
+    }
+
+    fn on_page_failed<'a>(
+        &'a self,
+        url: &'a str,
+        error: &'a ScrapeError,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if self.quiet {
+                return;
+            }
+            if let Some(ref tx) = self.tx {
+                let _ = tx
+                    .send(ScrapeProgress::Failed {
+                        url: url.to_string(),
+                        error: error.clone(),
+                    })
+                    .await;
+            }
+        })
+    }
+
+    fn on_finished<'a>(
+        &'a self,
+        total: usize,
+        successful: usize,
+        failed: usize,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if self.quiet {
+                return;
+            }
+            if let Some(ref tx) = self.tx {
+                let _ = tx
+                    .send(ScrapeProgress::Finished {
+                        total,
+                        successful,
+                        failed,
+                    })
+                    .await;
+            }
+        })
+    }
+
+    fn on_robots_blocked<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if self.quiet {
+                return;
+            }
+            if let Some(ref tx) = self.tx {
+                let _ = tx
+                    .send(ScrapeProgress::Failed {
+                        url: url.to_string(),
+                        error: ScrapeError::Other("blocked by robots.txt".into()),
+                    })
+                    .await;
+            }
+        })
+    }
+}
+
+/// No-op observer for dry-run/quiet mode.
+pub struct NoopObserver;
+
+impl ProgressObserver for NoopObserver {
+    fn on_page_started<'a>(
+        &'a self,
+        _url: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+    fn on_page_completed<'a>(
+        &'a self,
+        _url: &'a str,
+        _chars: usize,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+    fn on_page_failed<'a>(
+        &'a self,
+        _url: &'a str,
+        _error: &'a ScrapeError,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+    fn on_finished<'a>(
+        &'a self,
+        _total: usize,
+        _successful: usize,
+        _failed: usize,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+    fn on_robots_blocked<'a>(
+        &'a self,
+        _url: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn live_observer_sends_started_when_not_quiet() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let observer = LiveProgressObserver::new(Some(tx), false);
+
+        observer.on_page_started("https://example.com").await;
+
+        let msg = rx.recv().await.expect("should receive message");
+        assert!(
+            matches!(msg, ScrapeProgress::Started { ref url } if url == "https://example.com"),
+            "expected Started event"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_observer_suppresses_when_quiet() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let observer = LiveProgressObserver::new(Some(tx), true);
+
+        observer.on_page_started("https://example.com").await;
+        observer
+            .on_page_completed("https://example.com", 100)
+            .await;
+        observer
+            .on_page_failed(
+                "https://example.com",
+                &ScrapeError::Other("test".into()),
+            )
+            .await;
+        observer.on_finished(1, 0, 1).await;
+
+        assert!(rx.try_recv().is_err(), "quiet mode should suppress all events");
+    }
+
+    #[tokio::test]
+    async fn live_observer_noop_when_no_tx() {
+        let observer = LiveProgressObserver::new(None, false);
+
+        observer.on_page_started("https://example.com").await;
+        observer
+            .on_page_completed("https://example.com", 100)
+            .await;
+        observer
+            .on_page_failed(
+                "https://example.com",
+                &ScrapeError::Other("test".into()),
+            )
+            .await;
+        observer.on_finished(1, 0, 1).await;
+        observer.on_robots_blocked("https://example.com/robots").await;
+    }
+
+    #[tokio::test]
+    async fn live_observer_sends_completed_with_chars() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let observer = LiveProgressObserver::new(Some(tx), false);
+
+        observer.on_page_completed("https://example.com", 42).await;
+
+        let msg = rx.recv().await.expect("should receive message");
+        assert!(
+            matches!(msg, ScrapeProgress::Completed { ref url, chars } if url == "https://example.com" && chars == 42),
+            "expected Completed event with chars"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_observer_sends_finished_counts() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let observer = LiveProgressObserver::new(Some(tx), false);
+
+        observer.on_finished(10, 8, 2).await;
+
+        let msg = rx.recv().await.expect("should receive message");
+        assert!(
+            matches!(msg, ScrapeProgress::Finished { total: 10, successful: 8, failed: 2 }),
+            "expected Finished with correct counts"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_observer_sends_robots_blocked_as_failed() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let observer = LiveProgressObserver::new(Some(tx), false);
+
+        observer.on_robots_blocked("https://example.com/blocked").await;
+
+        let msg = rx.recv().await.expect("should receive message");
+        assert!(
+            matches!(msg, ScrapeProgress::Failed { ref url, ref error } if url == "https://example.com/blocked" && matches!(error, ScrapeError::Other(s) if s == "blocked by robots.txt")),
+            "expected Failed event for robots block"
+        );
+    }
+
+    #[tokio::test]
+    async fn noop_observer_is_silent() {
+        let observer = NoopObserver;
+
+        observer.on_page_started("https://example.com").await;
+        observer
+            .on_page_completed("https://example.com", 100)
+            .await;
+        observer
+            .on_page_failed(
+                "https://example.com",
+                &ScrapeError::Other("test".into()),
+            )
+            .await;
+        observer.on_finished(1, 0, 1).await;
+        observer.on_robots_blocked("https://example.com/robots").await;
+    }
+}

--- a/crates/webfang_core/src/application/progress_observer.rs
+++ b/crates/webfang_core/src/application/progress_observer.rs
@@ -18,10 +18,8 @@ use crate::application::progress_types::{ScrapeError, ScrapeProgress};
 /// pattern in `domain::repository::VectorRepository`.
 pub trait ProgressObserver: Send + Sync {
     /// A page scrape has started.
-    fn on_page_started<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+    fn on_page_started<'a>(&'a self, url: &'a str)
+        -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
     /// A page scrape completed successfully.
     fn on_page_completed<'a>(
@@ -234,18 +232,16 @@ mod tests {
         let observer = LiveProgressObserver::new(Some(tx), true);
 
         observer.on_page_started("https://example.com").await;
+        observer.on_page_completed("https://example.com", 100).await;
         observer
-            .on_page_completed("https://example.com", 100)
-            .await;
-        observer
-            .on_page_failed(
-                "https://example.com",
-                &ScrapeError::Other("test".into()),
-            )
+            .on_page_failed("https://example.com", &ScrapeError::Other("test".into()))
             .await;
         observer.on_finished(1, 0, 1).await;
 
-        assert!(rx.try_recv().is_err(), "quiet mode should suppress all events");
+        assert!(
+            rx.try_recv().is_err(),
+            "quiet mode should suppress all events"
+        );
     }
 
     #[tokio::test]
@@ -253,17 +249,14 @@ mod tests {
         let observer = LiveProgressObserver::new(None, false);
 
         observer.on_page_started("https://example.com").await;
+        observer.on_page_completed("https://example.com", 100).await;
         observer
-            .on_page_completed("https://example.com", 100)
-            .await;
-        observer
-            .on_page_failed(
-                "https://example.com",
-                &ScrapeError::Other("test".into()),
-            )
+            .on_page_failed("https://example.com", &ScrapeError::Other("test".into()))
             .await;
         observer.on_finished(1, 0, 1).await;
-        observer.on_robots_blocked("https://example.com/robots").await;
+        observer
+            .on_robots_blocked("https://example.com/robots")
+            .await;
     }
 
     #[tokio::test]
@@ -289,7 +282,14 @@ mod tests {
 
         let msg = rx.recv().await.expect("should receive message");
         assert!(
-            matches!(msg, ScrapeProgress::Finished { total: 10, successful: 8, failed: 2 }),
+            matches!(
+                msg,
+                ScrapeProgress::Finished {
+                    total: 10,
+                    successful: 8,
+                    failed: 2
+                }
+            ),
             "expected Finished with correct counts"
         );
     }
@@ -299,7 +299,9 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
         let observer = LiveProgressObserver::new(Some(tx), false);
 
-        observer.on_robots_blocked("https://example.com/blocked").await;
+        observer
+            .on_robots_blocked("https://example.com/blocked")
+            .await;
 
         let msg = rx.recv().await.expect("should receive message");
         assert!(
@@ -313,16 +315,13 @@ mod tests {
         let observer = NoopObserver;
 
         observer.on_page_started("https://example.com").await;
+        observer.on_page_completed("https://example.com", 100).await;
         observer
-            .on_page_completed("https://example.com", 100)
-            .await;
-        observer
-            .on_page_failed(
-                "https://example.com",
-                &ScrapeError::Other("test".into()),
-            )
+            .on_page_failed("https://example.com", &ScrapeError::Other("test".into()))
             .await;
         observer.on_finished(1, 0, 1).await;
-        observer.on_robots_blocked("https://example.com/robots").await;
+        observer
+            .on_robots_blocked("https://example.com/robots")
+            .await;
     }
 }

--- a/crates/webfang_core/src/application/progress_types.rs
+++ b/crates/webfang_core/src/application/progress_types.rs
@@ -303,11 +303,11 @@ impl ProgressState {
                 self.update_eta();
             },
             ScrapeProgress::Finished {
-                total: _,
+                total,
                 successful: _,
                 failed: _,
             } => {
-                // Final event — counts already tracked via Completed/Failed updates
+                self.total = total;
             },
         }
     }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -9,6 +9,7 @@ use crate::application::crawl_options::CrawlOptions;
 use crate::cli::completions::generate_completions;
 use crate::cli::error::CliExit;
 use crate::cli::export_flow::{run_export, save_files, ExportConfig};
+use crate::application::progress_observer::NoopObserver;
 use crate::cli::scrape_flow::scrape_urls;
 use crate::cli::url_discovery::discover_urls;
 use crate::domain::repository::DynVectorRepository;
@@ -155,7 +156,7 @@ pub async fn run(
         &urls_to_scrape,
         &scraper_config,
         &opts,
-        None,
+        &NoopObserver,
         shared_downloader
             .as_deref()
             .map(|d| d as &dyn crate::domain::ports::AssetDownloaderPort),

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -9,7 +9,6 @@ use crate::application::crawl_options::CrawlOptions;
 use crate::cli::completions::generate_completions;
 use crate::cli::error::CliExit;
 use crate::cli::export_flow::{run_export, save_files, ExportConfig};
-use crate::application::progress_observer::NoopObserver;
 use crate::cli::scrape_flow::scrape_urls;
 use crate::cli::url_discovery::discover_urls;
 use crate::domain::repository::DynVectorRepository;
@@ -42,9 +41,10 @@ pub fn handle_completions(shell: Shell) -> CliExit {
 /// Main orchestration entry point.
 ///
 /// Coordinates the full scraping pipeline:
-/// 1. URL discovery
+/// 1. URL discovery + config preparation
 /// 2. Scraping with progress
 /// 3. Export results
+/// 4. Report failures + exit code
 #[instrument(level = "info", skip(opts, ai_cleaner), fields(url = %opts.url))]
 pub async fn run(
     opts: CrawlOptions,
@@ -62,52 +62,14 @@ pub async fn run(
         return run_batch(opts).await;
     }
 
-    let urls_to_scrape = if opts.crawl.single_page {
-        plan_urls(true, opts.url.clone(), Vec::new())
-    } else {
-        // Create crawler config from CrawlOptions
-        let mut crawler_config = CrawlerConfig::builder(opts.url.clone())
-            .max_pages(opts.crawl.max_pages)
-            .max_depth(opts.crawl.max_depth)
-            .include_patterns(opts.crawl.include_patterns.clone())
-            .exclude_patterns(opts.crawl.exclude_patterns.clone())
-            .ignore_robots(opts.crawl.ignore_robots)
-            .use_sitemap(opts.crawl.use_sitemap);
-        if let Some(ref sitemap_url) = opts.crawl.sitemap_url {
-            crawler_config = crawler_config.sitemap_url(sitemap_url);
-        }
-        let crawler_config = crawler_config.build();
-
-        // URL discovery phase
-        let discovered_urls = match discover_urls(&crawler_config, &opts).await {
-            Err(e) => {
-                return CliExit::NetworkError(format!("URL discovery failed: {e}"));
-            },
-            Ok(urls) if urls.is_empty() => {
-                return CliExit::EmptyDiscovery("No URLs discovered from sitemaps".into());
-            },
-            Ok(urls) => urls,
-        };
-
-        plan_urls(false, opts.url.clone(), discovered_urls)
+    // Phase 1: Prepare scraper config, URLs, and observer
+    let prepare = match prepare_phase(&opts).await {
+        Err(e) => return e,
+        Ok(p) => p,
     };
 
-    // Create scraper config
-    let mut scraper_config = ScraperConfig::default()
-        .with_output_dir(opts.export.output_dir.clone())
-        .with_scraper_concurrency(opts.network.concurrency.resolve())
-        .with_max_pages(opts.crawl.max_pages)
-        .with_selector(opts.crawl.selector.clone());
-
-    // Apply download flags (builder pattern requires conditional application)
-    if opts.network.download_images {
-        scraper_config = scraper_config.with_images();
-    }
-    if opts.network.download_documents {
-        scraper_config = scraper_config.with_documents();
-    }
-
     // Wire asset download config from CLI args
+    let mut scraper_config = prepare.scraper_config;
     scraper_config =
         scraper_config.with_asset_h2_profile(parse_asset_h2_profile(&opts.network.h2_profile));
     scraper_config =
@@ -118,7 +80,6 @@ pub async fn run(
     scraper_config = scraper_config.with_download_concurrency(opts.download_concurrency);
 
     // Create shared Downloader once for connection pooling across all page scrapes.
-    // Propagates error on failure — the user must know if asset downloads can't start.
     let shared_downloader = if scraper_config.has_downloads() {
         match crate::adapters::downloader::Downloader::new(scraper_config.to_download_config()) {
             Ok(dl) => Some(std::sync::Arc::new(dl)),
@@ -130,9 +91,7 @@ pub async fn run(
         None
     };
 
-    // Initialize elastic ingestion if requested (`--elastic` → SQLite, or
-    // `--output-vectors` → headless JSONL stream). Both are erased to
-    // `DynVectorRepository` so the field type is feature-independent.
+    // Initialize elastic ingestion if requested
     let elastic_ingestion = match build_elastic_ingestion(&opts).await {
         Ok(v) => v,
         Err(e) => return e,
@@ -148,55 +107,37 @@ pub async fn run(
         );
     }
 
-    // Scraping phase
-    let (results, failures): (
-        Vec<domain::ScrapedContent>,
-        Vec<(String, crate::error::ScraperError)>,
-    ) = scrape_urls(
-        &urls_to_scrape,
+    let observer: Box<dyn crate::application::progress_observer::ProgressObserver> = Box::new(
+        crate::application::progress_observer::LiveProgressObserver::new(None, opts.export.quiet),
+    );
+
+    // Phase 2: Scrape
+    let (results, failures) = scrape_phase(
+        &prepare.urls_to_scrape,
         &scraper_config,
         &opts,
-        &NoopObserver,
+        observer.as_ref(),
         shared_downloader
             .as_deref()
             .map(|d| d as &dyn crate::domain::ports::AssetDownloaderPort),
     )
     .await;
 
-    // Post-scrape: elastic ingestion. Fail-fast — a broken pipe / write error
-    // (D2) propagates as a fatal `IoError` and aborts the crawl.
+    // Elastic ingestion post-scrape (fail-fast — D2)
     if let Some(ref ingestion) = elastic_ingestion {
         if let Err(e) = run_elastic_ingestion(ingestion, &results).await {
             return CliExit::IoError(format!("Falló la ingesta de vectores: {e}"));
         }
     }
 
-    // Report failures — preserve the full root-cause chain via `Error::source()`
-    // so the cause (e.g. wreq::Error → I/O → timeout) is not flattened (D4).
-    for (url, error) in &failures {
-        let mut chain = error.to_string();
-        let mut src = std::error::Error::source(error);
-        while let Some(cause) = src {
-            chain.push_str(&format!("  ← {cause}"));
-            src = cause.source();
-        }
-        eprintln!("Failed to scrape {url}: {chain}");
+    // Phase 3: Report failures + exit code
+    if let Some(exit) = report_phase(&results, &failures) {
+        return exit;
     }
 
-    // Partial failure: some succeeded, some failed → exit 69 (H4 fix)
-    if !failures.is_empty() && !results.is_empty() {
-        return CliExit::PartialSuccess {
-            success: results.len(),
-            failed: failures.len(),
-        };
-    }
-
-    if results.is_empty() {
-        eprintln!("No pages were successfully scraped");
-        return CliExit::NetworkError("No pages were successfully scraped".into());
-    }
-
-    info!("Successfully scraped {} pages", results.len());
+    // Phase 4: Export
+    // Clone output_dir before it is consumed by ExportConfig (owned PathBuf)
+    let output_dir = opts.export.output_dir.clone();
 
     // Obsidian options
     let obsidian_options = ObsidianOptions {
@@ -209,31 +150,34 @@ pub async fn run(
     };
 
     // Determine output directory for individual files
-    let output_dir = if opts.export.quick_save {
-        let base = opts
-            .export
-            .obsidian_vault
-            .as_deref()
-            .unwrap_or(&opts.export.output_dir);
+    let file_output_dir = if opts.export.quick_save {
+        let base = opts.export.obsidian_vault.as_deref().unwrap_or(&output_dir);
         let inbox = base.join("_inbox");
         if !inbox.exists() {
             let _ = std::fs::create_dir_all(&inbox);
         }
         inbox
     } else {
-        opts.export.output_dir.clone()
+        output_dir.clone()
     };
 
-    // Export phase
+    // Save individual files (Markdown, etc.)
+    save_files(
+        &results,
+        &file_output_dir,
+        &opts.export.output_format,
+        &obsidian_options,
+    );
+
     let export_config = ExportConfig {
         results: &results,
-        output_dir: opts.export.output_dir.clone(),
+        output_dir,
         format: opts.export.output_format,
         export_format: opts.export.export_format,
         clean_ai: opts.ai,
         quick_save: opts.export.quick_save,
         vault_path: opts.export.obsidian_vault.as_ref(),
-        obsidian_options: obsidian_options.clone(),
+        obsidian_options,
         state_store: None, // TODO: Add state store
         resume: opts.crawl.resume,
         ai_threshold: opts.ai_config.threshold,
@@ -241,14 +185,6 @@ pub async fn run(
         ai_offline: opts.ai_config.offline,
         ai_model: opts.ai_config.model.clone(),
     };
-
-    // Save individual files (Markdown, etc.)
-    save_files(
-        &results,
-        &output_dir,
-        &opts.export.output_format,
-        &obsidian_options,
-    );
 
     #[cfg(feature = "ai")]
     let export_result = run_export(export_config, ai_cleaner).await;
@@ -265,6 +201,116 @@ pub async fn run(
             e
         },
     }
+}
+
+/// Prepare scraper config and discover URLs.
+///
+/// Returns the initial `ScraperConfig` (before asset/download wiring) and
+/// the list of URLs to scrape.  On discovery failure, returns the
+/// appropriate `CliExit` error.
+async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
+    let urls_to_scrape = if opts.crawl.single_page {
+        plan_urls(true, opts.url.clone(), Vec::new())
+    } else {
+        let mut crawler_config = CrawlerConfig::builder(opts.url.clone())
+            .max_pages(opts.crawl.max_pages)
+            .max_depth(opts.crawl.max_depth)
+            .include_patterns(opts.crawl.include_patterns.clone())
+            .exclude_patterns(opts.crawl.exclude_patterns.clone())
+            .ignore_robots(opts.crawl.ignore_robots)
+            .use_sitemap(opts.crawl.use_sitemap);
+        if let Some(ref sitemap_url) = opts.crawl.sitemap_url {
+            crawler_config = crawler_config.sitemap_url(sitemap_url);
+        }
+        let crawler_config = crawler_config.build();
+
+        let discovered_urls = match discover_urls(&crawler_config, opts).await {
+            Err(e) => {
+                return Err(CliExit::NetworkError(format!("URL discovery failed: {e}")));
+            },
+            Ok(urls) if urls.is_empty() => {
+                return Err(CliExit::EmptyDiscovery(
+                    "No URLs discovered from sitemaps".into(),
+                ));
+            },
+            Ok(urls) => urls,
+        };
+
+        plan_urls(false, opts.url.clone(), discovered_urls)
+    };
+
+    let mut scraper_config = ScraperConfig::default()
+        .with_output_dir(opts.export.output_dir.clone())
+        .with_scraper_concurrency(opts.network.concurrency.resolve())
+        .with_max_pages(opts.crawl.max_pages)
+        .with_selector(opts.crawl.selector.clone());
+
+    if opts.network.download_images {
+        scraper_config = scraper_config.with_images();
+    }
+    if opts.network.download_documents {
+        scraper_config = scraper_config.with_documents();
+    }
+
+    Ok(PrepareResult {
+        urls_to_scrape,
+        scraper_config,
+    })
+}
+
+struct PrepareResult {
+    urls_to_scrape: Vec<url::Url>,
+    scraper_config: ScraperConfig,
+}
+
+/// Run the scraping loop over all URLs with progress events.
+async fn scrape_phase(
+    urls: &[url::Url],
+    scraper_config: &ScraperConfig,
+    opts: &CrawlOptions,
+    observer: &dyn crate::application::progress_observer::ProgressObserver,
+    downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
+) -> (
+    Vec<domain::ScrapedContent>,
+    Vec<(String, crate::error::ScraperError)>,
+) {
+    scrape_urls(urls, scraper_config, opts, observer, downloader).await
+}
+
+/// Report failures and determine the exit code.
+///
+/// Returns `None` if all pages scraped successfully (caller proceeds to export).
+fn report_phase(
+    results: &[domain::ScrapedContent],
+    failures: &[(String, crate::error::ScraperError)],
+) -> Option<CliExit> {
+    // Preserve the full root-cause chain via `Error::source()` (D4)
+    for (url, error) in failures {
+        let mut chain = error.to_string();
+        let mut src = std::error::Error::source(error);
+        while let Some(cause) = src {
+            chain.push_str(&format!("  ← {cause}"));
+            src = cause.source();
+        }
+        eprintln!("Failed to scrape {url}: {chain}");
+    }
+
+    if !failures.is_empty() && !results.is_empty() {
+        return Some(CliExit::PartialSuccess {
+            success: results.len(),
+            failed: failures.len(),
+        });
+    }
+
+    if results.is_empty() {
+        eprintln!("No pages were successfully scraped");
+        return Some(CliExit::NetworkError(
+            "No pages were successfully scraped".into(),
+        ));
+    }
+
+    info!("Successfully scraped {} pages", results.len());
+    None
 }
 
 /// Run the elastic ingestion pipeline on all scraped results.

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -50,54 +50,24 @@ pub async fn run(
     opts: CrawlOptions,
     #[cfg(feature = "ai")] ai_cleaner: Option<std::sync::Arc<dyn SemanticCleaner>>,
 ) -> CliExit {
-    // Dry-run mode: list planned URLs without any network requests
     if opts.export.dry_run {
         println!("Dry-run: 1 URL(s) would be scraped:");
         println!("  {}", opts.url);
         return CliExit::Success;
     }
-
-    // Batch mode: process URLs from stdin or file, then exit early
     if opts.batch.enabled {
         return run_batch(opts).await;
     }
-
-    // Phase 1: Prepare scraper config, URLs, and observer
     let prepare = match prepare_phase(&opts).await {
         Err(e) => return e,
         Ok(p) => p,
     };
 
-    // Wire asset download config from CLI args
-    let mut scraper_config = prepare.scraper_config;
-    scraper_config =
-        scraper_config.with_asset_h2_profile(parse_asset_h2_profile(&opts.network.h2_profile));
-    scraper_config =
-        scraper_config.with_asset_include_patterns(opts.crawl.include_patterns.clone());
-    scraper_config =
-        scraper_config.with_asset_exclude_patterns(opts.crawl.exclude_patterns.clone());
-    scraper_config = scraper_config.with_asset_naming(parse_asset_naming(&opts.asset_naming));
-    scraper_config = scraper_config.with_download_concurrency(opts.download_concurrency);
-
-    // Create shared Downloader once for connection pooling across all page scrapes.
-    let shared_downloader = if scraper_config.has_downloads() {
-        match crate::adapters::downloader::Downloader::new(scraper_config.to_download_config()) {
-            Ok(dl) => Some(std::sync::Arc::new(dl)),
-            Err(e) => {
-                return CliExit::IoError(format!("No se pudo crear el descargador de assets: {e}"));
-            },
-        }
-    } else {
-        None
-    };
-
-    // Initialize elastic ingestion if requested
     let elastic_ingestion = match build_elastic_ingestion(&opts).await {
         Ok(v) => v,
         Err(e) => return e,
     };
 
-    // Warn if --output-vectors is specified but AI feature is unavailable
     #[cfg(not(feature = "ai"))]
     if opts.elastic.output_vectors.is_some() && opts.ai {
         warn!(
@@ -107,39 +77,49 @@ pub async fn run(
         );
     }
 
-    let observer: Box<dyn crate::application::progress_observer::ProgressObserver> = Box::new(
+    let observer = Box::new(
         crate::application::progress_observer::LiveProgressObserver::new(None, opts.export.quiet),
     );
-
-    // Phase 2: Scrape
     let (results, failures) = scrape_phase(
         &prepare.urls_to_scrape,
-        &scraper_config,
+        &prepare.scraper_config,
         &opts,
         observer.as_ref(),
-        shared_downloader
+        prepare
+            .shared_downloader
             .as_deref()
             .map(|d| d as &dyn crate::domain::ports::AssetDownloaderPort),
     )
     .await;
 
-    // Elastic ingestion post-scrape (fail-fast — D2)
     if let Some(ref ingestion) = elastic_ingestion {
         if let Err(e) = run_elastic_ingestion(ingestion, &results).await {
             return CliExit::IoError(format!("Falló la ingesta de vectores: {e}"));
         }
     }
 
-    // Phase 3: Report failures + exit code
     if let Some(exit) = report_phase(&results, &failures) {
         return exit;
     }
 
-    // Phase 4: Export
-    // Clone output_dir before it is consumed by ExportConfig (owned PathBuf)
+    #[cfg(feature = "ai")]
+    {
+        export_phase(&results, &opts, ai_cleaner).await
+    }
+    #[cfg(not(feature = "ai"))]
+    {
+        export_phase(&results, &opts).await
+    }
+}
+
+/// Export scraped results to files and run AI cleaning if requested.
+async fn export_phase(
+    results: &[domain::ScrapedContent],
+    opts: &CrawlOptions,
+    #[cfg(feature = "ai")] ai_cleaner: Option<std::sync::Arc<dyn SemanticCleaner>>,
+) -> CliExit {
     let output_dir = opts.export.output_dir.clone();
 
-    // Obsidian options
     let obsidian_options = ObsidianOptions {
         wiki_links: opts.export.obsidian_wiki_links,
         relative_assets: opts.export.obsidian_relative_assets,
@@ -149,7 +129,6 @@ pub async fn run(
         vault_path: opts.export.obsidian_vault.clone(),
     };
 
-    // Determine output directory for individual files
     let file_output_dir = if opts.export.quick_save {
         let base = opts.export.obsidian_vault.as_deref().unwrap_or(&output_dir);
         let inbox = base.join("_inbox");
@@ -161,16 +140,15 @@ pub async fn run(
         output_dir.clone()
     };
 
-    // Save individual files (Markdown, etc.)
     save_files(
-        &results,
+        results,
         &file_output_dir,
         &opts.export.output_format,
         &obsidian_options,
     );
 
     let export_config = ExportConfig {
-        results: &results,
+        results,
         output_dir,
         format: opts.export.output_format,
         export_format: opts.export.export_format,
@@ -178,7 +156,7 @@ pub async fn run(
         quick_save: opts.export.quick_save,
         vault_path: opts.export.obsidian_vault.as_ref(),
         obsidian_options,
-        state_store: None, // TODO: Add state store
+        state_store: None,
         resume: opts.crawl.resume,
         ai_threshold: opts.ai_config.threshold,
         ai_max_tokens: opts.ai_config.max_tokens,
@@ -252,15 +230,41 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
         scraper_config = scraper_config.with_documents();
     }
 
+    // Wire asset download config from CLI args
+    scraper_config =
+        scraper_config.with_asset_h2_profile(parse_asset_h2_profile(&opts.network.h2_profile));
+    scraper_config =
+        scraper_config.with_asset_include_patterns(opts.crawl.include_patterns.clone());
+    scraper_config =
+        scraper_config.with_asset_exclude_patterns(opts.crawl.exclude_patterns.clone());
+    scraper_config = scraper_config.with_asset_naming(parse_asset_naming(&opts.asset_naming));
+    scraper_config = scraper_config.with_download_concurrency(opts.download_concurrency);
+
+    // Create shared Downloader once for connection pooling across all page scrapes.
+    let shared_downloader = if scraper_config.has_downloads() {
+        match crate::adapters::downloader::Downloader::new(scraper_config.to_download_config()) {
+            Ok(dl) => Some(std::sync::Arc::new(dl)),
+            Err(e) => {
+                return Err(CliExit::IoError(format!(
+                    "No se pudo crear el descargador de assets: {e}"
+                )));
+            },
+        }
+    } else {
+        None
+    };
+
     Ok(PrepareResult {
         urls_to_scrape,
         scraper_config,
+        shared_downloader,
     })
 }
 
 struct PrepareResult {
     urls_to_scrape: Vec<url::Url>,
     scraper_config: ScraperConfig,
+    shared_downloader: Option<std::sync::Arc<crate::adapters::downloader::Downloader>>,
 }
 
 /// Run the scraping loop over all URLs with progress events.

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -1,13 +1,13 @@
 //! Scraping flow logic extracted from orchestrator.
 
 use std::path::PathBuf;
-use tokio::sync::mpsc;
 use tracing::{info, warn};
 use url::Url;
 
 use crate::application::crawl_options::CrawlOptions;
 use crate::application::export_factory;
-use crate::application::progress_types::{ScrapeError, ScrapeProgress, ScrapeStatus};
+use crate::application::progress_observer::ProgressObserver;
+use crate::application::progress_types::ScrapeError;
 use crate::application::scrape_single_url_for_tui;
 use crate::domain::ScrapedContent;
 use crate::infrastructure::crawler::robots_utils::{is_allowed_by_robots, new_robots_cache};
@@ -87,16 +87,15 @@ pub async fn apply_resume_mode(
     (filtered, state_store)
 }
 
-/// Scrape all URLs with progress events via mpsc channel.
+/// Scrape all URLs, reporting progress via the provided observer.
 ///
-/// When progress_tx is provided (non-TUI mode), emits ScrapeProgress events.
-/// When progress_tx is None (TUI mode), no progress events are emitted.
-/// The --quiet flag suppresses all output including progress events.
+/// The observer handles quiet/channel logic internally — callers pass
+/// `&NoopObserver` for dry-run or `&LiveProgressObserver` for live output.
 pub async fn scrape_urls(
     urls: &[Url],
     scraper_config: &ScraperConfig,
     opts: &CrawlOptions,
-    progress_tx: Option<mpsc::Sender<ScrapeProgress>>,
+    observer: &dyn ProgressObserver,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
 ) -> (
     Vec<ScrapedContent>,
@@ -160,44 +159,14 @@ pub async fn scrape_urls(
         let url_str = url.as_str();
         let _url_host = url.host_str().unwrap_or("unknown").to_string();
 
-        // Emit progress event: Started
-        if !opts.export.quiet {
-            if let Some(ref tx) = progress_tx {
-                let _ = tx
-                    .send(ScrapeProgress::Started {
-                        url: url_str.to_string(),
-                    })
-                    .await;
-            }
-        }
-
-        // Emit progress event: StatusChanged to Fetching
-        if !opts.export.quiet {
-            if let Some(ref tx) = progress_tx {
-                let _ = tx
-                    .send(ScrapeProgress::StatusChanged {
-                        url: url_str.to_string(),
-                        status: ScrapeStatus::Fetching,
-                    })
-                    .await;
-            }
-        }
+        observer.on_page_started(url_str).await;
 
         // Robots.txt enforcement — skip disallowed URLs unless --ignore-robots
         if !opts.crawl.ignore_robots {
             let domain = url.host_str().unwrap_or("unknown");
             if !is_allowed_by_robots(url_str, domain, &robots_cache).await {
                 info!("Blocked by robots.txt: {}", url_str);
-                if !opts.export.quiet {
-                    if let Some(ref tx) = progress_tx {
-                        let _ = tx
-                            .send(ScrapeProgress::Failed {
-                                url: url_str.to_string(),
-                                error: ScrapeError::Other("blocked by robots.txt".into()),
-                            })
-                            .await;
-                    }
-                }
+                observer.on_robots_blocked(url_str).await;
                 failures.push((
                     url_str.to_string(),
                     crate::error::ScraperError::Validation("blocked by robots.txt".into()),
@@ -212,53 +181,23 @@ pub async fn scrape_urls(
             Ok(content) => {
                 let chars = content.content.chars().count();
                 results.push(content);
-                // Emit progress event: Completed (only if not quiet)
-                if !opts.export.quiet {
-                    if let Some(ref tx) = progress_tx {
-                        let _ = tx
-                            .send(ScrapeProgress::Completed {
-                                url: url_str.to_string(),
-                                chars,
-                            })
-                            .await;
-                    }
-                }
+                observer.on_page_completed(url_str, chars).await;
             },
             Err(e) => {
                 let url_str = url.as_str().to_string();
                 warn!("Failed to scrape {}: {}", url_str, e);
-                // Emit progress event: Failed (borrows `e` before it is moved)
-                if !opts.export.quiet {
-                    if let Some(ref tx) = progress_tx {
-                        let _ = tx
-                            .send(ScrapeProgress::Failed {
-                                url: url_str.clone(),
-                                error: ScrapeError::Other(format!("{e}")),
-                            })
-                            .await;
-                    }
-                }
-                failures.push((url_str.clone(), e));
+                let scrape_err = ScrapeError::Other(format!("{e}"));
+                observer.on_page_failed(&url_str, &scrape_err).await;
+                failures.push((url_str, e));
             },
         }
     }
 
-    // Count totals from results/failures
     let total_successful = results.len();
     let total_failed = failures.len();
-
-    // Emit Finished event when all done (only if not quiet)
-    if !opts.export.quiet {
-        if let Some(ref tx) = progress_tx {
-            let _ = tx
-                .send(ScrapeProgress::Finished {
-                    total: processing_count,
-                    successful: total_successful,
-                    failed: total_failed,
-                })
-                .await;
-        }
-    }
+    observer
+        .on_finished(processing_count, total_successful, total_failed)
+        .await;
 
     (results, failures)
 }

--- a/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -6,7 +6,7 @@ expression: redacted
     at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
 
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:229
+    at crates/webfang_core/src/cli/scrape_flow.rs:188
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped

--- a/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -6,7 +6,7 @@ expression: redacted
     at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
 
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
-    at crates/webfang_core/src/cli/scrape_flow.rs:229
+    at crates/webfang_core/src/cli/scrape_flow.rs:188
 
 Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← client error (Connect)  ← tcp connect error  ← Connection refused (os error 111)
 No pages were successfully scraped

--- a/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -6,7 +6,7 @@ expression: "redact_nondeterministic(output_dir.path(), &stderr)"
     at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
 
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:229
+    at crates/webfang_core/src/cli/scrape_flow.rs:188
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped


### PR DESCRIPTION
## Summary

- Split 220-line `run()` God Function into 4 phases: `prepare_phase`, `scrape_phase`, `report_phase`, `export_phase` — now 65 LOC
- Introduced `ProgressObserver` trait + `LiveProgressObserver` + `NoopObserver` to replace 59 LOC of duplicated boilerplate
- Fixed `ProgressState::Finished` count drift (`self.total = total` instead of discarded `_`)
- Removed redundant `StatusChanged(Fetching)` emission

Closes #229

## Changes

| File | Change |
|------|--------|
| `application/progress_observer.rs` | NEW: `ProgressObserver` trait + `LiveProgressObserver` + `NoopObserver` (327 LOC) |
| `application/mod.rs` | Added `pub mod progress_observer` |
| `application/progress_types.rs` | Fixed `Finished` arm: `self.total = total` instead of `_` |
| `cli/orchestrator.rs` | Split `run()` into 4 phases (220→65 LOC). Config building + download setup moved to `prepare_phase`. Export extracted to `export_phase` |
| `cli/scrape_flow.rs` | Migrated 6 emission blocks to observer calls. Removed `StatusChanged(Fetching)`. Changed signature: `&dyn ProgressObserver` replaces `Option<mpsc::Sender>` |
| `tests/snapshots/*` | Updated line number references |

## Architecture

```
run() [65 LOC]
  ├── prepare_phase()    → ScraperConfig + URLs + ProgressObserver + Downloader
  ├── scrape_phase()     → URL loop with observer events
  ├── report_phase()     → Error reporting + exit code
  └── export_phase()     → save_files + ExportConfig + run_export
```

`ProgressObserver` uses `Pin<Box<dyn Future>>` desugaring (matching `VectorRepository` pattern) — dyn-compatible without `async_trait` crate.

## Test Plan

- [x] `cargo check` — compiles
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo nextest run` — 1699/1699 tests pass
- [x] Snapshot tests updated for line number changes
- [x] `orchestrator_no_hardcoded_ai_literals` test preserved (ExportConfig kept inline)

## Notes

- TUI progress bar wiring deferred to #250 (separate concern: `run_progress_view` never invoked, `scrape_urls_for_tui` has no observer param)
- `LiveProgressObserver` created with `None` tx — progress events are wired but channel not yet connected to TUI. This is intentional: the trait infrastructure is in place, TUI wiring is #250