### PR TITLE
fix(cli): skip AI cleaner construction on --dry-run

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -430,7 +430,7 @@ async fn __main() -> CliExit {
     };
 
     #[cfg(feature = "ai")]
-    let ai_cleaner: Option<Arc<dyn SemanticCleaner>> = if opts.ai {
+    let ai_cleaner: Option<Arc<dyn SemanticCleaner>> = if opts.ai && !opts.export.dry_run {
         // Resolve model variant: CLI flag takes precedence over AI_MODEL_ID env var
         let model_variant = if opts.ai_config.model.is_empty() {
             webfang_ai::AiModel::from_env_or_default()


### PR DESCRIPTION
Closes #340

## Summary

`--dry-run` is a cheap URL listing that should never trigger model loading or network I/O. This PR guards the `ai_cleaner` construction with `!opts.export.dry_run` so the orchestrator short-circuits cleanly.

## Why before #339

#339 (fail-fast error propagation) makes `SemanticCleanerImpl::new()` failures propagate as `CliExit` instead of being swallowed. Without this guard, `--dry-run --clean-ai --offline` with an empty cache would **fail with an error** instead of printing the URL list — breaking dry-run semantics.

## Change

One line in `crates/webfang_cli/src/main.rs:433`:

```diff
- let ai_cleaner: Option<Arc<dyn SemanticCleaner>> = if opts.ai {
+ let ai_cleaner: Option<Arc<dyn SemanticCleaner>> = if opts.ai && !opts.export.dry_run {
```

## Verification

- `cargo check -p webfang_cli` ✅
- Pre-existing `webfang_core` warning (dead_code `parse_threshold`) unchanged — identical on main