### PR TITLE
fix(http): make create_http_client timeout configurable via HttpClientConfig

### DIFF
--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -10,6 +10,7 @@ use tracing::{debug, info, instrument, span, warn, Level};
 use url::Url;
 
 use crate::application::url_filter::is_allowed;
+use crate::domain::http_config::HttpClientConfig;
 use crate::domain::{CrawlError, CrawlerConfig, DiscoveredUrl, ScrapedContent, ValidUrl};
 use crate::error::{Result as ScraperResult, ScraperError};
 use crate::infrastructure::crawler::binary_utils::derive_filename_from_response;
@@ -102,8 +103,17 @@ pub async fn discover_urls_for_tui(
 
         Ok(urls)
     } else {
-        // DOM scraping - extract links from single page
-        let client = super::super::create_http_client()?;
+        // DOM scraping - extract links from single page.
+        // Honor the configured request timeout (#289). The connect timeout is
+        // capped at 10s, replicating the #281 policy used by the sitemap branch.
+        // user_agent stays None (Default) so this path keeps rotating random pool
+        // agents instead of injecting config.user_agent.
+        let http_config = HttpClientConfig {
+            timeout_secs: config.timeout_secs,
+            connect_timeout_secs: config.timeout_secs.min(10), // #281 policy, replicated at call site
+            ..Default::default()
+        };
+        let client = super::super::create_http_client_with_config(&http_config)?;
 
         info!("Fetching {} for link extraction", base_url);
         let response = client
@@ -973,5 +983,88 @@ mod tests {
         assert_eq!(urls.len(), 2);
         assert!(urls.contains(&"https://example.com/page1".to_string()));
         assert!(urls.contains(&"https://external.com/page2".to_string()));
+    }
+
+    // #289 acceptance tests: the TUI DOM discovery path must honor CrawlerConfig
+    // timeouts. Both build a real wreq client (boring-sys2 FFI), hence not(miri).
+
+    #[tokio::test]
+    #[cfg(not(miri))]
+    async fn test_discover_urls_for_tui_respects_request_timeout() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // wiremock completes TCP instantly then delays the HTTP response, so this
+        // exercises the request timeout (timeout_secs), not the connect timeout.
+        let server = MockServer::start().await;
+        Mock::given(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("<html></html>")
+                    .set_delay(Duration::from_secs(10)),
+            )
+            .mount(&server)
+            .await;
+
+        let seed = Url::parse(&server.uri()).unwrap();
+        let config = CrawlerConfig::builder(seed)
+            .timeout_secs(2)
+            .use_sitemap(false)
+            .build();
+
+        let start = std::time::Instant::now();
+        let result = discover_urls_for_tui(&server.uri(), &config).await;
+        let elapsed = start.elapsed();
+
+        let err = result.expect_err("slow response should time out");
+        assert!(
+            elapsed < Duration::from_secs(6),
+            "2s request timeout should fire well before 6s, took {elapsed:?}"
+        );
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("timeout") || msg.contains("http error"),
+            "error should mention timeout/http error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(not(miri))]
+    async fn test_discover_urls_for_tui_respects_connect_timeout() {
+        use tokio::net::TcpListener;
+
+        // TLS blackhole: accept TCP connections and hold them open without ever
+        // completing the TLS handshake. wiremock cannot simulate this (it always
+        // finishes TCP+TLS), so a raw listener is used. This exercises the connect
+        // timeout, which covers TCP+TLS establishment (reqwest semantics).
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                // Keep the socket alive and silent so the handshake never finishes.
+                tokio::spawn(async move {
+                    let _socket = socket;
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                });
+            }
+        });
+
+        let target = format!("https://127.0.0.1:{port}");
+        let seed = Url::parse(&target).unwrap();
+        let config = CrawlerConfig::builder(seed)
+            .timeout_secs(2)
+            .use_sitemap(false)
+            .build();
+
+        let start = std::time::Instant::now();
+        let result = discover_urls_for_tui(&target, &config).await;
+        let elapsed = start.elapsed();
+
+        let err = result.expect_err("TLS blackhole should fail to connect");
+        eprintln!("connect-timeout error variant: {err:?}");
+        assert!(
+            elapsed < Duration::from_secs(6),
+            "2s connect timeout should fire well before 6s, took {elapsed:?}"
+        );
     }
 }

--- a/crates/webfang_core/src/application/http_client/client.rs
+++ b/crates/webfang_core/src/application/http_client/client.rs
@@ -27,7 +27,6 @@ use crate::infrastructure::observability::metrics_instruments::{
 };
 use wreq::header::{HeaderMap, HeaderName, HeaderValue};
 use wreq::Client;
