### PR TITLE
fix(ci): increase Coverage job timeout from 20min to 40min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     if: github.event_name == 'workflow_dispatch'
     needs: [test-full]
     steps:


### PR DESCRIPTION
Closes #260

## Summary
- Increase `timeout-minutes` for the Coverage job from 20 to 40
- `cargo llvm-cov --all-features` occasionally exceeds 20min on cold cache or high runner load
- Dispatch-only informational job with `fail_ci_if_error: false` — zero risk
- Command, needs, triggers unchanged