### PR TITLE
fix(crawler): wire --timeout-secs into WreqDownloader, ObscuraDownloader, and sitemap discovery

### DIFF
--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -225,6 +225,10 @@ required-features = ["ui"]
 name = "progress_e2e_wiring"
 path = "../../tests/progress_e2e_wiring.rs"
 
+[[test]]
+name = "engine_js_strategy_timeout"
+path = "../../tests/engine_js_strategy_timeout_test.rs"
+
 [lints.clippy]
 doc_markdown = "allow"
 uninlined_format_args = "allow"

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -3,6 +3,8 @@
 //! Functions for discovering URLs from websites via sitemaps or DOM scraping.
 //! Part of the TUI workflow: discover → select → scrape.
 
+use std::time::Duration;
+
 use anyhow::Result;
 use tracing::{debug, info, instrument, span, warn, Level};
 use url::Url;
@@ -454,6 +456,13 @@ async fn crawl_with_sitemap_internal(
 ) -> Result<Vec<DiscoveredUrl>, CrawlError> {
     info!("Crawling with sitemap for {}", base_url);
 
+    let discovery_client = wreq::Client::builder()
+        .emulation(wreq_util::Emulation::Chrome145)
+        .timeout(Duration::from_secs(config.timeout_secs))
+        .connect_timeout(Duration::from_secs(config.timeout_secs.min(10)))
+        .build()
+        .map_err(|e| CrawlError::Internal(format!("failed to build discovery client: {e}")))?;
+
     // Use default batch size (10,000) - SitemapConfig handles pagination
     // CrawlerConfig doesn't have batch_size, we use SitemapConfig for that
     const DEFAULT_BATCH_SIZE: usize = 10_000;
@@ -466,7 +475,7 @@ async fn crawl_with_sitemap_internal(
         },
         _ => {
             tracing::info!("Auto-discovering sitemap URL for {}", base_url);
-            match discover_sitemap_url(base_url).await {
+            match discover_sitemap_url(base_url, &discovery_client).await {
                 Ok(url) => {
                     tracing::info!("Discovered sitemap URL: {}", url);
                     url
@@ -519,7 +528,8 @@ async fn crawl_with_sitemap_internal(
             sitemap_url,
             target_path
         );
-        return crawl_with_subpath_sitemaps(base_url, &base, &parser, 3, 0).await;
+        return crawl_with_subpath_sitemaps(base_url, &base, &parser, 3, 0, &discovery_client)
+            .await;
     }
 
     // Following own-borrow-over-clone: use Url directly, not String
@@ -560,6 +570,7 @@ async fn crawl_with_subpath_sitemaps(
     parser: &SitemapParser,
     max_depth: usize,
     current_depth: usize,
+    client: &wreq::Client,
 ) -> Result<Vec<DiscoveredUrl>, CrawlError> {
     if current_depth >= max_depth {
         tracing::warn!(
@@ -582,7 +593,7 @@ async fn crawl_with_subpath_sitemaps(
             if let Ok(sitemap_url) = base.join(&candidate) {
                 let sitemap_str = sitemap_url.as_str();
                 tracing::debug!("Trying sub-path sitemap: {}", sitemap_str);
-                if let Ok(response) = wreq::Client::new().head(sitemap_str).send().await {
+                if let Ok(response) = client.head(sitemap_str).send().await {
                     if response.status().is_success() {
                         tracing::info!("Found sub-path sitemap: {}", sitemap_str);
                         if let Ok(urls) = parser.parse_from_url(sitemap_str).await {
@@ -624,7 +635,7 @@ async fn crawl_with_subpath_sitemaps(
 ///
 /// * `Ok(String)` - Discovered sitemap URL
 /// * `Err(CrawlError)` - Error during discovery
-async fn discover_sitemap_url(base_url: &str) -> Result<String, CrawlError> {
+async fn discover_sitemap_url(base_url: &str, client: &wreq::Client) -> Result<String, CrawlError> {
     let base = Url::parse(base_url).map_err(|e| CrawlError::InvalidUrl(e.to_string()))?;
 
     // Try robots.txt first
@@ -633,7 +644,7 @@ async fn discover_sitemap_url(base_url: &str) -> Result<String, CrawlError> {
         .map_err(|e| CrawlError::InvalidUrl(e.to_string()))?;
 
     tracing::info!("Checking robots.txt: {}", robots_url);
-    if let Ok(response) = wreq::get(robots_url.as_str()).send().await {
+    if let Ok(response) = client.get(robots_url.as_str()).send().await {
         tracing::info!("robots.txt status: {}", response.status());
         if response.status().is_success() {
             if let Ok(content) = response.text().await {
@@ -688,7 +699,7 @@ async fn discover_sitemap_url(base_url: &str) -> Result<String, CrawlError> {
 
         // Quick HEAD request to check if exists
         tracing::info!("Trying fallback sitemap: {}", sitemap_str);
-        if let Ok(response) = wreq::Client::new().head(sitemap_str).send().await {
+        if let Ok(response) = client.head(sitemap_str).send().await {
             tracing::info!("  Status: {}", response.status());
             if response.status().is_success() {
                 tracing::debug!("Found sitemap at fallback location: {}", sitemap_str);
@@ -708,7 +719,7 @@ async fn discover_sitemap_url(base_url: &str) -> Result<String, CrawlError> {
             if let Ok(sitemap_url) = base.join(&candidate) {
                 let sitemap_str = sitemap_url.as_str();
                 tracing::debug!("Trying sub-path sitemap: {}", sitemap_str);
-                if let Ok(response) = wreq::Client::new().head(sitemap_str).send().await {
+                if let Ok(response) = client.head(sitemap_str).send().await {
                     if response.status().is_success() {
                         tracing::info!("Found sitemap at sub-path: {}", sitemap_str);
                         return Ok(sitemap_str.to_string());

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -227,22 +227,26 @@ impl Engine {
     /// Set the JavaScript rendering strategy.
     pub fn with_js_strategy(mut self, strategy: JsStrategy) -> Self {
         self.js_strategy = strategy;
+        let timeout = self.config.timeout_secs;
+        let connect_timeout = timeout.min(10);
         match strategy {
             JsStrategy::Static => {
-                self.fetch_router =
-                    Some(FetchRouter::Static(Arc::new(WreqDownloader::new(30, 10))));
+                self.fetch_router = Some(FetchRouter::Static(Arc::new(WreqDownloader::new(
+                    timeout,
+                    connect_timeout,
+                ))));
             },
             JsStrategy::Hybrid => {
-                let l1 = WreqDownloader::new(30, 10);
-                let l2 = ObscuraDownloader::new();
+                let l1 = WreqDownloader::new(timeout, connect_timeout);
+                let l2 = ObscuraDownloader::new(timeout);
                 let l3 = ChromiumoxideDownloader::new(Arc::clone(&self.cookie_bridge));
                 self.fetch_router =
                     Some(FetchRouter::Hybrid(Arc::new(HybridRouter::new(l1, l2, l3))));
             },
             JsStrategy::Full => {
                 // Full strategy: use Chromiumoxide only via HybridRouter with wreq fallback
-                let l1 = WreqDownloader::new(30, 10);
-                let l2 = ObscuraDownloader::new();
+                let l1 = WreqDownloader::new(timeout, connect_timeout);
+                let l2 = ObscuraDownloader::new(timeout);
                 let l3 = ChromiumoxideDownloader::new(Arc::clone(&self.cookie_bridge));
                 self.fetch_router =
                     Some(FetchRouter::Hybrid(Arc::new(HybridRouter::new(l1, l2, l3))));

--- a/crates/webfang_core/src/infrastructure/downloader/obscura_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/obscura_downloader.rs
@@ -23,23 +23,27 @@ use std::time::Instant;
 /// Memory budget for one Obscura subprocess (~30 MB).
 const OBSCURA_MEMORY_COST: usize = 30_000_000;
 
-/// Hard timeout per page fetch.
-const OBSCURA_TIMEOUT: Duration = Duration::from_secs(15);
+/// Default timeout per page fetch.
+const DEFAULT_OBSCURA_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Subprocess-based downloader that shells out to `obscura fetch --dump markdown`.
 ///
 /// No cookies, no connection pool — each invocation is independent.
-pub struct ObscuraDownloader;
+pub struct ObscuraDownloader {
+    timeout: Duration,
+}
 
 impl ObscuraDownloader {
-    pub(crate) fn new() -> Self {
-        Self
+    pub(crate) fn new(timeout_secs: u64) -> Self {
+        Self {
+            timeout: Duration::from_secs(timeout_secs),
+        }
     }
 }
 
 impl Default for ObscuraDownloader {
     fn default() -> Self {
-        Self::new()
+        Self::new(DEFAULT_OBSCURA_TIMEOUT.as_secs())
     }
 }
 
@@ -54,7 +58,7 @@ impl Downloader for ObscuraDownloader {
         let url_string = url.to_string();
 
         let result = timeout(
-            OBSCURA_TIMEOUT,
+            self.timeout,
             tokio::task::spawn_blocking(move || {
                 Command::new("obscura")
                     .args(["fetch", "--dump", "markdown", &url_string])
@@ -101,7 +105,7 @@ impl Downloader for ObscuraDownloader {
                     DOWNLOAD_OBSCURA_LATENCY.record(start.elapsed().as_secs_f64(), &[]);
                     DOWNLOAD_OBSCURA_TIMEOUT.add(1, &[]);
                 }
-                Err(DownloadError::Timeout(OBSCURA_TIMEOUT.as_secs()))
+                Err(DownloadError::Timeout(self.timeout.as_secs()))
             },
             Err(_) => {
                 #[cfg(feature = "otel-metrics")]
@@ -109,7 +113,7 @@ impl Downloader for ObscuraDownloader {
                     DOWNLOAD_OBSCURA_LATENCY.record(start.elapsed().as_secs_f64(), &[]);
                     DOWNLOAD_OBSCURA_TIMEOUT.add(1, &[]);
                 }
-                Err(DownloadError::Timeout(OBSCURA_TIMEOUT.as_secs()))
+                Err(DownloadError::Timeout(self.timeout.as_secs()))
             },
         }
     }
@@ -129,14 +133,14 @@ mod tests {
 
     #[test]
     fn test_obscura_downloader_basics() {
-        let dl = ObscuraDownloader::new();
+        let dl = ObscuraDownloader::new(15);
         assert!(!dl.supports_interactions());
         assert_eq!(dl.memory_cost(), 30_000_000);
     }
 
     #[test]
     fn test_obscura_default() {
-        let dl = ObscuraDownloader;
+        let dl = ObscuraDownloader::default();
         assert_eq!(dl.memory_cost(), OBSCURA_MEMORY_COST);
     }
 }

--- a/tests/behavioral/cli/crawl_test.rs
+++ b/tests/behavioral/cli/crawl_test.rs
@@ -2,6 +2,8 @@
 
 use crate::cmd;
 use crate::BehavioralTest;
+use std::time::{Duration, Instant};
+use tokio::time::timeout;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -393,5 +395,80 @@ async fn include_pattern_only_scrapes_matching_urls() {
         1,
         "expected 1 .md file (/page-a only, seed excluded by include pattern), got {}",
         md_files.len()
+    );
+}
+
+/// Crawl mode with `--js-strategy static` must respect `--timeout-secs`.
+///
+/// End-to-end guard for the user-visible contract behind issue #280: a crawl
+/// against a slow endpoint with `--timeout-secs 2` must fail fast (~2s), not
+/// hang on a hardcoded timeout. Uses `--use-sitemap` so URL discovery fetches
+/// the fast sitemap instead of DOM-scraping the slow seed (DOM discovery uses
+/// a legacy client with its own 30s timeout, unrelated to this contract).
+/// The engine-level fix (`Engine::with_js_strategy`) is covered directly by
+/// `tests/engine_js_strategy_timeout_test.rs`.
+#[tokio::test]
+async fn crawl_js_strategy_respects_timeout_secs() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Slow</h1></article></body></html>")
+                .set_delay(Duration::from_secs(10)),
+        )
+        .mount(&t.server)
+        .await;
+
+    let base = t.server.uri();
+    let slow_url = format!("{base}/slow");
+    let sitemap_url = format!("{base}/sitemap.xml");
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{base}/slow</loc></url>
+</urlset>"#
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+
+    let out_path = t.out.path().to_path_buf();
+
+    let start = Instant::now();
+    let output = timeout(
+        Duration::from_secs(15),
+        tokio::task::spawn_blocking(move || {
+            cmd()
+                .arg("--url")
+                .arg(&slow_url)
+                .arg("--sitemap-url")
+                .arg(&sitemap_url)
+                .arg("--use-sitemap")
+                .arg("--js-strategy")
+                .arg("static")
+                .arg("--timeout-secs")
+                .arg("2")
+                .arg("--max-depth")
+                .arg("0")
+                .arg("--output")
+                .arg(out_path)
+                .arg("--quiet")
+                .output()
+        }),
+    )
+    .await
+    .expect("test must not hang")
+    .expect("task must not panic")
+    .expect("command must execute");
+
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "JS strategy timeout test should complete in under 10s, took {:?}",
+        elapsed
+    );
+    assert!(
+        !output.status.success(),
+        "request should have timed out, but command succeeded"
     );
 }

--- a/tests/engine_js_strategy_timeout_test.rs
+++ b/tests/engine_js_strategy_timeout_test.rs
@@ -1,0 +1,92 @@
+//! Engine-level regression test for issue #280.
+//!
+//! `Engine::with_js_strategy()` previously built its `WreqDownloader` with a
+//! hardcoded 30s timeout, ignoring `CrawlerConfig::timeout_secs`. This test
+//! drives the public `crawl_site_with_options` API — the only entry point that
+//! applies `with_js_strategy` — against a slow endpoint and asserts the crawl
+//! aborts near the configured 2s timeout instead of hanging ~30s.
+//!
+//! No CLI path reaches `with_js_strategy` today (CLI crawl mode goes through
+//! `scrape_flow`; batch/MCP use `crawl_site`, which leaves the fetch router
+//! unset), so this API-level test is the only behavioral coverage of the fix.
+
+use std::time::{Duration, Instant};
+
+use tokio::time::timeout;
+use url::Url;
+use webfang_core::application::{crawl_site_with_options, EngineOptions};
+use webfang_core::domain::{CrawlerConfig, JsStrategy};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// `crawl_site_with_options` with `JsStrategy::Static` must honor
+/// `CrawlerConfig::timeout_secs`: a 30s-delayed response with a 2s configured
+/// timeout must abort in well under 10s and yield no successfully crawled pages.
+#[tokio::test]
+async fn engine_js_strategy_respects_config_timeout() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/slow"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Slow</h1></article></body></html>")
+                .set_delay(Duration::from_secs(30)),
+        )
+        .mount(&server)
+        .await;
+
+    let seed: Url = format!("{}/slow", server.uri())
+        .parse()
+        .expect("valid seed URL");
+    let config = CrawlerConfig::builder(seed)
+        .max_depth(0)
+        .max_pages(1)
+        .timeout_secs(2)
+        .delay_ms(1)
+        .ignore_robots(true)
+        .build();
+
+    let options = EngineOptions {
+        js_strategy: JsStrategy::Static,
+        ignore_robots: true,
+        ..Default::default()
+    };
+
+    let start = Instant::now();
+    let result = timeout(
+        Duration::from_secs(15),
+        crawl_site_with_options(config, options),
+    )
+    .await
+    .expect("crawl must not hang — with_js_strategy must honor config.timeout_secs");
+    let elapsed = start.elapsed();
+
+    // The engine must have actually attempted the seed fetch — guards against
+    // a vacuous pass where the crawl aborts before any request is sent.
+    let requests = server.received_requests().await.expect("requests recorded");
+    assert!(
+        requests.iter().any(|r| r.url.path() == "/slow"),
+        "engine must attempt the seed URL via the JS strategy fetch router"
+    );
+
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "engine with JS strategy should time out near 2s, took {:?}",
+        elapsed
+    );
+
+    match result {
+        Ok(crawl) => {
+            assert_eq!(
+                crawl.total_pages, 0,
+                "timed-out seed must not produce crawled pages"
+            );
+            assert!(
+                crawl.errors >= 1,
+                "timed-out seed must be counted as an error"
+            );
+        },
+        Err(e) => panic!("crawl should complete with errors, not fail outright: {e}"),
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #280, Fixes #281.

### #280 — WreqDownloader + ObscuraDownloader

`Engine::with_js_strategy()` hardcoded `WreqDownloader::new(30, 10)` in all three JS strategy branches, ignoring `--timeout-secs`. `ObscuraDownloader` had a hardcoded 15s timeout.

**Changes:**
- `engine.rs`: reads `self.config.timeout_secs`, derives `connect_timeout = min(10, timeout_secs)`, propagates to WreqDownloader and ObscuraDownloader
- `obscura_downloader.rs`: added `timeout: Duration` field, configurable constructor, `Default` uses 15s

### #281 — Sitemap discovery

`discover_sitemap_url()` and `crawl_with_subpath_sitemaps()` used bare `wreq::get()` and `wreq::Client::new()` with NO timeout — could hang indefinitely on slow DNS/TCP.

**Changes:**
- `discovery.rs`: builds ONE `wreq::Client` with `config.timeout_secs` + Chrome145 in `crawl_with_sitemap_internal`, passes it to both callees. Replaces 4 bare wreq calls (eliminating 10+ ephemeral clients).

### Tests
- `engine_js_strategy_timeout_test.rs`: engine-level regression test via `crawl_site_with_options` + `JsStrategy::Static` + 2s timeout vs 30s-delayed wiremock
- `crawl_test.rs`: CLI behavioral test with `--js-strategy static --timeout-secs 2`

## Verification

- `cargo check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- Both regression tests PASS (~2s each)

## Known follow-ups (out of scope)

- `create_http_client()` in DOM discovery (`client.rs:557`) has its own hardcoded 30s timeout
- `--js-strategy` CLI flag is parsed but no CLI path reaches `crawl_site_with_options`
- `discovery.rs` builds `wreq::Client` in application layer (pre-existing Clean Architecture debt)