### PR TITLE
fix(infra): cablear los 8 benchmarks huérfanos + bench de overhead de tracing

### DIFF
--- a/benches/cosine_similarity.rs
+++ b/benches/cosine_similarity.rs
@@ -1,10 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use webfang_core::infrastructure::export::vector_exporter::cosine_similarity;
 
-// Only compile with ai feature
-#[cfg(feature = "ai")]
-use webfang::infrastructure::ai::embedding_ops::cosine_similarity;
-
-#[cfg(feature = "ai")]
 fn bench_cosine_similarity(c: &mut Criterion) {
     let dims = 384;
     // Deterministic data — no rand crate needed
@@ -13,9 +9,9 @@ fn bench_cosine_similarity(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("cosine_similarity");
     group.throughput(Throughput::Elements(1));
-    group.bench_function("simd_384d", |bencher| {
+    group.bench_function("384d", |bencher| {
         bencher.iter(|| {
-            let result = cosine_similarity(black_box(&a), black_box(&b));
+            let result = cosine_similarity(black_box(&a), black_box(&b)).expect("equal dimensions");
             assert!((-1.0..=1.0).contains(&result));
             black_box(result)
         })
@@ -23,14 +19,5 @@ fn bench_cosine_similarity(c: &mut Criterion) {
     group.finish();
 }
 
-#[cfg(feature = "ai")]
 criterion_group!(benches, bench_cosine_similarity);
-
-#[cfg(feature = "ai")]
 criterion_main!(benches);
-
-// Placeholder when ai feature is disabled
-#[cfg(not(feature = "ai"))]
-fn main() {
-    println!("Benchmarks require --features ai");
-}

--- a/benches/export.rs
+++ b/benches/export.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use webfang::domain::entities::ScrapedContent;
-use webfang::domain::value_objects::ValidUrl;
+use webfang_core::domain::entities::ScrapedContent;
+use webfang_core::domain::value_objects::ValidUrl;
 
 fn sample_chunks(count: usize) -> Vec<ScrapedContent> {
     (0..count)
@@ -32,14 +32,14 @@ fn bench_export(c: &mut Criterion) {
     let chunks_100: Vec<_> = sample_chunks(100)
         .into_iter()
         .map(|sc| {
-            let chunk: webfang::domain::DocumentChunk = sc.into();
+            let chunk: webfang_core::domain::DocumentChunk = sc.into();
             chunk
         })
         .collect();
     let chunks_1000: Vec<_> = sample_chunks(1000)
         .into_iter()
         .map(|sc| {
-            let chunk: webfang::domain::DocumentChunk = sc.into();
+            let chunk: webfang_core::domain::DocumentChunk = sc.into();
             chunk
         })
         .collect();
@@ -137,7 +137,7 @@ fn bench_export(c: &mut Criterion) {
         b.iter(|| {
             let mut count = 0;
             for line in black_box(&jsonl_data).lines() {
-                let _: webfang::domain::DocumentChunk = serde_json::from_str(line).unwrap();
+                let _: webfang_core::domain::DocumentChunk = serde_json::from_str(line).unwrap();
                 count += 1;
             }
             assert_eq!(count, 1000);

--- a/benches/html_conversion.rs
+++ b/benches/html_conversion.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use webfang::infrastructure::converter::html_to_markdown::convert_to_markdown;
+use webfang_core::infrastructure::converter::html_to_markdown::convert_to_markdown;
 
 fn realistic_html() -> String {
     r#"<!DOCTYPE html>

--- a/benches/link_extraction.rs
+++ b/benches/link_extraction.rs
@@ -9,7 +9,7 @@
 //! - `own-slice-over-accept`: Accept &str not &String
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use webfang::infrastructure::crawler::{extract_links, normalize_url};
+use webfang_core::infrastructure::crawler::{extract_links, normalize_url};
 
 /// Generate HTML with n links for benchmarking
 fn generate_html_with_links(n: usize) -> String {

--- a/benches/readability.rs
+++ b/benches/readability.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use webfang::infrastructure::converter::html_cleaner::clean_html;
-use webfang::infrastructure::scraper::readability;
+use webfang_core::infrastructure::converter::html_cleaner::clean_html;
+use webfang_core::infrastructure::scraper::readability;
 
 fn realistic_html() -> String {
     r##"<!DOCTYPE html>

--- a/benches/sitemap_parsing.rs
+++ b/benches/sitemap_parsing.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use webfang::application::crawler::parse_sitemap;
 use url::Url;
+use webfang_core::application::crawler::parse_sitemap;
 
 fn generate_sitemap_xml(url_count: usize) -> String {
     let mut xml = String::from(

--- a/benches/tracing_overhead.rs
+++ b/benches/tracing_overhead.rs
@@ -1,0 +1,86 @@
+//! Tracing overhead benchmark (observability roadmap #356, Fase 2).
+//!
+//! Measures the cost of the `#[instrument]` tracing added to the hot paths,
+//! comparing a normal run (no subscriber) against a `--trace-file` run
+//! (`FileTraceLayer` active).
+//!
+//! Methodology:
+//! - A representative instrumented hot-path unit mirrors the codebase pattern
+//!   (`#[instrument(skip_all, fields(...))]` + field recording + one event).
+//! - `disabled`: no active subscriber — what a plain `webfang` run does.
+//!   `#[instrument]` still builds the span but it is immediately disabled.
+//! - `file_trace`: a `FileTraceLayer` subscriber scoped around the whole
+//!   measurement loop via `with_default` — what `--trace-file` does, including
+//!   the JSONL serialization and file I/O.
+//!
+//! The ratio `file_trace / disabled - 1` is the cost of enabling tracing.
+//! Acceptance (Fase 2): < 5% on representative page-sized work. Note a real
+//! crawl page does strictly MORE work than this unit (HTTP fetch + parse +
+//! extraction), so real-world overhead is at or below what is measured here.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use tracing::instrument;
+use tracing_subscriber::layer::SubscriberExt;
+use webfang_core::infrastructure::observability::FileTraceLayer;
+
+/// A representative instrumented hot-path unit: scans a body (like content or
+/// WAF scanning), records span fields, and emits one event — mirroring what a
+/// `crawl_page` / `scrape` span does per page.
+#[instrument(skip_all, fields(url = "https://example.com/article", stage = "bench"))]
+fn instrumented_page_unit(body: &str) -> usize {
+    let mut acc = 0usize;
+    for b in body.as_bytes() {
+        acc = acc.wrapping_add(usize::from(*b));
+        acc ^= acc.rotate_left(7);
+    }
+    tracing::debug!(
+        bytes = body.len(),
+        checksum = acc % 100_000,
+        "page processed"
+    );
+    acc
+}
+
+/// Builds a ~`target_kb` KiB body from a realistic article paragraph.
+fn sample_body(target_kb: usize) -> String {
+    let paragraph = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
+                     Sed do eiusmod tempor incididunt ut labore et dolore magna \
+                     aliqua. Ut enim ad minim veniam, quis nostrud exercitation \
+                     ullamco laboris nisi ut aliquip ex ea commodo consequat. ";
+    let target = target_kb * 1024;
+    let repeats = (target / paragraph.len()).max(1);
+    paragraph.repeat(repeats)
+}
+
+fn bench_tracing_overhead(c: &mut Criterion) {
+    // Trace file in the temp dir (usually tmpfs → low I/O variance).
+    let trace_path = std::env::temp_dir().join("webfang_tracing_overhead_bench.jsonl");
+    let layer = FileTraceLayer::new(trace_path.clone()).expect("trace file must open");
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let dispatch = tracing::Dispatch::new(subscriber);
+
+    // Two work sizes: a light operation and a full-page-sized unit.
+    for (label, body) in [("16kib", sample_body(16)), ("128kib", sample_body(128))] {
+        let mut group = c.benchmark_group(format!("tracing_overhead/{label}"));
+        group.throughput(Throughput::Bytes(body.len() as u64));
+
+        group.bench_function("disabled", |b| {
+            b.iter(|| black_box(instrumented_page_unit(black_box(&body))))
+        });
+
+        // Subscriber scoped around the whole measurement loop (set once, as in
+        // a real run), not per iteration.
+        group.bench_function("file_trace", |b| {
+            tracing::dispatcher::with_default(&dispatch, || {
+                b.iter(|| black_box(instrumented_page_unit(black_box(&body))));
+            })
+        });
+
+        group.finish();
+    }
+
+    let _ = std::fs::remove_file(&trace_path);
+}
+
+criterion_group!(benches, bench_tracing_overhead);
+criterion_main!(benches);

--- a/benches/url_parsing.rs
+++ b/benches/url_parsing.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use webfang::validate_and_parse_url;
 use url::Url;
+use webfang_core::validate_and_parse_url;
 
 fn bench_url_parse(c: &mut Criterion) {
     // Standard URLs

--- a/benches/waf_detection.rs
+++ b/benches/waf_detection.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use webfang::infrastructure::http::waf_engine::WafInspector;
+use webfang_core::infrastructure::http::waf_engine::WafInspector;
 use wreq::header::HeaderMap;
 
 fn bench_waf_verify_integrity(c: &mut Criterion) {
@@ -30,25 +30,13 @@ fn generate_html_body() -> String {
 </div>
 </body></html>"#;
 
-    // Include some WAF signatures for realistic detection
-    let signatures = [
-        "cf-turnstile",
-        "Just a moment...",
-        "g-recaptcha",
-        "datadome",
-        "challenge-platform",
-    ];
-
+    // Repeat the clean template until ~500KB. No WAF signatures are embedded:
+    // `verify_integrity` should scan the whole body and return `Ok`, which
+    // benchmarks the full clean-scan path (the common case, and the worst case
+    // for scanning since nothing short-circuits on an early detection).
     let mut body = String::new();
-    // Repeat until ~500KB
     while body.len() < 500_000 {
         body.push_str(template);
-        // Insert a signature every 10 templates for realism
-        if body.len() % (template.len() * 10) < template.len() {
-            if let Some(sig) = signatures.get((body.len() / template.len()) % signatures.len()) {
-                body.push_str(&format!("<div class=\"waf-marker\">{}</div>", sig));
-            }
-        }
     }
     body
 }

--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -226,6 +226,53 @@ path = "../../tests/http_client_integration.rs"
 name = "ai_error_propagation"
 path = "../../tests/ai_error_propagation.rs"
 
+# ---------------------------------------------------------------------------
+# Benchmarks (criterion). The bench files live in the root `benches/` tree
+# (outside this crate's directory), so they must be wired explicitly — the
+# workspace root is virtual (no `[package]`) and won't auto-discover them.
+# `harness = false` because criterion provides its own `main` via
+# `criterion_main!`.
+# ---------------------------------------------------------------------------
+[[bench]]
+name = "cosine_similarity"
+path = "../../benches/cosine_similarity.rs"
+harness = false
+
+[[bench]]
+name = "export"
+path = "../../benches/export.rs"
+harness = false
+
+[[bench]]
+name = "html_conversion"
+path = "../../benches/html_conversion.rs"
+harness = false
+
+[[bench]]
+name = "link_extraction"
+path = "../../benches/link_extraction.rs"
+harness = false
+
+[[bench]]
+name = "readability"
+path = "../../benches/readability.rs"
+harness = false
+
+[[bench]]
+name = "sitemap_parsing"
+path = "../../benches/sitemap_parsing.rs"
+harness = false
+
+[[bench]]
+name = "url_parsing"
+path = "../../benches/url_parsing.rs"
+harness = false
+
+[[bench]]
+name = "waf_detection"
+path = "../../benches/waf_detection.rs"
+harness = false
+
 [lints.clippy]
 doc_markdown = "allow"
 uninlined_format_args = "allow"

--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -273,6 +273,11 @@ name = "waf_detection"
 path = "../../benches/waf_detection.rs"
 harness = false
 
+[[bench]]
+name = "tracing_overhead"
+path = "../../benches/tracing_overhead.rs"
+harness = false
+
 [lints.clippy]
 doc_markdown = "allow"
 uninlined_format_args = "allow"


### PR DESCRIPTION
## Linked Issue

Closes #364

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

Dos entregables en commits separados:

1. **Cablear + arreglar los 8 benches huérfanos** (cierra #364).
2. **Bench de overhead de tracing** que verifica rigurosamente el criterio `< 5%` de la Fase 2 de #356.

---

## Commit 1 — cableado + fixes (#364)

Los 8 benchmarks de `benches/` **nunca compilaron**: la raíz del workspace es virtual (sin `[package]`), así que no se auto-descubren.

**Cableado** (`webfang_core/Cargo.toml`): 8 entradas `[[bench]]` con `path = "../../benches/<name>.rs"` y `harness = false`.

**Fixes** (drift que impedía compilar):
- Rename del crate path stale `webfang::` → `webfang_core::`.
- `cosine_similarity.rs`: path correcto `infrastructure::export::vector_exporter::cosine_similarity`, manejo del `Result`, y elimino el gate `#[cfg(feature = "ai")]` incorrecto.
- `waf_detection.rs`: elimino la inyección contradictoria de firmas WAF (embebía marcadores reales pero afirmaba `is_ok()`; el inspector los detectaba bien). Body limpio → benchmarkea el clean-scan completo.

**Diagnóstico de #364 corregido:** NO había incompatibilidad criterion 0.5/0.8 (proyecto y benches usan 0.5.1). Los problemas reales eran el cableado + el drift.

### Baseline (criterio de aceptación 1)

`cargo bench --bench export`:

| Bench | time | thrpt |
|-------|------|-------|
| export_jsonl / 100 chunks | 55 µs | 1.81 Melem/s |
| export_jsonl / 1000 chunks | 544 µs | 1.84 Melem/s |
| export_vector / 1000 | 1.68 ms | 594 Kelem/s |
| export_deserialize / 1000 jsonl | 592 µs | 1011 MiB/s |

---

## Commit 2 — bench de overhead de tracing (verifica Fase 2 de #356)

`benches/tracing_overhead.rs`: A/B entre **sin subscriber** (run normal) y **FileTraceLayer activo** (`--trace-file`, incluye serialización JSONL + I/O), sobre una unidad instrumentada representativa (`#[instrument(skip_all, fields)]` + evento), a 2 tamaños de trabajo.

### Resultado medido

| work | disabled | file_trace | overhead |
|------|----------|------------|----------|
| 16 KiB | 10.558 µs | 10.543 µs | **−0.14%** |
| 128 KiB | 85.256 µs | 85.201 µs | **−0.06%** |

Overhead dentro del ruido de medición (< 0.2%). El claim **`< 5%` queda verificado con margen amplio**. Una página real hace MÁS trabajo que esta unidad (HTTP fetch + parse + extraction), así que el overhead real es ≤ al medido.

El `FileTraceLayer` graba todos los niveles (sin filtro) y el subscriber es un `registry()` pelado, así que el brazo `file_trace` ejerce el path real (span + serialización + escritura).

## Test Plan

- [x] Los 8+1 benches compilan (`cargo bench --no-run`)
- [x] `cargo bench --benches -- --test` → todos `Success`, 0 fallos
- [x] `cargo bench --bench export` establece baseline
- [x] `cargo bench --bench tracing_overhead` mide overhead < 5%
- [x] `cargo clippy --benches` limpio

## Contributor Checklist

- [x] Linked an issue with `Closes #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers