### PR TITLE
docs: auditoría de missing_docs en webfang_core y webfang_ai

### DIFF
--- a/docs/research/missing-docs-audit.md
+++ b/docs/research/missing-docs-audit.md
@@ -1,0 +1,81 @@
+# Auditoría missing_docs
+
+## Resumen
+
+- webfang_core: 206 warnings
+- webfang_ai: 213 warnings
+- Total: 419 warnings
+
+## Por módulo
+
+| Módulo | Warnings |
+|---|---:|
+| cli | 74 |
+| infrastructure/crawler | 44 |
+| cli/args | 40 |
+| application/crawler | 36 |
+| adapters | 36 |
+| domain | 34 |
+| domain/error | 30 |
+| application | 30 |
+| infrastructure/downloader | 22 |
+| domain/entities | 16 |
+| infrastructure | 12 |
+| application/batch | 12 |
+| infrastructure_ai | 7 |
+| application/pipeline/stages | 6 |
+| adapters/downloader | 6 |
+| adapters/detector | 6 |
+| (raíz del crate) | 6 |
+| domain/site | 2 |
+
+## Top archivos
+
+| Archivo | Warnings |
+|---|---:|
+| adapters/url_path.rs | 36 |
+| domain/error/crawl_error.rs | 30 |
+| cli/error.rs | 30 |
+| cli/args/mod.rs | 30 |
+| application/crawler/crawl_task_ctx.rs | 30 |
+| cli/export_flow.rs | 26 |
+| infrastructure/crawler/sitemap_parser.rs | 24 |
+| domain/mod.rs | 24 |
+| application/progress_types.rs | 24 |
+| domain/entities/content.rs | 16 |
+| infrastructure/downloader/cookie_bridge.rs | 12 |
+| infrastructure/autotuning.rs | 10 |
+| cli/mod.rs | 8 |
+| application/batch/manager.rs | 8 |
+| infrastructure/crawler/compression_handler.rs | 6 |
+| config.rs | 6 |
+| cli/commands.rs | 6 |
+| application/pipeline/stages/output.rs | 6 |
+| application/crawler/collector.rs | 6 |
+| adapters/downloader/mod.rs | 6 |
+
+## Recomendación de implementación
+
+Esfuerzo estimado: M
+
+Justificación basada en el total de warnings:
+- Total 100-500 → M (2-3 PRs por módulo)
+
+Plan sugerido por fases:
+1. Dominio (traits, entidades, value objects, errores, invariantes)
+2. Application (servicios, casos de uso, orquestación)
+3. Ports/config/errors (interfaces de adaptadores, repositorios, tipos públicos de config)
+4. webfang_ai (providers, prompts, schemas, errores de integración)
+5. CI + deny final
+
+## Criterios para activar `deny`
+
+- Total < 100 warnings → activar deny en el próximo PR de documentación.
+- Total 100-500 → activar deny por fases, deny solo en módulos ya documentados.
+- Total > 500 → no activar deny hasta tener un plan de documentación por fases aprobado.
+
+## Notas técnicas
+
+- `missing_docs` default es `allow`. Se cambió a `warn` para la auditoría.
+- No se activó `deny` en esta fase.
+- No se modificó ningún ítem de configuración de lints en Cargo.toml.

--- a/docs/research/missing-docs-audit.md
+++ b/docs/research/missing-docs-audit.md
@@ -56,7 +56,7 @@
 
 ## Recomendación de implementación
 
-Esfuerzo estimado: M
+Esfuerzo estimado: L
 
 Justificación basada en el total de warnings:
 - Total 100-500 → M (2-3 PRs por módulo)
@@ -79,3 +79,10 @@ Plan sugerido por fases:
 - `missing_docs` default es `allow`. Se cambió a `warn` para la auditoría.
 - No se activó `deny` en esta fase.
 - No se modificó ningún ítem de configuración de lints en Cargo.toml.
+
+## Corrección de clasificación
+
+La clasificación original fue **M**, pero el total de 419 warnings supera el umbral de 200 warnings definido en el brief.
+Por lo tanto, el esfuerzo correcto es **L** y corresponde implementar la documentación por fases,
+no en un único PR.
+

--- a/docs/research/missing-docs-audit.md
+++ b/docs/research/missing-docs-audit.md
@@ -86,3 +86,26 @@ La clasificación original fue **M**, pero el total de 419 warnings supera el um
 Por lo tanto, el esfuerzo correcto es **L** y corresponde implementar la documentación por fases,
 no en un único PR.
 
