### PR TITLE
fix(ai): propagate AI cleaner init error and respect HF_HOME

### DIFF
--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -275,7 +275,7 @@ impl SemanticCleanerImpl {
         // mode is cache-first: hf_hub returns the cached path when present and
         // transparently downloads missing assets otherwise.
         let (model_path, tokenizer_path) = if config.offline_mode {
-            let cache = HfCache::default();
+            let cache = HfCache::from_env();
             let cache_repo = cache.repo(Repo::new(config.repo.clone(), RepoType::Model));
 
             let model_path =
@@ -294,7 +294,7 @@ impl SemanticCleanerImpl {
             debug!("Resolved model and tokenizer from offline cache");
             (model_path, tokenizer_path)
         } else {
-            let api = ApiBuilder::new()
+            let api = ApiBuilder::from_env()
                 .with_progress(false)
                 .build()
                 .map_err(|e| SemanticError::Download {

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -430,7 +430,7 @@ async fn __main() -> CliExit {
     };
 
     #[cfg(feature = "ai")]
-    let ai_cleaner: Option<Arc<dyn SemanticCleaner>> = if opts.ai {
+    let ai_cleaner: Option<Arc<dyn SemanticCleaner>> = if opts.ai && !opts.export.dry_run {
         // Resolve model variant: CLI flag takes precedence over AI_MODEL_ID env var
         let model_variant = if opts.ai_config.model.is_empty() {
             webfang_ai::AiModel::from_env_or_default()

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -32,7 +32,7 @@ use inquire::Text;
 #[cfg(any(feature = "ai", feature = "adaptive-selectors"))]
 use std::sync::Arc;
 #[cfg(feature = "ai")]
-use webfang_ai::{ModelConfig, SemanticCleanerImpl};
+use webfang_ai::{ModelConfig, SemanticCleanerImpl, SemanticError};
 #[cfg(feature = "adaptive-selectors")]
 use webfang_core::application::adaptive_engine::{AdaptiveSelectorEngine, AdaptiveSelectorOptions};
 use webfang_core::application::crawl_options::CrawlOptions;
@@ -456,13 +456,15 @@ async fn __main() -> CliExit {
             Ok(config) => match SemanticCleanerImpl::new(config).await {
                 Ok(cleaner) => Some(Arc::new(cleaner) as Arc<dyn SemanticCleaner>),
                 Err(e) => {
-                    tracing::warn!("No se pudo inicializar el limpiador semántico AI: {e}");
-                    None
+                    let msg = format!("No se pudo inicializar el limpiador semántico AI: {e}");
+                    return match e {
+                        SemanticError::Download { .. } => CliExit::NetworkError(msg),
+                        _ => CliExit::ConfigError(msg),
+                    };
                 },
             },
             Err(e) => {
-                tracing::warn!("Configuración de umbral AI inválida: {e}");
-                None
+                return CliExit::ConfigError(format!("Configuración de umbral AI inválida: {e}"));
             },
         }
     } else {

--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -244,7 +244,6 @@ path = "../../tests/http_client_integration.rs"
 [[test]]
 name = "ai_error_propagation"
 path = "../../tests/ai_error_propagation.rs"
-required-features = ["ai"]
 
 [lints.clippy]
 doc_markdown = "allow"

--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -241,6 +241,11 @@ path = "../../tests/downloader_headers_test.rs"
 name = "http_client_integration"
 path = "../../tests/http_client_integration.rs"
 
+[[test]]
+name = "ai_error_propagation"
+path = "../../tests/ai_error_propagation.rs"
+required-features = ["ai"]
+
 [lints.clippy]
 doc_markdown = "allow"
 uninlined_format_args = "allow"

--- a/crates/webfang_core/src/cli/export_flow.rs
+++ b/crates/webfang_core/src/cli/export_flow.rs
@@ -51,8 +51,8 @@ pub async fn run_export(
     if config.clean_ai {
         match ai_cleaner {
             Some(cleaner) => run_ai_export(&config, cleaner).await,
-            None => Err(CliExit::UsageError(
-                "AI semantic cleaning requires the 'ai' feature. Recompile with --features ai"
+            None => Err(CliExit::ConfigError(
+                "Se solicitó limpieza semántica AI pero el limpiador no está disponible (no se propagó una falla de inicialización)"
                     .into(),
             )),
         }

--- a/tests/ai_error_propagation.rs
+++ b/tests/ai_error_propagation.rs
@@ -6,8 +6,9 @@
 //! "Recompile with --features ai" message that the bug produced.
 //!
 //! The vector is deterministic and network-free: `--clean-ai --offline` with
-//! `HF_HUB_CACHE` pointed at an empty temp dir, so offline resolution fails
-//! fast with `SemanticError::OfflineMode` before any scrape happens.
+//! `HF_HOME` pointed at an empty temp dir (the cleaner resolves its hf_hub
+//! cache via `Cache::from_env()`), so offline resolution fails fast with
+//! `SemanticError::OfflineMode` before any scrape happens.
 //!
 //! Run with: `cargo nextest run --features ai --test ai_error_propagation`
 
@@ -36,7 +37,7 @@ fn clean_ai_offline_empty_cache_surfaces_real_error() {
         .arg("granite-97m")
         .arg("--output")
         .arg(output_dir.path())
-        .env("HF_HUB_CACHE", cache_dir.path())
+        .env("HF_HOME", cache_dir.path())
         .output()
         .expect("run webfang binary");
 

--- a/tests/ai_error_propagation.rs
+++ b/tests/ai_error_propagation.rs
@@ -65,3 +65,62 @@ fn clean_ai_offline_empty_cache_surfaces_real_error() {
         redact_nondeterministic(output_dir.path(), &stderr)
     );
 }
+
+/// `--clean-ai` online (no `--offline`) with an empty `HF_HOME` cache and the
+/// HTTP(S) proxy pointed at a dead address must fail the model download fast
+/// and surface the real `Download` cause as `NetworkError` (exit 69), never the
+/// false "Recompile with --features ai" message.
+///
+/// Deterministic and network-free: the proxy `http://127.0.0.1:1` is refused
+/// instantly, so hf_hub never reaches the real endpoint nor downloads anything.
+#[test]
+fn clean_ai_download_failure_surfaces_network_error() {
+    let cache_dir = tempfile::TempDir::new().expect("create empty hf_hub cache");
+    let output_dir = tempfile::TempDir::new().expect("create output dir");
+
+    let output = Command::new(webfang_path())
+        .arg("--url")
+        .arg("https://example.com")
+        .arg("--clean-ai")
+        .arg("--ai-model")
+        .arg("granite-97m")
+        .arg("--output")
+        .arg(output_dir.path())
+        .env("HF_HOME", cache_dir.path())
+        .env("HTTP_PROXY", "http://127.0.0.1:1")
+        .env("HTTPS_PROXY", "http://127.0.0.1:1")
+        .env("ALL_PROXY", "http://127.0.0.1:1")
+        .output()
+        .expect("run webfang binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(69),
+        "expected NetworkError exit code 69, got {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("Recompile with --features ai"),
+        "stderr must NOT contain the misleading recompile message:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Error descargando modelo"),
+        "stderr must surface the real Download cause:\n{stderr}"
+    );
+
+    // The online path races model + tokenizer via try_join!, so the asset named
+    // in the failing URL is not stable across runs — redact it for a
+    // deterministic snapshot.
+    insta::with_settings!({
+        filters => vec![(r"resolve/main/[A-Za-z0-9._/-]+", "resolve/main/[ASSET]")],
+    }, {
+        insta::assert_snapshot!(
+            "clean_ai_download_failure_surfaces_network_error",
+            redact_nondeterministic(output_dir.path(), &stderr)
+        );
+    });
+}

--- a/tests/ai_error_propagation.rs
+++ b/tests/ai_error_propagation.rs
@@ -1,0 +1,66 @@
+//! AI error propagation behavioral tests (#339).
+//!
+//! Verifies that when the AI semantic cleaner fails to initialize in an
+//! ai-enabled build, `--clean-ai` surfaces the REAL initialization error with
+//! the correct exit code, instead of the misleading
+//! "Recompile with --features ai" message that the bug produced.
+//!
+//! The vector is deterministic and network-free: `--clean-ai --offline` with
+//! `HF_HUB_CACHE` pointed at an empty temp dir, so offline resolution fails
+//! fast with `SemanticError::OfflineMode` before any scrape happens.
+//!
+//! Run with: `cargo nextest run --features ai --test ai_error_propagation`
+
+#![cfg(feature = "ai")]
+
+#[path = "common/cli_harness.rs"]
+mod common;
+use common::{redact_nondeterministic, webfang_path};
+
+use assert_cmd::Command;
+
+/// `--clean-ai --offline` with an empty hf_hub cache must fail fast with the
+/// real `OfflineMode` cause (exit 78, ConfigError), never the false
+/// "Recompile with --features ai" message.
+#[test]
+fn clean_ai_offline_empty_cache_surfaces_real_error() {
+    let cache_dir = tempfile::TempDir::new().expect("create empty hf_hub cache");
+    let output_dir = tempfile::TempDir::new().expect("create output dir");
+
+    let output = Command::new(webfang_path())
+        .arg("--url")
+        .arg("https://example.com")
+        .arg("--clean-ai")
+        .arg("--offline")
+        .arg("--ai-model")
+        .arg("granite-97m")
+        .arg("--output")
+        .arg(output_dir.path())
+        .env("HF_HUB_CACHE", cache_dir.path())
+        .output()
+        .expect("run webfang binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(78),
+        "expected ConfigError exit code 78, got {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("Recompile with --features ai"),
+        "stderr must NOT contain the misleading recompile message:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Modo offline"),
+        "stderr must surface the real OfflineMode cause:\n{stderr}"
+    );
+
+    insta::assert_snapshot!(
+        "clean_ai_offline_empty_cache_surfaces_real_error",
+        redact_nondeterministic(output_dir.path(), &stderr)
+    );
+}

--- a/tests/snapshots/ai_error_propagation__clean_ai_download_failure_surfaces_network_error.snap
+++ b/tests/snapshots/ai_error_propagation__clean_ai_download_failure_surfaces_network_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_core/../../tests/ai_error_propagation.rs
+expression: "redact_nondeterministic(output_dir.path(), &stderr)"
+---
+Error: No se pudo inicializar el limpiador semántico AI: Error descargando modelo 'ibm-granite/granite-embedding-97m-multilingual-r2': HuggingFace API error: request error: error sending request for url (https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2/resolve/main/[ASSET])

--- a/tests/snapshots/ai_error_propagation__clean_ai_offline_empty_cache_surfaces_real_error.snap
+++ b/tests/snapshots/ai_error_propagation__clean_ai_offline_empty_cache_surfaces_real_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_core/../../tests/ai_error_propagation.rs
+expression: "redact_nondeterministic(output_dir.path(), &stderr)"
+---
+Error: No se pudo inicializar el limpiador semántico AI: Modo offline: modelo 'ibm-granite/granite-embedding-97m-multilingual-r2' no está en caché


### PR DESCRIPTION
## Linked Issue

Closes #339

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- In an ai-enabled build, when the semantic cleaner failed to initialize, `main.rs` swallowed the error (`warn!` + `None`), the pipeline scraped anyway, and `--clean-ai` ended with a misleading `Recompile with --features ai` even though the feature WAS compiled. This PR propagates the real typed `SemanticError` to the user with the correct exit code instead.
- Makes the hf_hub cache resolution respect `HF_HOME` (offline and online) via `Cache::from_env()` / `ApiBuilder::from_env()` — backward compatible (falls back to the same default when `HF_HOME` is unset), and required for hermetic tests.
- Restores the `--dry-run` guard so a dry run stays a cheap preview that never initializes or downloads the model.

Follow-up to #351 (fix for #338): that PR made `SemanticCleanerImpl::new()` auto-download the model and produce rich typed errors; this PR is the propagation layer #351 left untouched. Together: the model auto-downloads, and if it cannot (offline / network / hash), the user sees the real cause in Spanish with the right exit code — no wasted scrape, no false "recompile" message.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_cli/src/main.rs` | Propagate `SemanticError` as `CliExit` instead of `warn!`+`None` (`Download`→`NetworkError` exit 69, other variants→`ConfigError` exit 78); restore `&& !opts.export.dry_run` guard |
| `crates/webfang_core/src/cli/export_flow.rs` | Honest defensive guard message in the `None`-in-ai-build branch (no longer claims the feature is missing) |
| `crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs` | Offline `HfCache::default()`→`from_env()` and online `ApiBuilder::new()`→`from_env()` so the cache respects `HF_HOME` |
| `crates/webfang_core/Cargo.toml` | Wire new behavioral test (`required-features = ["ai"]`) |
| `tests/ai_error_propagation.rs` | Two behavioral tests: offline + empty cache → exit 78 (`OfflineMode`); dead-proxy download failure → exit 69 (`Download`) |
| `tests/snapshots/ai_error_propagation__*.snap` (×2) | Golden snapshots for both tests |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (0 warnings)
- [x] `cargo nextest run --features ai --test ai_error_propagation` passes (2 tests)
- [x] `cargo nextest run -p webfang_ai` passes (136 tests)
- [x] Manually verified: offline + empty `HF_HOME` → exit 78 with `Modo offline`; dead-proxy → exit 69 with `Error descargando modelo`; neither shows `Recompile with --features ai`

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [ ] Docs updated if behavior changed — see follow-ups

## Follow-ups (not in this PR)

- AGENTS.md states models cache in `~/.cache/webfang/models/`, but the code uses `~/.cache/huggingface/hub` (hf_hub native cache). This doc drift predates this PR (introduced by #351's switch to hf_hub) and will be corrected separately.
