### PR TITLE
feat(infra): performance tracing en hot paths (Fase 2 observability)

### DIFF
--- a/crates/webfang_core/src/application/pipeline/executor.rs
+++ b/crates/webfang_core/src/application/pipeline/executor.rs
@@ -1,4 +1,5 @@
 use super::{PipelineStage, ScrapedItem, StageOutcome};
+use tracing::{instrument, Instrument};
 
 #[cfg(feature = "otel-metrics")]
 use crate::infrastructure::observability::metrics_instruments::{
@@ -29,9 +30,18 @@ impl PipelineExecutor {
     /// Returns [`StageOutcome::Continue`] with the final item if every stage
     /// passes. Returns early on the first [`StageOutcome::Skip`] or
     /// [`StageOutcome::Reject`].
+    #[instrument(skip(self, item), fields(stages = self.stages.len(), url = %item.url))]
     pub async fn execute(&self, mut item: ScrapedItem) -> StageOutcome {
         for stage in &self.stages {
-            match stage.process(item).await {
+            // Per-stage span (issue #356): makes stage-level timing visible in
+            // traces. `.instrument()` is async-safe (no enter-guard across await).
+            let stage_span = tracing::info_span!(
+                "pipeline_stage",
+                stage = %stage.name(),
+                url = %item.url
+            );
+            let outcome = stage.process(item).instrument(stage_span).await;
+            match outcome {
                 StageOutcome::Continue(updated) => item = updated,
                 StageOutcome::Reject(reason) => {
                     #[cfg(feature = "otel-metrics")]
@@ -76,6 +86,70 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+
+    // ─── Span-capture test helper (Fase 2, issue #356) ───
+
+    /// MakeWriter that appends tracing output to a shared buffer so tests can
+    /// assert which spans were emitted.
+    #[derive(Clone)]
+    struct SharedWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedWriter {
+        type Writer = SharedWriterGuard;
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedWriterGuard(self.0.clone())
+        }
+    }
+
+    struct SharedWriterGuard(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedWriterGuard {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_emits_pipeline_spans() {
+        use tracing_subscriber::fmt::format::FmtSpan;
+
+        let buf = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let writer = SharedWriter(buf.clone());
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer)
+            .with_span_events(FmtSpan::NEW)
+            .with_ansi(false)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let mut executor = PipelineExecutor::new();
+        executor.add_stage(Box::new(TransformStage));
+        let item = ScrapedItem {
+            url: "https://example.com/traced".into(),
+            raw_html: "<p>content</p>".into(),
+            status_code: 200,
+            ..Default::default()
+        };
+        let _ = executor.execute(item).await;
+
+        let out = String::from_utf8_lossy(&buf.lock().unwrap()).to_string();
+        assert!(
+            out.contains("execute"),
+            "execute span should be emitted, got: {out}"
+        );
+        assert!(
+            out.contains("pipeline_stage"),
+            "pipeline_stage span should be emitted, got: {out}"
+        );
+        assert!(
+            out.contains("https://example.com/traced"),
+            "url field should be recorded, got: {out}"
+        );
+    }
 
     struct CountingStage {
         name: String,

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -575,6 +575,14 @@ pub async fn scrape_with_config(
 ///
 /// # Note
 /// Failed URLs are logged but don't stop the entire batch.
+#[instrument(
+    name = "scrape_multiple_with_limit",
+    skip(client, urls, config, downloader),
+    fields(
+        urls = urls.len(),
+        concurrency = config.scraper_concurrency
+    )
+)]
 pub async fn scrape_multiple_with_limit(
     client: &dyn HttpClientPort,
     urls: &[url::Url],

--- a/crates/webfang_core/src/infrastructure/export/file_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/file_exporter.rs
@@ -202,6 +202,7 @@ impl Exporter for FileExporter {
         }
     }
 
+    #[tracing::instrument(skip(self, documents), fields(exporter = "file", documents = documents.len()))]
     fn export_batch(&self, documents: &[DocumentChunkValidated]) -> ExportResult<()> {
         // Default: export one by one
         for doc in documents {

--- a/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
@@ -159,6 +159,7 @@ impl crate::domain::exporter::Exporter for JsonlExporter {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, documents), fields(exporter = "jsonl", documents = documents.len()))]
     fn export_batch(&self, documents: &[DocumentChunkValidated]) -> ExportResult<()> {
         let count = documents.len();
         let mut writer = self.writer()?;

--- a/crates/webfang_core/src/infrastructure/export/vector_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/vector_exporter.rs
@@ -241,6 +241,7 @@ impl Exporter for VectorExporter {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, documents), fields(exporter = "vector", documents = documents.len()))]
     fn export_batch(&self, documents: &[DocumentChunkValidated]) -> ExportResult<()> {
         if documents.is_empty() {
             return Ok(());


### PR DESCRIPTION
## Linked Issue

Closes #363

(Roadmap completa: #356 — Fase 2. **PR stackeado sobre #358 (Fase 1)**; retargetear a `main` cuando #358 mergee.)

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Da visibility de **dónde se va el tiempo** en los hot paths vía `#[instrument]` con fields relevantes, sin cambiar comportamiento.
- Pipeline (gap principal, 0 instrumentación): `execute()` + span `pipeline_stage` async-safe por stage.
- Exporters `export_batch` (jsonl/vector/file) y `scrape_multiple_with_limit`.

## Changes

| File | Change |
|------|--------|
| `application/pipeline/executor.rs` | `#[instrument]` en `execute()` + span `pipeline_stage` vía `.instrument()` + test de captura de spans (TDD) |
| `infrastructure/export/jsonl_exporter.rs` | `#[instrument]` en `export_batch` |
| `infrastructure/export/vector_exporter.rs` | `#[instrument]` en `export_batch` |
| `infrastructure/export/file_exporter.rs` | `#[instrument]` en `export_batch` |
| `application/scraper_service.rs` | `#[instrument]` en `scrape_multiple_with_limit` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (solo `parse_threshold` pre-existente de #353)
- [x] `cargo nextest run` pasa (1546/1546)
- [x] TDD: test de captura de spans RED → GREEN
- [x] Comportamiento preservado

## Notas

- `.instrument(span)` (async-safe) en vez de `span.enter()` para no holdear guards across await.
- `Engine::run` no se instrumenta (redundante con `crawl_site` + `crawl_page` de Fase 1).
- Overhead de creación de span despreciable (ns vs ms de I/O). Verificación cuantitativa bloqueada por #364 (benches huérfanos).

## Contributor Checklist

- [x] Linked an issue with `Closes #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers