### PR TITLE
fix(cli): drop elastic ingestion before runtime shutdown

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -151,6 +151,13 @@ pub async fn run(
         }
     }
 
+    // Release the ingestion pipeline (wreq connection pool + Rayon threads)
+    // while the runtime is still active. Without this, the hyper pool
+    // background task or Rayon thread join can block runtime shutdown.
+    // See issue #335.
+    drop(elastic_ingestion);
+    tokio::task::yield_now().await;
+
     if let Some(exit) = report_phase(&results, &failures) {
         return exit;
     }


### PR DESCRIPTION
Closes #335

## Summary

`--output-vectors` caused the process to hang indefinitely after printing the final summary. The `Arc<ElasticIngestion>` (holding a wreq connection pool + Rayon thread pool) survived until the end of `orchestrator::run()`, blocking tokio runtime shutdown.

## Fix

Explicitly `drop(elastic_ingestion)` after ingestion completes, plus `yield_now()` to give the hyper pool background task one poll cycle to exit cleanly. 7 lines, one file.

## Notes

- The 0-byte vectors file without `--features ai` is **expected behavior** — `StreamRepository::save_chunk` returns early when `embedding == None` (no AI → no embeddings → no records written).
- The hang was the real bug; the empty file was a red herring.

## Verification

- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo nextest run -p webfang_core orchestrator` — 17/17 ✅
- `cargo nextest run -p webfang_core stream` — 7/7 ✅