### PR TITLE
docs: mandato de observabilidad en AGENTS.md + guía de debugging (Fase 0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,6 +488,38 @@ Base the body on `.github/PULL_REQUEST_TEMPLATE.md` (it already documents these 
 
 **Avoid:** `adapters/tui/progress_widget.rs` (551 lines), `infrastructure/mcp_server/mod.rs` (1404 lines) — keep new components focused.
 
+## 🔭 Observability (MANDATORY for every change)
+
+**Iron rule:** any new feature, hot path, or behavior change MUST ship with observability. Code that cannot be traced in production is not done. There is no OpenTelemetry (removed in #356) — the stack is the `tracing` crate + the always-available **FileTraceLayer** (`--trace-file out.jsonl`) + native **correlation IDs**.
+
+### Required for new/changed code
+
+| Situation            | Requirement                                                                                          |
+| :------------------- | :--------------------------------------------------------------------------------------------------- |
+| New hot path / operation | `#[instrument(skip(...), fields(url = %url, ...))]` with the fields that identify the operation     |
+| Error path           | `log_scrape_error(&err, url, stage, correlation_id, "context")` — never a bare `warn!`/`eprintln!` for operational errors |
+| New crawl/batch flow | Generate a `CorrelationId` at entry and propagate it; each unit of work gets `.child()` (shared `trace_id`, unique `span_id`) |
+| Long-running op      | Periodic progress log + a final structured summary (`total`, `succeeded`, `errors`, `duration`, `trace_id`) |
+| Async spans          | Use `.instrument(span)` on futures — never hold a `span.enter()` guard across `.await`               |
+
+### Conventions
+
+- **Structured fields, not string soup:** `tracing::info!(pages = n, url = %url, "msg")` — never `format!` data into the message you'll want to query.
+- **Correlation:** every event/span of an operation carries its `trace_id`, so a whole operation is reconstructable with `jq 'select(.fields.trace_id == "...")'`.
+- **User-facing errors stay in Spanish; tracing fields/logs stay in English** (same rule as the rest of the codebase).
+- **No new metrics backends:** do not reintroduce OpenTelemetry or any external collector. Need a metric? Emit a structured tracing event and query it from the JSONL.
+- **Snapshots stay deterministic:** `correlation_id`/`trace_id` are internal and `#[serde(skip)]` on scraped output; redact any new non-deterministic field via `redact_nondeterministic()`.
+
+### Verifying your observability
+
+```bash
+webfang --url https://example.com --trace-file debug.jsonl -vvv
+jq 'select(.fields.trace_id == "0194...")' debug.jsonl   # reconstruct one operation
+jq 'select(.level == "ERROR")' debug.jsonl               # all errors with context
+```
+
+See `docs/debugging.md` and `scripts/analyze-trace.sh` for the full query cookbook. The observability module lives in `crates/webfang_core/src/infrastructure/observability/`.
+
 ## 🧪 Testing — Snapshots, Harness & Conventions
 
 ### Integration test structure

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ gitnexus analyze --index-only --skip-agents-md
 | Resource | Covers |
 |----------|--------|
 | [AGENTS.md](AGENTS.md) | AI agent instructions, GitNexus integration |
+| [docs/debugging.md](docs/debugging.md) | Tracing, correlation IDs, `jq` query cookbook (`scripts/analyze-trace.sh`) |
 | [Wiki](https://github.com/XaviCode1000/webfang/wiki) | Architecture, API reference, guides |
 | `webfang --help` | Full CLI reference |
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,164 @@
+# Debugging & Trace Analysis
+
+WebFang ships **built-in, always-available observability**. No external
+collector, no feature flags, no infrastructure: run with `--trace-file` and
+post-process the JSONL with `jq`.
+
+> **Mandate:** every new feature or hot path must be observable. See the
+> "Observability (MANDATORY)" section of `AGENTS.md`.
+
+---
+
+## The stack
+
+| Layer | What it does | Always on? |
+| :--- | :--- | :--- |
+| **FileTraceLayer** | Writes every `tracing` span/event to a JSONL file (`--trace-file`) | ✅ Yes |
+| **Correlation IDs** | Native `CorrelationId` (UUID v7 `trace_id` + `span_id`); one `trace_id` per operation, unique `span_id` per unit of work | ✅ Yes |
+| **Structured logging** | `tracing-subscriber` to stderr (`-v`/`-vv`/`-vvv`, `--log-format json`) | ✅ Yes |
+| **Tokio Console** | Async task/resource inspection for concurrency bugs | `--features console` |
+
+There is **no OpenTelemetry** (removed in #356). If you need a metric, emit a
+structured tracing event and query it from the JSONL.
+
+---
+
+## Generating a trace
+
+```bash
+# Full trace + verbose logging
+webfang --url https://example.com --trace-file debug.jsonl -vvv
+
+# Batch / crawl
+webfang --url https://example.com --max-pages 100 --trace-file crawl.jsonl -v
+```
+
+Each line of `debug.jsonl` is a JSON object:
+
+```json
+{
+  "timestamp": "2026-01-29T10:00:00.123Z",
+  "level": "INFO",
+  "target": "webfang_core::application::crawler::engine",
+  "span": "crawl_page",
+  "span_id": "0000000000000042",
+  "trace_id": "01949e0e8b8e70008000000000000001",
+  "fields": {
+    "url": "https://example.com/page1",
+    "depth": 1,
+    "correlation_id": "00-01949e0e8b8e70008000000000000001-0000000000000042-01"
+  }
+}
+```
+
+---
+
+## Query cookbook
+
+A ready-made script lives at `scripts/analyze-trace.sh`. The most useful
+queries:
+
+### Reconstruct one operation (crawl / scrape) by trace_id
+
+```bash
+TRACE=01949e0e8b8e70008000000000000001
+jq -c "select(.trace_id == \"$TRACE\" or (.fields.trace_id? // \"\" | contains(\"$TRACE\")))" debug.jsonl
+```
+
+### All errors, with full context
+
+```bash
+jq -c 'select(.level == "ERROR") | {target, url: .fields.url, stage: .fields.stage, error: .fields.error, msg: .fields.message}' debug.jsonl
+```
+
+### Slowest spans (where the time goes)
+
+```bash
+jq -r 'select(.span_duration_ms != null) | [.span_duration_ms, .span] | @tsv' debug.jsonl | sort -rn | head -20
+```
+
+### Time distribution per pipeline stage
+
+```bash
+jq -r 'select(.span == "pipeline_stage") | .fields.stage' debug.jsonl | sort | uniq -c | sort -rn
+```
+
+### Crawl progress over time
+
+```bash
+jq -c 'select(.fields.message? == "crawl progress") | {pages: .fields.pages_crawled, pct: .fields.progress_pct, eta_s: .fields.eta_secs}' debug.jsonl
+```
+
+### Final crawl summary
+
+```bash
+jq -c 'select(.fields.message? == "crawl completed")' debug.jsonl
+```
+
+### Count operations by span type
+
+```bash
+jq -r '.span // "event"' debug.jsonl | sort | uniq -c | sort -rn
+```
+
+### URLs that failed
+
+```bash
+jq -r 'select(.level == "ERROR") | .fields.url // empty' debug.jsonl | sort -u
+```
+
+---
+
+## Spans you will see
+
+| Span | Emitted by | Key fields |
+| :--- | :--- | :--- |
+| `crawl_site` / `crawl_site_with_options` | `crawler::engine` | `correlation_id`, `trace_id`, `seed_url`, `max_depth`, `max_pages` |
+| `crawl_page` | `crawler::engine::run_crawl_task` | `correlation_id`, `trace_id`, `url`, `depth` |
+| `execute` | `pipeline::PipelineExecutor` | `url`, `stages` |
+| `pipeline_stage` | `pipeline::PipelineExecutor` | `stage`, `url` |
+| `export_batch` | `JsonlExporter` / `VectorExporter` / `FileExporter` | `exporter`, `documents` |
+| `scrape_with_config` | `scraper_service` | `url`, `has_downloads` |
+| `scrape_multiple_with_limit` | `scraper_service` | `urls`, `concurrency` |
+
+Events (not spans): `crawl progress`, `crawl completed`, and any
+`log_scrape_error(...)` error carrying `error`, `url`, `stage`, `trace_id`.
+
+---
+
+## Concurrency debugging (Tokio Console)
+
+For deadlocks, starved tasks, or async resource leaks, use the Tokio Console:
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable" cargo run --features console -- --url https://example.com
+```
+
+This opens an interactive TUI showing live tasks, their states, and poll times.
+
+---
+
+## Troubleshooting
+
+| Symptom | First query / check |
+| :--- | :--- |
+| "The crawl is slow" | Slowest-spans query above; check `pipeline_stage` distribution and `export_batch` timings |
+| "Pages are failing silently" | `select(.level == "ERROR")` — every error path logs `url` + `stage` + `trace_id` |
+| "I can't tell which logs belong to one page" | Filter by `trace_id` (one per operation) or the per-page `crawl_page` span |
+| "WAF / blocks" | `select(.fields.message? == "WAF challenge detected")` and banned-domain warnings |
+| "Non-deterministic snapshot in tests" | The field must be redacted via `redact_nondeterministic()`; `correlation_id`/`trace_id` are already `#[serde(skip)]` on scraped output |
+
+---
+
+## For contributors
+
+When you add a hot path or operation, follow the observability mandate in
+`AGENTS.md`:
+
+- `#[instrument(skip(...), fields(url = %url, ...))]` on the function.
+- Propagate the operation's `CorrelationId`; derive `.child()` per unit of work.
+- Use `log_scrape_error(...)` on error paths (never a bare `warn!` for an
+  operational error).
+- Use `.instrument(span)` on async futures — never hold `span.enter()` across
+  `.await`.
+- Verify with: `webfang ... --trace-file debug.jsonl -vvv` and the queries above.

--- a/scripts/analyze-trace.sh
+++ b/scripts/analyze-trace.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# analyze-trace.sh — query cookbook for WebFang FileTraceLayer JSONL output.
+#
+# Usage:
+#   scripts/analyze-trace.sh <trace.jsonl> <command> [args]
+#
+# Generate a trace first:
+#   webfang --url https://example.com --trace-file debug.jsonl -vvv
+#
+# Commands:
+#   errors                 All ERROR events with url/stage/error context
+#   slow [N]               Top N slowest spans (default 20)
+#   stages                 Time/count distribution per pipeline stage
+#   progress               Crawl progress events over time
+#   summary                Final "crawl completed" summary
+#   counts                 Operation counts by span type
+#   urls-failed            Unique URLs that produced an ERROR
+#   trace <trace_id>       Reconstruct one operation by trace_id
+#   waf                    WAF challenges and banned-domain events
+#
+# Requires: jq
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  grep '^#' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+fi
+
+FILE="$1"
+CMD="$2"
+shift 2
+
+if [[ ! -f "$FILE" ]]; then
+  echo "error: trace file not found: $FILE" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required (https://jqlang.github.io/jq/)" >&2
+  exit 1
+fi
+
+case "$CMD" in
+  errors)
+    jq -c 'select(.level == "ERROR") | {target, url: .fields.url, stage: .fields.stage, error: .fields.error, msg: .fields.message}' "$FILE"
+    ;;
+  slow)
+    N="${1:-20}"
+    jq -r 'select(.span_duration_ms != null) | [.span_duration_ms, .span] | @tsv' "$FILE" | sort -rn | head -n "$N"
+    ;;
+  stages)
+    jq -r 'select(.span == "pipeline_stage") | .fields.stage' "$FILE" | sort | uniq -c | sort -rn
+    ;;
+  progress)
+    jq -c 'select(.fields.message? == "crawl progress") | {pages: .fields.pages_crawled, pct: .fields.progress_pct, eta_s: .fields.eta_secs}' "$FILE"
+    ;;
+  summary)
+    jq -c 'select(.fields.message? == "crawl completed")' "$FILE"
+    ;;
+  counts)
+    jq -r '.span // "event"' "$FILE" | sort | uniq -c | sort -rn
+    ;;
+  urls-failed)
+    jq -r 'select(.level == "ERROR") | .fields.url // empty' "$FILE" | sort -u
+    ;;
+  trace)
+    TRACE="${1:-}"
+    if [[ -z "$TRACE" ]]; then
+      echo "error: 'trace' requires a <trace_id> argument" >&2
+      exit 1
+    fi
+    jq -c "select(.trace_id == \"$TRACE\" or ((.fields.trace_id? // \"\") | contains(\"$TRACE\")))" "$FILE"
+    ;;
+  waf)
+    jq -c 'select((.fields.message? // "") | test("WAF|Banned domain"; "i"))' "$FILE"
+    ;;
+  *)
+    echo "error: unknown command: $CMD" >&2
+    grep '^#   ' "$0" | sed 's/^#   /  /'
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Linked Issue

