### PR TITLE
fix(crawler): robots URL construction, sitemap max_depth, batch error propagation

### DIFF
--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -195,6 +195,9 @@ impl BatchProcessor {
 ///
 /// Creates a new `CrawlerConfig` for the given URL, copying settings from
 /// the base config but using the specific URL as the seed.
+///
+/// Returns `Err(CrawlError)` if the crawl result has any errors (e.g., timeouts),
+/// ensuring the batch processor correctly counts failed URLs.
 async fn process_single_url(
     url: &str,
     base_config: CrawlerConfig,
@@ -209,9 +212,21 @@ async fn process_single_url(
         .delay_ms(base_config.delay_ms)
         .timeout_secs(base_config.timeout_secs)
         .ignore_robots(base_config.ignore_robots)
+        .exclude_patterns(base_config.exclude_patterns.clone())
+        .include_patterns(base_config.include_patterns.clone())
         .build();
 
-    crate::application::crawler::engine::crawl_site(config).await
+    let result = crate::application::crawler::engine::crawl_site(config).await?;
+
+    // Treat any crawl errors (timeouts, etc.) as failures for batch processing
+    if result.errors > 0 {
+        return Err(CrawlError::Internal(format!(
+            "crawl completed with {} error(s)",
+            result.errors
+        )));
+    }
+
+    Ok(result)
 }
 
 /// Errors that can occur during batch processing

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -523,12 +523,21 @@ async fn crawl_with_sitemap_internal(
     }
 
     // Following own-borrow-over-clone: use Url directly, not String
-    // Use explicit type annotation for type inference
-    // Apply include/exclude patterns from config (Fix: sitemap URLs were bypassing filters)
+    // Apply include/exclude patterns from config (Fix: sitemap URLs were bypassing filters).
+    //
+    // Depth assignment: the seed itself is depth 0; every other sitemap URL is one
+    // hop from the seed, hence depth 1. Filtering by `depth <= max_depth` enforces
+    // the CLI contract "0 = only seed URL" here, because the CLI scrape flow scrapes
+    // whatever discovery returns verbatim — there is no later depth gate (the Engine's
+    // `run_crawl_task` check is a separate, non-CLI code path).
+    let max_depth = config.max_depth;
     let discovered: Vec<DiscoveredUrl> = relevant_urls
         .into_iter()
         .filter(|url| is_allowed(url.as_str(), config))
-        .map(|url| DiscoveredUrl::html(url, 0, base.clone()))
+        .filter_map(|url| {
+            let depth = if url == base { 0 } else { 1 };
+            (depth <= max_depth).then(|| DiscoveredUrl::html(url, depth, base.clone()))
+        })
         .collect();
 
     #[cfg(feature = "otel-metrics")]
@@ -594,9 +603,10 @@ async fn crawl_with_subpath_sitemaps(
         tracing::warn!("no se encontraron sitemaps de subruta para {}", base_url);
         Ok(Vec::new())
     } else {
+        // Sub-path sitemap URLs are at depth 1 (one hop from seed)
         Ok(all_urls
             .into_iter()
-            .map(|url| DiscoveredUrl::html(url, 0, base.clone()))
+            .map(|url| DiscoveredUrl::html(url, 1, base.clone()))
             .collect())
     }
 }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -211,7 +211,7 @@ async fn export_phase(
 /// appropriate `CliExit` error.
 async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
     let urls_to_scrape = if opts.crawl.single_page {
-        plan_urls(true, opts.url.clone(), Vec::new())
+        plan_urls(true, false, opts.url.clone(), Vec::new())
     } else {
         let mut crawler_config = CrawlerConfig::builder(opts.url.clone())
             .max_pages(opts.crawl.max_pages)
@@ -238,7 +238,12 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
             Ok(urls) => urls,
         };
 
-        plan_urls(false, opts.url.clone(), discovered_urls)
+        plan_urls(
+            false,
+            opts.crawl.use_sitemap,
+            opts.url.clone(),
+            discovered_urls,
+        )
     };
 
     let mut scraper_config = ScraperConfig::default()
@@ -538,13 +543,23 @@ fn batch_exit_code(succeeded: usize, failed: usize) -> CliExit {
 
 fn plan_urls(
     single_page: bool,
+    use_sitemap: bool,
     seed_url: url::Url,
     discovered_urls: Vec<url::Url>,
 ) -> Vec<url::Url> {
     if single_page {
         vec![seed_url]
-    } else {
+    } else if use_sitemap {
+        // Sitemap is the source of truth — do not inject the seed URL.
         discovered_urls
+    } else {
+        // DOM discovery: always include the seed URL so it gets crawled
+        // even when link extraction only returns child URLs.
+        let mut urls = discovered_urls;
+        if !urls.contains(&seed_url) {
+            urls.insert(0, seed_url);
+        }
+        urls
     }
 }
 
@@ -617,13 +632,13 @@ mod tests {
             url::Url::parse("https://example.com/blog").unwrap(),
         ];
 
-        let result = plan_urls(true, seed.clone(), discovered);
+        let result = plan_urls(true, false, seed.clone(), discovered);
 
         assert_eq!(result, vec![seed]);
     }
 
     #[test]
-    fn plan_urls_normal_mode_returns_discovered() {
+    fn plan_urls_dom_mode_prepends_seed() {
         let seed = url::Url::parse("https://example.com").unwrap();
         let discovered = vec![
             url::Url::parse("https://example.com/a").unwrap(),
@@ -631,17 +646,35 @@ mod tests {
             url::Url::parse("https://example.com/c").unwrap(),
         ];
 
-        let result = plan_urls(false, seed, discovered.clone());
+        let result = plan_urls(false, false, seed.clone(), discovered.clone());
 
+        // DOM mode: the seed is prepended when absent so it always gets scraped.
+        let mut expected = vec![seed];
+        expected.extend(discovered);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn plan_urls_sitemap_mode_does_not_prepend_seed() {
+        let seed = url::Url::parse("https://example.com").unwrap();
+        let discovered = vec![
+            url::Url::parse("https://example.com/a").unwrap(),
+            url::Url::parse("https://example.com/b").unwrap(),
+        ];
+
+        let result = plan_urls(false, true, seed, discovered.clone());
+
+        // Sitemap mode: the sitemap is the source of truth — seed is NOT injected.
         assert_eq!(result, discovered);
     }
 
     #[test]
-    fn plan_urls_normal_mode_empty_discovered() {
+    fn plan_urls_dom_mode_empty_discovered() {
         let seed = url::Url::parse("https://example.com").unwrap();
-        let result = plan_urls(false, seed, Vec::new());
+        let result = plan_urls(false, false, seed.clone(), Vec::new());
 
-        assert!(result.is_empty());
+        // Even with no discovered URLs, the seed is always included in DOM mode.
+        assert_eq!(result, vec![seed]);
     }
 
     #[test]
@@ -651,21 +684,24 @@ mod tests {
             .map(|i| url::Url::parse(&format!("https://example.com/page{i}")).unwrap())
             .collect();
 
-        let result = plan_urls(true, seed.clone(), discovered);
+        let result = plan_urls(true, false, seed.clone(), discovered);
 
         assert_eq!(result, vec![seed]);
     }
 
     #[test]
-    fn plan_urls_preserves_order() {
+    fn plan_urls_dom_mode_preserves_order() {
         let seed = url::Url::parse("https://example.com").unwrap();
         let urls: Vec<_> = (0..10)
             .map(|i| url::Url::parse(&format!("https://example.com/page{i}")).unwrap())
             .collect();
 
-        let result = plan_urls(false, seed, urls.clone());
+        let result = plan_urls(false, false, seed.clone(), urls.clone());
 
-        assert_eq!(result, urls);
+        // Discovered order is preserved; the seed is prepended when absent.
+        let mut expected = vec![seed];
+        expected.extend(urls);
+        assert_eq!(result, expected);
     }
 
     // ===== batch_exit_code tests =====

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -173,10 +173,6 @@ pub async fn scrape_urls(
             if !is_allowed_by_robots(url_str, domain, &robots_cache).await {
                 info!("Blocked by robots.txt: {}", url_str);
                 observer.on_robots_blocked(url_str).await;
-                failures.push((
-                    url_str.to_string(),
-                    crate::error::ScraperError::Validation("blocked by robots.txt".into()),
-                ));
                 continue;
             }
         }

--- a/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use robotstxt::DefaultMatcher;
+use url::Url;
 
 /// Parsed robots.txt rules for a domain.
 ///
@@ -71,6 +72,19 @@ pub fn parse_crawl_delay(content: &str) -> Option<f64> {
     None
 }
 
+/// Build the robots.txt URL for a page URL, preserving its scheme and port.
+///
+/// The previous implementation hardcoded `https://{domain}/robots.txt`, which
+/// broke robots enforcement for plain-HTTP sites and non-standard ports (the
+/// port was dropped and the scheme forced to https). Deriving the URL from the
+/// page's own origin fixes both. Falls back to the https form if parsing fails.
+fn robots_txt_url(url: &str, domain: &str) -> String {
+    match Url::parse(url) {
+        Ok(parsed) => format!("{}/robots.txt", parsed.origin().ascii_serialization()),
+        Err(_) => format!("https://{domain}/robots.txt"),
+    }
+}
+
 /// Fetch and cache robots.txt rules for a domain.
 ///
 /// On cache miss, fetches `robots.txt` from the domain root using wreq.
@@ -79,7 +93,8 @@ pub fn parse_crawl_delay(content: &str) -> Option<f64> {
 ///
 /// # Arguments
 ///
-/// * `domain` - Domain to fetch robots.txt for
+/// * `domain` - Cache key for the site (typically the bare host)
+/// * `url` - A page URL on the site, used to derive the robots.txt origin
 /// * `cache` - Shared robots.txt rules cache
 ///
 /// # Returns
@@ -94,15 +109,19 @@ pub fn parse_crawl_delay(content: &str) -> Option<f64> {
 /// # #[tokio::main]
 /// # async fn main() {
 /// let cache = new_robots_cache();
-/// let rules = fetch_robots_rules("example.com", &cache).await;
+/// let rules = fetch_robots_rules("example.com", "https://example.com/page", &cache).await;
 /// # }
 /// ```
-pub async fn fetch_robots_rules(domain: &str, cache: &RobotsCache) -> Option<Arc<RobotsRules>> {
+pub async fn fetch_robots_rules(
+    domain: &str,
+    url: &str,
+    cache: &RobotsCache,
+) -> Option<Arc<RobotsRules>> {
     if let Some(rules) = cache.get(domain) {
         return Some(Arc::clone(rules.value()));
     }
 
-    let robots_url = format!("https://{domain}/robots.txt");
+    let robots_url = robots_txt_url(url, domain);
     tracing::debug!("Fetching robots.txt from {}", robots_url);
 
     let content = match wreq::get(&robots_url).send().await {
@@ -164,7 +183,7 @@ pub async fn fetch_robots_rules(domain: &str, cache: &RobotsCache) -> Option<Arc
 /// # }
 /// ```
 pub async fn is_allowed_by_robots(url: &str, domain: &str, cache: &RobotsCache) -> bool {
-    let rules = match fetch_robots_rules(domain, cache).await {
+    let rules = match fetch_robots_rules(domain, url, cache).await {
         Some(r) => r,
         None => return true, // fail-open
     };

--- a/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -1,13 +1,9 @@
 ---
 source: crates/webfang_core/../../tests/behavioral/main.rs
-assertion_line: 43
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
-
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:201
+    at crates/webfang_core/src/cli/scrape_flow.rs:197
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped

--- a/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/webfang_core/../../tests/behavioral/main.rs
-assertion_line: 43
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (http://127.0.0.1:<PORT>/robots.txt): client error (Connect)
+    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:144
 
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
-    at crates/webfang_core/src/cli/scrape_flow.rs:201
+    at crates/webfang_core/src/cli/scrape_flow.rs:197
 
 Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← client error (Connect)  ← tcp connect error  ← Connection refused (os error 111)
 No pages were successfully scraped

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -176,8 +176,15 @@ async fn test_single_page_requests_only_seed_and_writes_output() {
         .received_requests()
         .await
         .expect("request recording should be enabled");
-    assert_eq!(received_requests.len(), 1);
-    assert_eq!(received_requests[0].url.path(), "/");
+    // Filter out infrastructure requests (robots.txt) — we only care about
+    // page fetches. The robots_utils fix now correctly fetches robots.txt
+    // from the mock server origin (previously it hardcoded https:// and failed).
+    let page_requests: Vec<_> = received_requests
+        .iter()
+        .filter(|r| r.url.path() != "/robots.txt")
+        .collect();
+    assert_eq!(page_requests.len(), 1);
+    assert_eq!(page_requests[0].url.path(), "/");
 
     let output_entries = std::fs::read_dir(output_dir.path())
         .expect("read output dir")

--- a/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -3,11 +3,8 @@ source: crates/webfang_core/../../tests/cli_binary_test.rs
 assertion_line: 218
 expression: "redact_nondeterministic(output_dir.path(), &stderr)"
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
-
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:201
+    at crates/webfang_core/src/cli/scrape_flow.rs:197
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped


### PR DESCRIPTION
## Summary

Production bug fixes discovered while implementing behavioral tests for #270/#271.

### Fixes

1. **robots_utils**: Derive robots.txt URL from page origin (`scheme://host:port`) instead of hardcoding `https://{domain}/robots.txt` which dropped the port and forced https. This broke robots enforcement for **all** HTTP/custom-port sites (fail-open: disallowed URLs were fetched anyway).

2. **discovery**: Enforce `max_depth` in `crawl_with_sitemap_internal` — seed at depth 0, sitemap URLs at depth 1, filter by `depth <= max_depth`. Previously sitemap discovery ignored max_depth entirely.

3. **orchestrator**: `plan_urls` only prepends seed URL in DOM scraping mode, not sitemap mode. The sitemap is the source of truth for URL discovery — injecting the seed caused 404 failures when the seed wasn't in the sitemap.

4. **scrape_flow**: Robots-blocked URLs are skipped silently, not counted as failures. They represent expected behavior, not errors.

5. **processor**: Propagate `exclude_patterns`/`include_patterns` to per-URL `CrawlerConfig` in batch mode. Count crawl errors as batch failures for correct exit codes (69 on partial/all failures).

### Test updates
- Updated 3 snapshots affected by robots_utils fix (robots.txt warning removed, line numbers shifted)
- Updated `cli_binary_test.rs` to filter infrastructure requests (robots.txt) from page-fetch assertions
- Updated `plan_urls` unit tests for new `use_sitemap` parameter + added sitemap-mode test

### Verification
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt` clean
- `cargo nextest run -p webfang_core` — 0 failures

Closes #270 (root causes fixed; diagnostic tests in follow-up PR)