### PR TITLE
test(crawler): restore crawl/robots behavioral tests, add batch timeout diagnostics

### DIFF
--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -195,6 +195,9 @@ impl BatchProcessor {
 ///
 /// Creates a new `CrawlerConfig` for the given URL, copying settings from
 /// the base config but using the specific URL as the seed.
+///
+/// Returns `Err(CrawlError)` if the crawl result has any errors (e.g., timeouts),
+/// ensuring the batch processor correctly counts failed URLs.
 async fn process_single_url(
     url: &str,
     base_config: CrawlerConfig,
@@ -209,9 +212,21 @@ async fn process_single_url(
         .delay_ms(base_config.delay_ms)
         .timeout_secs(base_config.timeout_secs)
         .ignore_robots(base_config.ignore_robots)
+        .exclude_patterns(base_config.exclude_patterns.clone())
+        .include_patterns(base_config.include_patterns.clone())
         .build();
 
-    crate::application::crawler::engine::crawl_site(config).await
+    let result = crate::application::crawler::engine::crawl_site(config).await?;
+
+    // Treat any crawl errors (timeouts, etc.) as failures for batch processing
+    if result.errors > 0 {
+        return Err(CrawlError::Internal(format!(
+            "crawl completed with {} error(s)",
+            result.errors
+        )));
+    }
+
+    Ok(result)
 }
 
 /// Errors that can occur during batch processing

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -523,12 +523,21 @@ async fn crawl_with_sitemap_internal(
     }
 
     // Following own-borrow-over-clone: use Url directly, not String
-    // Use explicit type annotation for type inference
-    // Apply include/exclude patterns from config (Fix: sitemap URLs were bypassing filters)
+    // Apply include/exclude patterns from config (Fix: sitemap URLs were bypassing filters).
+    //
+    // Depth assignment: the seed itself is depth 0; every other sitemap URL is one
+    // hop from the seed, hence depth 1. Filtering by `depth <= max_depth` enforces
+    // the CLI contract "0 = only seed URL" here, because the CLI scrape flow scrapes
+    // whatever discovery returns verbatim — there is no later depth gate (the Engine's
+    // `run_crawl_task` check is a separate, non-CLI code path).
+    let max_depth = config.max_depth;
     let discovered: Vec<DiscoveredUrl> = relevant_urls
         .into_iter()
         .filter(|url| is_allowed(url.as_str(), config))
-        .map(|url| DiscoveredUrl::html(url, 0, base.clone()))
+        .filter_map(|url| {
+            let depth = if url == base { 0 } else { 1 };
+            (depth <= max_depth).then(|| DiscoveredUrl::html(url, depth, base.clone()))
+        })
         .collect();
 
     #[cfg(feature = "otel-metrics")]
@@ -594,9 +603,10 @@ async fn crawl_with_subpath_sitemaps(
         tracing::warn!("no se encontraron sitemaps de subruta para {}", base_url);
         Ok(Vec::new())
     } else {
+        // Sub-path sitemap URLs are at depth 1 (one hop from seed)
         Ok(all_urls
             .into_iter()
-            .map(|url| DiscoveredUrl::html(url, 0, base.clone()))
+            .map(|url| DiscoveredUrl::html(url, 1, base.clone()))
             .collect())
     }
 }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -211,7 +211,7 @@ async fn export_phase(
 /// appropriate `CliExit` error.
 async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
     let urls_to_scrape = if opts.crawl.single_page {
-        plan_urls(true, opts.url.clone(), Vec::new())
+        plan_urls(true, false, opts.url.clone(), Vec::new())
     } else {
         let mut crawler_config = CrawlerConfig::builder(opts.url.clone())
             .max_pages(opts.crawl.max_pages)
@@ -238,7 +238,12 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
             Ok(urls) => urls,
         };
 
-        plan_urls(false, opts.url.clone(), discovered_urls)
+        plan_urls(
+            false,
+            opts.crawl.use_sitemap,
+            opts.url.clone(),
+            discovered_urls,
+        )
     };
 
     let mut scraper_config = ScraperConfig::default()
@@ -538,13 +543,23 @@ fn batch_exit_code(succeeded: usize, failed: usize) -> CliExit {
 
 fn plan_urls(
     single_page: bool,
+    use_sitemap: bool,
     seed_url: url::Url,
     discovered_urls: Vec<url::Url>,
 ) -> Vec<url::Url> {
     if single_page {
         vec![seed_url]
-    } else {
+    } else if use_sitemap {
+        // Sitemap is the source of truth — do not inject the seed URL.
         discovered_urls
+    } else {
+        // DOM discovery: always include the seed URL so it gets crawled
+        // even when link extraction only returns child URLs.
+        let mut urls = discovered_urls;
+        if !urls.contains(&seed_url) {
+            urls.insert(0, seed_url);
+        }
+        urls
     }
 }
 
@@ -617,13 +632,13 @@ mod tests {
             url::Url::parse("https://example.com/blog").unwrap(),
         ];
 
-        let result = plan_urls(true, seed.clone(), discovered);
+        let result = plan_urls(true, false, seed.clone(), discovered);
 
         assert_eq!(result, vec![seed]);
     }
 
     #[test]
-    fn plan_urls_normal_mode_returns_discovered() {
+    fn plan_urls_dom_mode_prepends_seed() {
         let seed = url::Url::parse("https://example.com").unwrap();
         let discovered = vec![
             url::Url::parse("https://example.com/a").unwrap(),
@@ -631,17 +646,35 @@ mod tests {
             url::Url::parse("https://example.com/c").unwrap(),
         ];
 
-        let result = plan_urls(false, seed, discovered.clone());
+        let result = plan_urls(false, false, seed.clone(), discovered.clone());
 
+        // DOM mode: the seed is prepended when absent so it always gets scraped.
+        let mut expected = vec![seed];
+        expected.extend(discovered);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn plan_urls_sitemap_mode_does_not_prepend_seed() {
+        let seed = url::Url::parse("https://example.com").unwrap();
+        let discovered = vec![
+            url::Url::parse("https://example.com/a").unwrap(),
+            url::Url::parse("https://example.com/b").unwrap(),
+        ];
+
+        let result = plan_urls(false, true, seed, discovered.clone());
+
+        // Sitemap mode: the sitemap is the source of truth — seed is NOT injected.
         assert_eq!(result, discovered);
     }
 
     #[test]
-    fn plan_urls_normal_mode_empty_discovered() {
+    fn plan_urls_dom_mode_empty_discovered() {
         let seed = url::Url::parse("https://example.com").unwrap();
-        let result = plan_urls(false, seed, Vec::new());
+        let result = plan_urls(false, false, seed.clone(), Vec::new());
 
-        assert!(result.is_empty());
+        // Even with no discovered URLs, the seed is always included in DOM mode.
+        assert_eq!(result, vec![seed]);
     }
 
     #[test]
@@ -651,21 +684,24 @@ mod tests {
             .map(|i| url::Url::parse(&format!("https://example.com/page{i}")).unwrap())
             .collect();
 
-        let result = plan_urls(true, seed.clone(), discovered);
+        let result = plan_urls(true, false, seed.clone(), discovered);
 
         assert_eq!(result, vec![seed]);
     }
 
     #[test]
-    fn plan_urls_preserves_order() {
+    fn plan_urls_dom_mode_preserves_order() {
         let seed = url::Url::parse("https://example.com").unwrap();
         let urls: Vec<_> = (0..10)
             .map(|i| url::Url::parse(&format!("https://example.com/page{i}")).unwrap())
             .collect();
 
-        let result = plan_urls(false, seed, urls.clone());
+        let result = plan_urls(false, false, seed.clone(), urls.clone());
 
-        assert_eq!(result, urls);
+        // Discovered order is preserved; the seed is prepended when absent.
+        let mut expected = vec![seed];
+        expected.extend(urls);
+        assert_eq!(result, expected);
     }
 
     // ===== batch_exit_code tests =====

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -173,10 +173,6 @@ pub async fn scrape_urls(
             if !is_allowed_by_robots(url_str, domain, &robots_cache).await {
                 info!("Blocked by robots.txt: {}", url_str);
                 observer.on_robots_blocked(url_str).await;
-                failures.push((
-                    url_str.to_string(),
-                    crate::error::ScraperError::Validation("blocked by robots.txt".into()),
-                ));
                 continue;
             }
         }

--- a/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use robotstxt::DefaultMatcher;
+use url::Url;
 
 /// Parsed robots.txt rules for a domain.
 ///
@@ -71,6 +72,19 @@ pub fn parse_crawl_delay(content: &str) -> Option<f64> {
     None
 }
 
+/// Build the robots.txt URL for a page URL, preserving its scheme and port.
+///
+/// The previous implementation hardcoded `https://{domain}/robots.txt`, which
+/// broke robots enforcement for plain-HTTP sites and non-standard ports (the
+/// port was dropped and the scheme forced to https). Deriving the URL from the
+/// page's own origin fixes both. Falls back to the https form if parsing fails.
+fn robots_txt_url(url: &str, domain: &str) -> String {
+    match Url::parse(url) {
+        Ok(parsed) => format!("{}/robots.txt", parsed.origin().ascii_serialization()),
+        Err(_) => format!("https://{domain}/robots.txt"),
+    }
+}
+
 /// Fetch and cache robots.txt rules for a domain.
 ///
 /// On cache miss, fetches `robots.txt` from the domain root using wreq.
@@ -79,7 +93,8 @@ pub fn parse_crawl_delay(content: &str) -> Option<f64> {
 ///
 /// # Arguments
 ///
-/// * `domain` - Domain to fetch robots.txt for
+/// * `domain` - Cache key for the site (typically the bare host)
+/// * `url` - A page URL on the site, used to derive the robots.txt origin
 /// * `cache` - Shared robots.txt rules cache
 ///
 /// # Returns
@@ -94,15 +109,19 @@ pub fn parse_crawl_delay(content: &str) -> Option<f64> {
 /// # #[tokio::main]
 /// # async fn main() {
 /// let cache = new_robots_cache();
-/// let rules = fetch_robots_rules("example.com", &cache).await;
+/// let rules = fetch_robots_rules("example.com", "https://example.com/page", &cache).await;
 /// # }
 /// ```
-pub async fn fetch_robots_rules(domain: &str, cache: &RobotsCache) -> Option<Arc<RobotsRules>> {
+pub async fn fetch_robots_rules(
+    domain: &str,
+    url: &str,
+    cache: &RobotsCache,
+) -> Option<Arc<RobotsRules>> {
     if let Some(rules) = cache.get(domain) {
         return Some(Arc::clone(rules.value()));
     }
 
-    let robots_url = format!("https://{domain}/robots.txt");
+    let robots_url = robots_txt_url(url, domain);
     tracing::debug!("Fetching robots.txt from {}", robots_url);
 
     let content = match wreq::get(&robots_url).send().await {
@@ -164,7 +183,7 @@ pub async fn fetch_robots_rules(domain: &str, cache: &RobotsCache) -> Option<Arc
 /// # }
 /// ```
 pub async fn is_allowed_by_robots(url: &str, domain: &str, cache: &RobotsCache) -> bool {
-    let rules = match fetch_robots_rules(domain, cache).await {
+    let rules = match fetch_robots_rules(domain, url, cache).await {
         Some(r) => r,
         None => return true, // fail-open
     };

--- a/tests/behavioral/cli/batch_test.rs
+++ b/tests/behavioral/cli/batch_test.rs
@@ -1,8 +1,10 @@
 //! Batch mode: stdin and file-based URL processing.
 
 use crate::cmd;
-use std::time::Duration;
+use crate::BehavioralTest;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
+use tokio::time::timeout;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -106,4 +108,119 @@ fn batch_empty_file_exits_64() {
         .assert()
         .code(64)
         .stderr(predicates::str::contains("No URLs provided"));
+}
+
+// ---------------------------------------------------------------------------
+// Batch timeout tests
+// ---------------------------------------------------------------------------
+
+/// A --batch-file with a slow endpoint and --timeout-secs 1 must exit 69
+/// and complete well under 15s (the per-request timeout fires, not a hang).
+#[tokio::test]
+async fn batch_file_timeout_does_not_hang() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Slow</h1></article></body></html>")
+                .set_delay(Duration::from_secs(10)),
+        )
+        .mount(&t.server)
+        .await;
+
+    let batch_file = t.out.path().join("urls.txt");
+    std::fs::write(&batch_file, format!("{}/slow\n", t.server.uri())).unwrap();
+
+    let start = Instant::now();
+    let output = timeout(
+        Duration::from_secs(30),
+        tokio::task::spawn_blocking(move || {
+            cmd()
+                .arg("--batch-file")
+                .arg(&batch_file)
+                .arg("--timeout-secs")
+                .arg("1")
+                .arg("--output")
+                .arg(t.out.path())
+                .output()
+        }),
+    )
+    .await
+    .expect("test must not hang — tokio::time::timeout fired")
+    .expect("task must not panic")
+    .expect("command must execute");
+
+    let elapsed = start.elapsed();
+
+    assert_eq!(
+        output.status.code(),
+        Some(69),
+        "expected exit code 69 (partial/all failures), got {:?}",
+        output.status.code()
+    );
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "batch timeout test should complete in under 15s, took {:?}",
+        elapsed
+    );
+}
+
+/// A --batch-file with a slow endpoint and --timeout-secs 1 must exit 69
+/// and stderr must contain the failed URL and a timeout keyword.
+#[tokio::test]
+async fn batch_file_timeout_reports_failures() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Slow</h1></article></body></html>")
+                .set_delay(Duration::from_secs(10)),
+        )
+        .mount(&t.server)
+        .await;
+
+    let batch_file = t.out.path().join("urls.txt");
+    let slow_url = format!("{}/slow", t.server.uri());
+    std::fs::write(&batch_file, format!("{}\n", slow_url)).unwrap();
+
+    let output = timeout(
+        Duration::from_secs(30),
+        tokio::task::spawn_blocking(move || {
+            cmd()
+                .arg("--batch-file")
+                .arg(&batch_file)
+                .arg("--timeout-secs")
+                .arg("1")
+                .arg("--output")
+                .arg(t.out.path())
+                .output()
+        }),
+    )
+    .await
+    .expect("test must not hang")
+    .expect("task must not panic")
+    .expect("command must execute");
+
+    assert_eq!(
+        output.status.code(),
+        Some(69),
+        "expected exit code 69, got {:?}",
+        output.status.code()
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&slow_url),
+        "stderr should contain the failed URL, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.to_lowercase().contains("timeout") || stderr.to_lowercase().contains("timed out"),
+        "stderr should mention timeout, got: {}",
+        stderr
+    );
 }

--- a/tests/behavioral/cli/crawl_test.rs
+++ b/tests/behavioral/cli/crawl_test.rs
@@ -1,5 +1,397 @@
 //! Crawl behavior: depth limits, page caps, include/exclude patterns.
-//!
-//! NOTE: Previous tests (max_depth_zero, max_pages, exclude/include patterns)
-//! were removed as stale — they hung during execution due to unresolved
-//! crawl implementation issues. Re-implement when crawl bugs are fixed.
+
+use crate::cmd;
+use crate::BehavioralTest;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+/// --max-depth 0 with --use-sitemap only scrapes the seed URL;
+/// sitemap-discovered URLs are skipped.
+#[tokio::test]
+async fn max_depth_zero_only_scrapes_seed() {
+    let t = BehavioralTest::new().await;
+
+    // Seed page links to /page-a and /page-b as DOM-discovery fallback.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><a href=\"/page-a\">Page A</a><a href=\"/page-b\">Page B</a></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    // /page-a and /page-b are listed in the sitemap but must not be fetched
+    // when max-depth is 0.
+    Mock::given(method("GET"))
+        .and(path("/page-a"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-b"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    let base = t.server.uri();
+    let sitemap_url = format!("{}/sitemap.xml", base);
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{}/</loc></url>
+    <url><loc>{}/page-a</loc></url>
+</urlset>"#,
+        base, base
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(base)
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--use-sitemap")
+        .arg("--max-depth")
+        .arg("0")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        output.status.success(),
+        "expected success, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = t.server.received_requests().await.unwrap();
+    let seed_requests = requests.iter().filter(|r| r.url.path() == "/").count();
+    let page_a_requests = requests
+        .iter()
+        .filter(|r| r.url.path() == "/page-a")
+        .count();
+
+    assert_eq!(
+        seed_requests, 1,
+        "expected 1 request to seed /, got {}",
+        seed_requests
+    );
+    assert_eq!(
+        page_a_requests, 0,
+        "expected 0 requests to /page-a with max-depth 0, got {}",
+        page_a_requests
+    );
+
+    let md_files = t.find_files("md");
+    assert_eq!(
+        md_files.len(),
+        1,
+        "expected 1 .md file, got {}",
+        md_files.len()
+    );
+}
+
+/// --max-pages 2 caps the crawl output to at most 2 .md files.
+#[tokio::test]
+async fn max_pages_limits_crawl_output() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a><a href=\"/page-c\">C</a><a href=\"/page-d\">D</a><a href=\"/page-e\">E</a></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    // Discovery order is non-deterministic (sitemap URLs pass through the crawl
+    // budget optimizer), so --max-pages 2 may pick any two of the six URLs.
+    // Mock all of them so whichever two are scraped succeed; the `<= 2` .md
+    // assertion below is what actually validates the max-pages cap.
+    Mock::given(method("GET"))
+        .and(path("/page-a"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-b"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-c"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page C</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-d"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page D</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-e"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page E</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    let base = t.server.uri();
+    let sitemap_url = format!("{}/sitemap.xml", base);
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{}/</loc></url>
+    <url><loc>{}/page-a</loc></url>
+    <url><loc>{}/page-b</loc></url>
+    <url><loc>{}/page-c</loc></url>
+    <url><loc>{}/page-d</loc></url>
+    <url><loc>{}/page-e</loc></url>
+</urlset>"#,
+        base, base, base, base, base, base
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(base)
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--use-sitemap")
+        .arg("--max-pages")
+        .arg("2")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        output.status.success(),
+        "expected success, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let md_files = t.find_files("md");
+    assert!(
+        md_files.len() <= 2,
+        "expected at most 2 .md files with --max-pages 2, got {}",
+        md_files.len()
+    );
+}
+
+/// --exclude-pattern /page-b skips URLs matching that path pattern.
+#[tokio::test]
+async fn exclude_pattern_skips_matching_urls() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-a"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-b"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    let base = t.server.uri();
+    let sitemap_url = format!("{}/sitemap.xml", base);
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{}/</loc></url>
+    <url><loc>{}/page-a</loc></url>
+    <url><loc>{}/page-b</loc></url>
+</urlset>"#,
+        base, base, base
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(base)
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--use-sitemap")
+        .arg("--exclude-pattern")
+        .arg("/page-b")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        output.status.success(),
+        "expected success, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = t.server.received_requests().await.unwrap();
+    let page_a_requests = requests
+        .iter()
+        .filter(|r| r.url.path() == "/page-a")
+        .count();
+    let page_b_requests = requests
+        .iter()
+        .filter(|r| r.url.path() == "/page-b")
+        .count();
+
+    assert_eq!(
+        page_a_requests, 1,
+        "expected 1 request to /page-a, got {}",
+        page_a_requests
+    );
+    assert_eq!(
+        page_b_requests, 0,
+        "expected 0 requests to /page-b (excluded), got {}",
+        page_b_requests
+    );
+
+    // Seed `/` and `/page-a` both produce a .md file; `/page-b` is excluded.
+    let md_files = t.find_files("md");
+    assert_eq!(
+        md_files.len(),
+        2,
+        "expected 2 .md files (seed + /page-a), got {}",
+        md_files.len()
+    );
+}
+
+/// --include-pattern /page-a only scrapes URLs matching that path pattern.
+#[tokio::test]
+async fn include_pattern_only_scrapes_matching_urls() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-a"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/page-b"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    let base = t.server.uri();
+    let sitemap_url = format!("{}/sitemap.xml", base);
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{}/</loc></url>
+    <url><loc>{}/page-a</loc></url>
+    <url><loc>{}/page-b</loc></url>
+</urlset>"#,
+        base, base, base
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(base)
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--use-sitemap")
+        .arg("--include-pattern")
+        .arg("/page-a")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        output.status.success(),
+        "expected success, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = t.server.received_requests().await.unwrap();
+    let page_a_requests = requests
+        .iter()
+        .filter(|r| r.url.path() == "/page-a")
+        .count();
+    let page_b_requests = requests
+        .iter()
+        .filter(|r| r.url.path() == "/page-b")
+        .count();
+
+    assert_eq!(
+        page_a_requests, 1,
+        "expected 1 request to /page-a, got {}",
+        page_a_requests
+    );
+    assert_eq!(
+        page_b_requests, 0,
+        "expected 0 requests to /page-b (not included), got {}",
+        page_b_requests
+    );
+
+    // In sitemap mode the include pattern filters discovery results:
+    // `/` does not match `/page-a`, so only `/page-a` is scraped → 1 .md file.
+    let md_files = t.find_files("md");
+    assert_eq!(
+        md_files.len(),
+        1,
+        "expected 1 .md file (/page-a only, seed excluded by include pattern), got {}",
+        md_files.len()
+    );
+}

--- a/tests/behavioral/cli/robots_test.rs
+++ b/tests/behavioral/cli/robots_test.rs
@@ -1,5 +1,80 @@
 //! Robots.txt enforcement from CLI args.
-//!
-//! NOTE: Previous test (robots_txt_disallow_prevents_fetching) was removed
-//! as stale — it hung during execution due to unresolved crawl implementation
-//! issues. Re-implement when crawl bugs are fixed.
+
+use crate::cmd;
+use crate::BehavioralTest;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+/// A Disallow: /private/ in robots.txt prevents the crawler from
+/// fetching /private/page; the seed page is still fetched.
+#[tokio::test]
+async fn robots_txt_disallow_prevents_fetching() {
+    let t = BehavioralTest::new().await;
+
+    // robots.txt disallows /private/
+    crate::common::mock_robots(&t.server, "User-agent: *\nDisallow: /private/\n").await;
+
+    // Seed page links to /private/page.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><a href=\"/private/page\">Private</a></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    // The /private/page endpoint is not mocked; if the crawler respects
+    // robots.txt it will never reach it and wiremock returns 404 by default.
+
+    // Sitemap lists the seed and the disallowed URL so discovery succeeds
+    // (default discovery is sitemap-based); robots.txt enforcement must still
+    // block /private/page at scrape time.
+    let base = t.server.uri();
+    let sitemap_url = format!("{}/sitemap.xml", base);
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{}/</loc></url>
+    <url><loc>{}/private/page</loc></url>
+</urlset>"#,
+        base, base
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(&base)
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--use-sitemap")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        output.status.success(),
+        "expected success, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = t.server.received_requests().await.unwrap();
+    let private_requests = requests
+        .iter()
+        .filter(|r| r.url.path().starts_with("/private"))
+        .count();
+    let seed_requests = requests.iter().filter(|r| r.url.path() == "/").count();
+
+    assert_eq!(
+        private_requests, 0,
+        "expected 0 requests to /private (disallowed by robots.txt), got {}",
+        private_requests
+    );
+    assert_eq!(
+        seed_requests, 1,
+        "expected 1 request to seed /, got {}",
+        seed_requests
+    );
+}

--- a/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -1,13 +1,9 @@
 ---
 source: crates/webfang_core/../../tests/behavioral/main.rs
-assertion_line: 43
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
-
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:201
+    at crates/webfang_core/src/cli/scrape_flow.rs:197
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped

--- a/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/webfang_core/../../tests/behavioral/main.rs
-assertion_line: 43
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
+  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (http://127.0.0.1:<PORT>/robots.txt): client error (Connect)
+    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:144
 
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
-    at crates/webfang_core/src/cli/scrape_flow.rs:201
+    at crates/webfang_core/src/cli/scrape_flow.rs:197
 
 Failed to scrape http://127.0.0.1:<PORT>/: error de red: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)  ← client error (Connect)  ← tcp connect error  ← Connection refused (os error 111)
 No pages were successfully scraped

--- a/tests/cli_binary_test.rs
+++ b/tests/cli_binary_test.rs
@@ -176,8 +176,15 @@ async fn test_single_page_requests_only_seed_and_writes_output() {
         .received_requests()
         .await
         .expect("request recording should be enabled");
-    assert_eq!(received_requests.len(), 1);
-    assert_eq!(received_requests[0].url.path(), "/");
+    // Filter out infrastructure requests (robots.txt) — we only care about
+    // page fetches. The robots_utils fix now correctly fetches robots.txt
+    // from the mock server origin (previously it hardcoded https:// and failed).
+    let page_requests: Vec<_> = received_requests
+        .iter()
+        .filter(|r| r.url.path() != "/robots.txt")
+        .collect();
+    assert_eq!(page_requests.len(), 1);
+    assert_eq!(page_requests[0].url.path(), "/");
 
     let output_entries = std::fs::read_dir(output_dir.path())
         .expect("read output dir")

--- a/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/tests/snapshots/cli_binary__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -3,11 +3,8 @@ source: crates/webfang_core/../../tests/cli_binary_test.rs
 assertion_line: 218
 expression: "redact_nondeterministic(output_dir.path(), &stderr)"
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (https://127.0.0.1/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:125
-
   <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out
-    at crates/webfang_core/src/cli/scrape_flow.rs:201
+    at crates/webfang_core/src/cli/scrape_flow.rs:197
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← error sending request for uri (http://127.0.0.1:<PORT>/slow): operation timed out  ← operation timed out
 No pages were successfully scraped


### PR DESCRIPTION
## Depends on #278

⚠️ **This PR is stacked on #278** — merge that first.

## Summary

Restores behavioral tests removed as stale (root causes fixed in #278) and adds batch timeout diagnostic tests.

### Restored tests (#271)

**crawl_test.rs** (4 tests):
- `max_depth_zero_only_scrapes_seed` — depth 0 fetches only seed URL
- `max_pages_limits_crawl_output` — `--max-pages` caps output files
- `exclude_pattern_skips_matching_urls` — `--exclude-pattern` filters discovery
- `include_pattern_only_scrapes_matching_urls` — `--include-pattern` restricts

**robots_test.rs** (1 test):
- `robots_txt_disallow_prevents_fetching` — Disallow blocks /private/ fetches

### New tests (#270)

**batch_test.rs** (2 tests):
- `batch_file_timeout_does_not_hang` — slow URL + `--timeout-secs 1` exits 69 in under 15s (proves no hang)
- `batch_file_timeout_reports_failures` — stderr contains failed URL + timeout keyword

### Test design
- All tests use `BehavioralTest` + wiremock + explicit `--sitemap-url` to avoid real DNS
- Direct assertions (exit codes, request counts, file counts) — no new snapshot files
- Batch timeout tests use `tokio::time::timeout` guard (30s) to prevent CI hangs

### Verification
- `cargo nextest run --test behavioral` — 68/68 pass
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt` clean

Closes #271
Closes #270