Closes #372

(Roadmap: #356 — Fase 0, **cierra la roadmap**. PR stackeado sobre #371 (Fase 5); retargetear a `main` cuando la cadena mergee.)

## PR Type

- [x] Documentation only (`type:docs`)

## Summary

- **Mandato de proyecto:** nueva sección "🔭 Observability (MANDATORY)" en AGENTS.md — cualquier cambio o nueva feature debe incluir observabilidad (tracing, correlation IDs, error logging, progress/summary); prohibido reintroducir OpenTelemetry.
- **docs/debugging.md:** guía de FileTraceLayer + correlation IDs con query cookbook `jq`, tabla de spans, Tokio Console y troubleshooting.
- **scripts/analyze-trace.sh:** analizador de traces reutilizable (errors/slow/stages/progress/summary/trace/urls-failed/waf).
- **README:** link a la guía.

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Sección "Observability (MANDATORY for every change)" |
| `docs/debugging.md` | Nuevo: guía de debugging + query cookbook |
| `scripts/analyze-trace.sh` | Nuevo: analizador de traces (force-added, scripts/ gitignoreado) |
| `README.md` | Link a docs/debugging.md |

## Test Plan

- [x] `bash -n scripts/analyze-trace.sh` clean
- [x] Queries probadas contra JSONL sintético (errors/counts/trace/summary/slow/urls-failed OK)
- [x] Docs-only (sin cambios de código, no afecta build)

## Contributor Checklist

- [x] Linked an issue with `Closes #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers