### PR TITLE
docs(cli): clarify --force-js-render is a no-op and point to --js-strategy

### DIFF
--- a/crates/webfang_core/src/cli/args/crawler.rs
+++ b/crates/webfang_core/src/cli/args/crawler.rs
@@ -129,7 +129,8 @@ pub struct CrawlerArgs {
     )]
     pub adaptive_selectors: bool,
 
-    /// Force JavaScript rendering for SPA sites (not yet implemented)
+    /// No-op placeholder for future JavaScript rendering (Phase 2).
+    /// Use --js-strategy hybrid or --js-strategy full for JS rendering support.
     #[arg(long, default_value = "false", env = "WEBFANG_FORCE_JS_RENDER")]
     #[clap(next_help_heading = "Behavior")]
     pub force_js_render: bool,

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -91,6 +91,17 @@ Options:
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
 
+      --clean-ai
+          Use AI-powered semantic cleaning for better RAG output
+          
+          [env: WEBFANG_CLEAN_AI=]
+          [alias: --ai]
+
+      --adaptive-selectors
+          Enable adaptive CSS selector repair (2-tier cascade)
+          
+          [env: WEBFANG_ADAPTIVE_SELECTORS=]
+
       --force-js-render
           No-op placeholder for future JavaScript rendering (Phase 2). Use --js-strategy hybrid or --js-strategy full for JS rendering support
           
@@ -363,6 +374,29 @@ Options:
           Add rich metadata to frontmatter
           
           [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
+
+      --threshold <THRESHOLD>
+          Relevance threshold for AI semantic filtering (0.0-1.0)
+          
+          [env: WEBFANG_THRESHOLD=]
+          [default: 0.3]
+
+      --max-tokens <MAX_TOKENS>
+          Maximum tokens per chunk for AI processing
+          
+          [env: WEBFANG_MAX_TOKENS=]
+          [default: 32768]
+
+      --offline
+          Run AI model in offline mode
+          
+          [env: WEBFANG_OFFLINE=]
+
+      --ai-model <AI_MODEL>
+          AI model to use: granite-97m (default, fast) or granite-311m (higher quality)
+          
+          [env: AI_MODEL_ID=]
+          [possible values: granite-97m, granite-311m]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -91,19 +91,8 @@ Options:
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
 
-      --clean-ai
-          Use AI-powered semantic cleaning for better RAG output
-          
-          [env: WEBFANG_CLEAN_AI=]
-          [alias: --ai]
-
-      --adaptive-selectors
-          Enable adaptive CSS selector repair (2-tier cascade)
-          
-          [env: WEBFANG_ADAPTIVE_SELECTORS=]
-
       --force-js-render
-          Force JavaScript rendering for SPA sites (not yet implemented)
+          No-op placeholder for future JavaScript rendering (Phase 2). Use --js-strategy hybrid or --js-strategy full for JS rendering support
           
           [env: WEBFANG_FORCE_JS_RENDER=]
 
@@ -374,29 +363,6 @@ Options:
           Add rich metadata to frontmatter
           
           [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
-
-      --threshold <THRESHOLD>
-          Relevance threshold for AI semantic filtering (0.0-1.0)
-          
-          [env: WEBFANG_THRESHOLD=]
-          [default: 0.3]
-
-      --max-tokens <MAX_TOKENS>
-          Maximum tokens per chunk for AI processing
-          
-          [env: WEBFANG_MAX_TOKENS=]
-          [default: 32768]
-
-      --offline
-          Run AI model in offline mode
-          
-          [env: WEBFANG_OFFLINE=]
-
-      --ai-model <AI_MODEL>
-          AI model to use: granite-97m (default, fast) or granite-311m (higher quality)
-          
-          [env: AI_MODEL_ID=]
-          [possible values: granite-97m, granite-311m]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -91,6 +91,17 @@ Options:
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
 
+      --clean-ai
+          Use AI-powered semantic cleaning for better RAG output
+          
+          [env: WEBFANG_CLEAN_AI=]
+          [alias: --ai]
+
+      --adaptive-selectors
+          Enable adaptive CSS selector repair (2-tier cascade)
+          
+          [env: WEBFANG_ADAPTIVE_SELECTORS=]
+
       --force-js-render
           No-op placeholder for future JavaScript rendering (Phase 2). Use --js-strategy hybrid or --js-strategy full for JS rendering support
           
@@ -363,6 +374,29 @@ Options:
           Add rich metadata to frontmatter
           
           [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
+
+      --threshold <THRESHOLD>
+          Relevance threshold for AI semantic filtering (0.0-1.0)
+          
+          [env: WEBFANG_THRESHOLD=]
+          [default: 0.3]
+
+      --max-tokens <MAX_TOKENS>
+          Maximum tokens per chunk for AI processing
+          
+          [env: WEBFANG_MAX_TOKENS=]
+          [default: 32768]
+
+      --offline
+          Run AI model in offline mode
+          
+          [env: WEBFANG_OFFLINE=]
+
+      --ai-model <AI_MODEL>
+          AI model to use: granite-97m (default, fast) or granite-311m (higher quality)
+          
+          [env: AI_MODEL_ID=]
+          [possible values: granite-97m, granite-311m]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -91,19 +91,8 @@ Options:
           
           [env: WEBFANG_DOWNLOAD_ASSETS=]
 
-      --clean-ai
-          Use AI-powered semantic cleaning for better RAG output
-          
-          [env: WEBFANG_CLEAN_AI=]
-          [alias: --ai]
-
-      --adaptive-selectors
-          Enable adaptive CSS selector repair (2-tier cascade)
-          
-          [env: WEBFANG_ADAPTIVE_SELECTORS=]
-
       --force-js-render
-          Force JavaScript rendering for SPA sites (not yet implemented)
+          No-op placeholder for future JavaScript rendering (Phase 2). Use --js-strategy hybrid or --js-strategy full for JS rendering support
           
           [env: WEBFANG_FORCE_JS_RENDER=]
 
@@ -374,29 +363,6 @@ Options:
           Add rich metadata to frontmatter
           
           [env: WEBFANG_OBSIDIAN_RICH_METADATA=]
-
-      --threshold <THRESHOLD>
-          Relevance threshold for AI semantic filtering (0.0-1.0)
-          
-          [env: WEBFANG_THRESHOLD=]
-          [default: 0.3]
-
-      --max-tokens <MAX_TOKENS>
-          Maximum tokens per chunk for AI processing
-          
-          [env: WEBFANG_MAX_TOKENS=]
-          [default: 32768]
-
-      --offline
-          Run AI model in offline mode
-          
-          [env: WEBFANG_OFFLINE=]
-
-      --ai-model <AI_MODEL>
-          AI model to use: granite-97m (default, fast) or granite-311m (higher quality)
-          
-          [env: AI_MODEL_ID=]
-          [possible values: granite-97m, granite-311m]
 
       --tui
           Unified TUI mode: config form (collapsible sections) → URL selector → scraping


### PR DESCRIPTION
Closes #274

## Summary
- Update help text for `--force-js-render` to make clear it is a no-op placeholder for Phase 2
- Direct users to the functional alternative: `--js-strategy hybrid` or `--js-strategy full`

## Changes
- `crates/webfang_core/src/cli/args/crawler.rs`: 1 line changed (help text only)

## Verification
- `cargo check -p webfang_core` passes
- `cargo clippy -p webfang_core -- -D warnings` passes
- `cargo fmt` clean