### PR TITLE
feat(crawler): correlation IDs nativos y crawl-scoped (Fase 1 observability)

### DIFF
--- a/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
@@ -14,7 +14,7 @@ use crate::application::crawler::engine::FetchRouter;
 use crate::application::deduplicator::UrlDeduplicator;
 use crate::application::pipeline::{OutputStage, PipelineExecutor};
 use crate::application::rate_limiter::SharedRateLimiter;
-use crate::domain::CrawlerConfig;
+use crate::domain::{CorrelationId, CrawlerConfig};
 use crate::infrastructure::crawler::RobotsFetcher;
 use crate::infrastructure::crawler::UrlQueue;
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
@@ -27,6 +27,9 @@ use crate::infrastructure::network::session_pool::DomainSessionPool;
 pub struct CrawlTaskCtx {
     // --- Shared config (read-only) ---
     pub(crate) config: Arc<CrawlerConfig>,
+    /// Root correlation ID for the crawl — every task derives a child from it
+    /// so all pages share one `trace_id` (issue #356).
+    pub(crate) correlation_id: CorrelationId,
     pub(crate) visited: Arc<UrlDeduplicator>,
     pub(crate) visited_urls: Arc<RwLock<Vec<String>>>,
     pub(crate) queue: Arc<UrlQueue>,

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -9,7 +9,9 @@ use url::Url;
 
 use crate::application::url_filter::is_allowed;
 use crate::domain::http_config::HttpClientConfig;
-use crate::domain::{CrawlError, CrawlerConfig, DiscoveredUrl, ScrapedContent, ValidUrl};
+use crate::domain::{
+    CorrelationId, CrawlError, CrawlerConfig, DiscoveredUrl, ScrapedContent, ValidUrl,
+};
 use crate::error::{Result as ScraperResult, ScraperError};
 use crate::infrastructure::crawler::binary_utils::derive_filename_from_response;
 use crate::infrastructure::crawler::{
@@ -280,7 +282,7 @@ pub async fn extract_content(
                 // Store CLEAN HTML from Readability (not raw HTML with nav/ads/footer)
                 html: Some(article.content),
                 assets,
-                correlation_id: None,
+                correlation_id: Some(CorrelationId::new()),
             })
         },
         Err(e) => {
@@ -326,7 +328,7 @@ pub async fn extract_content(
                 date: None,
                 html: Some(html.to_owned()),
                 assets,
-                correlation_id: None,
+                correlation_id: Some(CorrelationId::new()),
             })
         },
     }
@@ -455,7 +457,7 @@ pub async fn scrape_single_url_for_tui(
             date: None,
             html: None,
             assets,
-            correlation_id: None,
+            correlation_id: Some(CorrelationId::new()),
         });
     }
 
@@ -1339,5 +1341,30 @@ work with when computing the document readability score.</p>
         assert!(result.is_ok());
         let content = result.unwrap();
         assert!(content.content.contains("main content"));
