### PR TITLE
fix(cli): timeout-secs covers body streaming and bare pattern warning for include/exclude

### DIFF
--- a/crates/webfang_core/src/application/url_filter.rs
+++ b/crates/webfang_core/src/application/url_filter.rs
@@ -11,6 +11,9 @@
 //! - **security-ssrf-prevention**: Delegates to domain::matches_pattern (SSRF-safe host comparison)
 
 use crate::domain::CrawlerConfig;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static BARE_PATTERN_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Check if a URL matches a glob-style pattern (dual-mode)
 ///
@@ -125,12 +128,25 @@ pub fn is_excluded(url: &str, patterns: &[String]) -> bool {
 #[inline]
 #[must_use]
 pub fn is_allowed(url: &str, config: &CrawlerConfig) -> bool {
-    // First check exclude patterns (deny takes precedence)
+    if !BARE_PATTERN_WARNED.swap(true, Ordering::SeqCst) {
+        let bare: Vec<&str> = config
+            .exclude_patterns
+            .iter()
+            .chain(config.include_patterns.iter())
+            .filter(|p| !p.starts_with('/') && !p.starts_with("*/") && !p.starts_with("*.'"))
+            .map(|p| p.as_str())
+            .collect();
+        if !bare.is_empty() {
+            tracing::warn!(
+                "Patterns without a leading / or */ are matched against hostname only, not the URL path. Use /pricing or */pricing for path matching. Affected: {:?}",
+                bare
+            );
+        }
+    }
+
     if is_excluded(url, &config.exclude_patterns) {
         return false;
     }
-
-    // Then check include patterns (if any are specified)
     config.matches_include(url)
 }
 

--- a/crates/webfang_core/src/cli/args/crawler.rs
+++ b/crates/webfang_core/src/cli/args/crawler.rs
@@ -166,7 +166,13 @@ pub struct CrawlerArgs {
     #[clap(next_help_heading = "Crawler Settings")]
     pub timeout_secs: u64,
 
-    /// URL patterns to include (glob-style)
+    /// URL patterns to include (glob-style). Three modes:
+    ///
+    /// * Path: starts with `/` → matched against URL path, e.g. `/pricing`, `/admin/*`
+    /// * Path glob: starts with `*/` → matched against URL path, e.g. `*/api/*`
+    /// * Host (default): matched against hostname, e.g. `example.com`, `*.example.com`
+    ///
+    /// Example: to exclude a path, use `--exclude-pattern "/admin/*"`, not `*admin*`
     #[arg(
         long = "include-pattern",
         env = "WEBFANG_INCLUDE",
@@ -175,7 +181,8 @@ pub struct CrawlerArgs {
     #[clap(next_help_heading = "Crawler Settings")]
     pub include_patterns: Vec<String>,
 
-    /// URL patterns to exclude (glob-style)
+    /// URL patterns to exclude (glob-style, same three modes as --include-pattern).
+    /// Deny takes precedence over allow.
     #[arg(
         long = "exclude-pattern",
         env = "WEBFANG_EXCLUDE",

--- a/crates/webfang_core/src/infrastructure/crawler/http_client.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/http_client.rs
@@ -98,7 +98,17 @@ pub async fn fetch_url(url: &str, config: &CrawlerConfig) -> Result<String, Craw
         });
     }
 
-    let text = response.text().await.map_err(|e| CrawlError::Network {
+    let text = tokio::time::timeout(Duration::from_secs(config.timeout_secs), response.text())
+        .await
+        .map_err(|_| CrawlError::Network {
+            message: format!(
+                "Response body read timed out after {}s for {}",
+                config.timeout_secs, url
+            ),
+            status_code: None,
+        })?;
+
+    let text = text.map_err(|e| CrawlError::Network {
         message: e.to_string(),
         status_code: None,
     })?;

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -135,12 +135,16 @@ Options:
           [default: 30]
 
       --include-pattern <INCLUDE_PATTERNS>
-          URL patterns to include (glob-style)
+          URL patterns to include (glob-style). Three modes:
+          
+          * Path: starts with `/` → matched against URL path, e.g. `/pricing`, `/admin/*` * Path glob: starts with `*/` → matched against URL path, e.g. `*/api/*` * Host (default): matched against hostname, e.g. `example.com`, `*.example.com`
+          
+          Example: to exclude a path, use `--exclude-pattern "/admin/*"`, not `*admin*`
           
           [env: WEBFANG_INCLUDE=]
 
       --exclude-pattern <EXCLUDE_PATTERNS>
-          URL patterns to exclude (glob-style)
+          URL patterns to exclude (glob-style, same three modes as --include-pattern). Deny takes precedence over allow
           
           [env: WEBFANG_EXCLUDE=]
 

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -135,12 +135,16 @@ Options:
           [default: 30]
 
       --include-pattern <INCLUDE_PATTERNS>
-          URL patterns to include (glob-style)
+          URL patterns to include (glob-style). Three modes:
+          
+          * Path: starts with `/` → matched against URL path, e.g. `/pricing`, `/admin/*` * Path glob: starts with `*/` → matched against URL path, e.g. `*/api/*` * Host (default): matched against hostname, e.g. `example.com`, `*.example.com`
+          
+          Example: to exclude a path, use `--exclude-pattern "/admin/*"`, not `*admin*`
           
           [env: WEBFANG_INCLUDE=]
 
       --exclude-pattern <EXCLUDE_PATTERNS>
-          URL patterns to exclude (glob-style)
+          URL patterns to exclude (glob-style, same three modes as --include-pattern). Deny takes precedence over allow
           
           [env: WEBFANG_EXCLUDE=]
 


### PR DESCRIPTION
Closes #266

### Summary
- `--timeout-secs` now covers the full request lifecycle including response body streaming via `tokio::time::timeout` around `response.text()`
- Expand `--include-pattern`/`--exclude-pattern` help text across three matching modes (path, path-glob, host)
- Add one-time `tracing::warn!` for bare host patterns that silently match hostname instead of URL path
- `--batch-file` hang resolved as a consequence of bug #1 fix (slow URLs no longer block semaphore slots)

### Verification
- 1171 tests pass (0 failures)
- Local server test: 2-second body timeout correctly fires against a 5-second delayed body server
- Batch with 2 URLs completes without hanging