### PR TITLE
feat(infra): cerrar gaps de la roadmap de observabilidad (error logging + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ webfang --url https://example.com --export-format jsonl
 webfang --url https://example.com --export-format vector
 ```
 
+### Debugging & tracing
+
+Every run can emit a JSONL trace (no external collector needed). Each
+operation shares a `trace_id`; each page gets its own `span_id`.
+
+```bash
+# Emit a trace + verbose logs
+webfang --url https://example.com --trace-file debug.jsonl -vvv
+
+# Reconstruct one operation, list errors, find the slowest spans
+scripts/analyze-trace.sh debug.jsonl trace <trace_id>
+scripts/analyze-trace.sh debug.jsonl errors
+scripts/analyze-trace.sh debug.jsonl slow 20
+```
+
+See [docs/debugging.md](docs/debugging.md) for the full query cookbook and
+[docs/troubleshooting.md](docs/troubleshooting.md) for common problems.
+
 ### AI cleaning
 
 ```bash

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -19,6 +19,7 @@ use crate::infrastructure::crawler::{
 };
 use crate::infrastructure::downloader::{DownloadError, Downloader};
 use crate::infrastructure::http::waf_engine::WafInspector;
+use crate::infrastructure::observability::log_scrape_error;
 use crate::infrastructure::scraper::{fallback, readability};
 use crate::ScraperConfig;
 
@@ -276,7 +277,13 @@ pub async fn extract_content(
                     MIN_FALLBACK_CONTENT,
                     e
                 );
-                warn!("{}", msg);
+                log_scrape_error(
+                    &msg,
+                    url.as_str(),
+                    "extract",
+                    None,
+                    "content extraction failed",
+                );
                 return Err(ScraperError::ExtractionFailed {
                     url: url.to_string(),
                     reason: msg,

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -18,6 +18,7 @@ use crate::domain::{
 };
 use crate::error::{Result, ScraperError};
 use crate::infrastructure::http::waf_engine::WafInspector;
+use crate::infrastructure::observability::log_scrape_error;
 use crate::ScraperConfig;
 use futures::stream::{self, StreamExt};
 use tracing::{debug, info, instrument, warn};
@@ -326,7 +327,10 @@ pub async fn scrape_with_config(
 
     let response = match client.get(url.as_str()).await {
         Ok(resp) => resp,
-        Err(e) => return Err(scraper_error_from_http(e, url.as_str())),
+        Err(e) => {
+            log_scrape_error(&e, url.as_str(), "fetch", None, "HTTP request failed");
+            return Err(scraper_error_from_http(e, url.as_str()));
+        },
     };
 
     if !(200..300).contains(&response.status) {
@@ -355,7 +359,13 @@ pub async fn scrape_with_config(
 
     // Detect WAF/CAPTCHA challenges disguised as HTTP 200
     if let Some(provider) = WafInspector::detect_body(&html) {
-        warn!("WAF challenge detected from {}: {}", url, provider);
+        log_scrape_error(
+            &provider,
+            url.as_str(),
+            "fetch",
+            None,
+            "WAF challenge detected",
+        );
         return Err(ScraperError::WafBlocked {
             url: url.to_string(),
             provider: provider.to_string(),

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -140,13 +140,9 @@ This opens an interactive TUI showing live tasks, their states, and poll times.
 
 ## Troubleshooting
 
-| Symptom | First query / check |
-| :--- | :--- |
-| "The crawl is slow" | Slowest-spans query above; check `pipeline_stage` distribution and `export_batch` timings |
-| "Pages are failing silently" | `select(.level == "ERROR")` — every error path logs `url` + `stage` + `trace_id` |
-| "I can't tell which logs belong to one page" | Filter by `trace_id` (one per operation) or the per-page `crawl_page` span |
-| "WAF / blocks" | `select(.fields.message? == "WAF challenge detected")` and banned-domain warnings |
-| "Non-deterministic snapshot in tests" | The field must be redacted via `redact_nondeterministic()`; `correlation_id`/`trace_id` are already `#[serde(skip)]` on scraped output |
+See [troubleshooting.md](troubleshooting.md) for common problems (slow
+crawls, silent page failures, WAF blocks, async deadlocks, poor content)
+and how to diagnose each with the trace queries above.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,103 @@
+# Troubleshooting
+
+Common problems and how to diagnose them with WebFang's built-in tracing.
+
+> Generate a trace first: `webfang --url <URL> --trace-file debug.jsonl -vvv`,
+> then query it with `scripts/analyze-trace.sh` or `jq`. See
+> [debugging.md](debugging.md) for the full query cookbook.
+
+---
+
+## The crawl is slow
+
+**Diagnose:**
+
+```bash
+scripts/analyze-trace.sh debug.jsonl slow 20      # slowest spans
+scripts/analyze-trace.sh debug.jsonl stages       # time per pipeline stage
+```
+
+**Common causes:**
+
+- A single stage dominates (e.g. `clean` with the AI feature) — check the
+  `stages` distribution.
+- Network latency / rate limiting — look for large gaps between `crawl_page`
+  spans; consider `--delay` and concurrency tuning.
+- Export bottleneck — check `export_batch` span durations.
+
+---
+
+## Pages are failing silently
+
+Every operational error is logged as a structured `ERROR` event with `url`,
+`stage`, and (when available) `trace_id`.
+
+```bash
+scripts/analyze-trace.sh debug.jsonl errors       # all errors with context
+scripts/analyze-trace.sh debug.jsonl urls-failed  # unique failed URLs
+```
+
+**Common causes by `stage`:**
+
+| `stage` | Meaning | Fix |
+| :--- | :--- | :--- |
+| `fetch` | HTTP/network failure or WAF challenge | Check connectivity; the site may be blocking — see WAF section below |
+| `extract` | Content extraction produced too little text | The page may be JS-rendered or non-article; try a CSS `--selector` or JS rendering |
+
+---
+
+## WAF / bot detection blocks
+
+```bash
+scripts/analyze-trace.sh debug.jsonl waf          # WAF challenges + banned domains
+```
+
+If you see `WAF challenge detected` errors:
+
+- The site is presenting a CAPTCHA / challenge page. WebFang bans the domain
+  for the rest of the crawl to avoid hammering it.
+- Try a different TLS fingerprint profile (`--tls-emulation`) or JS rendering.
+- Slow down (`--delay`, lower concurrency) to avoid rate-limit triggers.
+
+---
+
+## I can't tell which logs belong to one page / one crawl
+
+- One **crawl** shares a single `trace_id`. Filter by it:
+  ```bash
+  scripts/analyze-trace.sh debug.jsonl trace <trace_id>
+  ```
+- Each **page** is a `crawl_page` span with its own `span_id` under that
+  `trace_id`.
+
+---
+
+## Non-deterministic snapshot failures in tests
+
+`correlation_id` / `trace_id` are internal and `#[serde(skip)]` on scraped
+output, so they never appear in scraped JSON/JSONL snapshots. If a *new*
+field you added is non-deterministic (timestamps, ports, temp paths, random
+IDs), redact it via `redact_nondeterministic()` in `tests/common/cli_harness.rs`.
+
+---
+
+## Async deadlocks / starved tasks
+
+For concurrency bugs (a crawl hangs, tasks never complete), use the Tokio
+Console:
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable" cargo run --features console -- --url <URL>
+```
+
+This shows live task states and poll times, making stuck tasks visible.
+
+---
+
+## Empty or poor content
+
+- `content extraction failed` (`stage: extract`) — the fallback extractor got
+  less than the minimum content. The page is likely JS-rendered, an
+  interactive app, or not an article.
+- Try `--selector '.main-content'` (or the right CSS selector for the site),
+  or enable JS rendering for SPA content.


### PR DESCRIPTION
## Linked Issue

Closes #356

(Cierra los gaps que valían la pena de la roadmap de observabilidad. Lo diferido queda trackeado en #364 (benches) y #374 (error breakdown por tipo).)

## PR Type

- [x] New feature (`type:feature`)

## Summary

- **Cobertura de error logging (Fase 3):** `extract_content` (ExtractionFailed) y `scrape_with_config` (HTTP + WAF) ahora usan `log_scrape_error` con contexto estructurado (url + stage + error) en vez de `warn!` pelado.
- **Documentación (Fase 0):** nuevo `docs/troubleshooting.md` (guía standalone) + sección "Debugging & tracing" en README con ejemplos inline.

## Changes

| File | Change |
|------|--------|
| `application/crawler/discovery.rs` | ExtractionFailed → `log_scrape_error` |
| `application/scraper_service.rs` | HTTP error + WAF → `log_scrape_error` |
| `docs/troubleshooting.md` | Nuevo: guía de troubleshooting standalone |
| `docs/debugging.md` | Enlaza a troubleshooting.md |
| `README.md` | Sección "Debugging & tracing" con ejemplos |

## Decisiones documentadas (no hecho a propósito)

- **`ScrapedItem.correlation_id`:** sin consumidor que lo lea; la correlación del pipeline ya existe vía `trace_id` del span `crawl_page`. Agregar un campo muerto no aporta valor.
- **Error breakdown por tipo** → #374 (requiere infra de conteo tipado).
- **Overhead < 5% con benchmarks** → #364 (benches huérfanos).

## Test Plan

- [x] `cargo clippy` limpio (solo `parse_threshold` de #353)
- [x] `cargo nextest run` pasa (1553/1553)
- [x] Cambio warn!→error! no rompió snapshots

## Contributor Checklist

- [x] Linked an issue with `Closes #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers