### PR TITLE
refactor(http): consolidar los resolvers string→Profile en un único helper de domain

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -611,52 +611,26 @@ fn parse_asset_naming(s: &str) -> crate::adapters::downloader::AssetNamingStrate
     }
 }
 
-/// Parse H2/TLS profile from CLI string.
+/// Parse H2/TLS profile from CLI string for the asset download path.
 ///
-/// Resolves a profile name string to a `wreq_util::Profile` variant.
-///
-/// Tries exact match against known variants; defaults to `Chrome145` on
-/// unknown input.  This intentionally covers a subset of the ~100+
-/// variants — users who need edge/okhttp/safari profiles can configure
-/// the H2 profile via the HTTP client config directly.
+/// Delegates to the domain resolver
+/// [`crate::domain::profile::profile_from_name`], which accepts the full
+/// [`wreq_util::Profile`] catalog. Unlike the strict page-fetch path, the asset
+/// path is best-effort: an unknown name logs a warning and falls back to
+/// `Chrome145` rather than failing the run.
 fn parse_asset_h2_profile(s: &str) -> wreq_util::Profile {
-    use wreq_util::Profile;
-
-    match s {
-        // Chrome
-        "Chrome100" => Profile::Chrome100,
-        "Chrome101" => Profile::Chrome101,
-        "Chrome104" => Profile::Chrome104,
-        "Chrome107" => Profile::Chrome107,
-        "Chrome110" => Profile::Chrome110,
-        "Chrome116" => Profile::Chrome116,
-        "Chrome120" => Profile::Chrome120,
-        "Chrome131" => Profile::Chrome131,
-        "Chrome145" => Profile::Chrome145,
-        // Firefox
-        "Firefox135" => Profile::Firefox135,
-        "FirefoxAndroid135" => Profile::FirefoxAndroid135,
-        // Safari
-        "Safari18" => Profile::Safari18,
-        "SafariIos18_1_1" => Profile::SafariIos18_1_1,
-        "SafariIPad18" => Profile::SafariIPad18,
-        // OkHttp
-        "OkHttp4_12" => Profile::OkHttp4_12,
-        "OkHttp5" => Profile::OkHttp5,
-        // Fallback
-        _ => {
-            tracing::warn!(
-                "Unknown asset H2 profile '{s}', falling back to Chrome145. \
-                 Run `cargo doc -p wreq-util` to see all available profiles."
-            );
-            Profile::Chrome145
-        },
-    }
+    crate::domain::profile::profile_from_name(s).unwrap_or_else(|| {
+        tracing::warn!(
+            "Unknown asset H2 profile '{s}', falling back to Chrome145. \
+             Run `cargo doc -p wreq-util` to see all available profiles."
+        );
+        wreq_util::Profile::Chrome145
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{batch_exit_code, build_elastic_ingestion, plan_urls};
+    use super::{batch_exit_code, build_elastic_ingestion, parse_asset_h2_profile, plan_urls};
     use crate::application::crawl_options::CrawlOptions;
     use crate::cli::error::CliExit;
 
@@ -898,6 +872,28 @@ mod tests {
         assert!(
             in_export_config,
             "ExportConfig construction not found in source"
+        );
+    }
+
+    // ===== parse_asset_h2_profile tests =====
+
+    #[test]
+    fn parse_asset_h2_profile_resolves_known_non_default_profiles() {
+        assert_eq!(
+            parse_asset_h2_profile("Firefox135"),
+            wreq_util::Profile::Firefox135
+        );
+        assert_eq!(
+            parse_asset_h2_profile("Chrome120"),
+            wreq_util::Profile::Chrome120
+        );
+    }
+
+    #[test]
+    fn parse_asset_h2_profile_unknown_falls_back_to_chrome145() {
+        assert_eq!(
+            parse_asset_h2_profile("NetscapeNavigator"),
+            wreq_util::Profile::Chrome145
         );
     }
 }

--- a/crates/webfang_core/src/domain/http_config.rs
+++ b/crates/webfang_core/src/domain/http_config.rs
@@ -72,29 +72,29 @@ impl HttpClientConfig {
     ///
     /// This is the fallible boundary that converts a user-facing profile name
     /// (e.g. the `--h2-profile` CLI value) into the typed
-    /// [`Self::tls_emulation`] preset. Unknown names are an error — there is
+    /// [`Self::tls_emulation`] preset. It delegates to the domain resolver
+    /// [`crate::domain::profile::profile_from_name`], which accepts the full
+    /// [`wreq_util::Profile`] catalog. Unknown names are an error — there is
     /// **no** silent fallback to a default profile.
     ///
     /// # Errors
     ///
     /// Returns [`UnknownProfileError`] if `name` is not a recognized profile.
     pub fn profile_from_name(name: &str) -> Result<wreq_util::Profile, UnknownProfileError> {
-        match name {
-            "Chrome131" => Ok(wreq_util::Profile::Chrome131),
-            "Chrome145" => Ok(wreq_util::Profile::Chrome145),
-            _ => Err(UnknownProfileError {
-                name: name.to_owned(),
-            }),
-        }
+        crate::domain::profile::profile_from_name(name).ok_or_else(|| UnknownProfileError {
+            name: name.to_owned(),
+        })
     }
 }
 
 /// Error returned when an H2/TLS profile name is not recognized.
 ///
 /// The user-facing [`Display`](std::fmt::Display) message is in Spanish and
-/// lists the valid options, per the project's user-facing-error convention.
+/// lists the full dynamic catalog of valid options (every
+/// [`wreq_util::Profile`] variant), per the project's user-facing-error
+/// convention.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
-#[error("Perfil TLS desconocido: '{name}'. Opciones válidas: Chrome131, Chrome145")]
+#[error("Perfil TLS desconocido: '{name}'. Opciones válidas: {}", crate::domain::profile::valid_profile_names().join(", "))]
 pub struct UnknownProfileError {
     /// The unrecognized profile name supplied by the user.
     pub name: String,
@@ -178,6 +178,18 @@ mod tests {
     fn test_profile_from_name_unknown_returns_err() {
         let err = HttpClientConfig::profile_from_name("Firefox").unwrap_err();
         assert_eq!(err.name, "Firefox");
+    }
+
+    #[test]
+    fn test_profile_from_name_resolves_expanded_catalog() {
+        assert_eq!(
+            HttpClientConfig::profile_from_name("Chrome120").unwrap(),
+            wreq_util::Profile::Chrome120
+        );
+        assert_eq!(
+            HttpClientConfig::profile_from_name("Firefox135").unwrap(),
+            wreq_util::Profile::Firefox135
+        );
     }
 
     #[test]

--- a/crates/webfang_core/src/domain/mod.rs
+++ b/crates/webfang_core/src/domain/mod.rs
@@ -32,6 +32,7 @@ pub mod pattern_matching;
 /// Pipeline stage definitions and scraped item types for the crawl pipeline.
 pub mod pipeline_item;
 pub mod ports;
+pub mod profile;
 pub mod repositories;
 pub mod repository;
 pub mod result;
@@ -74,6 +75,7 @@ pub use link_extractor::{LinkExtractor, LinkProcessor};
 pub use pattern_matching::matches_pattern;
 pub use pipeline_item::{PipelineStage, ScrapedItem, StageOutcome};
 pub use ports::AssetDownloaderPort;
+pub use profile::{profile_from_name, valid_profile_names};
 pub use repositories::CrawlResultRepository;
 pub use repository::VectorRepository;
 pub use result::CrawlResult;

--- a/crates/webfang_core/src/domain/profile.rs
+++ b/crates/webfang_core/src/domain/profile.rs
@@ -1,0 +1,89 @@
+//! TLS/H2 profile name resolution.
+//!
+//! Single source of truth for mapping user-facing profile names (e.g. the
+//! `--h2-profile` CLI value) onto [`wreq_util::Profile`]. Both the strict
+//! page-fetch path ([`HttpClientConfig::profile_from_name`](super::HttpClientConfig::profile_from_name))
+//! and the best-effort asset path (`cli::orchestrator::parse_asset_h2_profile`)
+//! delegate here.
+
+use wreq_util::Profile;
+
+/// Resolve a profile name to a [`Profile`].
+///
+/// Accepts the exact variant name of the [`Profile`] enum (e.g. `"Chrome120"`,
+/// `"SafariIos18_1_1"`). Matching is case-sensitive and covers the full catalog:
+/// the lookup is driven by [`Profile::VARIANTS`], so profiles added by future
+/// `wreq-util` upgrades are accepted automatically.
+///
+/// Returns `None` for unknown names; each caller decides its failure policy
+/// (hard error for page-fetch, warn + fallback for assets).
+#[must_use]
+pub fn profile_from_name(name: &str) -> Option<Profile> {
+    Profile::VARIANTS
+        .iter()
+        .copied()
+        .find(|profile| profile_name(*profile) == name)
+}
+
+/// All valid profile names, for user-facing error messages.
+#[must_use]
+pub fn valid_profile_names() -> Vec<String> {
+    Profile::VARIANTS
+        .iter()
+        .copied()
+        .map(profile_name)
+        .collect()
+}
+
+/// The user-facing name of a profile (its exact enum variant name).
+fn profile_name(profile: Profile) -> String {
+    format!("{profile:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_variant_round_trips_through_its_debug_name() {
+        for profile in Profile::VARIANTS {
+            let name = format!("{profile:?}");
+            assert_eq!(
+                profile_from_name(&name),
+                Some(*profile),
+                "Debug name '{name}' must resolve back to its variant"
+            );
+        }
+    }
+
+    #[test]
+    fn resolves_known_profiles_across_families() {
+        assert_eq!(profile_from_name("Chrome120"), Some(Profile::Chrome120));
+        assert_eq!(profile_from_name("Chrome131"), Some(Profile::Chrome131));
+        assert_eq!(profile_from_name("Chrome145"), Some(Profile::Chrome145));
+        assert_eq!(profile_from_name("Firefox135"), Some(Profile::Firefox135));
+        assert_eq!(
+            profile_from_name("SafariIos18_1_1"),
+            Some(Profile::SafariIos18_1_1)
+        );
+        assert_eq!(profile_from_name("OkHttp5"), Some(Profile::OkHttp5));
+    }
+
+    #[test]
+    fn unknown_names_return_none() {
+        assert_eq!(profile_from_name("NetscapeNavigator"), None);
+        assert_eq!(profile_from_name(""), None);
+    }
+
+    #[test]
+    fn matching_is_case_sensitive() {
+        assert_eq!(profile_from_name("chrome120"), None);
+    }
+
+    #[test]
+    fn valid_profile_names_covers_full_catalog() {
+        let names = valid_profile_names();
+        assert_eq!(names.len(), Profile::VARIANTS.len());
+        assert!(names.contains(&"Chrome145".to_owned()));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #308

## PR Type

- [x] Code refactoring (`type:refactor`)

## Summary

- Consolida la resolución string→`wreq_util::Profile` (duplicada y divergente) en un único helper data-driven en domain (`domain/profile.rs`), impulsado por `Profile::VARIANTS`: cubre el catálogo completo de wreq-util (133 variantes) y rastrea upgrades de la dependencia sin mantenimiento manual.
- Page-fetch (`HttpClientConfig::profile_from_name`) y assets (`parse_asset_h2_profile`) aceptan ahora el **mismo** catálogo; cada path conserva su política de fallo: hard error + exit 78 (page-fetch) vs warn + fallback Chrome145 (assets).
- Cambio de comportamiento deliberado (según issue): page-fetch acepta el catálogo completo — `"Chrome120"` resuelve a Chrome120 en vez de caer a exit 78. Los nombres fuera de catálogo siguen fallando con el error en español, que ahora lista todas las opciones válidas dinámicamente.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/domain/profile.rs` | Nuevo: resolver único `profile_from_name(&str) -> Option<Profile>` + `valid_profile_names()` (+5 tests, round-trip sobre `VARIANTS` que fija el contrato Debug) |
| `crates/webfang_core/src/domain/mod.rs` | Módulo `profile` + re-exports |
| `crates/webfang_core/src/domain/http_config.rs` | `HttpClientConfig::profile_from_name` delega en el helper; `UnknownProfileError` lista el catálogo dinámico completo (+1 test) |
| `crates/webfang_core/src/cli/orchestrator.rs` | `parse_asset_h2_profile` reducido de match de 16 variantes a delegador con política warn+fallback (+2 tests, antes cero cobertura) |

## Test Plan

- [x] `cargo fmt --check` limpio
- [x] `cargo clippy --all-targets -- -D warnings` limpio (workspace completo)
- [x] `cargo nextest run` pasa: 1842 tests, 0 fallos
- [x] Tests existentes de `profile_from_name` / `UnknownProfileError` sin modificar y verdes (Chrome131/145 resuelven igual que antes)

## Contributor Checklist

- [x] Linked an issue with `Closes #308`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`refactor(domain): ...`, `refactor(cli): ...`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated (doc comments del resolver, la fachada y el error)