### PR TITLE
fix(crawler): honor tls_emulation in the rate-limited crawl client

### DIFF
--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -212,6 +212,7 @@ async fn process_single_url(
         .delay_ms(base_config.delay_ms)
         .timeout_secs(base_config.timeout_secs)
         .ignore_robots(base_config.ignore_robots)
+        .tls_emulation(base_config.tls_emulation)
         .exclude_patterns(base_config.exclude_patterns.clone())
         .include_patterns(base_config.include_patterns.clone())
         .build();

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -110,6 +110,7 @@ pub async fn discover_urls_for_tui(
         let http_config = HttpClientConfig {
             timeout_secs: config.timeout_secs,
             connect_timeout_secs: config.timeout_secs.min(10), // #281 policy, replicated at call site
+            tls_emulation: config.tls_emulation,               // #312 honor configured profile
             ..Default::default()
         };
         let client = super::super::create_http_client_with_config(&http_config)?;
@@ -565,6 +566,7 @@ async fn crawl_with_sitemap_internal(
     let http_config = HttpClientConfig {
         timeout_secs: config.timeout_secs,
         connect_timeout_secs: config.timeout_secs.min(10), // #281 policy
+        tls_emulation: config.tls_emulation,               // #312 honor configured profile
         ..Default::default()
     };
     let discovery_client = super::super::create_http_client_with_config(&http_config)

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -11,6 +11,7 @@ use crate::cli::error::CliExit;
 use crate::cli::export_flow::{run_export, save_files, ExportConfig};
 use crate::cli::scrape_flow::{apply_resume_mode, scrape_urls};
 use crate::cli::url_discovery::discover_urls;
+use crate::domain::http_config::HttpClientConfig;
 use crate::domain::repository::DynVectorRepository;
 use crate::error::ScraperError;
 use crate::Args;
@@ -242,6 +243,11 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
     let urls_to_scrape = if opts.crawl.single_page {
         plan_urls(true, false, opts.url.clone(), Vec::new())
     } else {
+        // Honor `--h2-profile` for URL discovery (#312): an unknown profile is a
+        // config error (exit 78), consistent with the scrape and batch phases.
+        let tls_emulation = HttpClientConfig::profile_from_name(&opts.network.h2_profile)
+            .map_err(|e| CliExit::ConfigError(e.to_string()))?;
+
         let mut crawler_config = CrawlerConfig::builder(opts.url.clone())
             .max_pages(opts.crawl.max_pages)
             .max_depth(opts.crawl.max_depth)
@@ -249,7 +255,8 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
             .exclude_patterns(opts.crawl.exclude_patterns.clone())
             .ignore_robots(opts.crawl.ignore_robots)
             .use_sitemap(opts.crawl.use_sitemap)
-            .timeout_secs(opts.network.timeout_secs);
+            .timeout_secs(opts.network.timeout_secs)
+            .tls_emulation(tls_emulation);
         if let Some(ref sitemap_url) = opts.crawl.sitemap_url {
             crawler_config = crawler_config.sitemap_url(sitemap_url);
         }
@@ -506,6 +513,14 @@ async fn run_batch(opts: CrawlOptions) -> CliExit {
     use crate::application::batch::BatchManager;
     use crate::domain::CrawlerConfig;
 
+    // Resolve the TLS/H2 fingerprint once so the batch crawl engine honors
+    // `--h2-profile` (#312). An unknown profile is a config error (exit 78),
+    // matching the scrape phase — never silently crawl with a wrong fingerprint.
+    let tls_emulation = match HttpClientConfig::profile_from_name(&opts.network.h2_profile) {
+        Ok(profile) => profile,
+        Err(e) => return CliExit::ConfigError(e.to_string()),
+    };
+
     let mut crawler_config = CrawlerConfig::builder(opts.url.clone())
         .max_pages(opts.crawl.max_pages)
         .max_depth(opts.crawl.max_depth)
@@ -513,7 +528,8 @@ async fn run_batch(opts: CrawlOptions) -> CliExit {
         .exclude_patterns(opts.crawl.exclude_patterns.clone())
         .ignore_robots(opts.crawl.ignore_robots)
         .use_sitemap(opts.crawl.use_sitemap)
-        .timeout_secs(opts.network.timeout_secs);
+        .timeout_secs(opts.network.timeout_secs)
+        .tls_emulation(tls_emulation);
     if let Some(ref sitemap_url) = opts.crawl.sitemap_url {
         crawler_config = crawler_config.sitemap_url(sitemap_url);
     }

--- a/crates/webfang_core/src/domain/site/crawler_config.rs
+++ b/crates/webfang_core/src/domain/site/crawler_config.rs
@@ -3,6 +3,7 @@
 //! Configuration for crawling a specific site.
 
 use url::Url;
+use wreq_util::Profile;
 
 use crate::domain::pattern_matching::matches_pattern;
 
@@ -37,6 +38,11 @@ pub struct CrawlerConfig {
     pub sitemap_url: Option<String>,
     /// Skip robots.txt enforcement.
     pub ignore_robots: bool,
+    /// TLS/HTTP2 fingerprint emulation preset applied to the crawl HTTP client.
+    ///
+    /// Threaded from the CLI `--h2-profile` value. Defaults to
+    /// [`Profile::Chrome145`], preserving the historical crawl fingerprint.
+    pub tls_emulation: Profile,
 }
 
 impl CrawlerConfig {
@@ -62,6 +68,7 @@ impl CrawlerConfig {
             use_sitemap: false,
             sitemap_url: None,
             ignore_robots: false,
+            tls_emulation: Profile::Chrome145,
         }
     }
 
@@ -105,6 +112,7 @@ pub struct CrawlerConfigBuilder {
     use_sitemap: bool,
     sitemap_url: Option<String>,
     ignore_robots: bool,
+    tls_emulation: Profile,
 }
 
 impl CrawlerConfigBuilder {
@@ -123,6 +131,7 @@ impl CrawlerConfigBuilder {
             use_sitemap: false,
             sitemap_url: None,
             ignore_robots: false,
+            tls_emulation: Profile::Chrome145,
         }
     }
 
@@ -204,6 +213,12 @@ impl CrawlerConfigBuilder {
         self
     }
 
+    /// Set the TLS/HTTP2 fingerprint emulation preset.
+    pub fn tls_emulation(mut self, profile: Profile) -> Self {
+        self.tls_emulation = profile;
+        self
+    }
+
     /// Build the final [`CrawlerConfig`], consuming this builder.
     #[must_use]
     pub fn build(self) -> CrawlerConfig {
@@ -220,6 +235,7 @@ impl CrawlerConfigBuilder {
             use_sitemap: self.use_sitemap,
             sitemap_url: self.sitemap_url,
             ignore_robots: self.ignore_robots,
+            tls_emulation: self.tls_emulation,
         }
     }
 }
@@ -267,6 +283,7 @@ mod tests {
         assert!(!config.use_sitemap);
         assert!(config.sitemap_url.is_none());
         assert!(!config.ignore_robots);
+        assert_eq!(config.tls_emulation, Profile::Chrome145);
         assert!(config.include_patterns.is_empty());
         assert!(config.exclude_patterns.is_empty());
     }
@@ -385,6 +402,7 @@ mod tests {
             .use_sitemap(true)
             .sitemap_url("https://example.com/sitemap.xml".to_string())
             .ignore_robots(true)
+            .tls_emulation(Profile::Chrome131)
             .include_pattern("/blog/*".to_string())
             .exclude_pattern("/admin/*".to_string())
             .build();
@@ -402,8 +420,22 @@ mod tests {
             Some("https://example.com/sitemap.xml")
         );
         assert!(config.ignore_robots);
+        assert_eq!(config.tls_emulation, Profile::Chrome131);
         assert_eq!(config.include_patterns.len(), 1);
         assert_eq!(config.exclude_patterns.len(), 1);
+    }
+
+    #[test]
+    fn builder_tls_emulation_defaults_to_chrome145_and_is_settable() {
+        let seed = Url::parse("https://example.com").unwrap();
+
+        let default_config = CrawlerConfig::builder(seed.clone()).build();
+        assert_eq!(default_config.tls_emulation, Profile::Chrome145);
+
+        let custom_config = CrawlerConfig::builder(seed)
+            .tls_emulation(Profile::Firefox135)
+            .build();
+        assert_eq!(custom_config.tls_emulation, Profile::Firefox135);
     }
 
     #[test]

--- a/crates/webfang_core/src/infrastructure/crawler/http_client.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/http_client.rs
@@ -10,49 +10,58 @@
 
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tracing::debug;
 use wreq::Client;
-use wreq_util::Emulation;
+use wreq_util::Profile;
 
+use crate::domain::http_config::HttpClientConfig;
 use crate::domain::{CrawlError, CrawlerConfig};
+use crate::infrastructure::http::create_http_client_with_config;
 
 /// Create a rate-limited HTTP client
 ///
-/// Following **mem-with-capacity**: Pre-allocates client with appropriate pool size.
+/// Delegates to the shared config-driven factory ([`create_http_client_with_config`],
+/// the #299 source of truth) so the crawl client carries the same Chrome Client
+/// Hints, pooled user-agent, pool tuning, compression, cookie store, and redirect
+/// policy as the scrape client — with the TLS/H2 fingerprint resolved from config
+/// instead of a hardcoded `Chrome145` (#312).
 ///
 /// # Arguments
 ///
 /// * `delay_ms` - Delay between requests in milliseconds
+/// * `tls_emulation` - TLS/HTTP2 fingerprint preset applied to the client
 ///
 /// # Returns
 ///
-/// Configured reqwest Client
+/// Configured wreq Client
+///
+/// # Errors
+///
+/// Returns an error if the underlying wreq client fails to build.
 ///
 /// # Examples
 ///
 /// ```
 /// use webfang_core::infrastructure::crawler::create_rate_limited_client;
+/// use wreq_util::Profile;
 ///
-/// let client = create_rate_limited_client(500).unwrap();
+/// let client = create_rate_limited_client(500, Profile::Chrome145).unwrap();
 /// ```
-pub fn create_rate_limited_client(delay_ms: u64) -> Result<Client> {
-    // Hardware-aware: limit connection pool for low-resource systems
-    let pool_size = std::cmp::max(6, num_cpus::get() - 1);
-
-    let client = Client::builder()
-        .emulation(Emulation::Chrome145)
-        .pool_max_idle_per_host(pool_size)
-        .pool_idle_timeout(Duration::from_secs(60))
-        .connect_timeout(Duration::from_secs(10))
-        .gzip(true)
-        .brotli(true)
-        .user_agent("webfang/2.0.0 (High-Performance Extraction)")
-        .build()?;
+pub fn create_rate_limited_client(delay_ms: u64, tls_emulation: Profile) -> Result<Client> {
+    // The connect timeout replicates the historical 10s cap of this client; the
+    // per-request timeout is applied by `fetch_url` from `CrawlerConfig`.
+    let http_config = HttpClientConfig {
+        tls_emulation,
+        connect_timeout_secs: 10,
+        ..Default::default()
+    };
+    let client = create_http_client_with_config(&http_config)
+        .context("failed to build rate-limited HTTP client")?;
 
     debug!(
-        "Created rate-limited HTTP client with pool_size={} delay_ms={}",
-        pool_size, delay_ms
+        "Created rate-limited HTTP client with delay_ms={} tls_emulation={:?}",
+        delay_ms, tls_emulation
     );
 
     Ok(client)
@@ -75,7 +84,7 @@ pub fn create_rate_limited_client(delay_ms: u64) -> Result<Client> {
 pub async fn fetch_url(url: &str, config: &CrawlerConfig) -> Result<String, CrawlError> {
     debug!("Fetching URL: {}", url);
 
-    let client = create_rate_limited_client(config.delay_ms)
+    let client = create_rate_limited_client(config.delay_ms, config.tls_emulation)
         .map_err(|e| CrawlError::Internal(format!("Failed to create HTTP client: {e}")))?;
 
     let response = client
@@ -112,13 +121,47 @@ mod tests {
 
     #[test]
     fn test_create_rate_limited_client() {
-        let client = create_rate_limited_client(500);
+        let client = create_rate_limited_client(500, Profile::Chrome145);
         assert!(client.is_ok());
     }
 
     #[test]
     fn test_create_rate_limited_client_zero_delay() {
-        let client = create_rate_limited_client(0);
+        let client = create_rate_limited_client(0, Profile::Chrome145);
         assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_create_rate_limited_client_honors_profile_param() {
+        // The profile parameter must be accepted and threaded into the client
+        // builder for every preset, not just the Chrome145 default (#312).
+        for profile in [Profile::Chrome145, Profile::Chrome131, Profile::Firefox135] {
+            assert!(
+                create_rate_limited_client(100, profile).is_ok(),
+                "client build should succeed for profile {profile:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_url_with_custom_profile_succeeds() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>ok</html>"))
+            .mount(&server)
+            .await;
+
+        let seed = url::Url::parse(&server.uri()).unwrap();
+        let config = CrawlerConfig::builder(seed)
+            .tls_emulation(Profile::Chrome131)
+            .build();
+
+        let html = fetch_url(&server.uri(), &config)
+            .await
+            .expect("fetch_url should succeed with a custom TLS profile");
+        assert_eq!(html, "<html>ok</html>");
     }
 }


### PR DESCRIPTION
Closes #312

## Summary

Route `create_rate_limited_client` through the shared config-driven factory (`create_http_client_with_config`, #299 source of truth) instead of hardcoding `Emulation::Chrome145`. The TLS/H2 fingerprint is now threaded from `--h2-profile` via `CrawlerConfig.tls_emulation`.

## Changes

- **`domain/site/crawler_config.rs`** — new `tls_emulation: Profile` field (default `Chrome145`, preserves behavior), builder method, unit tests
- **`infrastructure/crawler/http_client.rs`** — `create_rate_limited_client(delay_ms, tls_emulation)` delegates to `create_http_client_with_config`; `fetch_url` passes `config.tls_emulation`; multi-profile build test + wiremock behavioral test
- **`cli/orchestrator.rs`** — `prepare_phase` and `run_batch` parse `--h2-profile` via `HttpClientConfig::profile_from_name` (unknown → exit 78) and thread into builder
- **`application/batch/processor.rs`** — propagates `tls_emulation` in per-URL config rebuild
- **`application/crawler/discovery.rs`** — both `HttpClientConfig` constructions honor `config.tls_emulation`

## Design decisions

- Delegates to the #299 factory (single source of truth) rather than patching the literal — consistent with ADR 0001 / #143 and the #298 discovery fix pattern.
- `engine.rs` needed no change: `run_crawl_task` already passes `&ctx.config` to `fetch_url`, so the new field flows through existing plumbing.
- The crawl client now also carries Client Hints + pooled UA + cookie store (previously a bare client with a fixed bot UA). For the default Chrome145 this is strictly more fingerprint-consistent.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run -p webfang_core` — 1519 passed, 0 failed