### PR TITLE
fix(infra): honor tls_emulation in WreqDownloader::new

### DIFF
--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -80,18 +80,22 @@ pub enum FetchRouter {
 /// crawl [`Engine`] and the CLI scrape path. `timeout_secs` drives the wreq
 /// request timeout (connect timeout is clamped to 10s); `cookie_bridge` is
 /// shared with the Chromiumoxide layer for cookie injection.
+/// `tls_emulation` selects the TLS/HTTP2 fingerprint preset for wreq.
 pub fn build_fetch_router(
     strategy: &JsStrategy,
     timeout_secs: u64,
     cookie_bridge: Arc<RwLock<CookieBridge>>,
+    tls_emulation: wreq_util::Profile,
 ) -> FetchRouter {
     let connect_timeout = timeout_secs.min(10);
     match strategy {
-        JsStrategy::Static => {
-            FetchRouter::Static(Arc::new(WreqDownloader::new(timeout_secs, connect_timeout)))
-        },
+        JsStrategy::Static => FetchRouter::Static(Arc::new(WreqDownloader::new(
+            timeout_secs,
+            connect_timeout,
+            tls_emulation,
+        ))),
         JsStrategy::Hybrid => {
-            let l1 = WreqDownloader::new(timeout_secs, connect_timeout);
+            let l1 = WreqDownloader::new(timeout_secs, connect_timeout, tls_emulation);
             let l2 = ObscuraDownloader::new(timeout_secs);
             let l3 = ChromiumoxideDownloader::new(cookie_bridge);
             FetchRouter::Hybrid(Arc::new(HybridRouter::new(l1, l2, l3)))
@@ -283,7 +287,8 @@ impl Engine {
     /// Set the JavaScript rendering strategy.
     pub fn with_js_strategy(mut self, strategy: JsStrategy) -> Self {
         let timeout = self.config.timeout_secs;
-        let router = build_fetch_router(&strategy, timeout, Arc::clone(&self.cookie_bridge));
+        let tls = self.config.tls_emulation;
+        let router = build_fetch_router(&strategy, timeout, Arc::clone(&self.cookie_bridge), tls);
         self.js_strategy = strategy;
         self.fetch_router = Some(router);
         self
@@ -1080,7 +1085,12 @@ mod router_tests {
 
     #[test]
     fn build_fetch_router_static_returns_static_variant() {
-        let router = build_fetch_router(&JsStrategy::Static, 30, test_cookie_bridge());
+        let router = build_fetch_router(
+            &JsStrategy::Static,
+            30,
+            test_cookie_bridge(),
+            wreq_util::Profile::Chrome145,
+        );
         assert!(
             matches!(router, FetchRouter::Static(_)),
             "Static strategy must produce FetchRouter::Static"
@@ -1089,7 +1099,12 @@ mod router_tests {
 
     #[test]
     fn build_fetch_router_hybrid_returns_hybrid_variant() {
-        let router = build_fetch_router(&JsStrategy::Hybrid, 30, test_cookie_bridge());
+        let router = build_fetch_router(
+            &JsStrategy::Hybrid,
+            30,
+            test_cookie_bridge(),
+            wreq_util::Profile::Chrome145,
+        );
         assert!(
             matches!(router, FetchRouter::Hybrid(_)),
             "Hybrid strategy must produce FetchRouter::Hybrid"
@@ -1098,7 +1113,12 @@ mod router_tests {
 
     #[test]
     fn build_fetch_router_full_returns_full_variant() {
-        let router = build_fetch_router(&JsStrategy::Full, 30, test_cookie_bridge());
+        let router = build_fetch_router(
+            &JsStrategy::Full,
+            30,
+            test_cookie_bridge(),
+            wreq_util::Profile::Chrome145,
+        );
         assert!(
             matches!(router, FetchRouter::Full(..)),
             "Full strategy must produce FetchRouter::Full (chrome-direct), not Hybrid"

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -132,7 +132,12 @@ pub async fn scrape_urls(
             opts.network.js_strategy
         };
     let cookie_bridge = std::sync::Arc::new(std::sync::RwLock::new(CookieBridge::new()));
-    let router = build_fetch_router(&effective_strategy, http_config.timeout_secs, cookie_bridge);
+    let router = build_fetch_router(
+        &effective_strategy,
+        http_config.timeout_secs,
+        cookie_bridge,
+        http_config.tls_emulation,
+    );
 
     let _total_urls = urls.len();
 

--- a/crates/webfang_core/src/infrastructure/downloader/mod.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/mod.rs
@@ -39,8 +39,9 @@ use url::Url;
 /// ```ignore
 /// use webfang_core::infrastructure::downloader::wreq_downloader::WreqDownloader;
 /// use webfang_core::infrastructure::downloader::Downloader;
+/// use wreq_util::Profile;
 ///
-/// let downloader = WreqDownloader::new(30, 10);
+/// let downloader = WreqDownloader::new(30, 10, Profile::Chrome145);
 /// let page = downloader.fetch(&"https://example.com".parse().unwrap()).await.unwrap();
 /// assert!(!page.html.is_empty());
 /// ```

--- a/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
@@ -13,7 +13,7 @@ use futures::future::BoxFuture;
 use tracing::{debug, instrument};
 use url::Url;
 use wreq::Client;
-use wreq_util::Emulation;
+use wreq_util::Profile;
 
 #[cfg(feature = "otel-metrics")]
 use crate::infrastructure::observability::metrics_instruments::DOWNLOAD_WREQ_LATENCY;
@@ -38,8 +38,9 @@ const WREQ_MEMORY_COST: usize = 1_024 * 1_024; // ~1 MB
 /// ```ignore
 /// use webfang_core::infrastructure::downloader::wreq_downloader::WreqDownloader;
 /// use webfang_core::infrastructure::downloader::Downloader;
+/// use wreq_util::Profile;
 ///
-/// let downloader = WreqDownloader::new(30, 10);
+/// let downloader = WreqDownloader::new(30, 10, Profile::Chrome145);
 /// let page = downloader.fetch(&"https://example.com".parse().unwrap()).await.unwrap();
 /// assert_eq!(page.status, 200);
 /// ```
@@ -49,7 +50,7 @@ pub struct WreqDownloader {
 }
 
 impl WreqDownloader {
-    /// Create a new WreqDownloader with default Chrome 145 emulation.
+    /// Create a new WreqDownloader with the given TLS emulation profile.
     ///
     /// The client is built once and shared via `Arc` for connection pooling.
     ///
@@ -57,15 +58,32 @@ impl WreqDownloader {
     ///
     /// * `timeout_secs` - Request timeout in seconds
     /// * `connect_timeout_secs` - Connection timeout in seconds
+    /// * `tls_emulation` - TLS/HTTP2 fingerprint emulation preset
     ///
     /// # Panics
     ///
-    /// Panics if the wreq client cannot be built (should not happen with valid params).
-    pub fn new(timeout_secs: u64, connect_timeout_secs: u64) -> Self {
+    /// Panics if the wreq client cannot be built. Prefer [`try_new`](Self::try_new)
+    /// in fallible contexts.
+    pub fn new(timeout_secs: u64, connect_timeout_secs: u64, tls_emulation: Profile) -> Self {
+        Self::try_new(timeout_secs, connect_timeout_secs, tls_emulation)
+            .expect("failed to build wreq client — this should not happen")
+    }
+
+    /// Fallible constructor — builds the wreq client and propagates errors.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DownloadError::Internal`] if the underlying `wreq::Client`
+    /// cannot be constructed (e.g. TLS backend failure).
+    pub fn try_new(
+        timeout_secs: u64,
+        connect_timeout_secs: u64,
+        tls_emulation: Profile,
+    ) -> Result<Self, DownloadError> {
         let pool_size = std::cmp::max(6, num_cpus::get() - 1);
 
         let client = Client::builder()
-            .emulation(Emulation::Chrome145)
+            .emulation(tls_emulation)
             .timeout(Duration::from_secs(timeout_secs))
             .connect_timeout(Duration::from_secs(connect_timeout_secs))
             .pool_max_idle_per_host(pool_size)
@@ -75,17 +93,17 @@ impl WreqDownloader {
             .cookie_store(true)
             .redirect(wreq::redirect::Policy::limited(10))
             .build()
-            .expect("failed to build wreq client — this should not happen");
+            .map_err(|e| DownloadError::Internal(format!("wreq client build failed: {e}")))?;
 
         debug!(
-            "WreqDownloader created: pool_size={}, timeout={}s, connect_timeout={}s",
+            "WreqDownloader created: pool_size={}, timeout={}s, connect_timeout={}s, profile={tls_emulation:?}",
             pool_size, timeout_secs, connect_timeout_secs
         );
 
-        Self {
+        Ok(Self {
             client: Arc::new(client),
             timeout_secs,
-        }
+        })
     }
 
     /// Create a WreqDownloader from an existing `wreq::Client`.
@@ -280,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_wreq_downloader_creation() {
-        let downloader = WreqDownloader::new(30, 10);
+        let downloader = WreqDownloader::new(30, 10, Profile::Chrome145);
         assert!(!downloader.supports_interactions());
         assert_eq!(downloader.memory_cost(), WREQ_MEMORY_COST);
     }
@@ -288,7 +306,7 @@ mod tests {
     #[test]
     fn test_wreq_downloader_from_client() {
         let client = Client::builder()
-            .emulation(Emulation::Chrome145)
+            .emulation(Profile::Chrome145)
             .build()
             .unwrap();
         let downloader = WreqDownloader::from_client(client, 60, 15);
@@ -346,7 +364,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network — wiremock tests below cover same scenario"]
     async fn test_fetch_example_com() {
-        let downloader = WreqDownloader::new(10, 5);
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145);
         let url: Url = "https://example.com".parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -377,7 +395,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5);
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145);
         let url: Url = mock_server.uri().parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -398,7 +416,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5);
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145);
         let url: Url = format!("{}/notfound", mock_server.uri()).parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -423,7 +441,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5);
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145);
         let url: Url = mock_server.uri().parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -455,7 +473,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5);
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145);
         let url: Url = format!("{}/redirect", mock_server.uri()).parse().unwrap();
 
         let result = downloader.fetch(&url).await;

--- a/tests/downloader_headers_test.rs
+++ b/tests/downloader_headers_test.rs
@@ -12,6 +12,7 @@ use webfang_core::infrastructure::downloader::wreq_downloader::WreqDownloader;
 use webfang_core::infrastructure::downloader::Downloader;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+use wreq_util::Profile;
 
 #[tokio::test]
 #[cfg(not(miri))]
@@ -28,7 +29,7 @@ async fn wreq_downloader_populates_response_headers() {
         .mount(&server)
         .await;
 
-    let downloader = WreqDownloader::new(10, 5);
+    let downloader = WreqDownloader::new(10, 5, Profile::Chrome145);
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 
     let page = downloader
@@ -69,7 +70,7 @@ async fn wreq_downloader_headers_keys_are_lowercased() {
         .mount(&server)
         .await;
 
-    let downloader = WreqDownloader::new(10, 5);
+    let downloader = WreqDownloader::new(10, 5, Profile::Chrome145);
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 
     let page = downloader.fetch(&url).await.expect("fetch should succeed");


### PR DESCRIPTION
Closes #326

> **Depends on #322** — merge that first; this PR's diff auto-shrinks to just the downloader commit.

## Summary

Add Profile parameter to WreqDownloader::new() and replace .expect() with proper error propagation via try_new(). Thread tls_emulation from CrawlerConfig through build_fetch_router.

## Changes (this PR only)

- infrastructure/downloader/wreq_downloader.rs — new(timeout, connect_timeout, tls_emulation); try_new() -> Result<Self, DownloadError>; removed hardcoded Chrome145 and .expect().
- application/crawler/engine.rs — build_fetch_router accepts tls_emulation; with_js_strategy passes config.tls_emulation.
- cli/scrape_flow.rs — passes http_config.tls_emulation to build_fetch_router.
- infrastructure/downloader/mod.rs — doc example updated.
- tests/downloader_headers_test.rs — updated to new 3-arg signature.

## Verification

- cargo clippy --workspace --all-targets -- -D warnings — clean
- cargo nextest run -p webfang_core — all passed
- cargo nextest run --test downloader_headers_test — passed