### PR TITLE
fix(ai): validate --threshold range at parse time instead of panic

### DIFF
--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -170,16 +170,16 @@ impl ModelConfig {
     }
 
     /// Set relevance threshold for filtering
-    #[must_use]
-    pub fn with_relevance_threshold(mut self, threshold: f32) -> Self {
-        // Validate threshold range
-        assert!(
-            (0.0..=1.0).contains(&threshold),
-            "Relevance threshold must be between 0.0 and 1.0, got {}",
-            threshold
-        );
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticError::InvalidThreshold`] if `threshold` is outside [0.0, 1.0].
+    pub fn with_relevance_threshold(mut self, threshold: f32) -> Result<Self, SemanticError> {
+        if !(0.0..=1.0).contains(&threshold) {
+            return Err(SemanticError::InvalidThreshold { value: threshold });
+        }
         self.relevance_threshold = threshold;
-        self
+        Ok(self)
     }
 
     /// Set AI model variant
@@ -716,7 +716,8 @@ mod tests {
             .with_auto_download(false)
             .with_offline_mode(true)
             .with_max_tokens(256)
-            .with_relevance_threshold(0.5);
+            .with_relevance_threshold(0.5)
+            .unwrap();
 
         assert_eq!(config.repo, "test/repo");
         assert_eq!(config.model_file, "test.onnx");
@@ -727,9 +728,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Relevance threshold must be between")]
     fn test_model_config_invalid_threshold() {
-        let _ = ModelConfig::new().with_relevance_threshold(1.5);
+        let result = ModelConfig::new().with_relevance_threshold(1.5);
+        assert!(result.is_err());
+        match result {
+            Err(SemanticError::InvalidThreshold { value }) => {
+                assert_eq!(value, 1.5);
+            },
+            _ => panic!("Expected InvalidThreshold error"),
+        }
     }
 
     #[test]
@@ -782,7 +789,9 @@ mod tests {
 
     #[test]
     fn test_model_config_with_relevance_threshold() {
-        let config = ModelConfig::default().with_relevance_threshold(0.5);
+        let config = ModelConfig::default()
+            .with_relevance_threshold(0.5)
+            .unwrap();
         assert_eq!(config.relevance_threshold, 0.5);
     }
 
@@ -797,7 +806,8 @@ mod tests {
             .with_auto_download(false)
             .with_offline_mode(true)
             .with_max_tokens(256)
-            .with_relevance_threshold(0.4);
+            .with_relevance_threshold(0.4)
+            .unwrap();
 
         assert_eq!(config.repo, "test/repo");
         assert_eq!(config.model_file, "test.onnx");

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -444,18 +444,24 @@ async fn __main() -> CliExit {
             }
         };
 
-        match SemanticCleanerImpl::new(
-            ModelConfig::default()
-                .with_model_variant(model_variant)
-                .with_relevance_threshold(opts.ai_config.threshold)
-                .with_max_tokens(opts.ai_config.max_tokens)
-                .with_offline_mode(opts.ai_config.offline),
-        )
-        .await
-        {
-            Ok(cleaner) => Some(Arc::new(cleaner) as Arc<dyn SemanticCleaner>),
+        let model_config = ModelConfig::default()
+            .with_model_variant(model_variant)
+            .with_relevance_threshold(opts.ai_config.threshold)
+            .map(|c| {
+                c.with_max_tokens(opts.ai_config.max_tokens)
+                    .with_offline_mode(opts.ai_config.offline)
+            });
+
+        match model_config {
+            Ok(config) => match SemanticCleanerImpl::new(config).await {
+                Ok(cleaner) => Some(Arc::new(cleaner) as Arc<dyn SemanticCleaner>),
+                Err(e) => {
+                    tracing::warn!("No se pudo inicializar el limpiador semántico AI: {e}");
+                    None
+                },
+            },
             Err(e) => {
-                tracing::warn!("No se pudo inicializar el limpiador semántico AI: {e}");
+                tracing::warn!("Configuración de umbral AI inválida: {e}");
                 None
             },
         }

--- a/crates/webfang_core/src/cli/args/ai.rs
+++ b/crates/webfang_core/src/cli/args/ai.rs
@@ -1,11 +1,23 @@
 use clap::Args;
 
+fn parse_threshold(s: &str) -> Result<f32, String> {
+    let val: f32 = s
+        .parse()
+        .map_err(|_| format!("'{s}' no es un número válido"))?;
+    if !(0.0..=1.0).contains(&val) {
+        return Err(format!(
+            "'{s}' está fuera de rango (rango válido: 0.0 a 1.0)"
+        ));
+    }
+    Ok(val)
+}
+
 /// AI-powered semantic cleaning arguments.
 #[derive(Args, Debug, Default)]
 pub struct AiArgs {
     /// Relevance threshold for AI semantic filtering (0.0-1.0)
     #[cfg(feature = "ai")]
-    #[arg(long, default_value = "0.3", env = "WEBFANG_THRESHOLD")]
+    #[arg(long, default_value = "0.3", env = "WEBFANG_THRESHOLD", value_parser = parse_threshold)]
     #[clap(next_help_heading = "AI Settings")]
     pub threshold: f32,
 

--- a/crates/webfang_core/src/error.rs
+++ b/crates/webfang_core/src/error.rs
@@ -288,6 +288,17 @@ pub enum SemanticError {
         /// HuggingFace repository
         repo: String,
     },
+
+    /// Relevance threshold out of valid range [0.0, 1.0]
+    ///
+    /// This occurs when:
+    /// - User provides a threshold outside the valid range
+    /// - Programmatic API receives an invalid threshold value
+    #[error("Umbral de relevancia inválido: {value} (rango válido: 0.0 a 1.0)")]
+    InvalidThreshold {
+        /// The invalid threshold value provided
+        value: f32,
+    },
 }
 
 /// Result type alias using ScraperError as the error type.

--- a/tests/ai_integration.rs
+++ b/tests/ai_integration.rs
@@ -313,7 +313,9 @@ fn test_semantic_cleaner_impl_send_sync() {
 /// Test ModelConfig with relevance threshold
 #[test]
 fn test_model_config_with_relevance_threshold() {
-    let config = ModelConfig::default().with_relevance_threshold(0.5);
+    let config = ModelConfig::default()
+        .with_relevance_threshold(0.5)
+        .unwrap();
     assert_eq!(config.relevance_threshold, 0.5);
 }
 
@@ -329,7 +331,8 @@ fn test_model_config_full_builder() {
         .with_auto_download(true)
         .with_offline_mode(false)
         .with_max_tokens(512)
-        .with_relevance_threshold(0.4);
+        .with_relevance_threshold(0.4)
+        .unwrap();
 
     assert_eq!(config.repo, "sentence-transformers/all-MiniLM-L6-v2");
     assert_eq!(config.model_file, "model.onnx");


### PR DESCRIPTION
Closes #334

## Summary
- Add clap `value_parser` with [0.0, 1.0] range validation for `--threshold`, producing a clean Spanish usage error (exit 64) instead of a Rust panic (exit 101)
- Convert `ModelConfig::with_relevance_threshold` from `assert!` to `Result<Self, SemanticError>` as defense-in-depth for programmatic API usage
- Add `SemanticError::InvalidThreshold` variant with Spanish error message

## Changes
| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/args/ai.rs` | Custom `parse_threshold` value parser with range validation and Spanish errors |
| `crates/webfang_core/src/error.rs` | New `SemanticError::InvalidThreshold { value: f32 }` variant |
| `crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs` | `with_relevance_threshold` returns `Result` instead of panicking; 4 tests updated |
| `crates/webfang_cli/src/main.rs` | Builder chain restructured to handle `Result` |
| `tests/ai_integration.rs` | Added `.unwrap()` to 2 test calls |

## Verification
- `cargo check --features ai` ✅
- `cargo clippy --features ai -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo nextest run -p webfang_ai` → 136 passed, 0 failed ✅
- CLI validation: `--threshold 1.5` → exit 64, Spanish error ✅
- CLI validation: `--threshold=-0.1` → exit 64, Spanish error ✅