+    }
+
+    #[tokio::test]
+    async fn extract_content_populates_correlation_id_natively() {
+        // Fase 1 (issue #356): correlation_id must be populated natively,
+        // WITHOUT requiring the `otel` feature. Every scraped page must be
+        // correlatable with its own logs/traces out of the box.
+        let html = r#"<html><head><title>Test Page</title></head><body>
+            <article><h1>Hello</h1><p>This is a long enough paragraph of content that readability should be able to extract properly from the DOM structure.</p>
+            <p>Second paragraph with more content to ensure readability has enough material to work with for extraction.</p></article>
+        </body></html>"#;
+        let url = Url::parse("https://example.com/article").unwrap();
+        let config = ScraperConfig::default();
+
+        let result = extract_content(html, &url, &config, None, None).await;
+
+        assert!(result.is_ok());
+        let content = result.unwrap();
+        assert!(
+            content.correlation_id.is_some(),
+            "correlation_id must be populated natively (without the `otel` feature)"
+        );
+        // Must be a valid W3C traceparent: 00-{trace_id}-{span_id}-01
+        let corr = content.correlation_id.unwrap();
+        assert!(corr.to_traceparent().starts_with("00-"));
     }
 }

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -27,7 +27,9 @@ use crate::application::pipeline::{OutputStage, PipelineExecutor, ScrapedItem, S
 use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 use crate::application::url_filter::is_allowed;
 use crate::domain::clock::SystemClock;
-use crate::domain::{CrawlError, CrawlResult, CrawlerConfig, DiscoveredUrl, JsStrategy};
+use crate::domain::{
+    CorrelationId, CrawlError, CrawlResult, CrawlerConfig, DiscoveredUrl, JsStrategy,
+};
 use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::crawler::{
     extract_links, fetch_url, is_internal_link, UrlQueue, UrlSource,
@@ -151,6 +153,8 @@ impl Downloader for FetchRouter {
 /// `UrlDeduplicator`. Results collected via mpsc channel.
 pub struct Engine {
     config: Arc<CrawlerConfig>,
+    /// Root correlation ID for this crawl — all pages share its `trace_id`.
+    correlation_id: CorrelationId,
     collector: Option<ResultsCollector>,
     visited: Arc<UrlDeduplicator>,
     /// String URLs for checkpoint persistence (mirrors `visited` hashes).
@@ -231,6 +235,7 @@ impl Engine {
 
         Ok(Self {
             config,
+            correlation_id: CorrelationId::new(),
             collector: Some(collector),
             visited,
             visited_urls,
@@ -255,6 +260,15 @@ impl Engine {
             autoscale_level: None,
             signal_handle: None,
         })
+    }
+
+    /// Override the crawl's root correlation ID.
+    ///
+    /// Used by `crawl_site` / `crawl_site_with_options` to make the entry-point
+    /// tracing span share the same `trace_id` as the engine and all its pages.
+    fn with_correlation_id(mut self, correlation_id: CorrelationId) -> Self {
+        self.correlation_id = correlation_id;
+        self
     }
 
     /// Enable checkpoint persistence with the given interval and base directory.
@@ -501,6 +515,7 @@ impl Engine {
         // Build shared task context once — all spawned tasks share this Arc
         let task_ctx = Arc::new(CrawlTaskCtx {
             config: Arc::clone(&self.config),
+            correlation_id: self.correlation_id.clone(),
             visited: Arc::clone(&self.visited),
             visited_urls: Arc::clone(&self.visited_urls),
             queue: Arc::clone(&self.queue),
@@ -677,6 +692,20 @@ async fn run_crawl_task(
     let url_str = discovered_url.url.as_str().to_string();
     let url_depth = discovered_url.depth;
     let parent_url = discovered_url.url.clone();
+
+    // Per-page correlation (issue #356): share the crawl's trace_id, fresh
+    // span_id. Lets a whole crawl be reconstructed by trace_id while each
+    // page stays distinguishable by span_id.
+    let page_correlation = ctx.correlation_id.child();
+    let page_span = span!(
+        Level::DEBUG,
+        "crawl_page",
+        correlation_id = %page_correlation,
+        trace_id = %page_correlation.trace_id(),
+        url = %url_str,
+        depth = url_depth
+    );
+    let _page_guard = page_span.enter();
 
     // Session pool: check if domain is healthy before fetching
     let mut session_id = None;
@@ -954,9 +983,12 @@ impl Default for EngineOptions {
     )
 )]
 pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError> {
+    let correlation_id = CorrelationId::new();
     let span = span!(
         Level::INFO,
         "crawl_site",
+        correlation_id = %correlation_id,
+        trace_id = %correlation_id.trace_id(),
         seed_url = %config.seed_url,
         max_depth = config.max_depth,
         max_pages = config.max_pages
@@ -969,7 +1001,7 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
     );
 
     let ignore_robots = config.ignore_robots;
-    let mut engine = Engine::new(config, ignore_robots)?;
+    let mut engine = Engine::new(config, ignore_robots)?.with_correlation_id(correlation_id);
     let result = engine.run().await;
     engine.shutdown().await;
     result
@@ -1037,9 +1069,12 @@ pub async fn crawl_site_with_options(
     config: CrawlerConfig,
     options: EngineOptions,
 ) -> Result<CrawlResult, CrawlError> {
+    let correlation_id = CorrelationId::new();
     let span = span!(
         Level::INFO,
         "crawl_site_with_options",
+        correlation_id = %correlation_id,
+        trace_id = %correlation_id.trace_id(),
         seed_url = %config.seed_url,
         max_depth = config.max_depth,
         max_pages = config.max_pages
@@ -1056,7 +1091,8 @@ pub async fn crawl_site_with_options(
         options.ignore_robots
     );
 
-    let mut engine = Engine::new(config, options.ignore_robots)?;
+    let mut engine =
+        Engine::new(config, options.ignore_robots)?.with_correlation_id(correlation_id);
 
     // Apply checkpoint if path provided
     if let Some(ref path) = options.checkpoint_path {

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -481,10 +481,7 @@ pub async fn scrape_with_config(
                 // This is what downstream Markdown converters receive.
                 html: Some(article.content),
                 assets,
-                #[cfg(feature = "otel")]
-                correlation_id: crate::domain::CorrelationId::from_otel_context(),
-                #[cfg(not(feature = "otel"))]
-                correlation_id: None,
+                correlation_id: Some(crate::domain::CorrelationId::new()),
             });
         },
         Err(e) => {
@@ -537,10 +534,7 @@ pub async fn scrape_with_config(
                 date: None,
                 html: Some(html),
                 assets,
-                #[cfg(feature = "otel")]
-                correlation_id: crate::domain::CorrelationId::from_otel_context(),
-                #[cfg(not(feature = "otel"))]
-                correlation_id: None,
+                correlation_id: Some(crate::domain::CorrelationId::new()),
             });
         },
     }

--- a/crates/webfang_core/src/domain/entities/content.rs
+++ b/crates/webfang_core/src/domain/entities/content.rs
@@ -156,8 +156,13 @@ pub struct ScrapedContent {
     /// Downloaded assets (images, documents)
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub assets: Vec<DownloadedAsset>,
-    /// Distributed tracing correlation ID (links to OTel span context)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Distributed tracing correlation ID (internal — not serialized).
+    ///
+    /// Populated natively on every scrape (issue #356) and propagated
+    /// in-memory to `DocumentChunk` for the JSONL export correlation.
+    /// Skipped from `ScrapedContent` serialization to keep the user-facing
+    /// `--format json` output clean and deterministic.
+    #[serde(skip)]
     pub correlation_id: Option<CorrelationId>,
 }
 

--- a/crates/webfang_core/src/domain/value_objects.rs
+++ b/crates/webfang_core/src/domain/value_objects.rs
@@ -64,6 +64,32 @@ impl CorrelationId {
         Self { trace_id, span_id }
     }
 
+    /// Create a child correlation ID: same `trace_id`, fresh `span_id`.
+    ///
+    /// Used to correlate multiple operations under a single trace while
+    /// giving each its own span identity — e.g. every page of a crawl shares
+    /// the crawl's `trace_id` but gets a unique `span_id`, so the whole crawl
+    /// can be reconstructed by `trace_id` while each page stays distinguishable.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use webfang_core::domain::value_objects::CorrelationId;
+    ///
+    /// let crawl = CorrelationId::new();
+    /// let page = crawl.child();
+    /// assert_eq!(crawl.trace_id(), page.trace_id());
+    /// assert_ne!(crawl.span_id(), page.span_id());
+    /// ```
+    pub fn child(&self) -> Self {
+        use rand::Rng;
+        let mut rng = rand::rng();
+        Self {
+            trace_id: self.trace_id,
+            span_id: rng.random(),
+        }
+    }
+
     /// Generate W3C traceparent header value
     ///
     /// Returns format: `00-{trace_id}-{span_id}-01`
@@ -343,6 +369,40 @@ mod tests {
         assert_eq!(corr.trace_id(), cloned.trace_id());
         assert_eq!(corr.span_id(), cloned.span_id());
         assert_eq!(corr.to_traceparent(), cloned.to_traceparent());
+    }
+
+    #[test]
+    fn test_correlation_id_child_shares_trace_id() {
+        // Fase 1b (issue #356): a child correlation ID must keep the parent's
+        // trace_id (so all pages of a crawl share one trace) while getting a
+        // fresh span_id (so each page is a distinct span).
+        let parent = CorrelationId::new();
+        let child = parent.child();
+
+        assert_eq!(
+            parent.trace_id(),
+            child.trace_id(),
+            "child must share the parent's trace_id"
+        );
+        assert_ne!(
+            parent.span_id(),
+            child.span_id(),
+            "child must get a fresh span_id"
+        );
+    }
+
+    #[test]
+    fn test_correlation_id_children_share_trace_id() {
+        // Multiple children of the same parent all share the trace_id but have
+        // distinct span_ids — this lets a whole crawl be reconstructed by
+        // trace_id while keeping each page distinguishable.
+        let parent = CorrelationId::new();
+        let c1 = parent.child();
+        let c2 = parent.child();
+
+        assert_eq!(c1.trace_id(), c2.trace_id());
+        assert_eq!(c1.trace_id(), parent.trace_id());
+        assert_ne!(c1.span_id(), c2.span_id(), "siblings must differ");
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #357

(Roadmap completa de observabilidad: #356 — este PR implementa la Fase 1)

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Hace que cada scrape sea correlacionable **sin depender de OpenTelemetry**: `correlation_id` ahora se puebla nativamente en los 5 sitios de creación de `ScrapedContent` (antes era `None` en builds default).
- Introduce correlación a nivel crawl: todas las páginas comparten un `trace_id`, cada una con `span_id` único, permitiendo reconstruir un crawl entero desde el trace JSONL.
- `ScrapedContent.correlation_id` pasa a `#[serde(skip)]` (metadata interna de tracing, no contamina `--format json`; propaga in-memory a `DocumentChunk`).

## Changes

| File | Change |
|------|--------|
| `domain/value_objects.rs` | `CorrelationId::child()` (mismo trace_id, nuevo span_id) + tests + doctest |
| `application/crawler/discovery.rs` | 3 sitios de `extract_content` pueblan correlation_id nativo + test TDD |
| `application/scraper_service.rs` | 2 sitios de `scrape_with_config` pueblan correlation_id nativo (remueve feature gate otel) |
| `application/crawler/engine.rs` | Engine raíz correlation_id; spans con correlation_id+trace_id en crawl_site/crawl_site_with_options/run_crawl_task |
| `application/crawler/crawl_task_ctx.rs` | Campo `correlation_id` compartido entre tasks |
| `domain/entities/content.rs` | `correlation_id` → `#[serde(skip)]` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (solo warning pre-existente `parse_threshold` de #353)
- [x] `cargo nextest run` pasa (1545/1545)
- [x] TDD estricto: tests en RED antes de implementar
- [x] Doctests OK

## Uso

```bash
webfang --url https://example.com --trace-file debug.jsonl -vvv
jq 'select(.fields.trace_id == "019fafd6-...")' debug.jsonl        # crawl entero
jq 'select(.fields.trace_id == "...") | .fields.span_id' debug.jsonl  # páginas individuales
```

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers