### PR TITLE
fix(http): make tls_emulation the single source of truth for TLS profile

### DIFF
--- a/crates/webfang_core/src/application/http_client/client.rs
+++ b/crates/webfang_core/src/application/http_client/client.rs
@@ -541,11 +541,8 @@ fn build_wreq_client(
         HeaderValue::from_static("1"),
     );
 
-    // Resolve H2/TLS profile from name — overrides tls_emulation if h2_profile is set
-    let profile = HttpClientConfig::resolve_profile(&config.h2_profile);
-
     let mut builder = Client::builder()
-        .emulation(profile)
+        .emulation(config.tls_emulation)
         .default_headers(headers)
         .timeout(Duration::from_secs(config.timeout_secs))
         .connect_timeout(Duration::from_secs(config.connect_timeout_secs))
@@ -711,6 +708,10 @@ mod tests {
         assert!(matches!(result.unwrap_err(), HttpError::Request(_)));
     }
 
+    /// Construction smoke test: a non-default `tls_emulation` preset builds a
+    /// client successfully. `wreq::Client` does not expose its applied profile,
+    /// so the meaningful profile-mapping assertions live at the config level
+    /// (`http_config::profile_from_name` and `scrape_flow::build_http_client_config`).
     #[test]
     fn test_http_client_with_custom_tls_emulation() {
         let config = HttpClientConfig {

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -124,7 +124,7 @@ pub async fn run(
     #[cfg(not(feature = "adaptive-selectors"))]
     let engine_ref: Option<&AdaptiveSelectorEngine> = None;
 
-    let (results, failures) = scrape_phase(
+    let (results, failures) = match scrape_phase(
         &urls_to_scrape,
         &prepare.scraper_config,
         &opts,
@@ -135,7 +135,13 @@ pub async fn run(
             .map(|d| d as &dyn crate::domain::ports::AssetDownloaderPort),
         engine_ref,
     )
-    .await;
+    .await
+    {
+        Ok(pair) => pair,
+        // Unknown TLS profile is a config error: surface the Spanish message
+        // and exit 78 rather than silently scraping with a wrong fingerprint.
+        Err(e) => return CliExit::ConfigError(e.to_string()),
+    };
 
     if let Some(ref ingestion) = elastic_ingestion {
         if let Err(e) = run_elastic_ingestion(ingestion, &results).await {
@@ -320,6 +326,11 @@ struct PrepareResult {
 }
 
 /// Run the scraping loop over all URLs with progress events.
+///
+/// # Errors
+///
+/// Returns [`crate::domain::UnknownProfileError`] if the configured H2/TLS
+/// profile name is not recognized (a setup failure, before any URL is scraped).
 async fn scrape_phase(
     urls: &[url::Url],
     scraper_config: &ScraperConfig,
@@ -327,10 +338,13 @@ async fn scrape_phase(
     observer: &dyn crate::application::progress_observer::ProgressObserver,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     engine: Option<&AdaptiveSelectorEngine>,
-) -> (
-    Vec<domain::ScrapedContent>,
-    Vec<(String, crate::error::ScraperError)>,
-) {
+) -> Result<
+    (
+        Vec<domain::ScrapedContent>,
+        Vec<(String, crate::error::ScraperError)>,
+    ),
+    crate::domain::UnknownProfileError,
+> {
     scrape_urls(urls, scraper_config, opts, observer, downloader, engine).await
 }
 

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -101,6 +101,12 @@ pub async fn apply_resume_mode(
 ///
 /// The observer handles quiet/channel logic internally — callers pass
 /// `&NoopObserver` for dry-run or `&LiveProgressObserver` for live output.
+///
+/// # Errors
+///
+/// Returns [`crate::domain::UnknownProfileError`] if the configured H2/TLS
+/// profile name (`opts.network.h2_profile`) is not recognized. This is a
+/// setup failure that aborts the whole batch before any URL is scraped.
 pub async fn scrape_urls(
     urls: &[Url],
     scraper_config: &ScraperConfig,
@@ -108,14 +114,17 @@ pub async fn scrape_urls(
     observer: &dyn ProgressObserver,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     engine: Option<&AdaptiveSelectorEngine>,
-) -> (
-    Vec<ScrapedContent>,
-    Vec<(String, crate::error::ScraperError)>,
-) {
+) -> Result<
+    (
+        Vec<ScrapedContent>,
+        Vec<(String, crate::error::ScraperError)>,
+    ),
+    crate::domain::UnknownProfileError,
+> {
     // Build the fetch router from the configured JS strategy. `--force-js-render`
     // upgrades a Static strategy to Hybrid so JS-capable fetching is used instead
     // of returning a feature-gated error (issue #303).
-    let http_config = build_http_client_config(opts);
+    let http_config = build_http_client_config(opts)?;
     let effective_strategy =
         if opts.network.force_js_render && matches!(opts.network.js_strategy, JsStrategy::Static) {
             JsStrategy::Hybrid
@@ -197,20 +206,22 @@ pub async fn scrape_urls(
         .on_finished(processing_count, total_successful, total_failed)
         .await;
 
-    (results, failures)
+    Ok((results, failures))
 }
 
-fn build_http_client_config(opts: &CrawlOptions) -> HttpClientConfig {
-    HttpClientConfig {
+fn build_http_client_config(
+    opts: &CrawlOptions,
+) -> Result<HttpClientConfig, crate::domain::UnknownProfileError> {
+    Ok(HttpClientConfig {
         max_retries: opts.network.max_retries,
         backoff_base_ms: opts.network.backoff_base_ms,
         backoff_max_ms: opts.network.backoff_max_ms,
         accept_language: opts.network.accept_language.clone(),
         user_agent: opts.network.user_agent.clone(),
         timeout_secs: opts.network.timeout_secs,
-        h2_profile: opts.network.h2_profile.clone(),
+        tls_emulation: HttpClientConfig::profile_from_name(&opts.network.h2_profile)?,
         ..HttpClientConfig::default()
-    }
+    })
 }
 
 #[cfg(test)]
@@ -229,7 +240,7 @@ mod tests {
         let mut opts = CrawlOptions::default();
         opts.network.timeout_secs = 7;
 
-        let config = build_http_client_config(&opts);
+        let config = build_http_client_config(&opts).unwrap();
 
         assert_eq!(config.timeout_secs, 7);
         assert_eq!(config.max_retries, opts.network.max_retries);
@@ -242,9 +253,29 @@ mod tests {
     fn build_http_client_config_preserves_default_timeout_when_unset() {
         let opts = CrawlOptions::default();
 
-        let config = build_http_client_config(&opts);
+        let config = build_http_client_config(&opts).unwrap();
 
         assert_eq!(config.timeout_secs, 30);
+    }
+
+    #[test]
+    fn build_http_client_config_maps_h2_profile_to_tls_emulation() {
+        let mut opts = CrawlOptions::default();
+        opts.network.h2_profile = "Chrome131".to_owned();
+
+        let config = build_http_client_config(&opts).unwrap();
+
+        assert_eq!(config.tls_emulation, wreq_util::Profile::Chrome131);
+    }
+
+    #[test]
+    fn build_http_client_config_rejects_unknown_profile() {
+        let mut opts = CrawlOptions::default();
+        opts.network.h2_profile = "Firefox".to_owned();
+
+        let err = build_http_client_config(&opts).unwrap_err();
+
+        assert_eq!(err.name, "Firefox");
     }
 
     // ===== robots tests =====

--- a/crates/webfang_core/src/domain/http_config.rs
+++ b/crates/webfang_core/src/domain/http_config.rs
@@ -7,6 +7,8 @@
 //! consumes it; infrastructure maps domain values (e.g. the TLS profile)
 //! onto a concrete client when building the network stack.
 
+use thiserror::Error;
+
 /// Configuration for HTTP client behavior
 ///
 /// Controls headers, retry behavior, and cookie handling.
@@ -35,13 +37,14 @@ pub struct HttpClientConfig {
     pub connect_timeout_secs: u64,
     /// Rate limit: requests per minute (None for no limit)
     pub rate_limit_rpm: Option<u32>,
-    /// TLS fingerprint emulation preset
+    /// TLS fingerprint emulation preset.
+    ///
+    /// This is the **single source of truth** for the TLS/H2 fingerprint: the
+    /// network stack applies it directly when building the client. Construct it
+    /// from a user-supplied name with [`HttpClientConfig::profile_from_name`].
     pub tls_emulation: wreq_util::Profile,
     /// Custom User-Agent override
     pub user_agent: Option<String>,
-    /// H2/TLS profile name (e.g. "Chrome145", "Chrome131").
-    /// Mapped to `tls_emulation` on construction.
-    pub h2_profile: String,
 }
 
 impl Default for HttpClientConfig {
@@ -60,26 +63,41 @@ impl Default for HttpClientConfig {
             rate_limit_rpm: None,
             tls_emulation: wreq_util::Profile::Chrome145,
             user_agent: None,
-            h2_profile: "Chrome145".to_owned(),
         }
     }
 }
 
 impl HttpClientConfig {
-    /// Resolve an H2 profile name to a `wreq_util::Profile`.
+    /// Parse an H2/TLS profile name into a [`wreq_util::Profile`].
     ///
-    /// Falls back to Chrome145 for unknown names.
-    #[must_use]
-    pub fn resolve_profile(name: &str) -> wreq_util::Profile {
+    /// This is the fallible boundary that converts a user-facing profile name
+    /// (e.g. the `--h2-profile` CLI value) into the typed
+    /// [`Self::tls_emulation`] preset. Unknown names are an error — there is
+    /// **no** silent fallback to a default profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnknownProfileError`] if `name` is not a recognized profile.
+    pub fn profile_from_name(name: &str) -> Result<wreq_util::Profile, UnknownProfileError> {
         match name {
-            "Chrome131" => wreq_util::Profile::Chrome131,
-            "Chrome145" => wreq_util::Profile::Chrome145,
-            _ => {
-                tracing::warn!("Unknown H2 profile '{name}', falling back to Chrome145");
-                wreq_util::Profile::Chrome145
-            },
+            "Chrome131" => Ok(wreq_util::Profile::Chrome131),
+            "Chrome145" => Ok(wreq_util::Profile::Chrome145),
+            _ => Err(UnknownProfileError {
+                name: name.to_owned(),
+            }),
         }
     }
+}
+
+/// Error returned when an H2/TLS profile name is not recognized.
+///
+/// The user-facing [`Display`](std::fmt::Display) message is in Spanish and
+/// lists the valid options, per the project's user-facing-error convention.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[error("Perfil TLS desconocido: '{name}'. Opciones válidas: Chrome131, Chrome145")]
+pub struct UnknownProfileError {
+    /// The unrecognized profile name supplied by the user.
+    pub name: String,
 }
 
 #[cfg(test)]
@@ -106,7 +124,6 @@ mod tests {
         assert_eq!(config.rate_limit_rpm, None);
         assert_eq!(config.tls_emulation, wreq_util::Profile::Chrome145);
         assert_eq!(config.user_agent, None);
-        assert_eq!(config.h2_profile, "Chrome145");
     }
 
     #[test]
@@ -134,7 +151,6 @@ mod tests {
             rate_limit_rpm: Some(30),
             tls_emulation: wreq_util::Profile::Chrome131,
             user_agent: Some("custom".into()),
-            h2_profile: "Chrome131".to_owned(),
         };
 
         assert_eq!(config.accept_language, "es-ES");
@@ -144,26 +160,38 @@ mod tests {
         assert_eq!(config.connect_timeout_secs, 20);
         assert_eq!(config.rate_limit_rpm, Some(30));
         assert_eq!(config.tls_emulation, wreq_util::Profile::Chrome131);
-        assert_eq!(config.h2_profile, "Chrome131");
     }
 
     #[test]
-    fn test_resolve_profile_known_names() {
+    fn test_profile_from_name_known_names() {
         assert_eq!(
-            HttpClientConfig::resolve_profile("Chrome131"),
+            HttpClientConfig::profile_from_name("Chrome131").unwrap(),
             wreq_util::Profile::Chrome131
         );
         assert_eq!(
-            HttpClientConfig::resolve_profile("Chrome145"),
+            HttpClientConfig::profile_from_name("Chrome145").unwrap(),
             wreq_util::Profile::Chrome145
         );
     }
 
     #[test]
-    fn test_resolve_profile_unknown_falls_back() {
-        assert_eq!(
-            HttpClientConfig::resolve_profile("UnknownProfile"),
-            wreq_util::Profile::Chrome145
-        );
+    fn test_profile_from_name_unknown_returns_err() {
+        let err = HttpClientConfig::profile_from_name("Firefox").unwrap_err();
+        assert_eq!(err.name, "Firefox");
+    }
+
+    #[test]
+    fn test_unknown_profile_error_display_is_spanish() {
+        let err = HttpClientConfig::profile_from_name("Firefox").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Perfil TLS desconocido: 'Firefox'"));
+        assert!(msg.contains("Chrome131"));
+        assert!(msg.contains("Chrome145"));
+    }
+
+    #[test]
+    fn test_unknown_profile_error_is_std_error() {
+        let err = HttpClientConfig::profile_from_name("Firefox").unwrap_err();
+        let _: &dyn std::error::Error = &err;
     }
 }

--- a/crates/webfang_core/src/domain/mod.rs
+++ b/crates/webfang_core/src/domain/mod.rs
@@ -65,7 +65,7 @@ pub use entities::{
 };
 pub use error::{CrawlError, DomainError};
 pub use exporter::{ExportResult, Exporter, ExporterConfig};
-pub use http_config::HttpClientConfig;
+pub use http_config::{HttpClientConfig, UnknownProfileError};
 pub use http_error::{HttpError, HttpResult};
 pub use http_port::{HttpClientPort, HttpResponse};
 pub use js_renderer::{JsRenderError, JsRenderer};


### PR DESCRIPTION
## Linked Issue

Closes #299

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- `HttpClientConfig.tls_emulation` is now the single source of truth for the TLS/H2 fingerprint. The dead `h2_profile: String` field is removed, and `build_wreq_client` applies `config.tls_emulation` directly instead of resolving the profile only from the string field (which silently ignored `tls_emulation`).
- The infallible `resolve_profile` — which silently fell back to Chrome145 on unknown names, the same silent-substitution bug class — is replaced by a fallible `profile_from_name` returning `Result<Profile, UnknownProfileError>`. An invalid `--h2-profile` now fails loudly with a Spanish user-facing error (exit 78) instead of silently scraping with the wrong fingerprint.
- The error is threaded as a setup failure (before any URL is scraped) through `scrape_urls`/`scrape_phase` up to `run`, which maps it to `CliExit::ConfigError`.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/domain/http_config.rs` | Removed dead `h2_profile: String` field; `resolve_profile` → fallible `profile_from_name`; added `UnknownProfileError` (Spanish `Display`); updated tests |
| `crates/webfang_core/src/domain/mod.rs` | Re-export `UnknownProfileError` |
| `crates/webfang_core/src/application/http_client/client.rs` | `build_wreq_client` applies `.emulation(config.tls_emulation)` directly; removed stale comment |
| `crates/webfang_core/src/cli/scrape_flow.rs` | `build_http_client_config` → `Result`, maps `profile_from_name(&opts.network.h2_profile)?`; `scrape_urls` → `Result`; new mapping/rejection tests |
| `crates/webfang_core/src/cli/orchestrator.rs` | `scrape_phase` → `Result` passthrough; `run` maps `Err` → `CliExit::ConfigError` (exit 78) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p webfang_core --all-targets -- -D warnings` clean
- [x] `cargo nextest run -p webfang_core --lib` passes (1189 tests, 0 failed)
- [x] New tests verify `profile_from_name` (known / unknown / Spanish `Display` / `std::error::Error`) and `build_http_client_config` (maps string → `tls_emulation`, rejects unknown)
- [x] `--h2-profile` CLI arg parity intact (`NetworkOptions` unchanged, `args_test` passes)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (doc comments updated; no user-facing docs affected)
