### PR TITLE
fix(cli): document exit codes 64/3 in --help and wire EXIT_SCRAPER_FAILURE

### DIFF
--- a/crates/webfang_core/src/cli/args/ai.rs
+++ b/crates/webfang_core/src/cli/args/ai.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 
+#[cfg(feature = "ai")]
 fn parse_threshold(s: &str) -> Result<f32, String> {
     let val: f32 = s
         .parse()

--- a/crates/webfang_core/src/cli/args/mod.rs
+++ b/crates/webfang_core/src/cli/args/mod.rs
@@ -41,7 +41,7 @@ use clap::Parser;
 #[command(name = "webfang", version)]
 #[command(
     about = "High-performance web scraper with WAF evasion and AI-powered content cleaning",
-    after_help = "EXIT CODES:\n  0    Success\n  2    No URLs discovered\n  69   WAF block or network error\n  74   I/O error\n  76   Protocol error\n  78   Configuration error\n\nEXAMPLES:\n  webfang -u https://example.com\n  webfang -u https://example.com --ai\n  webfang -u https://example.com -f jsonl\n  webfang -u https://example.com -v\n  webfang -u https://example.com -vv  # DEBUG\n  webfang --url-list urls.txt --resume"
+    after_help = "EXIT CODES:\n  0    Success\n  2    No URLs discovered\n  3    All scrapers failed\n  64   Bad CLI arguments (usage error)\n  69   WAF block or network error\n  74   I/O error\n  76   Protocol error\n  78   Configuration error\n\nEXAMPLES:\n  webfang -u https://example.com\n  webfang -u https://example.com --ai\n  webfang -u https://example.com -f jsonl\n  webfang -u https://example.com -v\n  webfang -u https://example.com -vv  # DEBUG\n  webfang --url-list urls.txt --resume"
 )]
 #[command(args_conflicts_with_subcommands = true)]
 pub struct Args {

--- a/crates/webfang_core/src/cli/error.rs
+++ b/crates/webfang_core/src/cli/error.rs
@@ -135,6 +135,8 @@ pub enum CliExit {
     ConfigError(String),
     /// Exit 2 — no URLs discovered from sitemaps (technical success, null result)
     EmptyDiscovery(String),
+    /// Exit 3 — all scrapers failed on discovered URLs
+    ScraperFailure(String),
     /// Exit 69 — some URLs succeeded, some failed
     PartialSuccess {
         /// Number of successfully scraped URLs
@@ -171,6 +173,10 @@ impl std::process::Termination for CliExit {
             CliExit::EmptyDiscovery(msg) => {
                 eprintln!("Warning: {msg}");
                 ExitCode::from(EXIT_EMPTY_DISCOVERY)
+            },
+            CliExit::ScraperFailure(msg) => {
+                eprintln!("Error: {msg}");
+                ExitCode::from(EXIT_SCRAPER_FAILURE)
             },
             CliExit::PartialSuccess { .. } => ExitCode::from(EXIT_UNAVAILABLE),
         }
@@ -288,6 +294,7 @@ mod tests {
             (CliExit::ProtocolError("test".into()), EXIT_PROTOCOL),
             (CliExit::ConfigError("test".into()), EXIT_CONFIG),
             (CliExit::EmptyDiscovery("test".into()), EXIT_EMPTY_DISCOVERY),
+            (CliExit::ScraperFailure("test".into()), EXIT_SCRAPER_FAILURE),
             (
                 CliExit::PartialSuccess {
                     success: 1,

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -412,6 +412,8 @@ Options:
 EXIT CODES:
   0    Success
   2    No URLs discovered
+  3    All scrapers failed
+  64   Bad CLI arguments (usage error)
   69   WAF block or network error
   74   I/O error
   76   Protocol error

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -412,6 +412,8 @@ Options:
 EXIT CODES:
   0    Success
   2    No URLs discovered
+  3    All scrapers failed
+  64   Bad CLI arguments (usage error)
   69   WAF block or network error
   74   I/O error
   76   Protocol error


### PR DESCRIPTION
Closes #341

## Summary
- Document exit codes 64 (bad CLI arguments) and 3 (all scrapers failed) in `--help` EXIT CODES section
- Add `ScraperFailure(String)` variant to `CliExit` enum, mapping to the previously dead `EXIT_SCRAPER_FAILURE=3` constant
- Fix pre-existing `dead_code` warning: gate `parse_threshold` with `#[cfg(feature = "ai")]` (its only callsite is behind the same feature gate)

## Changes
| File | Change |
|:--|:--|
| `cli/error.rs` | New `ScraperFailure` variant + match arm + exhaustive test updated |
| `cli/args/mod.rs` | `after_help` now lists exit codes 3 and 64 |
| `cli/args/ai.rs` | `#[cfg(feature = "ai")]` on `parse_threshold` |

## Verification
- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅ (zero warnings)
- `cargo test -p webfang_core exit_code` — 11 tests ✅
- `test_all_variants_map_to_named_constants` covers new variant ✅