### PR TITLE
fix(tests): pre-build binary in CI + relax batch_test wall-clock assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
+      - name: Pre-build test binary
+        run: cargo build -p webfang_cli --bin webfang
       - name: Unit tests (lib)
         run: cargo nextest run --lib --test-threads 4 --retries 2
       - name: Integration tests
@@ -142,6 +144,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
+      - name: Pre-build test binary
+        run: cargo build -p webfang_cli --bin webfang --all-features
       - run: cargo nextest run --all-features --test-threads 4 --retries 2
 
   # ============================================================================

--- a/tests/behavioral/cli/batch_test.rs
+++ b/tests/behavioral/cli/batch_test.rs
@@ -115,7 +115,7 @@ fn batch_empty_file_exits_64() {
 // ---------------------------------------------------------------------------
 
 /// A --batch-file with a slow endpoint and --timeout-secs 1 must exit 69
-/// and complete well under 15s (the per-request timeout fires, not a hang).
+/// and complete well under 25s (the per-request timeout fires, not a hang).
 #[tokio::test]
 async fn batch_file_timeout_does_not_hang() {
     let t = BehavioralTest::new().await;
@@ -161,8 +161,8 @@ async fn batch_file_timeout_does_not_hang() {
         output.status.code()
     );
     assert!(
-        elapsed < Duration::from_secs(15),
-        "batch timeout test should complete in under 15s, took {:?}",
+        elapsed < Duration::from_secs(25),
+        "batch timeout test should complete in under 25s, took {:?}",
         elapsed
     );
 }


### PR DESCRIPTION
Closes #306

## Summary

- **CI pre-build step**: added `cargo build -p webfang_cli --bin webfang` to both `test-core` and `test-full` jobs, after cache restore and before nextest. `webfang_path()` no longer triggers a cold ~60s BoringSSL compile during a timed test.
- **Wall-clock assertion relaxed**: `batch_file_timeout_does_not_hang` inner bound from `< 15s` to `< 25s` (still well under the 30s outer `tokio::time::timeout` hang guard). Exit-code-69 assertion untouched.

## Root cause (from #306 investigation)

The 60.8s was NOT batch code — it was `webfang_path()` doing a synchronous `cargo build` on cold CI cache, billed to whichever test called `cmd()` first. The flake was a too-tight wall-clock assertion under `--test-threads 4` process contention.

## Verification

- 6/6 batch tests pass with `--retries 0` under both default and `--test-threads 4`
- `batch_empty_stdin_exits_64`: 60.8s → **0.010s** (warm binary)
- Cold-cache run reproduced the original bug, confirming the pre-build is the real fix
- No production code (`crates/`) touched