-use wreq_util::Emulation;
 
 /// Client Hints headers for Chrome 145 (2026 Standard)
 /// These headers must match the TLS fingerprint to avoid "Headless Spoofing" detection
@@ -566,29 +565,41 @@ fn build_wreq_client(
         .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))
 }
 
-// Legacy function - simplified, returns wreq::Client directly
-/// Create configured HTTP client
+/// Create a bare `wreq::Client` that honors the given domain config.
 ///
-/// This function creates a client with basic configuration.
-/// For more control, use `HttpClient::new()` with `HttpClientConfig`.
-pub fn create_http_client() -> Result<Client, ScraperError> {
-    let agents = UserAgentCache::fallback_agents();
-    let user_agent = get_random_user_agent_from_pool(&agents);
+/// This is the config-driven counterpart of `HttpClient::new`: it returns the
+/// raw inner client (no retry middleware) for callers that manage requests
+/// themselves, while still applying the Chrome Client Hints headers, the
+/// resolved H2/TLS profile, request/connect timeouts, and pool tuning from
+/// `config`.
+///
+/// User-agent resolution: `config.user_agent` is used when set; otherwise a
+/// random agent is drawn from the fallback pool, preserving the historical
+/// rotation behavior of `create_http_client`.
+///
+/// # Errors
+///
+/// Returns `ScraperError::Config` if the underlying client fails to build.
+pub fn create_http_client_with_config(config: &HttpClientConfig) -> Result<Client, ScraperError> {
+    let user_agent = match config.user_agent.clone() {
+        Some(ua) => ua,
+        None => get_random_user_agent_from_pool(&UserAgentCache::fallback_agents()),
+    };
 
     tracing::debug!("Using user agent: {}", user_agent);
 
-    let client = Client::builder()
-        .emulation(Emulation::Chrome145)
-        .user_agent(user_agent)
-        .timeout(Duration::from_secs(30))
-        .gzip(true)
-        .brotli(true)
-        .cookie_store(true)
-        .redirect(wreq::redirect::Policy::limited(10))
-        .build()
-        .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))?;
+    build_wreq_client(config, Some(user_agent))
+}
 
-    Ok(client)
+// Legacy function - simplified, returns wreq::Client directly
+/// Create configured HTTP client
+///
+/// Equivalent to `create_http_client_with_config(&HttpClientConfig::default())`:
+/// a Chrome145 client with a random pooled user agent, a 30s request timeout,
+/// and a 10s connect timeout, plus the Chrome Client Hints default headers.
+/// For more control, use `HttpClient::new()` with `HttpClientConfig`.
+pub fn create_http_client() -> Result<Client, ScraperError> {
+    create_http_client_with_config(&HttpClientConfig::default())
 }
 
 /// Get random user agent from pool (legacy function)

--- a/crates/webfang_core/src/application/http_client/client.rs
+++ b/crates/webfang_core/src/application/http_client/client.rs
@@ -71,63 +71,7 @@ impl HttpClient {
     ///
     /// Returns `ScraperError::Config` if client creation fails
     pub fn new(config: HttpClientConfig) -> Result<Self, ScraperError> {
-        let pool_size = std::cmp::max(6, num_cpus::get() - 1);
-
-        // Build Client Hints headers for Chrome 145 (2026 Standard)
-        // These MUST match the TLS fingerprint to avoid "Headless Spoofing" detection
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            HeaderName::from_static("sec-ch-ua"),
-            HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA),
-        );
-        headers.insert(
-            HeaderName::from_static("sec-ch-ua-mobile"),
-            HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_MOBILE),
-        );
-        headers.insert(
-            HeaderName::from_static("sec-ch-ua-platform"),
-            HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_PLATFORM),
-        );
-        // Additional security headers (Sec-Fetch)
-        headers.insert(
-            HeaderName::from_static("sec-fetch-dest"),
-            HeaderValue::from_static("document"),
-        );
-        headers.insert(
-            HeaderName::from_static("sec-fetch-mode"),
-            HeaderValue::from_static("navigate"),
-        );
-        headers.insert(
-            HeaderName::from_static("sec-fetch-site"),
-            HeaderValue::from_static("none"),
-        );
-        headers.insert(
-            HeaderName::from_static("sec-fetch-user"),
-            HeaderValue::from_static("?1"),
-        );
-        headers.insert(
-            HeaderName::from_static("upgrade-insecure-requests"),
-            HeaderValue::from_static("1"),
-        );
-
-        // Resolve H2/TLS profile from name — overrides tls_emulation if h2_profile is set
-        let profile = HttpClientConfig::resolve_profile(&config.h2_profile);
-
-        let builder = Client::builder()
-            .emulation(profile)
-            .default_headers(headers)
-            .timeout(Duration::from_secs(config.timeout_secs))
-            .connect_timeout(Duration::from_secs(config.connect_timeout_secs))
-            .pool_max_idle_per_host(pool_size)
-            .pool_idle_timeout(Duration::from_secs(60))
-            .gzip(true)
-            .brotli(true)
-            .cookie_store(true)
-            .redirect(wreq::redirect::Policy::limited(10));
-
-        let client = builder
-            .build()
-            .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))?;
+        let client = build_wreq_client(&config, None)?;
 
         let mut user_agents = UserAgentCache::fallback_agents();
         if let Some(ref ua) = config.user_agent {
@@ -538,6 +482,88 @@ impl HttpClient {
             }
         }
     }
