### PR TITLE
fix(cli): remove dead --force-js-render flag

### DIFF
--- a/crates/webfang_core/src/application/crawl_options.rs
+++ b/crates/webfang_core/src/application/crawl_options.rs
@@ -157,8 +157,6 @@ pub struct NetworkOptions {
     pub download_images: bool,
     /// Download documents from the page.
     pub download_documents: bool,
-    /// Force JavaScript rendering for SPA sites.
-    pub force_js_render: bool,
     /// TLS/HTTP2 profile name (e.g. Chrome145).
     pub h2_profile: String,
     /// JavaScript rendering strategy (static, hybrid, full).
@@ -253,7 +251,6 @@ impl Default for NetworkOptions {
             backoff_max_ms: 10000,
             download_images: false,
             download_documents: false,
-            force_js_render: false,
             h2_profile: "Chrome145".to_owned(),
             js_strategy: JsStrategy::default(),
             obscura_binary: "obscura".to_owned(),
@@ -368,7 +365,6 @@ mod tests {
         assert_eq!(net.backoff_max_ms, 10000);
         assert!(!net.download_images);
         assert!(!net.download_documents);
-        assert!(!net.force_js_render);
         assert_eq!(net.h2_profile, "Chrome145");
         assert_eq!(net.js_strategy, JsStrategy::Static);
         assert_eq!(net.obscura_binary, "obscura");

--- a/crates/webfang_core/src/cli/args/crawler.rs
+++ b/crates/webfang_core/src/cli/args/crawler.rs
@@ -145,12 +145,6 @@ pub struct CrawlerArgs {
     )]
     pub adaptive_selectors: bool,
 
-    /// No-op placeholder for future JavaScript rendering (Phase 2).
-    /// Use --js-strategy hybrid or --js-strategy full for JS rendering support.
-    #[arg(long, default_value = "false", env = "WEBFANG_FORCE_JS_RENDER")]
-    #[clap(next_help_heading = "Behavior")]
-    pub force_js_render: bool,
-
     // ========== Display ==========
     /// Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
     #[arg(short, long, action = clap::ArgAction::Count, env = "WEBFANG_VERBOSE")]

--- a/crates/webfang_core/src/cli/args/mod.rs
+++ b/crates/webfang_core/src/cli/args/mod.rs
@@ -188,7 +188,6 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
                 backoff_max_ms: args.crawler.backoff_max_ms,
                 download_images: args.crawler.download_images || args.crawler.download_assets,
                 download_documents: args.crawler.download_documents || args.crawler.download_assets,
-                force_js_render: args.crawler.force_js_render,
                 h2_profile: args.crawler.h2_profile,
                 js_strategy: args.crawler.js_strategy,
                 obscura_binary: args.crawler.obscura_binary,

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -380,7 +380,6 @@ pub fn apply_tui_config_args(mut args: Args, config_values: &serde_json::Value) 
             _ => JsStrategy::Static,
         };
     }
-    apply_bool!("force_js_render", args.crawler.force_js_render);
 
     // ========================================================================
     // Download

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -10,7 +10,6 @@ use crate::application::export_factory;
 use crate::application::progress_observer::ProgressObserver;
 use crate::application::scrape_single_url_for_tui;
 use crate::domain::entities::progress::{ScrapeError, ScrapeStatus};
-use crate::domain::JsStrategy;
 use crate::domain::ScrapedContent;
 use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