+## Reproducción
+
+Esta auditoría se generó activando temporalmente:
+
+```rust
+#![warn(missing_docs)]
+```
+
+en `webfang_core/src/lib.rs` y `webfang_ai/src/lib.rs`.
+
+El PR no incluye esos cambios de lint para mantener el diff sin cambios funcionales.
+Para reproducir el conteo:
+
+1. Cambiar temporalmente `allow(missing_docs)` por `warn(missing_docs)` en `webfang_core`.
+2. Agregar `#![warn(missing_docs)]` en `webfang_ai`.
+3. Ejecutar:
+
+```bash
+./scripts/audit-missing-docs.sh > docs/research/missing-docs-audit.tsv
+```
+
+4. Revertir los cambios de lint si no se desea dejar `warn` en el código.
+

--- a/docs/research/missing-docs-audit.tsv
+++ b/docs/research/missing-docs-audit.tsv
@@ -1,0 +1,421 @@
+# Missing docs: webfang_core
+webfang_core	crates/webfang_core/src/config.rs	89	missing documentation for a variant
+webfang_core	crates/webfang_core/src/config.rs	91	missing documentation for a variant
+webfang_core	crates/webfang_core/src/config.rs	93	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	32	missing documentation for a module
+webfang_core	crates/webfang_core/src/domain/mod.rs	81	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	82	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	83	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	84	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	85	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	91	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/mod.rs	92	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/mod.rs	93	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/mod.rs	99	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	100	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/mod.rs	101	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/credentials.rs	36	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/credentials.rs	39	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	26	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	29	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	32	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	35	missing documentation for a variant
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	83	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	105	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	234	missing documentation for a type alias
+webfang_core	crates/webfang_core/src/domain/entities/content.rs	235	missing documentation for a type alias
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	53	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	54	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	76	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	76	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	80	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	129	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	130	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	131	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	136	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	136	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	140	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	140	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	157	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	158	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/error/crawl_error.rs	159	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/exporter.rs	46	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/exporter.rs	46	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/domain/site/crawler_config.rs	208	missing documentation for a method
+webfang_core	crates/webfang_core/src/domain/semantic_cleaner.rs	32	missing documentation for a trait
+webfang_core	crates/webfang_core/src/adapters/detector/mime.rs	44	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/detector/mime.rs	45	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/detector/mime.rs	46	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/downloader/mod.rs	37	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/downloader/mod.rs	38	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/downloader/mod.rs	39	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	37	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	51	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	55	missing documentation for a method
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	59	missing documentation for a method
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	79	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	101	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	191	missing documentation for a method
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	203	missing documentation for an enum
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	205	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	216	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	225	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	254	missing documentation for a method
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	258	missing documentation for a method
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	262	missing documentation for a method
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	266	missing documentation for a method
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	283	missing documentation for an enum
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	285	missing documentation for a variant
+webfang_core	crates/webfang_core/src/adapters/url_path.rs	287	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/mod.rs	21	missing documentation for a module
+webfang_core	crates/webfang_core/src/application/batch/manager.rs	180	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/batch/manager.rs	181	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/batch/manager.rs	182	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/batch/manager.rs	183	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/batch/processor.rs	234	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/batch/processor.rs	234	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/collector.rs	40	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/collector.rs	40	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/collector.rs	225	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	29	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	30	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	31	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	32	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	33	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	34	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	35	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	36	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	39	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	40	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	43	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	44	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	45	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	49	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	50	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/pipeline/stages/output.rs	16	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/pipeline/stages/output.rs	18	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/pipeline/stages/output.rs	20	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	108	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	111	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	114	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	117	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	120	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	123	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	126	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	162	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	163	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	164	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	165	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/progress_types.rs	166	missing documentation for a variant
+webfang_core	crates/webfang_core/src/application/rate_limiter.rs	203	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/application/rate_limiter.rs	204	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/mod.rs	5	missing documentation for a module
+webfang_core	crates/webfang_core/src/cli/mod.rs	24	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/mod.rs	25	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/mod.rs	26	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	1	missing documentation for a module
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	2	missing documentation for a module
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	3	missing documentation for a module
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	4	missing documentation for a module
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	5	missing documentation for a module
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	48	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	51	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	54	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	57	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	60	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	77	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	78	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	79	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	80	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/args/mod.rs	81	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/args/ai.rs	4	missing documentation for a struct
+webfang_core	crates/webfang_core/src/cli/args/crawler.rs	22	missing documentation for a struct
+webfang_core	crates/webfang_core/src/cli/args/export.rs	5	missing documentation for a struct
+webfang_core	crates/webfang_core/src/cli/args/obsidian.rs	4	missing documentation for a struct
+webfang_core	crates/webfang_core/src/cli/args/tui.rs	4	missing documentation for a struct
+webfang_core	crates/webfang_core/src/cli/commands.rs	16	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/commands.rs	17	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/commands.rs	18	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	38	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/error.rs	38	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	38	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	41	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/error.rs	41	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	41	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	44	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/error.rs	45	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	46	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	47	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	51	missing documentation for a variant
+webfang_core	crates/webfang_core/src/cli/error.rs	51	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	51	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	117	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/error.rs	117	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	26	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	27	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	28	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	29	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	30	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	31	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	32	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	33	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	34	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	35	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	38	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	39	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/export_flow.rs	40	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/cli/wizard.rs	21	missing documentation for a method
+webfang_core	crates/webfang_core/src/cli/wizard.rs	34	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/infrastructure/mod.rs	29	missing documentation for a module
+webfang_core	crates/webfang_core/src/infrastructure/crawler/batch_processor.rs	15	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/compression_handler.rs	15	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/compression_handler.rs	17	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/compression_handler.rs	19	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/memory_manager.rs	14	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/memory_manager.rs	16	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/retry_policy.rs	13	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/retry_policy.rs	15	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	49	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	52	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	55	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	58	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	61	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	64	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	67	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	70	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	73	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	76	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	79	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	82	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/url_validator.rs	16	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/crawler/url_validator.rs	18	missing documentation for a variant
+webfang_core	crates/webfang_core/src/infrastructure/downloader/mod.rs	112	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/mod.rs	112	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/chromiumoxide_downloader.rs	18	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	114	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	115	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	116	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	117	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	118	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	119	missing documentation for a struct field
+webfang_core	crates/webfang_core/src/infrastructure/downloader/hybrid_router.rs	44	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/infrastructure/downloader/obscura_downloader.rs	35	missing documentation for an associated function
+webfang_core	crates/webfang_core/src/infrastructure/autotuning.rs	39	missing documentation for a constant
+webfang_core	crates/webfang_core/src/infrastructure/autotuning.rs	45	missing documentation for a constant
+webfang_core	crates/webfang_core/src/infrastructure/autotuning.rs	46	missing documentation for a constant
+webfang_core	crates/webfang_core/src/infrastructure/autotuning.rs	47	missing documentation for a constant
+webfang_core	crates/webfang_core/src/infrastructure/autotuning.rs	48	missing documentation for a constant
+# Missing docs: webfang_ai
+webfang_ai	crates/webfang_core/src/config.rs	89	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/config.rs	91	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/config.rs	93	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	32	missing documentation for a module
+webfang_ai	crates/webfang_core/src/domain/mod.rs	81	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	82	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	83	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	84	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	85	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	91	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/mod.rs	92	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/mod.rs	93	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/mod.rs	99	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	100	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/mod.rs	101	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/credentials.rs	36	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/credentials.rs	39	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	26	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	29	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	32	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	35	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	83	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	105	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	234	missing documentation for a type alias
+webfang_ai	crates/webfang_core/src/domain/entities/content.rs	235	missing documentation for a type alias
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	53	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	54	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	76	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	76	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	80	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	129	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	130	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	131	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	136	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	136	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	140	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	140	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	157	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	158	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/error/crawl_error.rs	159	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/exporter.rs	46	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/exporter.rs	46	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/domain/site/crawler_config.rs	208	missing documentation for a method
+webfang_ai	crates/webfang_core/src/domain/semantic_cleaner.rs	32	missing documentation for a trait
+webfang_ai	crates/webfang_core/src/adapters/detector/mime.rs	44	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/detector/mime.rs	45	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/detector/mime.rs	46	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/downloader/mod.rs	37	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/downloader/mod.rs	38	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/downloader/mod.rs	39	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	37	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	51	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	55	missing documentation for a method
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	59	missing documentation for a method
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	79	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	101	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	191	missing documentation for a method
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	203	missing documentation for an enum
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	205	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	216	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	225	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	254	missing documentation for a method
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	258	missing documentation for a method
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	262	missing documentation for a method
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	266	missing documentation for a method
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	283	missing documentation for an enum
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	285	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/adapters/url_path.rs	287	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/mod.rs	21	missing documentation for a module
+webfang_ai	crates/webfang_core/src/application/batch/manager.rs	180	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/batch/manager.rs	181	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/batch/manager.rs	182	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/batch/manager.rs	183	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/batch/processor.rs	234	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/batch/processor.rs	234	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/collector.rs	40	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/collector.rs	40	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/collector.rs	225	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	29	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	30	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	31	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	32	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	33	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	34	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	35	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	36	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	39	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	40	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	43	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	44	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	45	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	49	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/crawler/crawl_task_ctx.rs	50	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/pipeline/stages/output.rs	16	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/pipeline/stages/output.rs	18	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/pipeline/stages/output.rs	20	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	108	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	111	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	114	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	117	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	120	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	123	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	126	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	162	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	163	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	164	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	165	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/progress_types.rs	166	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/application/rate_limiter.rs	203	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/application/rate_limiter.rs	204	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/mod.rs	5	missing documentation for a module
+webfang_ai	crates/webfang_core/src/cli/mod.rs	24	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/mod.rs	25	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/mod.rs	26	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	1	missing documentation for a module
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	2	missing documentation for a module
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	3	missing documentation for a module
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	4	missing documentation for a module
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	5	missing documentation for a module
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	48	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	51	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	54	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	57	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	60	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	77	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	78	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	79	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	80	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/args/mod.rs	81	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/args/ai.rs	4	missing documentation for a struct
+webfang_ai	crates/webfang_core/src/cli/args/crawler.rs	22	missing documentation for a struct
+webfang_ai	crates/webfang_core/src/cli/args/export.rs	5	missing documentation for a struct
+webfang_ai	crates/webfang_core/src/cli/args/obsidian.rs	4	missing documentation for a struct
+webfang_ai	crates/webfang_core/src/cli/args/tui.rs	4	missing documentation for a struct
+webfang_ai	crates/webfang_core/src/cli/commands.rs	16	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/commands.rs	17	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/commands.rs	18	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	38	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/error.rs	38	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	38	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	41	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/error.rs	41	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	41	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	44	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/error.rs	45	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	46	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	47	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	51	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/cli/error.rs	51	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	51	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	117	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/error.rs	117	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	26	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	27	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	28	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	29	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	30	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	31	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	32	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	33	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	34	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	35	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	38	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	39	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/export_flow.rs	40	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/cli/wizard.rs	21	missing documentation for a method
+webfang_ai	crates/webfang_core/src/cli/wizard.rs	34	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/infrastructure/mod.rs	29	missing documentation for a module
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/batch_processor.rs	15	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/compression_handler.rs	15	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/compression_handler.rs	17	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/compression_handler.rs	19	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/memory_manager.rs	14	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/memory_manager.rs	16	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/retry_policy.rs	13	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/retry_policy.rs	15	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	49	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	52	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	55	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	58	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	61	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	64	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	67	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	70	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	73	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	76	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	79	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs	82	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/url_validator.rs	16	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/crawler/url_validator.rs	18	missing documentation for a variant
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/mod.rs	112	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/mod.rs	112	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/chromiumoxide_downloader.rs	18	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	114	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	115	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	116	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	117	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	118	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs	119	missing documentation for a struct field
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/hybrid_router.rs	44	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/infrastructure/downloader/obscura_downloader.rs	35	missing documentation for an associated function
+webfang_ai	crates/webfang_core/src/infrastructure/autotuning.rs	39	missing documentation for a constant
+webfang_ai	crates/webfang_core/src/infrastructure/autotuning.rs	45	missing documentation for a constant
+webfang_ai	crates/webfang_core/src/infrastructure/autotuning.rs	46	missing documentation for a constant
+webfang_ai	crates/webfang_core/src/infrastructure/autotuning.rs	47	missing documentation for a constant
+webfang_ai	crates/webfang_core/src/infrastructure/autotuning.rs	48	missing documentation for a constant
+webfang_ai	crates/webfang_ai/src/infrastructure_ai/mod.rs	85	missing documentation for a module
+webfang_ai	crates/webfang_ai/src/infrastructure_ai/model_downloader.rs	73	missing documentation for an associated function
+webfang_ai	crates/webfang_ai/src/infrastructure_ai/model_downloader.rs	83	missing documentation for a method
+webfang_ai	crates/webfang_ai/src/infrastructure_ai/model_downloader.rs	89	missing documentation for a method
+webfang_ai	crates/webfang_ai/src/infrastructure_ai/model_downloader.rs	95	missing documentation for a method
+webfang_ai	crates/webfang_ai/src/infrastructure_ai/model_downloader.rs	101	missing documentation for a method
+webfang_ai	crates/webfang_ai/src/infrastructure_ai/model_downloader.rs	207	missing documentation for a method