+}
+
+/// Build the inner `wreq::Client` shared by `HttpClient::new` and the
+/// bare-client factories.
+///
+/// Applies the Chrome Client Hints + Sec-Fetch default headers (these MUST
+/// match the TLS fingerprint to avoid "Headless Spoofing" detection), the
+/// resolved H2/TLS profile, request/connect timeouts, connection-pool tuning,
+/// compression, cookie storage, and a bounded redirect policy.
+///
+/// When `user_agent` is `Some`, it is set as the build-time `User-Agent`;
+/// when `None`, no build-time UA is applied (callers such as `HttpClient`
+/// set the UA per request instead).
+///
+/// # Errors
+///
+/// Returns `ScraperError::Config` if the underlying client fails to build.
+fn build_wreq_client(
+    config: &HttpClientConfig,
+    user_agent: Option<String>,
+) -> Result<Client, ScraperError> {
+    let pool_size = std::cmp::max(6, num_cpus::get() - 1);
+
+    // Build Client Hints headers for Chrome 145 (2026 Standard)
+    // These MUST match the TLS fingerprint to avoid "Headless Spoofing" detection
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua"),
+        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua-mobile"),
+        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_MOBILE),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua-platform"),
+        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_PLATFORM),
+    );
+    // Additional security headers (Sec-Fetch)
+    headers.insert(
+        HeaderName::from_static("sec-fetch-dest"),
+        HeaderValue::from_static("document"),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-fetch-mode"),
+        HeaderValue::from_static("navigate"),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-fetch-site"),
+        HeaderValue::from_static("none"),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-fetch-user"),
+        HeaderValue::from_static("?1"),
+    );
+    headers.insert(
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
+    );
+
+    // Resolve H2/TLS profile from name — overrides tls_emulation if h2_profile is set
+    let profile = HttpClientConfig::resolve_profile(&config.h2_profile);
+
+    let mut builder = Client::builder()
+        .emulation(profile)
+        .default_headers(headers)
+        .timeout(Duration::from_secs(config.timeout_secs))
+        .connect_timeout(Duration::from_secs(config.connect_timeout_secs))
+        .pool_max_idle_per_host(pool_size)
+        .pool_idle_timeout(Duration::from_secs(60))
+        .gzip(true)
+        .brotli(true)
+        .cookie_store(true)
+        .redirect(wreq::redirect::Policy::limited(10));
+
+    if let Some(ua) = user_agent {
+        builder = builder.user_agent(ua);
+    }
+
+    builder
+        .build()
+        .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))
 }
 
 // Legacy function - simplified, returns wreq::Client directly

--- a/crates/webfang_core/src/application/http_client/mod.rs
+++ b/crates/webfang_core/src/application/http_client/mod.rs
@@ -42,4 +42,6 @@ pub mod port;
 pub use crate::domain::http_config::HttpClientConfig;
 pub use crate::domain::http_error::{HttpError, HttpResult};
 pub use crate::domain::http_port::{HttpClientPort, HttpResponse};
-pub use client::{create_http_client, get_random_user_agent_from_pool, HttpClient};
+pub use client::{
+    create_http_client, create_http_client_with_config, get_random_user_agent_from_pool, HttpClient,
+};

--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -36,6 +36,7 @@ pub use crawler::{
 };
 pub use deduplicator::UrlDeduplicator;
 pub use http_client::create_http_client;
