### PR TITLE
feat(crawler): progress tracking y summary estructurado (Fase 4 observability)

### DIFF
--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -21,6 +21,7 @@ use super::checkpoint::{
 };
 use super::collector::{CrawlMessage, ResultsCollector};
 use super::concurrency_level::{ConcurrencyLevel, SharedConcurrencyLevel};
+use super::progress::CrawlProgress;
 use crate::application::crawler::crawl_task_ctx::CrawlTaskCtx;
 use crate::application::deduplicator::UrlDeduplicator;
 use crate::application::pipeline::{OutputStage, PipelineExecutor, ScrapedItem, StageOutcome};
@@ -534,6 +535,9 @@ impl Engine {
             output_stages: self.output_stages.to_vec(),
         });
 
+        // Progress tracking start (issue #356 Fase 4)
+        let start = std::time::Instant::now();
+
         // Main crawl loop
         while !url_queue.is_empty() || !tasks.is_empty() {
             // Check shutdown signal
@@ -570,6 +574,20 @@ impl Engine {
                 if pages > 0 && pages.is_multiple_of(self.checkpoint_interval) {
                     debug!("Periodic checkpoint save at {pages} pages");
                     self.save_checkpoint().await;
+
+                    // Periodic structured progress log (issue #356 Fase 4)
+                    let progress =
+                        CrawlProgress::new(pages, config_clone.max_pages, start.elapsed());
+                    info!(
+                        pages_crawled = pages,
+                        max_pages = config_clone.max_pages,
+                        progress_pct = progress.progress_pct(),
+                        elapsed_secs = start.elapsed().as_secs(),
+                        pages_per_sec = progress.pages_per_sec(),
+                        eta_secs = progress.eta_secs(),
+                        trace_id = %self.correlation_id.trace_id(),
+                        "crawl progress"
+                    );
                 }
             }
 
@@ -636,7 +654,23 @@ impl Engine {
         let total_pages = collected_urls.len();
         let errors = self.error_count.load(std::sync::atomic::Ordering::SeqCst);
 
-        info!("Crawl complete: {} pages, {} errors", total_pages, errors);
+        // Structured crawl summary (issue #356 Fase 4)
+        let duration = start.elapsed();
+        let succeeded = total_pages.saturating_sub(errors);
+        let summary_rate = if duration.as_secs_f64() > 0.0 {
+            total_pages as f64 / duration.as_secs_f64()
+        } else {
+            0.0
+        };
+        info!(
+            total_pages = total_pages,
+            succeeded = succeeded,
+            errors = errors,
+            duration_secs = duration.as_secs(),
+            pages_per_sec = summary_rate,
+            trace_id = %self.correlation_id.trace_id(),
+            "crawl completed"
+        );
 
         Ok(CrawlResult::new(collected_urls, total_pages, errors))
     }

--- a/crates/webfang_core/src/application/crawler/mod.rs
+++ b/crates/webfang_core/src/application/crawler/mod.rs
@@ -8,6 +8,7 @@ pub mod concurrency_level;
 pub mod crawl_task_ctx;
 pub mod discovery;
 pub mod engine;
+pub mod progress;
 
 pub use collector::{ResultsAdapter, ResultsCollector};
 pub use concurrency_level::{ConcurrencyLevel, SharedConcurrencyLevel};
@@ -18,3 +19,4 @@ pub use discovery::{
 pub use engine::{
     build_fetch_router, crawl_site, crawl_site_with_options, EngineOptions, FetchRouter,
 };
+pub use progress::CrawlProgress;

--- a/crates/webfang_core/src/application/crawler/progress.rs
+++ b/crates/webfang_core/src/application/crawler/progress.rs
@@ -1,0 +1,100 @@
+//! Crawl progress metrics (issue #356, Fase 4).
+//!
+//! Pure computation helper for periodic progress logging during a crawl.
+//! Kept free of I/O and tracing so the metrics are unit-testable in isolation.
+
+use std::time::Duration;
+
+/// Computes crawl progress metrics for periodic logging.
+#[derive(Debug, Clone, Copy)]
+pub struct CrawlProgress {
+    /// Pages crawled so far.
+    pub pages_crawled: u64,
+    /// Target page limit (`max_pages`).
+    pub max_pages: usize,
+    /// Time elapsed since the crawl started.
+    pub elapsed: Duration,
+}
+
+impl CrawlProgress {
+    /// Create a progress snapshot.
+    pub fn new(pages_crawled: u64, max_pages: usize, elapsed: Duration) -> Self {
+        Self {
+            pages_crawled,
+            max_pages,
+            elapsed,
+        }
+    }
+
+    /// Completion percentage (0.0–100.0) relative to `max_pages`.
+    ///
+    /// Returns 0.0 when `max_pages` is 0 (no target).
+    pub fn progress_pct(&self) -> f64 {
+        if self.max_pages == 0 {
+            return 0.0;
+        }
+        (self.pages_crawled as f64 / self.max_pages as f64) * 100.0
+    }
+
+    /// Average pages per second over the elapsed time.
+    ///
+    /// Returns 0.0 when no time has elapsed.
+    pub fn pages_per_sec(&self) -> f64 {
+        let secs = self.elapsed.as_secs_f64();
+        if secs <= 0.0 {
+            return 0.0;
+        }
+        self.pages_crawled as f64 / secs
+    }
+
+    /// Estimated seconds remaining to reach `max_pages` at the current rate.
+    ///
+    /// Returns 0 when the rate is zero or there is no target.
+    pub fn eta_secs(&self) -> u64 {
+        let rate = self.pages_per_sec();
+        if rate <= 0.0 || self.max_pages == 0 {
+            return 0;
+        }
+        let remaining = (self.max_pages as f64 - self.pages_crawled as f64).max(0.0);
+        (remaining / rate) as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_progress_pct() {
+        let p = CrawlProgress::new(50, 200, Duration::from_secs(10));
+        assert!((p.progress_pct() - 25.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_pages_per_sec() {
+        let p = CrawlProgress::new(100, 200, Duration::from_secs(10));
+        assert!((p.pages_per_sec() - 10.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_eta_secs() {
+        // 10 pages/s, 100 pages remaining → 10s ETA
+        let p = CrawlProgress::new(100, 200, Duration::from_secs(10));
+        assert_eq!(p.eta_secs(), 10);
+    }
+
+    #[test]
+    fn test_eta_never_negative_past_target() {
+        // Already past max_pages → ETA clamps to 0
+        let p = CrawlProgress::new(250, 200, Duration::from_secs(10));
+        assert_eq!(p.eta_secs(), 0);
+    }
+
+    #[test]
+    fn test_zero_guards() {
+        let p = CrawlProgress::new(0, 0, Duration::from_secs(0));
+        assert_eq!(p.progress_pct(), 0.0);
+        assert_eq!(p.pages_per_sec(), 0.0);
+        assert_eq!(p.eta_secs(), 0);
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #368

(Roadmap: #356 — Fase 4. **PR stackeado sobre #367 (Fase 3)**; retargetear a `main` cuando la cadena mergee.)

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Progress tracking en crawls largos + summary estructurado al finalizar, reconstruible desde el trace file.
- Nuevo helper puro `CrawlProgress` (progress_pct, pages_per_sec, eta_secs).
- `Engine::run()` loguea `crawl progress` periódico y `crawl completed` final con `trace_id`.

## Changes

| File | Change |
|------|--------|
| `application/crawler/progress.rs` | Nuevo: `CrawlProgress` + 5 unit tests |
| `application/crawler/mod.rs` | Registro + export |
| `application/crawler/engine.rs` | Start instant + progress log periódico + summary estructurado |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (solo `parse_threshold` de #353)
- [x] `cargo nextest run` pasa (1553/1553)
- [x] 5 unit tests de CrawlProgress

## Notas

- Error breakdown por tipo diferido (requiere conteo tipado de errores, follow-up).
- Reusa `correlation_id` de Fase 1 para el `trace_id`.

## Contributor Checklist

- [x] Linked an issue with `Closes #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers