### PR TITLE
test(http): harden timeout test assertions + add custom-UA wire verification

### DIFF
--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -1070,8 +1070,8 @@ mod tests {
         );
         let msg = err.to_string().to_lowercase();
         assert!(
-            msg.contains("timeout") || msg.contains("http error"),
-            "error should mention timeout/http error, got: {msg}"
+            msg.contains("timed out") || msg.contains("timeout"),
+            "expected timeout message, got: {msg}"
         );
     }
 
@@ -1108,10 +1108,16 @@ mod tests {
         let elapsed = start.elapsed();
 
         let err = result.expect_err("TLS blackhole should fail to connect");
-        eprintln!("connect-timeout error variant: {err:?}");
         assert!(
             elapsed < Duration::from_secs(6),
             "2s connect timeout should fire well before 6s, took {elapsed:?}"
+        );
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("client error (connect)")
+                || msg.contains("connection")
+                || msg.contains("connect"),
+            "expected connect-failure message, got: {msg}"
         );
     }
 

--- a/crates/webfang_core/src/application/http_client/client.rs
+++ b/crates/webfang_core/src/application/http_client/client.rs
@@ -751,7 +751,7 @@ mod tests {
 mod wiremock_tests {
     use super::*;
     use crate::domain::http_config::HttpClientConfig;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -888,6 +888,38 @@ mod wiremock_tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), expected_body);
+    }
+
+    /// `user_agent: Some(..)` in `HttpClientConfig` must reach the wire as a
+    /// `user-agent` header.
+    ///
+    /// `wreq::Client` does not expose its applied profile or default headers,
+    /// so we verify at the wire: the mock only answers 200 when the request
+    /// carries the exact `user-agent` we configured, and `.expect(1)` plus
+    /// `server.verify()` prove the header matched exactly once. Real network
+    /// I/O to localhost, hence not(miri).
+    #[tokio::test]
+    #[cfg(not(miri))]
+    async fn test_custom_user_agent_reaches_wire() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(header("user-agent", "custom-ua-test"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let config = HttpClientConfig {
+            user_agent: Some("custom-ua-test".to_string()),
+            ..Default::default()
+        };
+        let client = create_http_client_with_config(&config).unwrap();
+
+        let response = client.get(server.uri()).send().await.unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+
+        server.verify().await;
     }
 }
 


### PR DESCRIPTION
Closes #300

## Summary

Hardens the three weaknesses in #289's timeout tests (findings REL-2 and REL-3):

1. **Connect-timeout attribution**: added message substring assertion (`client error (connect)` / `connection` / `connect`) alongside the existing `< 6s` deadline. Removed debug `eprintln!`. Cannot downcast the error variant because `discovery.rs:124` wraps via `anyhow!("HTTP error: {e}")` (string interpolation erases the source chain).

2. **Request-timeout tautology removed**: dropped the `|| msg.contains("http error")` branch that matched ANY error from the anyhow wrapper. Now asserts `"timed out" || "timeout"` — both genuine timeout indicators from wreq's Display impl.

3. **New custom-UA wire test**: `test_custom_user_agent_reaches_wire` in `client.rs` wiremock_tests — verifies `user_agent: Some(..)` in `HttpClientConfig` actually arrives as a `user-agent` header on the wire. Uses `wiremock::matchers::header` (net-new pattern in this repo) + `.expect(1)` + `server.verify()`.

## Verification

- 16/16 `discovery::tests` pass (timeout tests ~2s each, as designed)
- Custom-UA test passes in 0.012s
- `cargo clippy --all-targets --all-features -D warnings` clean
- No production code touched — test modules only