+pub use http_client::create_http_client_with_config;
 pub use http_client::HttpClientPort;
 pub use rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 pub use scraper_service::{

--- a/crates/webfang_core/src/infrastructure/http/mod.rs
+++ b/crates/webfang_core/src/infrastructure/http/mod.rs
@@ -4,5 +4,6 @@
 //! This module exists for architectural consistency.
 
 pub use crate::application::http_client::create_http_client;
+pub use crate::application::http_client::create_http_client_with_config;
 
 pub mod waf_engine;

--- a/crates/webfang_core/src/lib.rs
+++ b/crates/webfang_core/src/lib.rs
@@ -66,7 +66,7 @@ pub use application::{
     batch::{BatchJob, BatchProcessor, BatchProgress, BatchResult},
     crawl_options::CrawlOptions,
     crawl_site, crawl_site_with_options, crawl_with_sitemap, create_http_client,
-    detect_spa_content, discover_urls_for_tui, extract_domain,
+    create_http_client_with_config, detect_spa_content, discover_urls_for_tui, extract_domain,
     http_client::{HttpClient, HttpClientConfig, HttpError},
     is_allowed, is_excluded, is_internal_link, matches_pattern, scrape_multiple_with_limit,
     scrape_single_url_for_tui, scrape_with_config, scrape_with_readability, EngineOptions,


### PR DESCRIPTION
## Linked Issue

Closes #289

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `create_http_client()` hardcoded `.timeout(30s)` with no `connect_timeout`, ignoring the user's `--timeout-secs`. This PR adds `create_http_client_with_config(&HttpClientConfig)` backed by a shared private builder (`build_wreq_client`) extracted from `HttpClient::new`; `create_http_client()` now delegates to it with `HttpClientConfig::default()` — single source of truth, no parallel builders.
- The TUI discovery DOM path (`discover_urls_for_tui`) now honors `CrawlerConfig.timeout_secs`, with connect timeout capped at 10s (replicating the #281 sitemap policy at the call site; `user_agent` deliberately left `None` to preserve random-pool rotation).
- **Observable behavior change** for the 13 bare-client callers of the default path: they gain `connect_timeout(10s)`, Chrome Client Hints + Sec-Fetch default headers (stealth improvement — Chrome145 TLS without Client Hints was a detectable inconsistency per the code's own comment), and connection-pool tuning. UA semantics unchanged: random pool when `user_agent` is `None`; `HttpClient::new` still sets the UA per request (`get_inner`), so the wrapper is byte-identical.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/http_client/client.rs` | Extract private `build_wreq_client(config, user_agent)` from `HttpClient::new`; add `create_http_client_with_config`; `create_http_client()` delegates with `HttpClientConfig::default()` |
| `crates/webfang_core/src/application/crawler/discovery.rs` | DOM branch uses the configurable factory with `{timeout_secs, connect_timeout_secs: min(10)}`; two new acceptance tests (wiremock response-delay, TLS-blackhole connect timeout) |
| `application/http_client/mod.rs`, `application/mod.rs`, `infrastructure/http/mod.rs`, `lib.rs` | Re-export `create_http_client_with_config` (4 sites) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` — 1819 passed, 0 failed, 15 skipped
- [x] New acceptance tests: request timeout fires at ~2s against a 10s-delayed response; connect timeout fires at ~2s against a TLS-handshake blackhole (wreq surfaces `client error (Connect)`, confirming `connect_timeout` covers TCP+TLS establishment)

## Review

Native bounded review (lineage `review-add5695307160745`, medium tier, 290 changed lines):
- `review-reliability` lens: **allow**, 0 BLOCKER/CRITICAL — differential read confirmed the refactor is behavior-preserving for `HttpClient::new` and the default-path delta is exactly the documented one.
- Receipt approved; `pre-commit` gate: allow (content-bound artifacts match).
- Note: `pre-push` gate returned `gate_invalidated` (base-diff target shape vs publication-gate semantics mismatch — tooling-side, not content; maintainer authorized proceeding). `pre-pr` gate timed out on remote query.

## Follow-ups (from review findings)

- #296 — validate `--timeout-secs 0` (REL-1, behavior-activated WARNING)
- #297 — wire orphaned `tests/http_client_integration.rs` into `Cargo.toml`
- #298 — route sitemap discovery client through the factory (REL-4)
- #299 — `tls_emulation` field silently ignored (REL-5)
- #300 — harden #289 timeout tests (REL-2/REL-3)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (factory doc comments)