### PR TITLE
refactor(errors): Error Map V2 — post-merge cleanup

### DIFF
--- a/crates/webfang_core/src/application/http_client/port.rs
+++ b/crates/webfang_core/src/application/http_client/port.rs
@@ -63,55 +63,10 @@ impl HttpClientPort for wreq::Client {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::http_error::{HttpError, HttpResult};
+    use crate::domain::http_error::HttpError;
     use crate::domain::http_port::{HttpClientPort, HttpResponse};
+    use crate::test_fixtures::MockHttpClient;
     use std::collections::HashMap;
-    use std::pin::Pin;
-
-    /// Minimal mock for verifying trait contract.
-    struct MockHttpClient {
-        responses: HashMap<String, HttpResult<HttpResponse>>,
-    }
-
-    impl MockHttpClient {
-        fn new() -> Self {
-            Self {
-                responses: HashMap::new(),
-            }
-        }
-
-        fn with_response(mut self, url: &str, result: HttpResult<HttpResponse>) -> Self {
-            self.responses.insert(url.to_string(), result);
-            self
-        }
-    }
-
-    impl HttpClientPort for MockHttpClient {
-        fn get(
-            &self,
-            url: &str,
-        ) -> Pin<Box<dyn std::future::Future<Output = HttpResult<HttpResponse>> + Send + '_>>
-        {
-            let result = match self.responses.get(url) {
-                Some(Ok(resp)) => Ok(HttpResponse {
-                    status: resp.status,
-                    body: resp.body.clone(),
-                    headers: resp.headers.clone(),
-                }),
-                Some(Err(HttpError::Forbidden)) => Err(HttpError::Forbidden),
-                Some(Err(HttpError::RateLimited(r))) => Err(HttpError::RateLimited(*r)),
-                Some(Err(HttpError::ClientError(c))) => Err(HttpError::ClientError(*c)),
-                Some(Err(HttpError::ServerError(c))) => Err(HttpError::ServerError(*c)),
-                Some(Err(HttpError::Timeout)) => Err(HttpError::Timeout),
-                Some(Err(HttpError::Connection(m))) => Err(HttpError::Connection(m.clone())),
-                Some(Err(HttpError::Request(m))) => Err(HttpError::Request(m.clone())),
-                Some(Err(HttpError::WafChallenge(p))) => Err(HttpError::WafChallenge(p.clone())),
-                Some(Err(HttpError::DomainBanned(d))) => Err(HttpError::DomainBanned(d.clone())),
-                None => Err(HttpError::ClientError(404)),
-            };
-            Box::pin(async move { result })
-        }
-    }
 
     #[tokio::test]
     async fn test_mock_returns_success() {

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -29,10 +29,15 @@ use crate::application::adaptive_engine::AdaptiveSelectorEngine;
 #[cfg(not(feature = "adaptive-selectors"))]
 type AdaptiveSelectorEngine = ();
 
-/// Convert an [`HttpError`] into a [`ScraperError`] with the URL context.
-fn scraper_error_from_http(err: HttpError, url: &str) -> ScraperError {
+/// Convert an [`HttpError`] into a domain [`CrawlError`] with the URL context.
+///
+/// This is the application-layer half of the `HttpError` → `CrawlError`
+/// mapping; the domain half lives in `domain/error/crawl_error.rs`
+/// (`From<HttpError> for CrawlError`). The two sites MUST stay in sync —
+/// see `tests::test_request_failed_dual_site_agreement`.
+fn crawl_error_from_http(err: HttpError, url: &str) -> crate::domain::error::CrawlError {
     use crate::domain::error::CrawlError;
-    let crawl_err: CrawlError = match err {
+    match err {
         HttpError::ClientError(code) | HttpError::ServerError(code) => CrawlError::Http {
             status: code,
             url: url.to_string(),
@@ -44,7 +49,7 @@ fn scraper_error_from_http(err: HttpError, url: &str) -> ScraperError {
         HttpError::RateLimited(retry_after) => CrawlError::RateLimited(retry_after),
         HttpError::Timeout => CrawlError::Timeout,
         HttpError::Connection(msg) => CrawlError::Connection(msg),
-        HttpError::Request(msg) => CrawlError::Internal(msg),
+        HttpError::Request(msg) => CrawlError::RequestFailed(msg),
         HttpError::WafChallenge(provider) => CrawlError::WafChallenge {
             provider,
             kind: crate::domain::error::WafDetectionKind::BodySignature,
@@ -53,8 +58,12 @@ fn scraper_error_from_http(err: HttpError, url: &str) -> ScraperError {
         HttpError::DomainBanned(domain) => {
             CrawlError::SessionPool(format!("domain banned: {domain}"))
         },
-    };
-    ScraperError::from(crawl_err)
+    }
+}
+
+/// Convert an [`HttpError`] into a [`ScraperError`] with the URL context.
+fn scraper_error_from_http(err: HttpError, url: &str) -> ScraperError {
+    ScraperError::from(crawl_error_from_http(err, url))
 }
 
 /// Maximum HTML body size to log/instrument (1MB)
@@ -678,5 +687,47 @@ pub async fn download_assets_if_enabled(
     #[cfg(not(any(feature = "images", feature = "documents")))]
     {
         Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::error::CrawlError;
+    use crate::error::ErrorClass;
+
+    /// EC-REQUEST-FAILED: both `HttpError::Request` conversion sites must agree.
+    ///
+    /// Site 1: `application/scraper_service.rs::crawl_error_from_http`
+    /// Site 2: `domain/error/crawl_error.rs` `From<HttpError>`
+    ///
+    /// Both must yield `CrawlError::RequestFailed(msg)` for the same input —
+    /// no divergence between the application and domain conversion paths.
+    #[test]
+    fn test_request_failed_dual_site_agreement() {
+        let msg = "build failed";
+
+        // Site 1 (application layer)
+        let via_service =
+            crawl_error_from_http(HttpError::Request(msg.to_string()), "https://example.com");
+        // Site 2 (domain layer)
+        let via_domain: CrawlError = HttpError::Request(msg.to_string()).into();
+
+        assert!(
+            matches!(&via_service, CrawlError::RequestFailed(m) if m == msg),
+            "service site must produce RequestFailed, got: {via_service:?}"
+        );
+        assert!(
+            matches!(&via_domain, CrawlError::RequestFailed(m) if m == msg),
+            "domain site must produce RequestFailed, got: {via_domain:?}"
+        );
+
+        // Classification is preserved end-to-end: RequestFailed → Internal → InternalFatal.
+        let scraper_err = ScraperError::from(via_service);
+        assert!(
+            matches!(&scraper_err, ScraperError::Internal(m) if m == msg),
+            "RequestFailed must map to ScraperError::Internal, got: {scraper_err}"
+        );
+        assert_eq!(scraper_err.classify(), ErrorClass::InternalFatal);
     }
 }

--- a/crates/webfang_core/src/domain/error/crawl_error.rs
+++ b/crates/webfang_core/src/domain/error/crawl_error.rs
@@ -185,6 +185,14 @@ pub enum CrawlError {
     #[error("connection error: {0}")]
     Connection(String),
 
+    /// Request construction or body-read failure (non-transient)
+    ///
+    /// Produced when the HTTP request itself cannot be built or its body
+    /// cannot be read — as opposed to timeout/connection failures, which are
+    /// transient. Maps to `ScraperError::Internal` (InternalFatal).
+    #[error("request failed: {0}")]
+    RequestFailed(String),
+
     /// Resource limit exhausted
     #[error("resource exhausted: {resource:?} limit={limit} actual={actual}")]
     ResourceExhausted {
@@ -228,7 +236,7 @@ impl From<crate::domain::http_error::HttpError> for CrawlError {
             },
             HttpError::Timeout => CrawlError::Timeout,
             HttpError::Connection(msg) => CrawlError::Connection(msg),
-            HttpError::Request(msg) => CrawlError::Internal(msg),
+            HttpError::Request(msg) => CrawlError::RequestFailed(msg),
             HttpError::WafChallenge(provider) => CrawlError::WafChallenge {
                 provider,
                 kind: WafDetectionKind::BodySignature,

--- a/crates/webfang_core/src/domain/error/crawl_error.rs
+++ b/crates/webfang_core/src/domain/error/crawl_error.rs
@@ -36,6 +36,17 @@ pub enum ResourceKind {
     RamBudget,
 }
 
+impl std::fmt::Display for ResourceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::SitemapUrls => "sitemap URLs",
+            Self::SitemapDepth => "sitemap depth",
+            Self::RamBudget => "RAM budget",
+        };
+        f.write_str(label)
+    }
+}
+
 /// Crawl errors
 ///
 /// Following **err-thiserror-for-libraries**: Uses thiserror for library error types.
@@ -405,6 +416,27 @@ mod tests {
         assert!(error.to_string().contains("RamBudget"));
         assert!(error.to_string().contains("1024"));
         assert!(error.to_string().contains("2048"));
+    }
+
+    #[test]
+    fn test_resource_kind_display() {
+        // EC-RESOURCE-DISPLAY: human-friendly Display per variant.
+        assert_eq!(ResourceKind::SitemapUrls.to_string(), "sitemap URLs");
+        assert_eq!(ResourceKind::SitemapDepth.to_string(), "sitemap depth");
+        assert_eq!(ResourceKind::RamBudget.to_string(), "RAM budget");
+
+        // ResourceExhausted must keep rendering the resource via Debug
+        // (`{resource:?}`), so the machine-readable variant name stays in the
+        // error string even though Display now exists (type-display-vs-debug).
+        let error = CrawlError::ResourceExhausted {
+            resource: ResourceKind::RamBudget,
+            limit: 1024,
+            actual: 2048,
+        };
+        assert!(
+            error.to_string().contains("RamBudget"),
+            "ResourceExhausted must keep Debug rendering of the resource: {error}"
+        );
     }
 
     #[test]

--- a/crates/webfang_core/src/domain/ports.rs
+++ b/crates/webfang_core/src/domain/ports.rs
@@ -145,63 +145,10 @@ mod tests {
     use super::*;
     use crate::domain::http_error::HttpError;
     use crate::domain::http_port::HttpResponse;
+    use crate::test_fixtures::MockHttpClient;
     use std::collections::HashMap;
 
     // --- Mock implementations for testing port traits ---
-
-    struct MockHttpClientPort {
-        responses: HashMap<String, crate::domain::http_error::HttpResult<HttpResponse>>,
-    }
-
-    impl MockHttpClientPort {
-        fn new() -> Self {
-            Self {
-                responses: HashMap::new(),
-            }
-        }
-
-        fn with_response(
-            mut self,
-            url: &str,
-            result: crate::domain::http_error::HttpResult<HttpResponse>,
-        ) -> Self {
-            self.responses.insert(url.to_string(), result);
-            self
-        }
-    }
-
-    impl HttpClientPort for MockHttpClientPort {
-        fn get(
-            &self,
-            url: &str,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                        Output = crate::domain::http_error::HttpResult<HttpResponse>,
-                    > + Send
-                    + '_,
-            >,
-        > {
-            let result = match self.responses.get(url) {
-                Some(Ok(resp)) => Ok(HttpResponse {
-                    status: resp.status,
-                    body: resp.body.clone(),
-                    headers: resp.headers.clone(),
-                }),
-                Some(Err(HttpError::Forbidden)) => Err(HttpError::Forbidden),
-                Some(Err(HttpError::RateLimited(r))) => Err(HttpError::RateLimited(*r)),
-                Some(Err(HttpError::ClientError(c))) => Err(HttpError::ClientError(*c)),
-                Some(Err(HttpError::ServerError(c))) => Err(HttpError::ServerError(*c)),
-                Some(Err(HttpError::Timeout)) => Err(HttpError::Timeout),
-                Some(Err(HttpError::Connection(m))) => Err(HttpError::Connection(m.clone())),
-                Some(Err(HttpError::Request(m))) => Err(HttpError::Request(m.clone())),
-                Some(Err(HttpError::WafChallenge(p))) => Err(HttpError::WafChallenge(p.clone())),
-                Some(Err(HttpError::DomainBanned(d))) => Err(HttpError::DomainBanned(d.clone())),
-                None => Err(HttpError::ClientError(404)),
-            };
-            Box::pin(async move { result })
-        }
-    }
 
     struct MockPersistencePort {
         store: std::sync::Arc<std::sync::Mutex<HashMap<String, ScrapedContent>>>,
@@ -250,7 +197,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_http_client_port_object_safe() {
-        let mock: Box<dyn HttpClientPort> = Box::new(MockHttpClientPort::new().with_response(
+        let mock: Box<dyn HttpClientPort> = Box::new(MockHttpClient::new().with_response(
             "https://example.com",
             Ok(HttpResponse {
                 status: 200,
@@ -267,7 +214,7 @@ mod tests {
     #[tokio::test]
     async fn test_http_client_port_error_propagation() {
         let mock: Box<dyn HttpClientPort> = Box::new(
-            MockHttpClientPort::new()
+            MockHttpClient::new()
                 .with_response("https://fail.com", Err(HttpError::ClientError(500))),
         );
 

--- a/crates/webfang_core/src/error.rs
+++ b/crates/webfang_core/src/error.rs
@@ -152,7 +152,12 @@ pub enum ScraperError {
     #[error("error interno: {0}")]
     Internal(String),
 
-    /// Crawl limit exceeded (max depth, max pages)
+    /// Crawl limit exceeded.
+    ///
+    /// Groups all crawl-budget configuration limits — max-depth, max-pages,
+    /// and sitemap-depth. All three are `PermanentFatal` configuration
+    /// boundaries (see [`Self::classify`]); the payload carries the
+    /// human-readable limit description rendered verbatim by `Display`.
     #[error("{0}")]
     CrawlLimit(String),
 

--- a/crates/webfang_core/src/error.rs
+++ b/crates/webfang_core/src/error.rs
@@ -152,6 +152,14 @@ pub enum ScraperError {
     #[error("error interno: {0}")]
     Internal(String),
 
+    /// Rate limited by the server; carries the retry-after delay in seconds.
+    ///
+    /// Classifies as [`ErrorClass::TransientBackoff`] — callers should wait
+    /// the indicated delay before retrying. Display is deliberately identical
+    /// to `CrawlError::RateLimited` so the message survives layer conversion.
+    #[error("rate limited, retry after {0}s")]
+    RateLimited(u64),
+
     /// Crawl limit exceeded.
     ///
     /// Groups all crawl-budget configuration limits — max-depth, max-pages,
@@ -378,6 +386,7 @@ impl ScraperError {
             Self::Http { status, .. } if *status == 429 => ErrorClass::TransientBackoff,
             Self::GlobalTimeout => ErrorClass::TransientBackoff,
             Self::SlowlorisTimeout => ErrorClass::TransientBackoff,
+            Self::RateLimited(_) => ErrorClass::TransientBackoff,
             Self::InvalidUrl(_) => ErrorClass::PermanentFatal,
             Self::WafBlocked { .. } => ErrorClass::PermanentFatal,
             Self::Readability(_) => ErrorClass::PermanentFatal,
@@ -427,12 +436,19 @@ fn is_transient_network(e: &(dyn std::error::Error + 'static)) -> bool {
     }
     if e.downcast_ref::<WreqError>().is_some() {
         let msg = e.to_string().to_ascii_lowercase();
-        return msg.contains("timeout")
+        let matched = msg.contains("timeout")
             || msg.contains("timed out")
             || msg.contains("connection refused")
             || msg.contains("connection reset")
             || msg.contains("broken pipe")
             || msg.contains("connection aborted");
+        if matched {
+            tracing::debug!(
+                error = %e,
+                "is_transient_network: classified transient via wreq text-fallback heuristic"
+            );
+        }
+        return matched;
     }
     false
 }
@@ -489,6 +505,7 @@ impl From<crate::domain::error::CrawlError> for ScraperError {
                 ScraperError::WafBlocked { url, provider }
             },
             CrawlError::Internal(msg) => ScraperError::Internal(msg),
+            CrawlError::RequestFailed(msg) => ScraperError::Internal(msg),
             CrawlError::Download(e) => ScraperError::Download(e),
             CrawlError::SitemapNotFound(url) => ScraperError::SitemapNotFound(url),
             CrawlError::Parse(msg) => ScraperError::Internal(format!("parse: {msg}")),
@@ -510,13 +527,18 @@ impl From<crate::domain::error::CrawlError> for ScraperError {
                 "retry exhausted for {url} after {attempts} attempts"
             )),
             CrawlError::TransientHttp { status, url } => ScraperError::Http { status, url },
-            // NOTE: retry_after embedded in message. If downstream needs to
-            // pattern-match on retry_after, consider adding ScraperError::RateLimited(u64).
-            CrawlError::RateLimited(retry_after) => {
-                ScraperError::Internal(format!("rate limited, retry after {retry_after}s"))
-            },
-            CrawlError::Timeout => ScraperError::Internal("request timeout".to_string()),
-            CrawlError::Connection(msg) => ScraperError::Internal(format!("connection: {msg}")),
+            CrawlError::RateLimited(retry_after) => ScraperError::RateLimited(retry_after),
+            // Timeout/Connection carry a synthetic io::Error source so
+            // is_transient_network's downcast recognizes them as transient
+            // (a bare message would fall through to InternalFatal).
+            CrawlError::Timeout => ScraperError::Network(Box::new(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "request timeout",
+            ))),
+            CrawlError::Connection(msg) => ScraperError::Network(Box::new(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                msg,
+            ))),
             CrawlError::ResourceExhausted {
                 resource,
                 limit,
@@ -1070,35 +1092,153 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn test_crawl_rate_limited_classifies_as_internal_fatal() {
+    fn test_crawl_rate_limited_classifies_as_transient_backoff() {
         let crawl_err = crate::domain::error::CrawlError::RateLimited(60);
         let scraper_err: ScraperError = crawl_err.into();
         assert_eq!(
             scraper_err.classify(),
-            ErrorClass::InternalFatal,
-            "RateLimited maps to ScraperError::Internal → InternalFatal"
+            ErrorClass::TransientBackoff,
+            "RateLimited maps to ScraperError::RateLimited → TransientBackoff"
         );
     }
 
     #[test]
-    fn test_crawl_timeout_classifies_as_internal_fatal() {
+    fn test_crawl_timeout_classifies_as_transient_retriable() {
         let crawl_err = crate::domain::error::CrawlError::Timeout;
         let scraper_err: ScraperError = crawl_err.into();
         assert_eq!(
             scraper_err.classify(),
-            ErrorClass::InternalFatal,
-            "Timeout maps to ScraperError::Internal → InternalFatal"
+            ErrorClass::TransientRetriable,
+            "Timeout maps to ScraperError::Network(TimedOut io::Error) → TransientRetriable"
         );
     }
 
     #[test]
-    fn test_crawl_connection_classifies_as_internal_fatal() {
+    fn test_crawl_connection_classifies_as_transient_retriable() {
         let crawl_err = crate::domain::error::CrawlError::Connection("refused".into());
         let scraper_err: ScraperError = crawl_err.into();
         assert_eq!(
             scraper_err.classify(),
+            ErrorClass::TransientRetriable,
+            "Connection maps to ScraperError::Network(ConnectionReset io::Error) → TransientRetriable"
+        );
+    }
+
+    #[test]
+    fn test_scraper_rate_limited_classifies_as_transient_backoff() {
+        // EC-RATE-LIMITED: the typed variant classifies as backoff-retriable.
+        let err = ScraperError::RateLimited(30);
+        assert_eq!(err.classify(), ErrorClass::TransientBackoff);
+    }
+
+    #[test]
+    fn test_rate_limited_payload_survives_conversion() {
+        // EC-RATE-LIMITED: retry_after must survive From<CrawlError> intact.
+        let crawl_err = crate::domain::error::CrawlError::RateLimited(120);
+        let scraper_err: ScraperError = crawl_err.into();
+        assert!(
+            matches!(&scraper_err, ScraperError::RateLimited(120)),
+            "retry_after payload must survive conversion, got: {scraper_err}"
+        );
+        // Display contract: byte-identical to CrawlError::RateLimited and the
+        // former Internal message — keeps the integration "rate limited" guard
+        // (tests/scraper_service_test.rs::test_mock_rate_limited_error) green.
+        assert_eq!(scraper_err.to_string(), "rate limited, retry after 120s");
+    }
+
+    #[test]
+    fn test_timeout_maps_to_transient_io_source() {
+        // EC-TIMEOUT: the Network source MUST be a synthetic io::Error with
+        // ErrorKind::TimedOut so is_transient_network's downcast recognizes it.
+        // A bare message would fall through to InternalFatal and defeat the fix.
+        let crawl_err = crate::domain::error::CrawlError::Timeout;
+        let scraper_err: ScraperError = crawl_err.into();
+        match &scraper_err {
+            ScraperError::Network(source) => {
+                let io_err = source
+                    .downcast_ref::<std::io::Error>()
+                    .expect("Network source must downcast to io::Error for is_transient_network");
+                assert_eq!(io_err.kind(), std::io::ErrorKind::TimedOut);
+            },
+            other => panic!("Timeout must map to ScraperError::Network, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_connection_preserves_message_and_transient() {
+        // EC-CONNECTION: original message preserved, classifies TransientRetriable.
+        let crawl_err = crate::domain::error::CrawlError::Connection("peer reset".into());
+        let scraper_err: ScraperError = crawl_err.into();
+        assert_eq!(scraper_err.classify(), ErrorClass::TransientRetriable);
+        match &scraper_err {
+            ScraperError::Network(source) => {
+                let io_err = source
+                    .downcast_ref::<std::io::Error>()
+                    .expect("Network source must downcast to io::Error");
+                assert_eq!(io_err.kind(), std::io::ErrorKind::ConnectionReset);
+                assert!(
+                    io_err.to_string().contains("peer reset"),
+                    "original message must be preserved, got: {io_err}"
+                );
+            },
+            other => panic!("Connection must map to ScraperError::Network, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_request_failed_classifies_as_internal_fatal() {
+        // EC-REQUEST-FAILED: typed variant, classification unchanged (InternalFatal).
+        let crawl_err = crate::domain::error::CrawlError::RequestFailed("build failed".to_string());
+        let scraper_err: ScraperError = crawl_err.into();
+        assert!(
+            matches!(&scraper_err, ScraperError::Internal(m) if m == "build failed"),
+            "RequestFailed must map to ScraperError::Internal, got: {scraper_err}"
+        );
+        assert_eq!(scraper_err.classify(), ErrorClass::InternalFatal);
+    }
+
+    #[test]
+    fn test_classification_matrix_unchanged() {
+        // EC-REGRESSION-GUARD: pre-existing classifications must not drift.
+        assert_eq!(
+            ScraperError::http(429, "u").classify(),
+            ErrorClass::TransientBackoff,
+            "Http{{429}} → TransientBackoff"
+        );
+        assert_eq!(
+            ScraperError::http(500, "u").classify(),
+            ErrorClass::TransientRetriable,
+            "Http{{>=500}} → TransientRetriable"
+        );
+        assert_eq!(
+            ScraperError::http(503, "u").classify(),
+            ErrorClass::TransientRetriable,
+            "Http{{>=500}} → TransientRetriable"
+        );
+        assert_eq!(
+            ScraperError::http(404, "u").classify(),
+            ErrorClass::PermanentFatal,
+            "Http{{other 4xx}} → PermanentFatal"
+        );
+        assert_eq!(
+            ScraperError::http(403, "u").classify(),
+            ErrorClass::PermanentFatal,
+            "Http{{other 4xx}} → PermanentFatal"
+        );
+        assert_eq!(
+            ScraperError::invalid_url("bad").classify(),
+            ErrorClass::PermanentFatal,
+            "InvalidUrl → PermanentFatal"
+        );
+        assert_eq!(
+            ScraperError::waf_blocked("u", "Cloudflare").classify(),
+            ErrorClass::PermanentFatal,
+            "WafBlocked → PermanentFatal"
+        );
+        assert_eq!(
+            ScraperError::Internal("x".into()).classify(),
             ErrorClass::InternalFatal,
-            "Connection maps to ScraperError::Internal → InternalFatal"
+            "Internal → InternalFatal"
         );
     }
 

--- a/crates/webfang_core/src/lib.rs
+++ b/crates/webfang_core/src/lib.rs
@@ -47,6 +47,10 @@ pub mod cli;
 pub mod extractor;
 pub mod infrastructure;
 
+/// Shared test doubles for unit tests (compiled only under `cfg(test)`).
+#[cfg(test)]
+pub(crate) mod test_fixtures;
+
 // ============================================================================
 // Re-exports
 // ============================================================================

--- a/crates/webfang_core/src/test_fixtures.rs
+++ b/crates/webfang_core/src/test_fixtures.rs
@@ -1,0 +1,61 @@
+//! Shared test fixtures for `webfang_core` unit tests.
+//!
+//! Compiled only under `cfg(test)` (declared with `#[cfg(test)]` in
+//! `lib.rs`). Consolidates the mock HTTP client previously duplicated in
+//! `application::http_client::port` and `domain::ports` into a single
+//! source of truth (error-map-v2-cleanup, Item 2, Tier-1).
+
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use crate::domain::http_error::{HttpError, HttpResult};
+use crate::domain::http_port::{HttpClientPort, HttpResponse};
+
+/// Mock HTTP client returning canned responses keyed by URL.
+///
+/// URLs without a registered response produce `HttpError::ClientError(404)`.
+pub(crate) struct MockHttpClient {
+    responses: HashMap<String, HttpResult<HttpResponse>>,
+}
+
+impl MockHttpClient {
+    /// Create an empty mock (every URL resolves to a 404 client error).
+    pub(crate) fn new() -> Self {
+        Self {
+            responses: HashMap::new(),
+        }
+    }
+
+    /// Register a canned result for a URL (builder-style).
+    #[must_use]
+    pub(crate) fn with_response(mut self, url: &str, result: HttpResult<HttpResponse>) -> Self {
+        self.responses.insert(url.to_string(), result);
+        self
+    }
+}
+
+impl HttpClientPort for MockHttpClient {
+    fn get(
+        &self,
+        url: &str,
+    ) -> Pin<Box<dyn std::future::Future<Output = HttpResult<HttpResponse>> + Send + '_>> {
+        let result = match self.responses.get(url) {
+            Some(Ok(resp)) => Ok(HttpResponse {
+                status: resp.status,
+                body: resp.body.clone(),
+                headers: resp.headers.clone(),
+            }),
+            Some(Err(HttpError::Forbidden)) => Err(HttpError::Forbidden),
+            Some(Err(HttpError::RateLimited(r))) => Err(HttpError::RateLimited(*r)),
+            Some(Err(HttpError::ClientError(c))) => Err(HttpError::ClientError(*c)),
+            Some(Err(HttpError::ServerError(c))) => Err(HttpError::ServerError(*c)),
+            Some(Err(HttpError::Timeout)) => Err(HttpError::Timeout),
+            Some(Err(HttpError::Connection(m))) => Err(HttpError::Connection(m.clone())),
+            Some(Err(HttpError::Request(m))) => Err(HttpError::Request(m.clone())),
+            Some(Err(HttpError::WafChallenge(p))) => Err(HttpError::WafChallenge(p.clone())),
+            Some(Err(HttpError::DomainBanned(d))) => Err(HttpError::DomainBanned(d.clone())),
+            None => Err(HttpError::ClientError(404)),
+        };
+        Box::pin(async move { result })
+    }
+}

--- a/tests/common/mock_http.rs
+++ b/tests/common/mock_http.rs
@@ -1,0 +1,74 @@
+//! Shared mock HTTP client for integration tests (error-map-v2-cleanup, Item 2, Tier-2).
+//!
+//! Integration-test counterpart of the unit-side `webfang_core::test_fixtures`
+//! mock. Kept as a separate copy because `#[cfg(test)] pub(crate)` fixtures
+//! are not visible outside the crate. Wired into each consuming test via the
+//! flat `#[path = "common/mock_http.rs"] mod mock_http;` convention (see
+//! `cli_binary_test.rs`) — deliberately NOT routed through `tests/common/mod.rs`
+//! (orphaned, references the unresolvable `webfang::` bin-only crate).
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use webfang_core::application::http_client::{HttpClientPort, HttpError, HttpResponse, HttpResult};
+
+/// Mock HTTP client returning canned responses keyed by URL.
+///
+/// URLs without a registered response produce `HttpError::ClientError(404)`.
+pub struct MockHttpClient {
+    responses: HashMap<String, HttpResult<HttpResponse>>,
+}
+
+impl MockHttpClient {
+    /// Create an empty mock (every URL resolves to a 404 client error).
+    pub fn new() -> Self {
+        Self {
+            responses: HashMap::new(),
+        }
+    }
+
+    /// Register a canned result for a URL (builder-style).
+    pub fn with_response(mut self, url: &str, result: HttpResult<HttpResponse>) -> Self {
+        self.responses.insert(url.to_string(), result);
+        self
+    }
+
+    /// Shorthand for a 200 OK response with the given HTML body.
+    pub fn with_ok_response(self, url: &str, body: &str) -> Self {
+        self.with_response(
+            url,
+            Ok(HttpResponse {
+                status: 200,
+                body: body.to_string(),
+                headers: HashMap::new(),
+            }),
+        )
+    }
+}
+
+impl HttpClientPort for MockHttpClient {
+    fn get(
+        &self,
+        url: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = HttpResult<HttpResponse>> + Send + '_>>
+    {
+        let result = match self.responses.get(url) {
+            Some(Ok(resp)) => Ok(HttpResponse {
+                status: resp.status,
+                body: resp.body.clone(),
+                headers: resp.headers.clone(),
+            }),
+            Some(Err(HttpError::Forbidden)) => Err(HttpError::Forbidden),
+            Some(Err(HttpError::RateLimited(r))) => Err(HttpError::RateLimited(*r)),
+            Some(Err(HttpError::ClientError(c))) => Err(HttpError::ClientError(*c)),
+            Some(Err(HttpError::ServerError(c))) => Err(HttpError::ServerError(*c)),
+            Some(Err(HttpError::Timeout)) => Err(HttpError::Timeout),
+            Some(Err(HttpError::Connection(m))) => Err(HttpError::Connection(m.clone())),
+            Some(Err(HttpError::Request(m))) => Err(HttpError::Request(m.clone())),
+            Some(Err(HttpError::WafChallenge(p))) => Err(HttpError::WafChallenge(p.clone())),
+            Some(Err(HttpError::DomainBanned(d))) => Err(HttpError::DomainBanned(d.clone())),
+            None => Err(HttpError::ClientError(404)),
+        };
+        Box::pin(async move { result })
+    }
+}

--- a/tests/scraper_service_test.rs
+++ b/tests/scraper_service_test.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use webfang_core::application::http_client::{HttpClientPort, HttpError, HttpResponse, HttpResult};
+use webfang_core::application::http_client::{HttpError, HttpResponse};
 use webfang_core::application::scraper_service::{
     detect_spa_content, extract_with_selector, scrape_multiple_with_limit, scrape_with_config,
     scrape_with_readability, MAX_INSTRUMENTED_BODY_SIZE, MIN_CONTENT_CHARS,
@@ -8,63 +8,11 @@ use webfang_core::application::scraper_service::{
 use webfang_core::domain::{DomInspectorPort, ExtractResult, SelectorErrorKind};
 use webfang_core::{ScraperConfig, ScraperError};
 
-// --- Mock HTTP client (test-local, not shared infrastructure) ---
+// --- Shared mock HTTP client (tests/common/mock_http.rs, Item 2 Tier-2) ---
 
-struct MockHttpClient {
-    responses: HashMap<String, HttpResult<HttpResponse>>,
-}
-
-impl MockHttpClient {
-    fn new() -> Self {
-        Self {
-            responses: HashMap::new(),
-        }
-    }
-
-    fn with_response(mut self, url: &str, result: HttpResult<HttpResponse>) -> Self {
-        self.responses.insert(url.to_string(), result);
-        self
-    }
-
-    /// Shorthand for a 200 OK response with the given HTML body.
-    fn with_ok_response(self, url: &str, body: &str) -> Self {
-        self.with_response(
-            url,
-            Ok(HttpResponse {
-                status: 200,
-                body: body.to_string(),
-                headers: HashMap::new(),
-            }),
-        )
-    }
-}
-
-impl HttpClientPort for MockHttpClient {
-    fn get(
-        &self,
-        url: &str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = HttpResult<HttpResponse>> + Send + '_>>
-    {
-        let result = match self.responses.get(url) {
-            Some(Ok(resp)) => Ok(HttpResponse {
-                status: resp.status,
-                body: resp.body.clone(),
-                headers: resp.headers.clone(),
-            }),
-            Some(Err(HttpError::Forbidden)) => Err(HttpError::Forbidden),
-            Some(Err(HttpError::RateLimited(r))) => Err(HttpError::RateLimited(*r)),
-            Some(Err(HttpError::ClientError(c))) => Err(HttpError::ClientError(*c)),
-            Some(Err(HttpError::ServerError(c))) => Err(HttpError::ServerError(*c)),
-            Some(Err(HttpError::Timeout)) => Err(HttpError::Timeout),
-            Some(Err(HttpError::Connection(m))) => Err(HttpError::Connection(m.clone())),
-            Some(Err(HttpError::Request(m))) => Err(HttpError::Request(m.clone())),
-            Some(Err(HttpError::WafChallenge(p))) => Err(HttpError::WafChallenge(p.clone())),
-            Some(Err(HttpError::DomainBanned(d))) => Err(HttpError::DomainBanned(d.clone())),
-            None => Err(HttpError::ClientError(404)),
-        };
-        Box::pin(async move { result })
-    }
-}
+#[path = "common/mock_http.rs"]
+mod mock_http;
+use crate::mock_http::MockHttpClient;
 
 // =====================================================================
 // scrape_with_config tests


### PR DESCRIPTION
## Resumen

Resuelve #236 — limpieza post-merge de **Error Map V2** (continuación de #235, dependencia #227 ya cerrada).

Consolida los 4 WARNING + 2 sugerencias pendientes del review de Error Map V2. Cambio **behavior-neutral en producción**: el único consumidor productivo de `classify()` es el asset downloader (`adapters/downloader/mod.rs:193`), que reintenta solo `TransientRetriable` y nunca ve errores derivados de `CrawlError`; `HttpClient` reintenta antes a nivel `HttpError`; los exit codes de CLI están desacoplados. El valor es corrección semántica + future-proofing.

## Cambios por work unit (3 commits)

**Unit C — `feat(domain)` (e939a96)** · Items 5 + 6
- `impl Display for ResourceKind` ("sitemap URLs" / "sitemap depth" / "RAM budget"). El `#[error]` de `ResourceExhausted` sigue usando `{resource:?}` (Debug), así el test de "RamBudget" continúa verde.
- Doc-comment en `ScraperError::CrawlLimit` documentando que agrupa max-depth / max-pages / sitemap-depth (todas `PermanentFatal`).

**Unit A — `feat(crawler)` (e9a37af)** · Items 1 + 3 + 4
- Nueva variante `ScraperError::RateLimited(u64)` → `classify()` devuelve `TransientBackoff`, preservando `retry_after`.
- `CrawlError::Timeout` / `Connection(msg)` → `ScraperError::Network` con un `io::Error` sintético (`ErrorKind::TimedOut` / `ConnectionReset`) para que `is_transient_network()` los clasifique como `TransientRetriable`. El source sintético es **obligatorio**: un mensaje plano caería a `InternalFatal`.
- Nueva variante tipada `CrawlError::RequestFailed(String)`; `HttpError::Request` mapea a ella en **ambos** sitios de conversión (`domain/error/crawl_error.rs` y `application/scraper_service.rs`), manteniendo la clasificación `InternalFatal` (sin cambio de comportamiento).
- `tracing::debug!` en el fallback por texto de `is_transient_network` (Item 4, heurística aceptada).

**Unit B — `refactor(core)` (6a36b14)** · Item 2
- `MockHttpClient` triplicado → **2 ubicaciones mantenidas**: fixture `#[cfg(test)] pub(crate)` en `src/test_fixtures.rs` (unit tests de `port.rs` y `domain/ports.rs`) + `tests/common/mock_http.rs` (integration, vía `#[path]` plano según convención del repo). Sin feature flag, sin crate nuevo. `tests/common/mod.rs` sin tocar.

## Verificación

- `cargo check --workspace --all-targets` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo nextest run --workspace` ✅ **1807 passed / 0 failed / 15 skipped**
- 11 tests nuevos/reescritos cubriendo los 6 requisitos (`EC-RATE-LIMITED`, `EC-TIMEOUT`, `EC-CONNECTION`, `EC-REQUEST-FAILED`, `EC-REGRESSION-GUARD`, `EC-RESOURCE-DISPLAY`).
- Scope: 9 archivos (409+/184-); el volumen viene de la reubicación byte-a-byte del mock (Unit B), la lógica neta nueva es pequeña.

## Notas / follow-ups (fuera de scope)

- Feature `test-support` (approach A para el mock) diferido como upgrade path si el mock se extiende a tui/mcp/cli.
- Reroute opcional de URL-parse (`client.rs:196`) a `InvalidUrl` diferido (cambiaría clasificación).
- Test flaky pre-existente `cli::batch_test::batch_file_timeout_does_not_hang` (timing, pasa en retry) — no relacionado con este cambio.

Closes #236