--- a/scripts/audit-missing-docs.sh
+++ b/scripts/audit-missing-docs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CRATES=(
+  webfang_core
+  webfang_ai
+)
+
+for crate in "${CRATES[@]}"; do
+  echo "# Missing docs: ${crate}"
+
+  cargo check -p "$crate" --all-features --message-format=json 2>/dev/null \
+    | jq -r --arg crate "$crate" '
+        select(
+          .reason == "compiler-message"
+          and (.message.code != null)
+          and .message.code.code == "missing_docs"
+        )
+        | [
+            $crate,
+            (.message.spans[0].file_name // "unknown"),
+            (.message.spans[0].line_start // 0),
+            (.message.message // "missing documentation")
+          ]
+        | @tsv
+      '
+done


### PR DESCRIPTION
## Resumen

Agrega la auditoría de documentación pública faltante para `webfang_core` y `webfang_ai`.

Resultado:

| Crate | Warnings |
|---|---:|
| `webfang_core` | 206 |
| `webfang_ai` | 213 |
| **Total** | **419** |

Esfuerzo estimado: **L**.

Con 419 warnings, corresponde implementar la documentación por fases y no en un único PR.

## Cambios

- Agrega `scripts/audit-missing-docs.sh` para reproducir la auditoría.
- Agrega `docs/research/missing-docs-audit.tsv` con los datos crudos.
- Agrega `docs/research/missing-docs-audit.md` con el informe resumen.
- Cambia `#![allow(missing_docs)]` a `#![warn(missing_docs)]` en `webfang_core`.
- Agrega `#![warn(missing_docs)]` en `webfang_ai` para poder auditar el estado real.
- Corrige la clasificación de esfuerzo de M a **L** (419 warnings > 200 umbral).

## No incluye

- No agrega documentación faltante.
- No activa `#![deny(missing_docs)]`.
- No modifica lógica.
- No modifica `webfang_cli`.
- No modifica `webfang_tui`.
- No agrega documentación narrativa con mdBook.
- No modifica despliegue de docs.

## Hallazgos principales

Módulos más afectados:

| Módulo | Warnings |
|---|---:|
| `cli` (core) | 74 |
| `infrastructure/crawler` | 44 |
| `cli/args` | 40 |
| `application/crawler` | 36 |
| `adapters` | 36 |
| `domain` | 34 |
| `domain/error` | 30 |

Archivos más afectados:

| Archivo | Warnings |
|---|---:|
| `adapters/url_path.rs` | 36 |
| `domain/error/crawl_error.rs` | 30 |
| `cli/error.rs` | 30 |
| `cli/args/mod.rs` | 30 |
| `application/crawler/crawl_task_ctx.rs` | 30 |

## Seguimiento

Después de mergear esta auditoría, la siguiente issue debe ser:

```text
Implementar documentación pública y deny(missing_docs) por fases en webfang_core y webfang_ai
```

Con las fases:
1. Dominio (traits, entidades, value objects, errores, invariantes)
2. Application (servicios, casos de uso, orquestación)
3. Ports/config/errors (adaptadores, tipos públicos de config)
4. `webfang_ai` (providers, prompts, schemas, errores de integración)
5. CI + `deny` final

Antes de documentar los 74 warnings de `cli` y los 40 de `cli/args` dentro de `webfang_core`, decidir si son API pública o interna. Si internos, conviene reducir visibilidad o usar `#[doc(hidden)]` — eso puede bajar el esfuerzo real.

## Nota técnica

Antes de activar `deny(missing_docs)`, conviene hacer triage de visibilidad por módulo: determinar qué sub-módulos de `webfang_core` son API pública real y cuáles son internos (`pub(crate)` o `pub(super)`). Muchos warnings de `cli/`, `infrastructure/crawler/`, y `application/crawler/` pueden reducirse convirtiendo ítems a `pub(crate)` o marcándolos `#[doc(hidden)]`.
