### PR TITLE
fix(crawler): enforce max_depth in crawl_with_subpath_sitemaps

### DIFF
--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -579,8 +579,16 @@ async fn crawl_with_sitemap_internal(
             sitemap_url,
             target_path
         );
-        return crawl_with_subpath_sitemaps(base_url, &base, &parser, 3, 0, &discovery_client)
-            .await;
+        return crawl_with_subpath_sitemaps(
+            base_url,
+            &base,
+            &parser,
+            3,
+            0,
+            config.max_depth,
+            &discovery_client,
+        )
+        .await;
     }
 
     // Following own-borrow-over-clone: use Url directly, not String
@@ -611,7 +619,13 @@ async fn crawl_with_sitemap_internal(
 ///
 /// For nested sites like `https://example.com/docs/en/`, this tries
 /// `/docs/sitemap.xml`, `/docs/en/sitemap.xml`, etc.
-/// Follows nested sitemaps recursively up to `max_depth` levels.
+/// Follows nested sitemaps recursively up to `sitemap_max_depth` levels.
+///
+/// `crawl_max_depth` is the crawl's configured max depth (CLI `--max-depth`),
+/// distinct from the sitemap-index recursion depth above. Sub-path sitemap URLs
+/// are one hop from the seed (depth 1), so when `crawl_max_depth` is 0 ("only
+/// the seed URL") none of them qualify and an empty list is returned — mirroring
+/// the `depth <= max_depth` gate in `crawl_with_sitemap_internal`.
 ///
 /// Following **own-borrow-over-clone**: Accepts `&Url` not `&String`.
 /// Following **err-no-unwrap-prod**: Proper error handling throughout.
@@ -619,15 +633,26 @@ async fn crawl_with_subpath_sitemaps(
     base_url: &str,
     base: &Url,
     parser: &SitemapParser,
-    max_depth: usize,
-    current_depth: usize,
+    sitemap_max_depth: usize,
+    sitemap_current_depth: usize,
+    crawl_max_depth: u8,
     client: &wreq::Client,
 ) -> Result<Vec<DiscoveredUrl>, CrawlError> {
-    if current_depth >= max_depth {
+    if sitemap_current_depth >= sitemap_max_depth {
         tracing::warn!(
             "sitemap recursion depth {} reached max {}, stopping",
-            current_depth,
-            max_depth
+            sitemap_current_depth,
+            sitemap_max_depth
+        );
+        return Ok(Vec::new());
+    }
+
+    // Sub-path sitemap URLs are depth 1; with a crawl max_depth of 0 none pass
+    // the gate, so short-circuit before probing the network.
+    if crawl_max_depth == 0 {
+        tracing::info!(
+            "crawl max_depth is 0, skipping sub-path sitemap URLs for {}",
+            base_url
         );
         return Ok(Vec::new());
     }

--- a/tests/behavioral/cli/crawl_test.rs
+++ b/tests/behavioral/cli/crawl_test.rs
@@ -101,6 +101,162 @@ async fn max_depth_zero_only_scrapes_seed() {
     );
 }
 
+/// Mount a sub-path sitemap fallback scenario and return the server base URL:
+/// - main `/sitemap.xml` lists only a URL outside `/blog/`, so discovery finds
+///   no relevant URLs and falls back to sub-path sitemaps;
+/// - `/blog/sitemap.xml` (HEAD probe + GET parse) lists two `/blog/` content URLs;
+/// - the two content pages return scrapeable HTML.
+async fn mount_subpath_scenario(server: &wiremock::MockServer) -> String {
+    let base = server.uri();
+
+    crate::common::mock_robots(server, "User-agent: *\n").await;
+
+    let main_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{}/about</loc></url>
+</urlset>"#,
+        base
+    );
+    crate::common::mock_sitemap(server, &format!("{}/sitemap.xml", base), &main_xml).await;
+
+    // The fallback probes candidates with HEAD before parsing them with GET.
+    Mock::given(method("HEAD"))
+        .and(path("/blog/sitemap.xml"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(server)
+        .await;
+
+    let subpath_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{}/blog/post-1</loc></url>
+    <url><loc>{}/blog/post-2</loc></url>
+</urlset>"#,
+        base, base
+    );
+    crate::common::mock_sitemap(server, &format!("{}/blog/sitemap.xml", base), &subpath_xml).await;
+
+    Mock::given(method("GET"))
+        .and(path("/blog/post-1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Post 1</h1></article></body></html>"),
+        )
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/blog/post-2"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><article><h1>Post 2</h1></article></body></html>"),
+        )
+        .mount(server)
+        .await;
+
+    base
+}
+
+/// --max-depth 0 on the sub-path sitemap fallback scrapes none of the
+/// sub-sitemap URLs: they are depth 1, so the crawl's max_depth gate filters
+/// them all out and discovery comes back empty (EmptyDiscovery exit).
+#[tokio::test]
+async fn subpath_sitemap_max_depth_zero_skips_content() {
+    let t = BehavioralTest::new().await;
+    let base = mount_subpath_scenario(&t.server).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(format!("{}/blog/", base))
+        .arg("--sitemap-url")
+        .arg(format!("{}/sitemap.xml", base))
+        .arg("--use-sitemap")
+        .arg("--max-depth")
+        .arg("0")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    // No scrapeable URL survives the depth gate -> EmptyDiscovery (non-success).
+    assert!(
+        !output.status.success(),
+        "expected empty-discovery failure, got success; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = t.server.received_requests().await.unwrap();
+    let post1 = requests
+        .iter()
+        .filter(|r| r.url.path() == "/blog/post-1")
+        .count();
+    let post2 = requests
+        .iter()
+        .filter(|r| r.url.path() == "/blog/post-2")
+        .count();
+    assert_eq!(
+        post1, 0,
+        "expected 0 requests to /blog/post-1 with max-depth 0, got {}",
+        post1
+    );
+    assert_eq!(
+        post2, 0,
+        "expected 0 requests to /blog/post-2 with max-depth 0, got {}",
+        post2
+    );
+}
+
+/// Control for `subpath_sitemap_max_depth_zero_skips_content`: with --max-depth 1
+/// the same sub-path sitemap URLs (depth 1) ARE discovered and scraped, proving
+/// the zero above comes from the depth gate and not a broken fallback.
+#[tokio::test]
+async fn subpath_sitemap_max_depth_one_scrapes_content() {
+    let t = BehavioralTest::new().await;
+    let base = mount_subpath_scenario(&t.server).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(format!("{}/blog/", base))
+        .arg("--sitemap-url")
+        .arg(format!("{}/sitemap.xml", base))
+        .arg("--use-sitemap")
+        .arg("--max-depth")
+        .arg("1")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        output.status.success(),
+        "expected success, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = t.server.received_requests().await.unwrap();
+    let post1 = requests
+        .iter()
+        .filter(|r| r.url.path() == "/blog/post-1")
+        .count();
+    let post2 = requests
+        .iter()
+        .filter(|r| r.url.path() == "/blog/post-2")
+        .count();
+    assert!(
+        post1 >= 1,
+        "expected >=1 request to /blog/post-1 with max-depth 1, got {}",
+        post1
+    );
+    assert!(
+        post2 >= 1,
+        "expected >=1 request to /blog/post-2 with max-depth 1, got {}",
+        post2
+    );
+}
+
 /// --max-pages 2 caps the crawl output to at most 2 .md files.
 #[tokio::test]
 async fn max_pages_limits_crawl_output() {


### PR DESCRIPTION
## Linked Issue

Closes #282

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- Thread `config.max_depth` into the sub-path sitemap fallback so `--max-depth 0` correctly returns only the seed URL instead of scraping all sub-sitemap URLs at depth 1.
- Rename sitemap recursion params to `sitemap_max_depth`/`sitemap_current_depth` to eliminate conceptual ambiguity with crawl depth.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/crawler/discovery.rs` | Added `crawl_max_depth: u8` param, early-return when 0, renamed recursion params, threaded `config.max_depth` at call site |
| `tests/behavioral/cli/crawl_test.rs` | 2 new wiremock tests: depth-0 skips sub-sitemap URLs, depth-1 scrapes them (control) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (273 tests, 0 failures)
- [x] New tests verify the exact acceptance criteria from the issue

## Contributor Checklist

- [x] Linked an issue with `Closes #282`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] No docs update needed (internal behavior fix)