### PR TITLE
fix(cli): validate --timeout-secs and reject 0 (instant timeouts)

### DIFF
--- a/crates/webfang_core/src/cli/args/crawler.rs
+++ b/crates/webfang_core/src/cli/args/crawler.rs
@@ -18,6 +18,22 @@ pub(crate) fn parse_download_concurrency(s: &str) -> Result<usize, String> {
     Ok(v)
 }
 
+/// Validate `--timeout-secs`: must be >= 1. A value of 0 makes wreq apply
+/// `Duration::from_secs(0)` as the request timeout, so every request fails
+/// instantly with "operation timed out". Rejecting here gives a clear CLI
+/// error instead of a crawl where every page fails.
+pub(crate) fn parse_timeout_secs(s: &str) -> Result<u64, String> {
+    let v: u64 = s
+        .parse()
+        .map_err(|_| format!("'{s}' no es un número válido para --timeout-secs"))?;
+    if v == 0 {
+        return Err(
+            "--timeout-secs debe ser >= 1 (0 hace que cada request falle al instante)".to_string(),
+        );
+    }
+    Ok(v)
+}
+
 /// Crawler and discovery configuration arguments.
 #[derive(Args, Debug, Default)]
 pub struct CrawlerArgs {
@@ -163,7 +179,12 @@ pub struct CrawlerArgs {
     pub max_depth: u8,
 
     /// Request timeout in seconds
-    #[arg(long, default_value = "30", env = "WEBFANG_TIMEOUT_SECS")]
+    #[arg(
+        long,
+        default_value = "30",
+        env = "WEBFANG_TIMEOUT_SECS",
+        value_parser = parse_timeout_secs
+    )]
     #[clap(next_help_heading = "Crawler Settings")]
     pub timeout_secs: u64,
 
@@ -302,4 +323,29 @@ pub struct CrawlerArgs {
     #[arg(long, default_value = "obscura", env = "WEBFANG_OBSCURA_BINARY")]
     #[clap(next_help_heading = "JS Rendering")]
     pub obscura_binary: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_timeout_secs_accepts_valid_value() {
+        assert_eq!(parse_timeout_secs("30"), Ok(30));
+    }
+
+    #[test]
+    fn parse_timeout_secs_rejects_zero() {
+        let err = parse_timeout_secs("0").unwrap_err();
+        assert_eq!(
+            err,
+            "--timeout-secs debe ser >= 1 (0 hace que cada request falle al instante)"
+        );
+    }
+
+    #[test]
+    fn parse_timeout_secs_rejects_non_numeric() {
+        let err = parse_timeout_secs("abc").unwrap_err();
+        assert_eq!(err, "'abc' no es un número válido para --timeout-secs");
+    }
 }

--- a/crates/webfang_core/src/domain/site/crawler_config.rs
+++ b/crates/webfang_core/src/domain/site/crawler_config.rs
@@ -216,7 +216,7 @@ impl CrawlerConfigBuilder {
             concurrency: self.concurrency,
             delay_ms: self.delay_ms,
             user_agent: self.user_agent,
-            timeout_secs: self.timeout_secs,
+            timeout_secs: self.timeout_secs.max(1),
             use_sitemap: self.use_sitemap,
             sitemap_url: self.sitemap_url,
             ignore_robots: self.ignore_robots,
@@ -457,5 +457,12 @@ mod tests {
         assert_eq!(config.max_depth, cloned.max_depth);
         assert_eq!(config.max_pages, cloned.max_pages);
         assert_eq!(config.seed_url, cloned.seed_url);
+    }
+
+    #[test]
+    fn builder_clamps_timeout_secs_to_minimum_one() {
+        let seed = Url::parse("https://example.com").unwrap();
+        let config = CrawlerConfig::builder(seed).timeout_secs(0).build();
+        assert_eq!(config.timeout_secs, 1);
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #296

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `--timeout-secs 0` made wreq apply `Duration::from_secs(0)` as the request timeout, so every request failed instantly with "operation timed out" and no clear error
- Added `parse_timeout_secs` clap `value_parser` (mirrors `parse_download_concurrency`) that rejects `0` and non-numeric input with clear Spanish errors before any request is made
- Defense-in-depth: `CrawlerConfigBuilder::build()` now clamps `timeout_secs` with `.max(1)` for programmatic construction paths

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/args/crawler.rs` | Added `parse_timeout_secs` fn + wired as `value_parser` on `--timeout-secs` + 3 unit tests |
| `crates/webfang_core/src/domain/site/crawler_config.rs` | `.max(1)` clamp in `build()` + 1 unit test |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run -p webfang_core -- timeout` — 28/28 passed (incl. 3 new)
- [x] `cargo nextest run -p webfang_core -- crawler_config` — 17/17 passed (incl. new clamp test)
- [x] Manually verified: `webfang --timeout-secs 0 -u http://example.com` → `error: invalid value '0' for '--timeout-secs <TIMEOUT_SECS>': --timeout-secs debe ser >= 1 (0 hace que cada request falle al instante)`

## Contributor Checklist

- [x] Linked an issue with `Closes #296`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No AI attribution trailers
- [x] Doc comments on new function