@@ -122,19 +121,11 @@ pub async fn scrape_urls(
     ),
     crate::error::ScraperError,
 > {
-    // Build the fetch router from the configured JS strategy. `--force-js-render`
-    // upgrades a Static strategy to Hybrid so JS-capable fetching is used instead
-    // of returning a feature-gated error (issue #303).
+    // Build the fetch router from the configured JS strategy.
     let http_config = build_http_client_config(opts)?;
-    let effective_strategy =
-        if opts.network.force_js_render && matches!(opts.network.js_strategy, JsStrategy::Static) {
-            JsStrategy::Hybrid
-        } else {
-            opts.network.js_strategy
-        };
     let cookie_bridge = std::sync::Arc::new(std::sync::RwLock::new(CookieBridge::new()));
     let router = build_fetch_router(
-        &effective_strategy,
+        &opts.network.js_strategy,
         http_config.timeout_secs,
         http_config.tls_emulation,
         cookie_bridge,

--- a/crates/webfang_tui/src/tui/collapsible_config.rs
+++ b/crates/webfang_tui/src/tui/collapsible_config.rs
@@ -279,9 +279,6 @@ impl CollapsibleConfig {
             .option("full", "Full (Chromiumoxide)")
             .initial_value("static")
             .done()
-            .checkbox("force_js_render", "Force JS Rendering")
-            .checked(false)
-            .done()
             .build()
     }
 

--- a/tests/args_test.rs
+++ b/tests/args_test.rs
@@ -73,7 +73,6 @@ fn args_with_all_fields_set() -> Args {
             download_images: true,
             download_documents: true,
             clean_ai: true,
-            force_js_render: true,
             verbose: 3,
             quiet: true,
             dry_run: true,
@@ -186,7 +185,6 @@ fn test_args_to_crawl_options_full_parity() {
     assert_eq!(opts.network.backoff_max_ms, 30_000);
     assert!(opts.network.download_images);
     assert!(opts.network.download_documents);
-    assert!(opts.network.force_js_render);
     assert_eq!(opts.network.h2_profile, "Chrome131");
     assert_eq!(
         opts.network.js_strategy,
@@ -345,7 +343,6 @@ fn test_args_to_crawl_options_defaults() {
     assert_eq!(opts.network.backoff_max_ms, 10_000);
     assert!(!opts.network.download_images);
     assert!(!opts.network.download_documents);
-    assert!(!opts.network.force_js_render);
 
     assert_eq!(
         opts.export.output_format,
@@ -421,7 +418,6 @@ proptest! {
         download_documents in proptest::bool::ANY,
         interactive in proptest::bool::ANY,
         config_tui in proptest::bool::ANY,
-        force_js_render in proptest::bool::ANY,
         quiet in proptest::bool::ANY,
         dry_run in proptest::bool::ANY,
         use_sitemap in proptest::bool::ANY,
@@ -447,7 +443,6 @@ proptest! {
                 download_documents,
                 clean_ai,
                 adaptive_selectors: false,
-                force_js_render,
                 verbose: 0,
                 quiet,
                 dry_run,
@@ -512,7 +507,6 @@ proptest! {
         prop_assert_eq!(opts.network.download_images, download_images);
         prop_assert_eq!(opts.network.download_documents, download_documents);
         prop_assert_eq!(opts.crawl.interactive, interactive);
-        prop_assert_eq!(opts.network.force_js_render, force_js_render);
         prop_assert_eq!(opts.quiet, quiet);
         prop_assert_eq!(opts.export.quiet, quiet);
         prop_assert_eq!(opts.export.dry_run, dry_run);
@@ -554,7 +548,6 @@ proptest! {
                 download_documents: false,
                 clean_ai: false,
                 adaptive_selectors: false,
-                force_js_render: false,
                 verbose,
                 quiet: false,
                 dry_run: false,
@@ -639,7 +632,6 @@ proptest! {
                 download_documents: false,
                 clean_ai: false,
                 adaptive_selectors: false,
-                force_js_render: false,
                 verbose: 0,
                 quiet: false,
                 dry_run: false,
@@ -718,7 +710,6 @@ proptest! {
                 download_documents: false,
                 clean_ai: false,
                 adaptive_selectors: false,
-                force_js_render: false,
                 verbose: 0,
                 quiet: false,
                 dry_run: false,
@@ -801,7 +792,6 @@ proptest! {
                 download_documents: false,
                 clean_ai: false,
                 adaptive_selectors: false,
-                force_js_render: false,
                 verbose: 0,
                 quiet: false,
                 dry_run: false,
@@ -876,7 +866,6 @@ proptest! {
                 download_documents: false,
                 clean_ai: false,
                 adaptive_selectors: false,
-                force_js_render: false,
                 verbose: 0,
                 quiet: false,
                 dry_run: false,
@@ -949,7 +938,6 @@ proptest! {
                 download_documents: false,
                 clean_ai: false,
                 adaptive_selectors: false,
-                force_js_render: false,
                 verbose: 0,
                 quiet: false,
                 dry_run: false,

--- a/tests/behavioral/snapshots/behavioral__help.snap
+++ b/tests/behavioral/snapshots/behavioral__help.snap
@@ -102,11 +102,6 @@ Options:
           
           [env: WEBFANG_ADAPTIVE_SELECTORS=]
 
-      --force-js-render
-          No-op placeholder for future JavaScript rendering (Phase 2). Use --js-strategy hybrid or --js-strategy full for JS rendering support
-          
-          [env: WEBFANG_FORCE_JS_RENDER=]
-
   -v, --verbose...
           Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
           

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -60,7 +60,6 @@ fn test_args_defaults() {
     assert!(!args.single_page);
     assert!(!args.resume);
     assert!(!args.clean_ai);
-    assert!(!args.force_js_render);
     assert!(!args.dry_run);
     assert!(!args.quiet);
     assert!(!args.obsidian_wiki_links);
@@ -392,7 +391,6 @@ fn test_args_boolean_flags_default_false() {
     assert!(!args.interactive);
     assert!(!args.resume);
     assert!(!args.clean_ai);
-    assert!(!args.force_js_render);
     assert!(!args.dry_run);
     assert!(!args.quiet);
     assert!(!args.quick_save);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -86,7 +86,6 @@ fn test_args_has_required_fields() {
         resume: false,
         state_dir: None,
         clean_ai: false,
-        force_js_render: false,
         dry_run: false,
         trace_file: None,
         quiet: false,

--- a/tests/snapshots/cli_binary__test_help_contains_scraper.snap
+++ b/tests/snapshots/cli_binary__test_help_contains_scraper.snap
@@ -102,11 +102,6 @@ Options:
           
           [env: WEBFANG_ADAPTIVE_SELECTORS=]
 
-      --force-js-render
-          No-op placeholder for future JavaScript rendering (Phase 2). Use --js-strategy hybrid or --js-strategy full for JS rendering support
-          
-          [env: WEBFANG_FORCE_JS_RENDER=]
-
   -v, --verbose...
           Verbosity level: -v (INFO), -vv (DEBUG), -vvv (TRACE)
           

--- a/tests/tui_integration.rs
+++ b/tests/tui_integration.rs
@@ -737,14 +737,6 @@ fn apply_tui_config_sets_js_strategy_static() {
     assert_eq!(result.js_strategy, JsStrategy::Static);
 }
 
-#[test]
-fn apply_tui_config_sets_force_js_render() {
-    let args = default_args();
-    let json = config_json(&[("force_js_render", serde_json::json!(true))]);
-    let result = apply_tui_config_args(args, &json);
-    assert!(result.force_js_render);
-}
-
 // --- Download fields ---
 
 #[test]
@@ -1217,13 +1209,6 @@ fn args_exclude_patterns_comma_separated() {
     let args = Args::try_parse_from(["webfang", "--exclude-pattern", "*/admin/*"])
         .expect("--exclude-pattern must parse");
     assert_eq!(args.exclude_patterns, vec!["*/admin/*"]);
-}
-
-#[test]
-fn args_force_js_render_flag() {
-    let args = Args::try_parse_from(["webfang", "--force-js-render"])
-        .expect("--force-js-render must parse");
-    assert!(args.force_js_render);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Linked Issue

Closes #342

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- Remove the `--force-js-render` CLI flag, which was redundant with `--js-strategy hybrid`
- The flag only worked in scrape mode (upgrading Static→Hybrid) but was a no-op in crawl mode, and its doc comment incorrectly claimed it was a no-op placeholder
- Users should use `--js-strategy hybrid|full` instead (the canonical API)

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/args/crawler.rs` | Remove flag definition + stale doc comment |
| `crates/webfang_core/src/cli/args/mod.rs` | Remove mapping to `NetworkOptions` |
| `crates/webfang_core/src/application/crawl_options.rs` | Remove struct field, default, test assertion |
| `crates/webfang_core/src/cli/preflight.rs` | Remove config file override |
| `crates/webfang_core/src/cli/scrape_flow.rs` | Remove Static→Hybrid upgrade logic + unused `JsStrategy` import |
| `crates/webfang_tui/src/tui/collapsible_config.rs` | Remove TUI checkbox |
| `tests/args_test.rs` | Remove assertions + proptest params |
| `tests/cli_tests.rs` | Remove assertions |
| `tests/integration_test.rs` | Remove struct field init |
| `tests/tui_integration.rs` | Remove 2 dedicated test functions |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (pre-existing `parse_threshold` warning on main, unrelated)
- [x] `cargo nextest run` passes — 3800 PASS, 0 FAIL
- [x] Verified zero remaining references to `force_js_render` / `force-js-render` / `FORCE_JS_RENDER`

## Contributor Checklist

- [x] Linked an issue with `Closes #342`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`fix(cli): ...`)
- [x] No `Co-Authored-By` / AI attribution trailers