### PR TITLE
fix(tests): make webfang_path() hermetic by always building with active features

### DIFF
--- a/tests/common/cli_harness.rs
+++ b/tests/common/cli_harness.rs
@@ -31,12 +31,19 @@ use std::path::Path;
 use wiremock::matchers::{method, path as wm_path};
 use wiremock::{Mock, ResponseTemplate};
 
-/// Resolve the path to the `webfang` binary.
+/// Resolve the path to the `webfang` binary, building it on demand.
 ///
 /// `webfang` is built by the `webfang_cli` crate (a workspace sibling),
 /// so `assert_cmd::cargo_bin` cannot locate it from `webfang_core` tests
 /// — `CARGO_BIN_EXE_webfang` is only set for the crate that owns the binary.
-/// We fall back to the workspace `target/` dir and, if missing, build it.
+///
+/// Hermeticity (#302): the binary is ALWAYS built with the feature set
+/// derived from the active `cfg!(feature = "ai")` gate — it is never reused
+/// on the sole basis of `target/debug/webfang` existing. A stale binary
+/// built without `ai` would otherwise be served to `--all-features` tests
+/// whose `--help` snapshots include AI-only flags. Cargo tracks features in
+/// its build fingerprint, so this is a ~0s no-op when the binary is already
+/// up to date and only rebuilds when the feature set actually differs.
 pub(crate) fn webfang_path() -> std::path::PathBuf {
     if let Ok(p) = std::env::var("CARGO_BIN_EXE_webfang") {
         return std::path::PathBuf::from(p);
@@ -47,15 +54,6 @@ pub(crate) fn webfang_path() -> std::path::PathBuf {
         .parent()
         .and_then(|p| p.parent())
         .expect("resolve workspace root");
-    for profile in ["debug", "release"] {
-        let mut candidate = workspace_root.join("target").join(profile).join("webfang");
-        if cfg!(windows) {
-            candidate.set_extension("exe");
-        }
-        if candidate.exists() {
-            return candidate;
-        }
-    }
     let cargo = option_env!("CARGO").unwrap_or("cargo");
     let build_args = if cfg!(feature = "ai") {
         vec![


### PR DESCRIPTION
Closes #302

## Summary

- Removed the "binary exists → return immediately" short-circuit from `webfang_path()` in `tests/common/cli_harness.rs`.
- Now always runs `cargo build -p webfang_cli --bin webfang [--all-features]` — cargo's fingerprint (which includes the feature set) makes it a ~0s no-op when the binary is already correct, and forces a rebuild on feature mismatch.
- `CARGO_BIN_EXE_webfang` env fast-path kept as first check.
- No CI changes needed — the #316 pre-build steps already align (`test-core` plain, `test-full` `--all-features`).

## Root cause

`webfang_path()` returned any existing `target/debug/webfang` without verifying its feature set. A binary built without `ai` (e.g. from a prior `--features ui` run) would be served to `--all-features` tests, causing `--help` snapshot mismatches (missing AI flags).

## Verification

- 17/17 help snapshot tests pass with `--all-features` (the failing scenario)
- 76/76 behavioral tests pass with `--features ui` (tests correctly cfg-gated out)
- `cargo clippy --all-targets --all-features -D warnings` clean

## Note

A second `webfang_path` copy exists at `crates/webfang_core/tests/exit_code_integration.rs:23` with the same old short-circuit. Low risk (exit codes are feature-independent) — potential follow-up.