### PR TITLE
refactor(http): route sitemap discovery client through create_http_client_with_config

### DIFF
--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -3,8 +3,6 @@
 //! Functions for discovering URLs from websites via sitemaps or DOM scraping.
 //! Part of the TUI workflow: discover → select → scrape.
 
-use std::time::Duration;
-
 use anyhow::Result;
 use tracing::{debug, info, instrument, span, warn, Level};
 use url::Url;
@@ -560,11 +558,16 @@ async fn crawl_with_sitemap_internal(
 ) -> Result<Vec<DiscoveredUrl>, CrawlError> {
     info!("Crawling with sitemap for {}", base_url);
 
-    let discovery_client = wreq::Client::builder()
-        .emulation(wreq_util::Emulation::Chrome145)
-        .timeout(Duration::from_secs(config.timeout_secs))
-        .connect_timeout(Duration::from_secs(config.timeout_secs.min(10)))
-        .build()
+    // Build the discovery client through the shared factory so sitemap probes
+    // carry the same Chrome Client Hints, pooled user-agent, pool tuning, and
+    // gzip/brotli as the DOM path (#298). Timeouts replicate the #281 policy:
+    // request timeout as configured, connect timeout capped at 10s.
+    let http_config = HttpClientConfig {
+        timeout_secs: config.timeout_secs,
+        connect_timeout_secs: config.timeout_secs.min(10), // #281 policy
+        ..Default::default()
+    };
+    let discovery_client = super::super::create_http_client_with_config(&http_config)
         .map_err(|e| CrawlError::Internal(format!("failed to build discovery client: {e}")))?;
 
     // Use default batch size (10,000) - SitemapConfig handles pagination
@@ -938,6 +941,7 @@ pub fn parse_sitemap(xml_content: &str, base_url: &Url) -> Result<Vec<String>, C
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn test_parse_sitemap_xml() {


### PR DESCRIPTION
## Linked Issue

Closes #298

## PR Type

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- `crawl_with_sitemap_internal` built its own `wreq::Client` inline while the DOM path used `create_http_client_with_config` (#289), duplicating the #281 timeout policy across two call sites and sending a different fingerprint (no Client Hints, no pooled UA) for sitemap probes against the same target.
- The sitemap discovery client is now built through the shared factory with an `HttpClientConfig` that replicates the #281 policy (request timeout as configured, connect timeout capped at 10s), gaining the same Chrome Client Hints, pooled user-agent, pool tuning, and gzip/brotli as the DOM path. `Profile::Chrome145` (factory default) == the previous `Emulation::Chrome145`, so the TLS fingerprint is unchanged.
- Build failure stays mapped to `CrawlError::Internal` (no `From<ScraperError> for CrawlError` exists, so a bare `?` would not compile).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/crawler/discovery.rs` | Replaced inline `wreq::Client::builder()` in `crawl_with_sitemap_internal` with `HttpClientConfig` + `create_http_client_with_config`; moved the now-lib-unused `std::time::Duration` import into the test module where it is still used |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo nextest run --test sitemap_integration` passes (8/8)
- [x] Manually verified the affected functionality

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed