### PR TITLE
fix(http): unificar 3 timeouts en 1 capa limpia

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -219,7 +219,8 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
             .include_patterns(opts.crawl.include_patterns.clone())
             .exclude_patterns(opts.crawl.exclude_patterns.clone())
             .ignore_robots(opts.crawl.ignore_robots)
-            .use_sitemap(opts.crawl.use_sitemap);
+            .use_sitemap(opts.crawl.use_sitemap)
+            .timeout_secs(opts.network.timeout_secs);
         if let Some(ref sitemap_url) = opts.crawl.sitemap_url {
             crawler_config = crawler_config.sitemap_url(sitemap_url);
         }
@@ -468,7 +469,8 @@ async fn run_batch(opts: CrawlOptions) -> CliExit {
         .include_patterns(opts.crawl.include_patterns.clone())
         .exclude_patterns(opts.crawl.exclude_patterns.clone())
         .ignore_robots(opts.crawl.ignore_robots)
-        .use_sitemap(opts.crawl.use_sitemap);
+        .use_sitemap(opts.crawl.use_sitemap)
+        .timeout_secs(opts.network.timeout_secs);
     if let Some(ref sitemap_url) = opts.crawl.sitemap_url {
         crawler_config = crawler_config.sitemap_url(sitemap_url);
     }

--- a/crates/webfang_core/src/infrastructure/crawler/http_client.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/http_client.rs
@@ -44,7 +44,6 @@ pub fn create_rate_limited_client(delay_ms: u64) -> Result<Client> {
         .emulation(Emulation::Chrome145)
         .pool_max_idle_per_host(pool_size)
         .pool_idle_timeout(Duration::from_secs(60))
-        .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
         .gzip(true)
         .brotli(true)
@@ -98,17 +97,7 @@ pub async fn fetch_url(url: &str, config: &CrawlerConfig) -> Result<String, Craw
         });
     }
 
-    let text = tokio::time::timeout(Duration::from_secs(config.timeout_secs), response.text())
-        .await
-        .map_err(|_| CrawlError::Network {
-            message: format!(
-                "Response body read timed out after {}s for {}",
-                config.timeout_secs, url
-            ),
-            status_code: None,
-        })?;
-
-    let text = text.map_err(|e| CrawlError::Network {
+    let text = response.text().await.map_err(|e| CrawlError::Network {
         message: e.to_string(),
         status_code: None,
     })?;


### PR DESCRIPTION
Implementa issue #268: unifica las 3 capas de timeout en el HTTP client en 1 sola capa limpia.

## Qué cambia

1. **Elimina el timeout hardcoded de 30s** en `create_rate_limited_client()` (http_client.rs): el timeout del cliente shadoweaba al --timeout-secs del usuario, haciendo que la conexión fallara a los 30s sin importar el valor configurado.

2. **Elimina el wrapper tokio::time::timeout** del body read (fetch_url()): wreq::RequestBuilder::timeout() ya cubre el ciclo de vida completo (resolve DNS + connect TLS + send + receive headers + read body), por lo que el wrapper de Tokio era redundante y potencialmenteconfuso.

3. **Cablea opts.network.timeout_secs** a través del orquestador hasta CrawlerConfig::builder() en prepare_phase() y run_batch() (bug preexistente: batch mode siempre usaba el default de 30s sin importar --timeout-secs).

## Resultado

--timeout-secs ahora controla el timeout de cada request de forma unificada (conexión + headers + body), como el usuario espera. El valor por defecto sigue siendo 30s.

## Criterios de aceptación
- cargo check ✅
- cargo fmt limpio ✅
- cargo nextest run --lib ✅ (118 tests, 0 failures)
- cargo test --test cli_binary --all-features -- test_help_contains_scraper ✅
- test_single_page_custom_timeout_is_used_by_scrape_client ✅