### PR TITLE
ci: add PR template and PR validation workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Linked Issue
+
+<!-- REQUIRED — use one of: Closes #N / Fixes #N / Resolves #N -->
+Closes #
+
+## PR Type
+
+<!-- Check exactly ONE, then add the matching label -->
+- [ ] Bug fix (`type:bug`)
+- [ ] New feature (`type:feature`)
+- [ ] Documentation only (`type:docs`)
+- [ ] Code refactoring (`type:refactor`)
+- [ ] Maintenance / tooling (`type:chore`)
+- [ ] Breaking change (`type:breaking-change`)
+
+## Summary
+
+<!-- 1-3 bullet points: what does this PR do and why -->
+-
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `path/to/file` | what changed |
+
+## Test Plan
+
+<!-- Adapt to the change. For Rust work: -->
+- [ ] `cargo fmt --check` clean
+- [ ] `cargo clippy -- -D warnings` clean
+- [ ] `cargo nextest run` passes
+- [ ] Manually verified the affected functionality
+
+## Contributor Checklist
+
+- [ ] Linked an issue with `Closes/Fixes/Resolves #N`
+- [ ] Added exactly one `type:*` label
+- [ ] Conventional commit format (`type(scope): description`)
+- [ ] No `Co-Authored-By` / AI attribution trailers
+- [ ] Docs updated if behavior changed

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,47 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require linked issue
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if ! printf '%s' "$BODY" | grep -qiE '(closes|fixes|resolves) #[0-9]+'; then
+            echo "::error::El cuerpo del PR debe vincular una issue con 'Closes #N', 'Fixes #N' o 'Resolves #N'."
+            exit 1
+          fi
+          echo "OK: issue vinculada."
+
+      - name: Require exactly one type:* label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          count=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            --jq '[.labels[].name | select(startswith("type:"))] | length')
+          if [ "$count" -ne 1 ]; then
+            echo "::error::El PR debe tener exactamente un label 'type:*' (encontrados: $count)."
+            exit 1
+          fi
+          echo "OK: label type:* presente."
+
+      - name: Require conventional branch name
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if ! printf '%s' "$HEAD_REF" | grep -qE '^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)/[a-z0-9._-]+$'; then
+            echo "::error::La rama '$HEAD_REF' debe seguir el patron type/description (ej: fix/mi-bug)."
+            exit 1
+          fi
+          echo "OK: nombre de rama."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,7 +467,7 @@ Always use `webfang_path()` from `tests/common/cli_harness.rs`, which:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **webfang** (7702 symbols, 18244 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **webfang** (7815 symbols, 18655 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 


### PR DESCRIPTION
Closes #284

## Summary

- Add a pull request template (`.github/PULL_REQUEST_TEMPLATE.md`) with linked-issue, PR-type, summary, changes, test-plan, and contributor-checklist sections.
- Add a PR validation workflow (`.github/workflows/pr-validation.yml`) that enforces on every `pull_request`: a linked issue (`Closes/Fixes/Resolves #N`), exactly one `type:*` label, and a conventional branch name (`type/description`).
- Create the missing `type:*` labels: `type:bug`, `type:docs`, `type:breaking-change` (repo already had `type:chore`, `type:feature`, `type:refactor`).

## PR Type

- [x] Maintenance / tooling (`type:chore`)

## Changes

| File | Change |
|------|--------|
| `.github/PULL_REQUEST_TEMPLATE.md` | New PR template (linked issue, type checkboxes, summary, changes table, cargo test plan, contributor checklist) |
| `.github/workflows/pr-validation.yml` | New workflow validating issue linkage + exactly one `type:*` label + conventional branch name (Spanish error messages, `pull-requests: read` permission) |
| repo labels | Created `type:bug`, `type:docs`, `type:breaking-change` |

## Test Plan

- [x] Workflow YAML validated (`python3 yaml.safe_load` → OK)
- [x] This PR itself exercises the new workflow — GitHub runs a workflow added in a PR against that same PR, so the `PR Validation` check below is the live test
- [x] No Rust code touched; `cargo` gates unaffected

## Notes

- `status:approved` is deliberately NOT enforced (maintainer decision — matches current repo usage where issues like #269/#270 carry only `bug`).
- No shellcheck reference (this is a Rust project).
