### PR TITLE
fix(orchestrator): wire --resume state persistence + behavioral tests

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -9,7 +9,7 @@ use crate::application::crawl_options::CrawlOptions;
 use crate::cli::completions::generate_completions;
 use crate::cli::error::CliExit;
 use crate::cli::export_flow::{run_export, save_files, ExportConfig};
-use crate::cli::scrape_flow::scrape_urls;
+use crate::cli::scrape_flow::{apply_resume_mode, scrape_urls};
 use crate::cli::url_discovery::discover_urls;
 use crate::domain::repository::DynVectorRepository;
 use crate::error::ScraperError;
@@ -18,6 +18,7 @@ use crate::CrawlerConfig;
 use crate::ScraperConfig;
 
 use crate::domain;
+use crate::infrastructure::export::state_store::StateStore;
 use crate::infrastructure::output::file_saver::ObsidianOptions;
 use crate::Shell;
 
@@ -93,6 +94,9 @@ pub async fn run(
         Ok(p) => p,
     };
 
+    let (urls_to_scrape, state_store) =
+        apply_resume_mode(prepare.urls_to_scrape, &opts, opts.url.as_str()).await;
+
     let elastic_ingestion = match build_elastic_ingestion(&opts).await {
         Ok(v) => v,
         Err(e) => return e,
@@ -121,7 +125,7 @@ pub async fn run(
     let engine_ref: Option<&AdaptiveSelectorEngine> = None;
 
     let (results, failures) = scrape_phase(
-        &prepare.urls_to_scrape,
+        &urls_to_scrape,
         &prepare.scraper_config,
         &opts,
         observer.as_ref(),
@@ -145,11 +149,11 @@ pub async fn run(
 
     #[cfg(feature = "ai")]
     {
-        export_phase(&results, &opts, ai_cleaner).await
+        export_phase(&results, &opts, state_store.as_ref(), ai_cleaner).await
     }
     #[cfg(not(feature = "ai"))]
     {
-        export_phase(&results, &opts).await
+        export_phase(&results, &opts, state_store.as_ref()).await
     }
 }
 
@@ -157,6 +161,7 @@ pub async fn run(
 async fn export_phase(
     results: &[domain::ScrapedContent],
     opts: &CrawlOptions,
+    state_store: Option<&StateStore>,
     #[cfg(feature = "ai")] ai_cleaner: Option<std::sync::Arc<dyn SemanticCleaner>>,
 ) -> CliExit {
     let output_dir = opts.export.output_dir.clone();
@@ -197,7 +202,7 @@ async fn export_phase(
         quick_save: opts.export.quick_save,
         vault_path: opts.export.obsidian_vault.as_ref(),
         obsidian_options,
-        state_store: None,
+        state_store,
         resume: opts.crawl.resume,
         ai_threshold: opts.ai_config.threshold,
         ai_max_tokens: opts.ai_config.max_tokens,

--- a/tests/behavioral/cli/mod.rs
+++ b/tests/behavioral/cli/mod.rs
@@ -5,6 +5,7 @@ mod download_test;
 mod dry_run_test;
 mod error_path_test;
 mod obsidian_test;
+mod resume_test;
 mod robots_test;
 mod single_page_test;
 mod sitemap_test;

--- a/tests/behavioral/cli/resume_test.rs
+++ b/tests/behavioral/cli/resume_test.rs
@@ -1,0 +1,307 @@
+//! Resume behavior: `--resume` skips already-processed URLs and persists
+//! state; `--state-dir` redirects the state file away from the shared cache.
+//!
+//! Every test passes a fresh temp `--state-dir`. The state file is keyed by
+//! host WITHOUT the port (`domain_from_url` → `127.0.0.1`), so all wiremock
+//! runs collide on `127.0.0.1.json`; a temp dir per test prevents cross-run
+//! contamination and never touches `~/.cache/webfang/state`.
+
+use crate::BehavioralTest;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+/// Host (no port) that `domain_from_url` derives from the wiremock origin —
+/// the state file is named `<domain>.json`.
+const DOMAIN: &str = "127.0.0.1";
+
+/// Mount `/page1` and `/page2` plus a sitemap listing exactly those two URLs,
+/// and return the sitemap URL. Sitemap mode keeps the discovered URL set
+/// deterministic (no DOM-crawl seed injection).
+async fn mount_resume_fixture(t: &BehavioralTest) -> String {
+    Mock::given(method("GET"))
+        .and(path("/page1"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><article><h1>Page One</h1><p>Body one.</p></article></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/page2"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><article><h1>Page Two</h1><p>Body two.</p></article></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    let base = t.server.uri();
+    let sitemap_url = format!("{base}/sitemap.xml");
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{base}/page1</loc></url>
+    <url><loc>{base}/page2</loc></url>
+</urlset>"#
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+    sitemap_url
+}
+
+/// Count requests the mock server has received for a given URL path.
+async fn count_path(server: &wiremock::MockServer, path: &str) -> usize {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path() == path)
+        .count()
+}
+
+/// A second `--resume` run with the same state dir skips already-processed
+/// URLs: the mock server receives no new page requests and the `.md` count is
+/// unchanged.
+#[tokio::test]
+async fn resume_skips_already_processed_urls() {
+    let t = BehavioralTest::new().await;
+    let sitemap_url = mount_resume_fixture(&t).await;
+    let state_dir = TempDir::new().unwrap();
+
+    let run1 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+    assert!(
+        run1.status.success(),
+        "first run should succeed: {}",
+        String::from_utf8_lossy(&run1.stderr)
+    );
+
+    assert_eq!(
+        count_path(&t.server, "/page1").await,
+        1,
+        "run1 fetches /page1"
+    );
+    assert_eq!(
+        count_path(&t.server, "/page2").await,
+        1,
+        "run1 fetches /page2"
+    );
+    let md_after_run1 = t.find_files("md").len();
+    assert!(
+        md_after_run1 >= 2,
+        "first run should produce at least 2 .md files, got {md_after_run1}"
+    );
+
+    // State persisted to the temp state dir.
+    assert!(
+        state_dir.path().join(format!("{DOMAIN}.json")).exists(),
+        "state file must persist after the first run"
+    );
+
+    // Second run, same state dir: every URL is already processed, so nothing
+    // is re-fetched and the output is untouched. (The run exits non-zero
+    // because an empty scrape list is a hard error — assert on counts, not
+    // exit success.)
+    let _run2 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert_eq!(
+        count_path(&t.server, "/page1").await,
+        1,
+        "resume must not re-fetch /page1"
+    );
+    assert_eq!(
+        count_path(&t.server, "/page2").await,
+        1,
+        "resume must not re-fetch /page2"
+    );
+    assert_eq!(
+        t.find_files("md").len(),
+        md_after_run1,
+        "resume must leave the .md count unchanged"
+    );
+}
+
+/// `--state-dir` writes the state JSON into the supplied directory and never
+/// into the default cache location.
+#[tokio::test]
+async fn state_dir_uses_custom_directory() {
+    let t = BehavioralTest::new().await;
+    let sitemap_url = mount_resume_fixture(&t).await;
+    let state_dir = TempDir::new().unwrap();
+    // Redirect the default-cache base so we can prove `--state-dir` wins: if
+    // the flag were ignored, the state would land under this fake XDG cache.
+    let fake_cache = TempDir::new().unwrap();
+
+    let run1 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .env("XDG_CACHE_HOME", fake_cache.path())
+        .output()
+        .expect("run binary");
+    assert!(
+        run1.status.success(),
+        "run should succeed: {}",
+        String::from_utf8_lossy(&run1.stderr)
+    );
+
+    assert!(
+        state_dir.path().join(format!("{DOMAIN}.json")).exists(),
+        "state file must live in the custom --state-dir"
+    );
+    assert!(
+        !fake_cache
+            .path()
+            .join("webfang")
+            .join("state")
+            .join(format!("{DOMAIN}.json"))
+            .exists(),
+        "state file must NOT be written to the default cache when --state-dir is set"
+    );
+
+    // Second run with the same custom dir skips the processed URLs.
+    let _run2 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .env("XDG_CACHE_HOME", fake_cache.path())
+        .output()
+        .expect("run binary");
+
+    assert_eq!(
+        count_path(&t.server, "/page1").await,
+        1,
+        "resume must not re-fetch /page1"
+    );
+    assert_eq!(
+        count_path(&t.server, "/page2").await,
+        1,
+        "resume must not re-fetch /page2"
+    );
+}
+
+/// State persists in `--state-dir` while results go to `--output`; a second
+/// run with the same state dir but a cleaned output dir still skips processed
+/// URLs (state, not output, drives resume).
+#[tokio::test]
+async fn resume_state_and_output_in_different_directories() {
+    let t = BehavioralTest::new().await;
+    let sitemap_url = mount_resume_fixture(&t).await;
+    let state_dir = TempDir::new().unwrap();
+
+    let run1 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+    assert!(
+        run1.status.success(),
+        "first run should succeed: {}",
+        String::from_utf8_lossy(&run1.stderr)
+    );
+
+    assert!(
+        state_dir.path().join(format!("{DOMAIN}.json")).exists(),
+        "state must persist in the state dir"
+    );
+    assert!(
+        t.find_files("md").len() >= 2,
+        "results must land in the output dir"
+    );
+
+    // Clean the output dir; keep the state dir.
+    for file in t.find_files("md") {
+        std::fs::remove_file(file).expect("remove .md file");
+    }
+    assert!(t.find_files("md").is_empty(), "output dir cleaned");
+
+    // Second run: same state dir, empty output. Resume skips the processed
+    // URLs, so nothing is re-scraped and the output stays empty.
+    let _run2 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert_eq!(
+        count_path(&t.server, "/page1").await,
+        1,
+        "resume must not re-fetch /page1 with a clean output dir"
+    );
+    assert_eq!(
+        count_path(&t.server, "/page2").await,
+        1,
+        "resume must not re-fetch /page2 with a clean output dir"
+    );
+    assert!(
+        t.find_files("md").is_empty(),
+        "no re-scrape means no new .md files in the cleaned output dir"
+    );
+}
+
+/// A corrupt state JSON does not crash the run: `apply_resume_mode` falls back
+/// to the full URL list, so every URL is still scraped and saved.
+#[tokio::test]
+async fn corrupt_state_falls_back_to_full_scrape() {
+    let t = BehavioralTest::new().await;
+    let sitemap_url = mount_resume_fixture(&t).await;
+    let state_dir = TempDir::new().unwrap();
+
+    std::fs::write(
+        state_dir.path().join(format!("{DOMAIN}.json")),
+        "not valid json!!!",
+    )
+    .expect("write corrupt state");
+
+    let output = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "corrupt state must not panic: {stderr}"
+    );
+
+    assert_eq!(
+        count_path(&t.server, "/page1").await,
+        1,
+        "corrupt state must still scrape /page1"
+    );
+    assert_eq!(
+        count_path(&t.server, "/page2").await,
+        1,
+        "corrupt state must still scrape /page2"
+    );
+    assert!(
+        t.find_files("md").len() >= 2,
+        "corrupt state must still produce .md files"
+    );
+}

--- a/tests/common/cli_harness.rs
+++ b/tests/common/cli_harness.rs
@@ -159,6 +159,23 @@ impl BehavioralTest {
             .arg(self.out.path());
         cmd
     }
+
+    /// Build a `Command` with `--resume` and a custom `--state-dir`, plus
+    /// `--url` and `--output`. The caller supplies a fresh temp dir for the
+    /// state so tests never read or write the shared default cache
+    /// (`~/.cache/webfang/state`), which collides across wiremock runs because
+    /// the state file is keyed by host without the port (`127.0.0.1.json`).
+    pub fn state_dir_cmd(&self, state_dir: &Path) -> assert_cmd::Command {
+        let mut cmd = Command::new(webfang_path());
+        cmd.arg("--resume")
+            .arg("--state-dir")
+            .arg(state_dir)
+            .arg("--url")
+            .arg(self.server.uri())
+            .arg("--output")
+            .arg(self.out.path());
+        cmd
+    }
 }
 
 /// Register a wiremock mock that responds to GET on the given relative path


### PR DESCRIPTION
## Linked Issue

Closes #276

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `--resume` and `--state-dir` were parsed into `CrawlOptions` but were **dead code**: `orchestrator::run` never called `apply_resume_mode` and hardcoded `ExportConfig.state_store: None`, so resume never filtered already-processed URLs nor persisted state. This wires it up.
- After `prepare_phase`, call `apply_resume_mode(urls, &opts, target_url)` to filter already-processed URLs and obtain the `StateStore`; scrape the filtered list; thread the store into `export_phase` → `ExportConfig.state_store` so `process_results` marks + persists processed URLs.
- Adds 4 end-to-end wiremock behavioral tests + a `state_dir_cmd` harness helper. `apply_resume_mode`'s own (unit-tested) logic is untouched.

> ⚠️ **Stacked PR**: based on `feat/adaptive-selectors` (#288) because both change `orchestrator::run`. Merge **after** #288 lands, then retarget this PR to `main`. The diff shown is the isolated #276 delta only.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/orchestrator.rs` | Wire `apply_resume_mode` after `prepare_phase`; scrape the filtered URLs; thread `Option<&StateStore>` into `export_phase` → `ExportConfig.state_store` (was hardcoded `None`) |
| `tests/behavioral/cli/resume_test.rs` | New: 4 behavioral tests (skip-on-rerun, custom `--state-dir`, state/output in different dirs, corrupt-state fallback) |
| `tests/behavioral/cli/mod.rs` | `mod resume_test;` |
| `tests/common/cli_harness.rs` | Add `state_dir_cmd(&self, state_dir)` helper (mirrors `resume_cmd` + `--state-dir`) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (incl. `--all-targets`)
- [x] `cargo nextest run` passes (`--test behavioral -- resume_test` 4/4; full behavioral 72/72; webfang_core 1478 passed / 0 failed)
- [x] Manually verified: with `--resume`, a second run (same state dir) issues 0 new requests; `--state-dir` redirects the state file; without `--resume`, behavior is byte-for-byte identical (no fs/env access, returns `(urls, None)`)

## Contributor Checklist

- [x] Linked an issue with `Closes #276`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`fix(orchestrator): ...` / `test(resume): ...`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed

---

**Review**: adversarial `review-reliability` lens (fresh context, isolated delta `08cdbc2..HEAD`) — verdict **ALLOW, 0 blockers**. Verified: fix correct end-to-end (filtered URLs reach `scrape_phase`, `StateStore` reaches `ExportConfig`, reference lifetimes sound); no-resume path identity-preserving; the 4 tests are non-vacuous — fresh temp `--state-dir` per test (never the default cache, which collides on `127.0.0.1.json` because `domain_from_url` strips the port) and deterministic request/file-count assertions; on the dead-flag base the second run would re-fetch and the tests would fail (differential proof intact).

Non-blocking follow-ups:
- **(warning, behavior-activated)** a `--resume` run where *every* URL is already processed exits non-zero ("No pages were successfully scraped", `orchestrator.rs:362`) — no data loss, but misleading for cron/`set -e`. Consider treating "all URLs already processed" as success (distinguish empty-after-filter from scrape-failure-empty in `report_phase`). Documented in-test.
- **(info, pre-existing — verified untouched by this delta)** corrupt state: pages scrape and `.md` save, but the run exits non-zero because `process_results` re-loads and propagates `Serialization` (`export_factory.rs:138`, `state_store.rs:321-324`). Test 4 tolerates this honestly.
- **(suggestion)** make `load_or_default` default on `Serialization` (like `NotFound`) so the first corrupt run self-heals the state file via the existing atomic `save()`.

> Note: the formal gentle-ai review receipt could not be completed from the sibling-worktree orchestration context (the capture hook routes to the session cwd; manual capture requires the lens's native canonical schema). The substantive adversarial review above was run and passed; CI gates (`pr-validation.yml`) are independent of the receipt.
