### PR TITLE
fix(crawler): fetch robots.txt through TLS-fingerprinted RobotsFetcher

### DIFF
--- a/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
@@ -15,7 +15,7 @@ use crate::application::deduplicator::UrlDeduplicator;
 use crate::application::pipeline::{OutputStage, PipelineExecutor};
 use crate::application::rate_limiter::SharedRateLimiter;
 use crate::domain::CrawlerConfig;
-use crate::infrastructure::crawler::RobotsCache;
+use crate::infrastructure::crawler::RobotsFetcher;
 use crate::infrastructure::crawler::UrlQueue;
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
 use crate::infrastructure::network::session_pool::DomainSessionPool;
@@ -33,7 +33,7 @@ pub struct CrawlTaskCtx {
     pub(crate) rate_limiter: SharedRateLimiter,
     pub(crate) session_pool: Option<DomainSessionPool>,
     pub(crate) ignore_robots: bool,
-    pub(crate) robots_cache: RobotsCache,
+    pub(crate) robots_fetcher: Arc<RobotsFetcher>,
 
     // --- Per-task mutable (atomics) ---
     pub(crate) error_count: Arc<AtomicUsize>,

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -28,9 +28,7 @@ use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 use crate::application::url_filter::is_allowed;
 use crate::domain::clock::SystemClock;
 use crate::domain::{CrawlError, CrawlResult, CrawlerConfig, DiscoveredUrl, JsStrategy};
-use crate::infrastructure::crawler::robots_utils::{
-    is_allowed_by_robots, new_robots_cache, RobotsCache,
-};
+use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::crawler::{
     extract_links, fetch_url, is_internal_link, UrlQueue, UrlSource,
 };
@@ -170,8 +168,8 @@ pub struct Engine {
     checkpoint_interval: u64,
     /// Skip robots.txt enforcement.
     ignore_robots: bool,
-    /// Shared robots.txt cache for the crawl session.
-    robots_cache: RobotsCache,
+    /// Shared robots.txt fetcher for the crawl session (TLS-fingerprinted, #337).
+    robots_fetcher: Arc<RobotsFetcher>,
     /// Optional domain session pool for per-domain rate limiting.
     session_pool: Option<DomainSessionPool>,
     /// Atomic counter for total pages crawled (used by checkpoint and signal handler).
@@ -224,6 +222,13 @@ impl Engine {
         let pages_crawled = Arc::new(AtomicU64::new(0));
         let shutdown = Arc::new(AtomicBool::new(false));
 
+        // Robots.txt fetcher — shares the crawl's TLS fingerprint so the
+        // robots.txt request is indistinguishable from a page fetch (#337).
+        let robots_fetcher = Arc::new(
+            RobotsFetcher::new(config_clone.tls_emulation, config_clone.timeout_secs)
+                .map_err(|e| CrawlError::Internal(e.to_string()))?,
+        );
+
         Ok(Self {
             config,
             collector: Some(collector),
@@ -237,7 +242,7 @@ impl Engine {
             checkpoint_path: None,
             checkpoint_interval: 100,
             ignore_robots,
-            robots_cache: new_robots_cache(),
+            robots_fetcher,
             session_pool: None,
             pages_crawled,
             shutdown,
@@ -502,7 +507,7 @@ impl Engine {
             rate_limiter: self.rate_limiter.clone(),
             session_pool: self.session_pool.clone(),
             ignore_robots: self.ignore_robots,
-            robots_cache: self.robots_cache.clone(),
+            robots_fetcher: Arc::clone(&self.robots_fetcher),
             error_count: Arc::clone(&self.error_count),
             pages_crawled: Arc::clone(&self.pages_crawled),
             collector: self.collector.as_ref().unwrap().clone(),
@@ -829,8 +834,7 @@ async fn run_crawl_task(
                             if is_internal_link(&link, seed_domain)
                                 && is_allowed(&link, &ctx.config)
                                 && (ctx.ignore_robots
-                                    || is_allowed_by_robots(&link, link_domain, &ctx.robots_cache)
-                                        .await)
+                                    || ctx.robots_fetcher.is_allowed(&link, link_domain).await)
                                 && ctx.visited.try_insert(&link)
                             {
                                 // Record URL string for checkpoint

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -12,7 +12,7 @@ use crate::application::scrape_single_url_for_tui;
 use crate::domain::entities::progress::{ScrapeError, ScrapeStatus};
 use crate::domain::JsStrategy;
 use crate::domain::ScrapedContent;
-use crate::infrastructure::crawler::robots_utils::{is_allowed_by_robots, new_robots_cache};
+use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
 use crate::infrastructure::export::state_store::StateStore;
 use crate::HttpClientConfig;
@@ -142,8 +142,10 @@ pub async fn scrape_urls(
 
     let _total_urls = urls.len();
 
-    // Robots.txt cache — shared across all URLs in this batch
-    let robots_cache = new_robots_cache();
+    // Robots.txt fetcher — shares the batch's TLS fingerprint so the robots.txt
+    // request is indistinguishable from a page fetch (#337). Shared across all
+    // URLs in this batch.
+    let robots_fetcher = RobotsFetcher::new(http_config.tls_emulation, http_config.timeout_secs)?;
 
     // Apply max_pages limit if configured
     let urls_to_process = if let Some(max_pages) = scraper_config.max_pages {
@@ -174,7 +176,7 @@ pub async fn scrape_urls(
         // Robots.txt enforcement — skip disallowed URLs unless --ignore-robots
         if !opts.crawl.ignore_robots {
             let domain = url.host_str().unwrap_or("unknown");
-            if !is_allowed_by_robots(url_str, domain, &robots_cache).await {
+            if !robots_fetcher.is_allowed(url_str, domain).await {
                 info!("Blocked by robots.txt: {}", url_str);
                 observer.on_robots_blocked(url_str).await;
                 continue;
@@ -232,9 +234,7 @@ fn build_http_client_config(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        apply_resume_mode, build_http_client_config, is_allowed_by_robots, new_robots_cache,
-    };
+    use super::{apply_resume_mode, build_http_client_config, RobotsFetcher};
     use crate::application::crawl_options::CrawlOptions;
     use tempfile::TempDir;
     use url::Url;
@@ -289,9 +289,13 @@ mod tests {
     #[cfg_attr(miri, ignore)] // btls/wreq FFI (BoringSSL TLS_method) not supported by Miri
     #[tokio::test]
     async fn robots_cache_allows_public_urls() {
-        let cache = new_robots_cache();
+        let fetcher = RobotsFetcher::new(wreq_util::Profile::Chrome145, 30).unwrap();
         // No robots.txt for localhost → fail-open → allowed
-        assert!(is_allowed_by_robots("http://localhost:18080/page", "localhost", &cache).await);
+        assert!(
+            fetcher
+                .is_allowed("http://localhost:18080/page", "localhost")
+                .await
+        );
     }
 
     #[test]

--- a/crates/webfang_core/src/infrastructure/crawler/mod.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/mod.rs
@@ -27,9 +27,7 @@ pub use link_extractor::{extract_links, is_internal_link, normalize_url};
 pub use resource_downloader::{
     DownloadConfig, DownloadedResource, PermitGuard, ResourceDownloader,
 };
-pub use robots_utils::{
-    get_crawl_delay, is_allowed_by_robots, new_robots_cache, RobotsCache, RobotsRules,
-};
+pub use robots_utils::{RobotsFetcher, RobotsRules};
 pub use sitemap_config::{SitemapConfig, SitemapConfigBuilder};
 pub use sitemap_parser::{resolve_url, SitemapError, SitemapParser};
 pub use url_queue::{UrlQueue, UrlSource};

--- a/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
@@ -1,17 +1,27 @@
 //! Robots.txt utilities
 //!
-//! Functions for handling robots.txt rules:
+//! Components for handling robots.txt rules:
 //! - Parsing Crawl-delay directives
-//! - Fetching and caching robots.txt rules
+//! - Fetching and caching robots.txt rules with a TLS-fingerprinted client
 //! - Checking URL permissions
 //!
-//! Extracted from discovery.rs to keep it orchestration-only.
+//! The [`RobotsFetcher`] owns a shared `wreq::Client` built with the caller's
+//! TLS/HTTP2 emulation profile (#337). Previously robots.txt was fetched with a
+//! bare `wreq::get()`, which spun up a throwaway client carrying the *default*
+//! TLS fingerprint — a bot signal for WAFs that compared it against the main
+//! page downloader's fingerprint. Routing the fetch through an emulated client
+//! keeps the robots.txt fingerprint consistent with the rest of the crawl.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashMap;
 use robotstxt::DefaultMatcher;
 use url::Url;
+use wreq::Client;
+use wreq_util::Profile;
+
+use crate::infrastructure::error::InfraError;
 
 /// Parsed robots.txt rules for a domain.
 ///
@@ -85,144 +95,176 @@ fn robots_txt_url(url: &str, domain: &str) -> String {
     }
 }
 
-/// Fetch and cache robots.txt rules for a domain.
+/// Fetches and caches robots.txt rules using a TLS-fingerprinted HTTP client.
 ///
-/// On cache miss, fetches `robots.txt` from the domain root using wreq.
-/// Parses the content and caches the result. Returns `None` if fetching
-/// or parsing fails (fail-open: treat as all-allowed).
+/// The internal `wreq::Client` is built once with the caller's TLS/HTTP2
+/// emulation [`Profile`] and shared via `Arc` (#337). This keeps the robots.txt
+/// fingerprint consistent with the main page downloader instead of leaking the
+/// default fingerprint through a throwaway `wreq::get()` client.
 ///
-/// # Arguments
-///
-/// * `domain` - Cache key for the site (typically the bare host)
-/// * `url` - A page URL on the site, used to derive the robots.txt origin
-/// * `cache` - Shared robots.txt rules cache
-///
-/// # Returns
-///
-/// Parsed robots.txt rules, or None if unavailable
-///
-/// # Examples
-///
-/// ```no_run
-/// use webfang_core::infrastructure::crawler::robots_utils::{new_robots_cache, fetch_robots_rules};
-///
-/// # #[tokio::main]
-/// # async fn main() {
-/// let cache = new_robots_cache();
-/// let rules = fetch_robots_rules("example.com", "https://example.com/page", &cache).await;
-/// # }
-/// ```
-pub async fn fetch_robots_rules(
-    domain: &str,
-    url: &str,
-    cache: &RobotsCache,
-) -> Option<Arc<RobotsRules>> {
-    if let Some(rules) = cache.get(domain) {
-        return Some(Arc::clone(rules.value()));
+/// Following **own-arc-shared**: the client is `Arc`-wrapped so the fetcher can
+/// be shared cheaply across spawned crawl tasks.
+pub struct RobotsFetcher {
+    /// Shared HTTP client built with the configured TLS emulation profile.
+    client: Arc<Client>,
+    /// Per-domain robots.txt rules cache (lock-free, shared across tasks).
+    cache: RobotsCache,
+}
+
+impl RobotsFetcher {
+    /// Create a new fetcher whose client uses the given TLS/HTTP2 `profile`.
+    ///
+    /// The client is built once and shared via `Arc` for connection pooling. It
+    /// mirrors the main downloader's fingerprint and enables gzip/brotli plus a
+    /// bounded redirect policy so the robots.txt fetch is indistinguishable from
+    /// a regular page fetch (#337).
+    ///
+    /// # Arguments
+    ///
+    /// * `profile` - TLS/HTTP2 fingerprint emulation preset applied to the client
+    /// * `timeout_secs` - Request timeout in seconds; the connect timeout is
+    ///   clamped to `min(timeout_secs, 10)`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InfraError::Network`] if the wreq client cannot be built.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
+    ///
+    /// let fetcher = RobotsFetcher::new(wreq_util::Profile::Chrome145, 30).unwrap();
+    /// ```
+    pub fn new(profile: Profile, timeout_secs: u64) -> Result<Self, InfraError> {
+        let connect_timeout_secs = timeout_secs.min(10);
+
+        let client = Client::builder()
+            .emulation(profile)
+            .timeout(Duration::from_secs(timeout_secs))
+            .connect_timeout(Duration::from_secs(connect_timeout_secs))
+            .gzip(true)
+            .brotli(true)
+            .redirect(wreq::redirect::Policy::limited(10))
+            .build()
+            .map_err(|e| InfraError::Network(Box::new(e)))?;
+
+        tracing::debug!(
+            "RobotsFetcher created: timeout={}s, connect_timeout={}s",
+            timeout_secs,
+            connect_timeout_secs
+        );
+
+        Ok(Self {
+            client: Arc::new(client),
+            cache: new_robots_cache(),
+        })
     }
 
-    let robots_url = robots_txt_url(url, domain);
-    tracing::debug!("Fetching robots.txt from {}", robots_url);
+    /// Fetch and cache robots.txt rules for a domain.
+    ///
+    /// On cache miss, fetches `robots.txt` from the domain root using the shared
+    /// emulated client. Parses the content and caches the result. Returns `None`
+    /// if fetching or parsing fails (fail-open: treat as all-allowed).
+    ///
+    /// # Arguments
+    ///
+    /// * `domain` - Cache key for the site (typically the bare host)
+    /// * `url` - A page URL on the site, used to derive the robots.txt origin
+    ///
+    /// # Returns
+    ///
+    /// Parsed robots.txt rules, or None if unavailable
+    async fn fetch_rules(&self, domain: &str, url: &str) -> Option<Arc<RobotsRules>> {
+        if let Some(rules) = self.cache.get(domain) {
+            return Some(Arc::clone(rules.value()));
+        }
 
-    let content = match wreq::get(&robots_url).send().await {
-        Ok(resp) if resp.status().is_success() => match resp.text().await {
-            Ok(text) => text,
-            Err(e) => {
-                tracing::warn!("Failed to read robots.txt body for {}: {}", domain, e);
+        let robots_url = robots_txt_url(url, domain);
+        tracing::debug!("Fetching robots.txt from {}", robots_url);
+
+        let content = match self.client.get(&robots_url).send().await {
+            Ok(resp) if resp.status().is_success() => match resp.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    tracing::warn!("Failed to read robots.txt body for {}: {}", domain, e);
+                    return None;
+                },
+            },
+            Ok(resp) => {
+                tracing::debug!(
+                    "robots.txt for {} returned status {}, treating as all-allowed",
+                    domain,
+                    resp.status()
+                );
                 return None;
             },
-        },
-        Ok(resp) => {
-            tracing::debug!(
-                "robots.txt for {} returned status {}, treating as all-allowed",
-                domain,
-                resp.status()
-            );
-            return None;
-        },
-        Err(e) => {
-            tracing::warn!("Failed to fetch robots.txt for {}: {}", domain, e);
-            return None;
-        },
-    };
+            Err(e) => {
+                tracing::warn!("Failed to fetch robots.txt for {}: {}", domain, e);
+                return None;
+            },
+        };
 
-    let crawl_delay = parse_crawl_delay(&content);
-    let rules = Arc::new(RobotsRules {
-        content,
-        crawl_delay_secs: crawl_delay,
-    });
-    cache.insert(domain.to_string(), Arc::clone(&rules));
-    Some(rules)
-}
+        let crawl_delay = parse_crawl_delay(&content);
+        let rules = Arc::new(RobotsRules {
+            content,
+            crawl_delay_secs: crawl_delay,
+        });
+        self.cache.insert(domain.to_string(), Arc::clone(&rules));
+        Some(rules)
+    }
 
-/// Check if a URL is allowed by the site's robots.txt.
-///
-/// Fetches robots.txt on first encounter (cached per domain).
-/// Uses the `robotstxt` crate's `DefaultMatcher` for path matching.
-/// Fail-open: if robots.txt cannot be fetched, the URL is allowed.
-///
-/// # Arguments
-///
-/// * `url` - The full URL to check
-/// * `domain` - The domain key for cache lookup
-/// * `cache` - Shared robots.txt rules cache
-///
-/// # Returns
-///
-/// `true` if the URL is allowed by robots.txt (or if robots.txt is unavailable).
-///
-/// # Examples
-///
-/// ```no_run
-/// use webfang_core::infrastructure::crawler::robots_utils::{new_robots_cache, is_allowed_by_robots};
-///
-/// # #[tokio::main]
-/// # async fn main() {
-/// let cache = new_robots_cache();
-/// assert!(is_allowed_by_robots("https://example.com/page", "example.com", &cache).await);
-/// # }
-/// ```
-pub async fn is_allowed_by_robots(url: &str, domain: &str, cache: &RobotsCache) -> bool {
-    let rules = match fetch_robots_rules(domain, url, cache).await {
-        Some(r) => r,
-        None => return true, // fail-open
-    };
+    /// Check if a URL is allowed by the site's robots.txt.
+    ///
+    /// Fetches robots.txt on first encounter (cached per domain).
+    /// Uses the `robotstxt` crate's `DefaultMatcher` for path matching.
+    /// Fail-open: if robots.txt cannot be fetched, the URL is allowed.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The full URL to check
+    /// * `domain` - The domain key for cache lookup
+    ///
+    /// # Returns
+    ///
+    /// `true` if the URL is allowed by robots.txt (or if robots.txt is unavailable).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let fetcher = RobotsFetcher::new(wreq_util::Profile::Chrome145, 30).unwrap();
+    /// assert!(fetcher.is_allowed("https://example.com/page", "example.com").await);
+    /// # }
+    /// ```
+    pub async fn is_allowed(&self, url: &str, domain: &str) -> bool {
+        let rules = match self.fetch_rules(domain, url).await {
+            Some(r) => r,
+            None => return true, // fail-open
+        };
 
-    let mut matcher = DefaultMatcher::default();
-    matcher.one_agent_allowed_by_robots(&rules.content, "*", url)
-}
+        let mut matcher = DefaultMatcher::default();
+        matcher.one_agent_allowed_by_robots(&rules.content, "*", url)
+    }
 
-/// Get the crawl-delay for a domain in seconds, if configured.
-///
-/// Returns `None` if no Crawl-delay directive was found.
-///
-/// # Arguments
-///
-/// * `domain` - Domain to get crawl-delay for
-/// * `cache` - Shared robots.txt rules cache
-///
-/// # Returns
-///
-/// Crawl-delay in seconds, or None if not configured
-///
-/// # Examples
-///
-/// ```
-/// use webfang_core::infrastructure::crawler::robots_utils::{new_robots_cache, get_crawl_delay};
-/// use std::sync::Arc;
-/// use webfang_core::infrastructure::crawler::robots_utils::RobotsRules;
-///
-/// let cache = new_robots_cache();
-/// cache.insert("example.com".to_string(), Arc::new(RobotsRules {
-///     content: String::new(),
-///     crawl_delay_secs: Some(5.0),
-/// }));
-///
-/// assert_eq!(get_crawl_delay("example.com", &cache), Some(5.0));
-/// assert_eq!(get_crawl_delay("unknown.com", &cache), None);
-/// ```
-pub fn get_crawl_delay(domain: &str, cache: &RobotsCache) -> Option<f64> {
-    cache.get(domain).and_then(|r| r.crawl_delay_secs)
+    /// Get the crawl-delay for a domain in seconds, if configured.
+    ///
+    /// Returns `None` if the domain has not been fetched yet or no Crawl-delay
+    /// directive was present in its robots.txt.
+    ///
+    /// # Arguments
+    ///
+    /// * `domain` - Domain to get crawl-delay for
+    ///
+    /// # Returns
+    ///
+    /// Crawl-delay in seconds, or None if not configured
+    pub fn get_crawl_delay(&self, domain: &str) -> Option<f64> {
+        self.cache.get(domain).and_then(|r| r.crawl_delay_secs)
+    }
 }
 
 #[cfg(test)]
@@ -260,35 +302,57 @@ Disallow: /tmp/";
         assert_eq!(parse_crawl_delay(robots_body_upper), Some(3.0));
     }
 
+    #[cfg_attr(miri, ignore)] // btls/wreq FFI (BoringSSL TLS_method) not supported by Miri
+    #[test]
+    fn test_fetcher_new_builds_client_for_profiles() {
+        let fetcher = RobotsFetcher::new(Profile::Chrome145, 30).expect("client should build");
+        // A freshly built fetcher has no cached rules for any domain.
+        assert_eq!(fetcher.get_crawl_delay("example.com"), None);
+
+        // The constructor honors the caller's profile selection.
+        assert!(RobotsFetcher::new(Profile::Firefox135, 5).is_ok());
+    }
+
+    #[cfg_attr(miri, ignore)] // btls/wreq FFI (BoringSSL TLS_method) not supported by Miri
     #[tokio::test]
     async fn test_robots_cache_hit() {
-        let cache = new_robots_cache();
-        let rules = Arc::new(RobotsRules {
-            content: "User-agent: *\nDisallow: /private/\n".to_string(),
-            crawl_delay_secs: Some(2.0),
-        });
-        cache.insert("example.com".to_string(), rules);
+        let fetcher = RobotsFetcher::new(Profile::Chrome145, 30).expect("client should build");
+        fetcher.cache.insert(
+            "example.com".to_string(),
+            Arc::new(RobotsRules {
+                content: "User-agent: *\nDisallow: /private/\n".to_string(),
+                crawl_delay_secs: Some(2.0),
+            }),
+        );
 
         // Should allow public URL
-        assert!(is_allowed_by_robots("https://example.com/public", "example.com", &cache).await);
+        assert!(
+            fetcher
+                .is_allowed("https://example.com/public", "example.com")
+                .await
+        );
         // Should disallow private URL
         assert!(
-            !is_allowed_by_robots("https://example.com/private/secret", "example.com", &cache)
+            !fetcher
+                .is_allowed("https://example.com/private/secret", "example.com")
                 .await
         );
     }
 
+    #[cfg_attr(miri, ignore)] // btls/wreq FFI (BoringSSL TLS_method) not supported by Miri
     #[test]
     fn test_get_crawl_delay_returns_cached_value() {
-        let cache = new_robots_cache();
-        let rules = Arc::new(RobotsRules {
-            content: String::new(),
-            crawl_delay_secs: Some(7.5),
-        });
-        cache.insert("slow-site.com".to_string(), rules);
+        let fetcher = RobotsFetcher::new(Profile::Chrome145, 30).expect("client should build");
+        fetcher.cache.insert(
+            "slow-site.com".to_string(),
+            Arc::new(RobotsRules {
+                content: String::new(),
+                crawl_delay_secs: Some(7.5),
+            }),
+        );
 
-        assert_eq!(get_crawl_delay("slow-site.com", &cache), Some(7.5));
-        assert_eq!(get_crawl_delay("unknown.com", &cache), None);
+        assert_eq!(fetcher.get_crawl_delay("slow-site.com"), Some(7.5));
+        assert_eq!(fetcher.get_crawl_delay("unknown.com"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #337

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- Refactored robots.txt fetching from bare `wreq::get()` (default fingerprint, no timeout, no compression) to a `RobotsFetcher` struct that builds a shared `wreq::Client` with `.emulation(profile)`, matching the main page downloader behavior.
- Eliminates the TLS fingerprint inconsistency that WAFs detect as a bot signal (robots.txt request looked like a scraper while page requests looked like a browser).
- Also fixes: no timeout (hang risk), no redirect policy, no gzip/brotli on robots.txt fetches.

## Changes

| File | Change |
|------|--------|
| `infrastructure/crawler/robots_utils.rs` | New `RobotsFetcher` struct with `Arc<Client>` + `RobotsCache`; client built with `.emulation(profile)`, timeout, connect_timeout, gzip/brotli, redirect policy. Removed old free functions. |
| `infrastructure/crawler/mod.rs` | Updated re-exports to `RobotsFetcher` + `RobotsRules` |
| `application/crawler/crawl_task_ctx.rs` | `robots_cache: RobotsCache` → `robots_fetcher: Arc<RobotsFetcher>` |
| `application/crawler/engine.rs` | Builds `Arc<RobotsFetcher>` from `config.tls_emulation`; call site uses `ctx.robots_fetcher.is_allowed()` |
| `cli/scrape_flow.rs` | Builds `RobotsFetcher` from `http_config.tls_emulation`; call site updated |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (0 warnings)
- [x] `cargo nextest run -p webfang_core` passes (1542 passed, 14 skipped, 0 failed)
- [x] Doctests pass (3/3)
- [ ] Manual TLS fingerprint verification (JA3 capture per profile)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed