### PR TITLE
feat(mcp): implement real MCP export tools with honest errors (issue #343 slice 1)

### DIFF
--- a/crates/webfang_core/src/application/crawl_result_repository.rs
+++ b/crates/webfang_core/src/application/crawl_result_repository.rs
@@ -193,7 +193,7 @@ impl CrawlResultRepository for CrawlResultRepositoryImpl {
     ///
     /// Overrides the default N+1 (`get_all_urls` → `find_by_url`) loop with
     /// one forward pass over the append-only log, reusing the same record
-    /// framing as [`Self::recover_index`]: `[4-byte LE length][JSON payload]
+    /// framing as `Self::recover_index`: `[4-byte LE length][JSON payload]
     /// [\n]`. A partial trailing record (torn write) stops the scan cleanly
     /// instead of erroring, preserving crash-safety.
     ///

--- a/crates/webfang_core/src/application/crawl_result_repository.rs
+++ b/crates/webfang_core/src/application/crawl_result_repository.rs
@@ -188,6 +188,71 @@ impl CrawlResultRepository for CrawlResultRepositoryImpl {
     fn get_all_urls(&self) -> Result<Vec<String>, CrawlError> {
         Ok(self.index.iter().map(|entry| entry.key().clone()).collect())
     }
+
+    /// Load all persisted content with a single sequential log scan.
+    ///
+    /// Overrides the default N+1 (`get_all_urls` → `find_by_url`) loop with
+    /// one forward pass over the append-only log, reusing the same record
+    /// framing as [`Self::recover_index`]: `[4-byte LE length][JSON payload]
+    /// [\n]`. A partial trailing record (torn write) stops the scan cleanly
+    /// instead of erroring, preserving crash-safety.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CrawlError::Storage`] if the log cannot be opened, a record
+    /// length/payload cannot be read (mid-record corruption), or a payload
+    /// fails to deserialize.
+    fn load_all(&self) -> Result<Vec<ScrapedContent>, CrawlError> {
+        use std::io::Read;
+
+        // A fresh repository has no log file yet (the background writer
+        // creates it asynchronously). No file means nothing persisted —
+        // return empty, matching the default trait method's behavior for an
+        // empty index.
+        if !self.log_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = std::fs::File::open(&self.log_path)
+            .map_err(|e| CrawlError::Storage(format!("no se pudo abrir log: {e}")))?;
+        let mut reader = std::io::BufReader::new(file);
+        let mut results = Vec::with_capacity(self.index.len());
+        let mut offset: u64 = 0;
+
+        loop {
+            let mut len_buf = [0u8; 4];
+            match reader.read_exact(&mut len_buf) {
+                Ok(()) => {},
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => {
+                    return Err(CrawlError::Storage(format!(
+                        "lectura corrupta en offset {offset}: {e}"
+                    )))
+                },
+            }
+
+            let len = u32::from_le_bytes(len_buf) as usize;
+
+            // A trailing record shorter than its declared length is a torn
+            // write — stop cleanly (crash-safe) rather than erroring.
+            let mut payload = vec![0u8; len];
+            if reader.read_exact(&mut payload).is_err() {
+                break;
+            }
+
+            // Skip the newline terminator.
+            let mut newline = [0u8; 1];
+            let _ = reader.read_exact(&mut newline);
+
+            let content: ScrapedContent = serde_json::from_slice(&payload)
+                .map_err(|e| CrawlError::Storage(format!("deserialización fallida: {e}")))?;
+            results.push(content);
+
+            offset += 4 + len as u64 + 1;
+        }
+
+        Ok(results)
+    }
 }
 
 /// Background writer task that processes write commands sequentially.
@@ -360,6 +425,44 @@ mod tests {
             urls,
             vec!["https://a.com/", "https://b.com/", "https://c.com/"]
         );
+    }
+
+    #[tokio::test]
+    async fn test_load_all_returns_all_saved() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+
+        repo.save(&make_content("https://a.com", "A")).unwrap();
+        repo.save(&make_content("https://b.com", "B")).unwrap();
+        repo.save(&make_content("https://c.com", "C")).unwrap();
+
+        // Wait for all three writes to be indexed
+        wait_for_index(&repo, "https://a.com/").await;
+        wait_for_index(&repo, "https://b.com/").await;
+        wait_for_index(&repo, "https://c.com/").await;
+
+        let all = repo.load_all().unwrap();
+        assert_eq!(all.len(), 3, "load_all should return all 3 saved items");
+
+        let mut titles: Vec<String> = all.iter().map(|c| c.title.clone()).collect();
+        titles.sort();
+        assert_eq!(titles, vec!["A", "B", "C"]);
+
+        // Content integrity: each item carries its expected body
+        for item in &all {
+            assert_eq!(item.content, format!("Content for {}", item.title));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_all_empty_repository_returns_empty_vec() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("crawl_results.bin");
+        let repo = CrawlResultRepositoryImpl::new(log_path, 64).unwrap();
+
+        let all = repo.load_all().unwrap();
+        assert!(all.is_empty(), "load_all on fresh repo should be empty");
     }
 
     #[tokio::test]

--- a/crates/webfang_core/src/domain/repositories.rs
+++ b/crates/webfang_core/src/domain/repositories.rs
@@ -42,6 +42,28 @@ pub trait CrawlResultRepository: Send + Sync {
     /// * `Ok(Vec<String>)` - List of crawled URLs
     /// * `Err(CrawlError)` - Query error
     fn get_all_urls(&self) -> Result<Vec<String>, CrawlError>;
+
+    /// Load all persisted content in bulk.
+    ///
+    /// Returns every saved [`ScrapedContent`] item. This is the bulk
+    /// alternative to the `get_all_urls` → `find_by_url` loop, avoiding an
+    /// N+1 query pattern for consumers that need the whole result set
+    /// (e.g. the MCP export tools).
+    ///
+    /// The default implementation iterates `get_all_urls` and resolves each
+    /// URL via `find_by_url`. Implementations with direct storage access
+    /// SHOULD override this with a single sequential scan for efficiency.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Vec<ScrapedContent>)` - All persisted content
+    /// * `Err(CrawlError)` - Query error
+    fn load_all(&self) -> Result<Vec<ScrapedContent>, CrawlError> {
+        self.get_all_urls()?
+            .into_iter()
+            .filter_map(|url| self.find_by_url(&url).transpose())
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -1,7 +1,14 @@
-//! Export tools — 4 tools for output format conversion
+//! Export tools — 4 tools for real output format conversion
 //!
 //! Tools: export_file, export_jsonl, export_vector,
 //! process_export_pipeline
+//!
+//! Every tool performs a REAL export via the existing `webfang_core`
+//! `export_factory` surface (jsonl/vector/auto) and reports honest
+//! success/error. Operational failures (no repository, empty results,
+//! missing content, I/O errors) map to `CallToolResult::error`
+//! (isError:true, Spanish). Invalid parameters (bad format) map to a
+//! protocol-level `McpError::invalid_params` — never a silent fallback.
 
 use super::McpHandler;
 use crate::mcp_server::params::*;
@@ -10,14 +17,94 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::tool;
 use rmcp::tool_router;
 use rmcp::{model::CallToolResult, model::Content, ErrorData as McpError};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::instrument;
+use webfang_core::application::export_factory::{create_exporter, process_results};
+use webfang_core::domain::entities::ExportFormat;
+use webfang_core::domain::DocumentChunkUnvalidated;
+use webfang_core::domain::ScrapedContent;
+
+/// Run a real export of persisted results to the given format.
+///
+/// Maps operational [`ExporterError`](webfang_core::domain::exporter::ExporterError)s
+/// to an honest `CallToolResult::error` (isError:true, Spanish) and reports the
+/// real written path on success.
+fn export_results(
+    results: &[ScrapedContent],
+    output_dir: PathBuf,
+    format: ExportFormat,
+    filename: &str,
+) -> Result<CallToolResult, McpError> {
+    let count = results.len();
+    match process_results(results, output_dir.clone(), format, filename, None, false) {
+        Ok(_) => {
+            let path = resolve_export_path(&output_dir, filename, format);
+            tracing::info!(documents = count, path = %path.display(), "export completed");
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Exportación completada: {count} documentos → {}",
+                path.display()
+            ))]))
+        },
+        Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+            "error al exportar: {e}"
+        ))])),
+    }
+}
+
+/// Compute the real on-disk path an export wrote to.
+///
+/// For concrete formats this is `{output_dir}/{filename}.{ext}`. For `Auto`
+/// the concrete extension is resolved from what actually exists (jsonl
+/// preferred, then json), so the reported path is always truthful.
+fn resolve_export_path(output_dir: &Path, filename: &str, format: ExportFormat) -> PathBuf {
+    match format {
+        ExportFormat::Auto => {
+            let jsonl = output_dir.join(format!("{filename}.jsonl"));
+            if jsonl.exists() {
+                jsonl
+            } else {
+                output_dir.join(format!("{filename}.json"))
+            }
+        },
+        concrete => output_dir.join(format!("{filename}.{}", concrete.extension())),
+    }
+}
+
+impl McpHandler {
+    /// Load all persisted crawl results, mapping operational failures to an
+    /// honest `CallToolResult::error` (isError:true, Spanish).
+    ///
+    /// Returns `Err(CallToolResult)` when no repository is wired, the bulk
+    /// load fails, or the repository holds zero results; callers propagate
+    /// this directly.
+    async fn load_results(&self) -> Result<Vec<ScrapedContent>, CallToolResult> {
+        let repo = match self.state.container.crawl_result_repository() {
+            Some(repo) => repo,
+            None => {
+                return Err(CallToolResult::error(vec![Content::text(
+                    "no hay repositorio de resultados disponible",
+                )]))
+            },
+        };
+        let results = repo.load_all().map_err(|e| {
+            CallToolResult::error(vec![Content::text(format!(
+                "no se pudieron cargar los resultados: {e}"
+            ))])
+        })?;
+        if results.is_empty() {
+            return Err(CallToolResult::error(vec![Content::text(
+                "no hay resultados disponibles para exportar",
+            )]));
+        }
+        Ok(results)
+    }
+}
 
 #[tool_router(router = tool_router_export, vis = "pub")]
 impl McpHandler {
-    /// Save scraped content as a file (Markdown, Text, or JSON)
+    /// Save caller-provided content as a structured export file (jsonl/vector)
     #[tool(
-        description = "Save scraped content as a file in Markdown, Text, or JSON format with YAML frontmatter."
+        description = "Save caller-provided content to a structured export file. Supported formats: jsonl, vector, auto. Reports the real written path."
     )]
     #[instrument(skip(self), fields(filename = %params.filename, format = %params.format))]
     async fn export_file(
@@ -26,76 +113,158 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, export);
 
-        let format = webfang_core::domain::entities::ExportFormat::parse_str(&params.format)
-            .unwrap_or(webfang_core::domain::entities::ExportFormat::Jsonl);
+        // Honest error on empty content (REQ-MCP-EXPORT-05).
+        if params.content.trim().is_empty() {
+            return Ok(CallToolResult::error(vec![Content::text(
+                "el contenido no puede estar vacío",
+            )]));
+        }
+
+        // Invalid format is a protocol-level invalid-params error, never a
+        // silent fallback (REQ-MCP-EXPORT-07).
+        let format = ExportFormat::parse_str(&params.format).map_err(|e| {
+            McpError::invalid_params(
+                format!("formato inválido: {e}"),
+                Some(serde_json::Value::String("format".to_string())),
+            )
+        })?;
 
         let output_dir = PathBuf::from(&params.output_dir);
-        match tokio::fs::create_dir_all(&output_dir).await {
-            Ok(_) => {
-                let path = output_dir.join(format!("{}.{}", params.filename, format.extension()));
+        let filename = params.filename.clone();
+
+        // Build a validated document chunk from the caller content. The chunk
+        // id/timestamp are generated internally; the synthetic URL satisfies
+        // validation (any parseable scheme) and scopes the doc to this tool.
+        let url = url::Url::parse(&format!("https://webfang.local/{filename}")).map_err(|e| {
+            McpError::invalid_params(
+                format!("nombre de archivo inválido: {e}"),
+                Some(serde_json::Value::String("filename".to_string())),
+            )
+        })?;
+        let scraped = ScrapedContent {
+            title: filename.clone(),
+            content: params.content.clone(),
+            url: webfang_core::domain::ValidUrl::new(url),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: vec![],
+            correlation_id: None,
+        };
+        let validated = match DocumentChunkUnvalidated::from_scraped_content(&scraped).validate() {
+            Ok(v) => v,
+            Err(e) => {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "contenido inválido: {e}"
+                ))]))
+            },
+        };
+
+        let exporter = match create_exporter(output_dir.clone(), &filename, format) {
+            Ok(exporter) => exporter,
+            Err(e) => {
+                return Ok(CallToolResult::error(vec![Content::text(format!(
+                    "no se pudo crear el exportador: {e}"
+                ))]))
+            },
+        };
+
+        match exporter.export(validated) {
+            Ok(()) => {
+                let path = resolve_export_path(&output_dir, &filename, format);
+                tracing::info!(documents = 1, path = %path.display(), "export completed");
                 Ok(CallToolResult::success(vec![Content::text(format!(
-                    "File ready at: {}",
+                    "Exportación completada: 1 documentos → {}",
                     path.display()
                 ))]))
             },
             Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
-                "failed to create directory: {e}"
+                "error al exportar: {e}"
             ))])),
         }
     }
 
-    /// Export scraped content to JSONL format (one JSON object per line, RAG-ready)
+    /// Export persisted crawl results to JSONL format (one JSON object per line)
     #[tool(
-        description = "Export content to JSONL format (one JSON object per line). Optimal for RAG pipeline ingestion."
+        description = "Export persisted crawl results to JSONL format (one JSON object per line). Optimal for RAG pipeline ingestion. Reports the real written path."
     )]
-    #[instrument(skip(self), fields(params = ?params))]
+    #[instrument(skip(self), fields(filename, format = "jsonl", results))]
     async fn export_jsonl(
         &self,
         Parameters(params): Parameters<ExportJsonlParams>,
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, export);
 
-        let output_dir = params.output_dir.as_deref().unwrap_or("./output");
-        let filename = params.filename.as_deref().unwrap_or("export");
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "JSONL exporter ready at: {output_dir}/{filename}.jsonl"
-        ))]))
+        let output_dir = PathBuf::from(params.output_dir.as_deref().unwrap_or("./output"));
+        let filename = params.filename.as_deref().unwrap_or("export").to_string();
+
+        let results = match self.load_results().await {
+            Ok(results) => results,
+            Err(err) => return Ok(err),
+        };
+        let span = tracing::Span::current();
+        span.record("filename", filename.as_str());
+        span.record("results", results.len());
+
+        export_results(&results, output_dir, ExportFormat::Jsonl, &filename)
     }
 
-    /// Export content with embeddings for vector database ingestion
+    /// Export persisted crawl results with embeddings for vector database ingestion
     #[tool(
-        description = "Export content with embeddings to JSON format for vector database ingestion. Includes metadata header."
+        description = "Export persisted crawl results to JSON format for vector database ingestion. Includes a metadata header. Reports the real written path."
     )]
-    #[instrument(skip(self), fields(params = ?params))]
+    #[instrument(skip(self), fields(filename, format = "vector", results))]
     async fn export_vector(
         &self,
         Parameters(params): Parameters<ExportVectorParams>,
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, export);
 
-        let output_dir = params.output_dir.as_deref().unwrap_or("./output");
-        let filename = params.filename.as_deref().unwrap_or("export");
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "Vector exporter ready at: {output_dir}/{filename}.json"
-        ))]))
+        let output_dir = PathBuf::from(params.output_dir.as_deref().unwrap_or("./output"));
+        let filename = params.filename.as_deref().unwrap_or("export").to_string();
+
+        let results = match self.load_results().await {
+            Ok(results) => results,
+            Err(err) => return Ok(err),
+        };
+        let span = tracing::Span::current();
+        span.record("filename", filename.as_str());
+        span.record("results", results.len());
+
+        export_results(&results, output_dir, ExportFormat::Vector, &filename)
     }
 
-    /// Full export pipeline: scrape → chunk → validate → export
+    /// Full export pipeline: load persisted results → export synchronously
     #[tool(
-        description = "Run the full export pipeline: scrape content, chunk it, validate, and export to the specified format."
+        description = "Run the export pipeline synchronously: load persisted crawl results and export them to the specified format (jsonl, vector, or auto; default jsonl). Reports the real written path; never queues."
     )]
-    #[instrument(skip(self), fields(params = ?params))]
+    #[instrument(skip(self), fields(format, results))]
     async fn process_export_pipeline(
         &self,
         Parameters(params): Parameters<ProcessExportPipelineParams>,
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, export);
 
-        let url = params.url.as_deref().unwrap_or("");
-        let format = params.format.as_deref().unwrap_or("jsonl");
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "Pipeline queued for: {url} → [{format}]"
-        ))]))
+        let format_str = params.format.as_deref().unwrap_or("jsonl");
+        let format = ExportFormat::parse_str(format_str).map_err(|e| {
+            McpError::invalid_params(
+                format!("formato inválido: {e}"),
+                Some(serde_json::Value::String("format".to_string())),
+            )
+        })?;
+
+        let results = match self.load_results().await {
+            Ok(results) => results,
+            Err(err) => return Ok(err),
+        };
+        let span = tracing::Span::current();
+        span.record("format", format_str);
+        span.record("results", results.len());
+
+        // The pipeline exports to the container's configured output directory.
+        let output_dir = self.state.container.scraper_config.output_dir.clone();
+        export_results(&results, output_dir, format, "export")
     }
 }
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -18,9 +18,11 @@ use rmcp::tool;
 use rmcp::tool_router;
 use rmcp::{model::CallToolResult, model::Content, ErrorData as McpError};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tracing::instrument;
 use webfang_core::application::export_factory::{create_exporter, process_results};
 use webfang_core::domain::entities::ExportFormat;
+use webfang_core::domain::CrawlResultRepository;
 use webfang_core::domain::DocumentChunkUnvalidated;
 use webfang_core::domain::ScrapedContent;
 
@@ -70,6 +72,38 @@ fn resolve_export_path(output_dir: &Path, filename: &str, format: ExportFormat) 
     }
 }
 
+/// Resolve persisted crawl results from an optional repository, mapping every
+/// operational failure to an honest `CallToolResult::error` (isError:true,
+/// Spanish).
+///
+/// Extracted from [`McpHandler::load_results`] as a free function so the
+/// `None`-repository branch — unreachable through `Container::new`, which
+/// always attempts to wire a repository and tolerates log corruption — can be
+/// unit-tested directly (REQ-MCP-EXPORT-05).
+fn load_results_from(
+    repo: Option<Arc<dyn CrawlResultRepository>>,
+) -> Result<Vec<ScrapedContent>, CallToolResult> {
+    let repo = match repo {
+        Some(repo) => repo,
+        None => {
+            return Err(CallToolResult::error(vec![Content::text(
+                "no hay repositorio de resultados disponible",
+            )]))
+        },
+    };
+    let results = repo.load_all().map_err(|e| {
+        CallToolResult::error(vec![Content::text(format!(
+            "no se pudieron cargar los resultados: {e}"
+        ))])
+    })?;
+    if results.is_empty() {
+        return Err(CallToolResult::error(vec![Content::text(
+            "no hay resultados disponibles para exportar",
+        )]));
+    }
+    Ok(results)
+}
+
 impl McpHandler {
     /// Load all persisted crawl results, mapping operational failures to an
     /// honest `CallToolResult::error` (isError:true, Spanish).
@@ -78,25 +112,7 @@ impl McpHandler {
     /// load fails, or the repository holds zero results; callers propagate
     /// this directly.
     async fn load_results(&self) -> Result<Vec<ScrapedContent>, CallToolResult> {
-        let repo = match self.state.container.crawl_result_repository() {
-            Some(repo) => repo,
-            None => {
-                return Err(CallToolResult::error(vec![Content::text(
-                    "no hay repositorio de resultados disponible",
-                )]))
-            },
-        };
-        let results = repo.load_all().map_err(|e| {
-            CallToolResult::error(vec![Content::text(format!(
-                "no se pudieron cargar los resultados: {e}"
-            ))])
-        })?;
-        if results.is_empty() {
-            return Err(CallToolResult::error(vec![Content::text(
-                "no hay resultados disponibles para exportar",
-            )]));
-        }
-        Ok(results)
+        load_results_from(self.state.container.crawl_result_repository())
     }
 }
 
@@ -270,4 +286,42 @@ impl McpHandler {
 
 pub fn build_router() -> ToolRouter<McpHandler> {
     McpHandler::tool_router_export()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// REQ-MCP-EXPORT-05 (repository unavailable): when no repository is wired,
+    /// the loader must return an honest `CallToolResult::error` (isError:true)
+    /// carrying the Spanish "no hay repositorio" message — never a fake success.
+    ///
+    /// This branch is unreachable through `Container::new` (which always
+    /// attempts to wire a repository and tolerates log corruption), so it is
+    /// exercised directly through the extracted `load_results_from` free
+    /// function by passing `None`.
+    #[test]
+    fn load_results_from_none_repository_is_honest_error() {
+        let err = load_results_from(None).expect_err("None repository must be an error");
+
+        // Serialize exactly as the MCP transport would, then assert the honest
+        // error contract: isError:true plus the Spanish message.
+        let json = serde_json::to_value(&err).expect("CallToolResult must serialize");
+        assert_eq!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "None-repository path must set isError:true, got: {json}"
+        );
+        let text = json
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|first| first.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap_or_default();
+        assert!(
+            text.contains("no hay repositorio de resultados disponible"),
+            "honest Spanish no-repository error expected, got: {text}"
+        );
+    }
 }

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -148,8 +148,10 @@ pub struct ExportFileParams {
     pub output_dir: String,
     /// Filename (without extension)
     pub filename: String,
-    /// Export format: markdown, text, json, jsonl, vector
+    /// Export format: jsonl, vector, auto
     pub format: String,
+    /// Content to export (written to the output file)
+    pub content: String,
 }
 
 #[derive(Deserialize, JsonSchema, Debug)]

--- a/crates/webfang_mcp/tests/mcp_protocol.rs
+++ b/crates/webfang_mcp/tests/mcp_protocol.rs
@@ -227,10 +227,12 @@ fn discover_urls_params_deserialize() {
 
 #[test]
 fn export_file_params_deserialize() {
-    let json = r#"{"output_dir": "/tmp", "filename": "test", "format": "markdown"}"#;
+    let json =
+        r#"{"output_dir": "/tmp", "filename": "test", "format": "jsonl", "content": "hello"}"#;
     let params: webfang_mcp::mcp_server::params::ExportFileParams =
         serde_json::from_str(json).unwrap();
-    assert_eq!(params.format, "markdown");
+    assert_eq!(params.format, "jsonl");
+    assert_eq!(params.content, "hello");
 }
 
 #[test]

--- a/tests/mcp_behavioral_test.rs
+++ b/tests/mcp_behavioral_test.rs
@@ -78,6 +78,187 @@ fn mcp_request(method: &str, params: Value) -> Value {
 }
 
 // ============================================================================
+// Export-tool helpers (issue #343 slice 1 — real export wiring)
+// ============================================================================
+
+/// Extract the first JSON-RPC object from an SSE (`data: ` prefixed) or direct
+/// JSON response body. Local copy — each integration test binary is standalone.
+fn extract_json(body: &str) -> Option<Value> {
+    if body.contains("data: ") {
+        body.lines()
+            .filter(|line| line.starts_with("data: "))
+            .filter_map(|line| {
+                let json_str = line.strip_prefix("data: ").unwrap_or(line);
+                serde_json::from_str::<Value>(json_str).ok()
+            })
+            .next()
+    } else {
+        serde_json::from_str::<Value>(body).ok()
+    }
+}
+
+/// Redact a known output directory path so insta snapshots stay stable
+/// run-to-run. Local helper: webfang_core's `tests/common` redactor is NOT
+/// importable from webfang_mcp (dependency direction is mcp → core).
+fn redact_path(text: &str, dir: &std::path::Path) -> String {
+    text.replace(dir.to_string_lossy().as_ref(), "[OUT_DIR]")
+}
+
+/// Start a test MCP server whose crawl-result repository is pre-seeded with
+/// `n` `ScrapedContent` items.
+///
+/// Returns `(base_url, server_handle, container_tmp)`. The container temp dir
+/// is returned so the caller keeps it alive (the append-only repository log
+/// lives inside it) and so tests can locate exports that default to the
+/// container's configured `output_dir` (e.g. `process_export_pipeline`).
+async fn start_seeded_server(n: usize) -> (String, tokio::task::JoinHandle<()>, tempfile::TempDir) {
+    use webfang_core::domain::{CrawlerConfig, ScrapedContent, ValidUrl};
+    use webfang_core::infrastructure::config::ScraperConfig;
+
+    let container_tmp = tempfile::TempDir::new().expect("create container temp dir");
+    let crawler_config =
+        CrawlerConfig::new(url::Url::parse("https://seed.example.com").expect("valid seed URL"));
+    let scraper_config = ScraperConfig {
+        output_dir: container_tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let container = Container::new(crawler_config, scraper_config)
+        .await
+        .expect("container creation failed");
+
+    // Seed the crawl-result repository with n items and wait for indexing.
+    let repo = container
+        .crawl_result_repository()
+        .expect("container must wire a crawl result repository");
+    for i in 0..n {
+        let url_str = format!("https://seed.example.com/page/{i}");
+        let url = url::Url::parse(&url_str).expect("valid seeded URL");
+        let content = ScrapedContent {
+            title: format!("Seed Title {i}"),
+            content: format!("Seed body content number {i} for export testing."),
+            url: ValidUrl::new(url),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: vec![],
+            correlation_id: None,
+        };
+        repo.save(&content).expect("save seeded content");
+    }
+    // Poll until the background writer has indexed every seeded URL.
+    for i in 0..n {
+        let url_str = format!("https://seed.example.com/page/{i}");
+        for _ in 0..80 {
+            if repo.find_by_url(&url_str).expect("find_by_url").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
+    let state = McpState::new(container);
+    let app = build_mcp_router(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let base_url = format!("http://{}", addr);
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    for _ in 0..20 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    (base_url, handle, container_tmp)
+}
+
+/// Initialize an MCP session (initialize + notifications/initialized) and
+/// return the session ID.
+async fn init_session(client: &Client, base_url: &str) -> String {
+    let init_body = mcp_request(
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "export-test", "version": "1.0.0" }
+        }),
+    );
+    let resp = client
+        .post(format!("{}/mcp", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&init_body)
+        .send()
+        .await
+        .expect("initialize should succeed");
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("initialize must return mcp-session-id");
+
+    let _ = client
+        .post(format!("{}/mcp", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&json!({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+        .send()
+        .await;
+
+    session_id
+}
+
+/// Call an MCP tool and return the parsed JSON-RPC response object.
+async fn call_tool(
+    client: &Client,
+    base_url: &str,
+    session_id: &str,
+    name: &str,
+    args: Value,
+) -> Value {
+    let body = mcp_request("tools/call", json!({ "name": name, "arguments": args }));
+    let resp = client
+        .post(format!("{}/mcp", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", session_id)
+        .json(&body)
+        .send()
+        .await
+        .expect("tools/call should succeed");
+    let text = resp.text().await.expect("read response body");
+    extract_json(&text).expect("response must parse as JSON-RPC")
+}
+
+/// Extract the first content text from a tool result object.
+fn tool_text(result: &Value) -> String {
+    result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|first| first.get("text"))
+        .and_then(|t| t.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Whether a tool result is flagged as an error (CallToolResult::error).
+fn is_tool_error(result: &Value) -> bool {
+    result
+        .get("isError")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+// ============================================================================
 // 1. Initialize request — returns server info
 // ============================================================================
 
@@ -388,4 +569,375 @@ async fn test_unknown_method_returns_error() {
         );
     }
     // HTTP error status is also acceptable
+}
+
+// ============================================================================
+// 4. Export tools — real exports + honest errors (issue #343 slice 1)
+// ============================================================================
+
+/// REQ-MCP-EXPORT-01: export_jsonl writes a real `.jsonl` file (one valid JSON
+/// object per line) and reports the real written path.
+#[tokio::test]
+async fn test_export_jsonl_writes_real_file() {
+    let (base_url, _handle, _container_tmp) = start_seeded_server(1).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let out = tempfile::TempDir::new().unwrap();
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_jsonl",
+        json!({ "output_dir": out.path().to_string_lossy(), "filename": "export" }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&result),
+        "export_jsonl should succeed: {}",
+        tool_text(&result)
+    );
+
+    // A real .jsonl file exists at the reported path.
+    let file_path = out.path().join("export.jsonl");
+    assert!(
+        file_path.exists(),
+        "export.jsonl must exist at {}",
+        file_path.display()
+    );
+
+    let body = std::fs::read_to_string(&file_path).unwrap();
+    let lines: Vec<&str> = body.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(!lines.is_empty(), "JSONL file must have at least one line");
+    let mut found_content = false;
+    for line in &lines {
+        let obj: Value = serde_json::from_str(line).expect("each JSONL line must be valid JSON");
+        assert_eq!(
+            obj.get("metadata_version").and_then(|v| v.as_str()),
+            Some("2.0.0"),
+            "JSONL line must carry the webfang metadata schema"
+        );
+        if obj
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .contains("Seed body content number 0")
+        {
+            found_content = true;
+        }
+    }
+    assert!(
+        found_content,
+        "exported JSONL must contain the seeded content"
+    );
+
+    let text = tool_text(&result);
+    insta::with_settings!({
+        filters => vec![
+            (r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:?\d{2}|Z)", "[TIMESTAMP]"),
+            (r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", "[UUID]"),
+            (r"127\.0\.0\.1:\d+", "127.0.0.1:[PORT]"),
+        ],
+    }, {
+        insta::assert_snapshot!("export_jsonl_success", redact_path(&text, out.path()));
+    });
+}
+
+/// REQ-MCP-EXPORT-02: export_vector writes a real `.json` file with a metadata
+/// header plus exported chunks, and reports the real path.
+#[tokio::test]
+async fn test_export_vector_writes_real_file() {
+    let (base_url, _handle, _container_tmp) = start_seeded_server(1).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let out = tempfile::TempDir::new().unwrap();
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_vector",
+        json!({ "output_dir": out.path().to_string_lossy(), "filename": "vectors" }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&result),
+        "export_vector should succeed: {}",
+        tool_text(&result)
+    );
+
+    let file_path = out.path().join("vectors.json");
+    assert!(
+        file_path.exists(),
+        "vectors.json must exist at {}",
+        file_path.display()
+    );
+
+    let body = std::fs::read_to_string(&file_path).unwrap();
+    let parsed: Value = serde_json::from_str(&body).expect("vector export must be valid JSON");
+    assert_eq!(
+        parsed.get("format_version").and_then(|v| v.as_str()),
+        Some("1.0"),
+        "vector export must carry the metadata header"
+    );
+    let docs = parsed
+        .get("documents")
+        .and_then(|d| d.as_array())
+        .expect("vector export must have a documents array");
+    assert!(!docs.is_empty(), "documents array must not be empty");
+    assert!(
+        body.contains("Seed body content number 0"),
+        "vector export must contain the seeded content"
+    );
+
+    let text = tool_text(&result);
+    insta::with_settings!({
+        filters => vec![
+            (r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:?\d{2}|Z)", "[TIMESTAMP]"),
+            (r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", "[UUID]"),
+            (r"127\.0\.0\.1:\d+", "127.0.0.1:[PORT]"),
+        ],
+    }, {
+        insta::assert_snapshot!("export_vector_success", redact_path(&text, out.path()));
+    });
+}
+
+/// REQ-MCP-EXPORT-03: process_export_pipeline performs a REAL synchronous
+/// export (never "queued") and reports the real path.
+#[tokio::test]
+async fn test_process_export_pipeline_real_export() {
+    let (base_url, _handle, container_tmp) = start_seeded_server(1).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "process_export_pipeline",
+        json!({ "format": "jsonl" }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&result),
+        "pipeline should succeed: {}",
+        tool_text(&result)
+    );
+
+    let text = tool_text(&result);
+    assert!(
+        !text.to_lowercase().contains("queued"),
+        "pipeline must NOT report queued: {text}"
+    );
+
+    // The pipeline defaults to the container's configured output_dir.
+    let file_path = container_tmp.path().join("export.jsonl");
+    assert!(
+        file_path.exists(),
+        "pipeline must write a real file at {}",
+        file_path.display()
+    );
+    let body = std::fs::read_to_string(&file_path).unwrap();
+    let lines: Vec<&str> = body.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(!lines.is_empty(), "pipeline export must have content");
+    for line in &lines {
+        let _: Value = serde_json::from_str(line).expect("pipeline JSONL line must be valid JSON");
+    }
+
+    insta::with_settings!({
+        filters => vec![
+            (r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:?\d{2}|Z)", "[TIMESTAMP]"),
+            (r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", "[UUID]"),
+            (r"127\.0\.0\.1:\d+", "127.0.0.1:[PORT]"),
+        ],
+    }, {
+        insta::assert_snapshot!("process_export_pipeline_success", redact_path(&text, container_tmp.path()));
+    });
+}
+
+/// REQ-MCP-EXPORT-04 (amended): export_file writes caller-provided content to a
+/// real file via the real create_exporter surface and reports the real path.
+#[tokio::test]
+async fn test_export_file_writes_content() {
+    let (base_url, _handle, _container_tmp) = start_seeded_server(0).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let out = tempfile::TempDir::new().unwrap();
+    let content = "Hello export file content written by the caller";
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_file",
+        json!({
+            "output_dir": out.path().to_string_lossy(),
+            "filename": "myfile",
+            "format": "jsonl",
+            "content": content
+        }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&result),
+        "export_file should succeed: {}",
+        tool_text(&result)
+    );
+
+    let file_path = out.path().join("myfile.jsonl");
+    assert!(
+        file_path.exists(),
+        "myfile.jsonl must exist at {}",
+        file_path.display()
+    );
+    let body = std::fs::read_to_string(&file_path).unwrap();
+    assert!(
+        body.contains(content),
+        "exported file body must contain the caller-provided content"
+    );
+
+    let text = tool_text(&result);
+    insta::with_settings!({
+        filters => vec![
+            (r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:?\d{2}|Z)", "[TIMESTAMP]"),
+            (r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", "[UUID]"),
+            (r"127\.0\.0\.1:\d+", "127.0.0.1:[PORT]"),
+        ],
+    }, {
+        insta::assert_snapshot!("export_file_success", redact_path(&text, out.path()));
+    });
+}
+
+/// REQ-MCP-EXPORT-05: an empty repository yields an honest CallToolResult::error
+/// (isError:true, Spanish) — never a fake success.
+#[tokio::test]
+async fn test_export_jsonl_empty_repo_honest_error() {
+    let (base_url, _handle, _container_tmp) = start_seeded_server(0).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let out = tempfile::TempDir::new().unwrap();
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_jsonl",
+        json!({ "output_dir": out.path().to_string_lossy(), "filename": "export" }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        is_tool_error(&result),
+        "empty repository must return isError:true, got: {}",
+        tool_text(&result)
+    );
+    let text = tool_text(&result);
+    assert!(
+        text.contains("no hay resultados"),
+        "honest Spanish empty-state error expected, got: {text}"
+    );
+    assert!(
+        !out.path().join("export.jsonl").exists(),
+        "no file should be written for an empty repository"
+    );
+}
+
+/// REQ-MCP-EXPORT-05: export_file with empty content yields an honest
+/// CallToolResult::error (isError:true, Spanish).
+#[tokio::test]
+async fn test_export_file_missing_content_honest_error() {
+    let (base_url, _handle, _container_tmp) = start_seeded_server(0).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let out = tempfile::TempDir::new().unwrap();
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_file",
+        json!({
+            "output_dir": out.path().to_string_lossy(),
+            "filename": "empty",
+            "format": "jsonl",
+            "content": "   "
+        }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        is_tool_error(&result),
+        "empty content must return isError:true, got: {}",
+        tool_text(&result)
+    );
+    let text = tool_text(&result);
+    assert!(
+        text.contains("contenido"),
+        "Spanish content error expected, got: {text}"
+    );
+}
+
+/// REQ-MCP-EXPORT-07: an unrecognized format is rejected with an explicit
+/// JSON-RPC invalid-params error — NOT the legacy silent fallback to Jsonl.
+#[tokio::test]
+async fn test_export_invalid_format_hard_error() {
+    let (base_url, _handle, _container_tmp) = start_seeded_server(0).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let out = tempfile::TempDir::new().unwrap();
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_file",
+        json!({
+            "output_dir": out.path().to_string_lossy(),
+            "filename": "bad",
+            "format": "bogus",
+            "content": "some content"
+        }),
+    )
+    .await;
+
+    let error = resp
+        .get("error")
+        .unwrap_or_else(|| panic!("invalid format must return a JSON-RPC error, got: {resp}"));
+    let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+    assert_eq!(
+        code, -32602,
+        "invalid format must map to JSON-RPC invalid-params (-32602), got: {error}"
+    );
+    assert!(
+        !out.path().join("bad.jsonl").exists(),
+        "no silent Jsonl fallback file may be written"
+    );
 }

--- a/tests/mcp_behavioral_test.rs
+++ b/tests/mcp_behavioral_test.rs
@@ -941,3 +941,52 @@ async fn test_export_invalid_format_hard_error() {
         "no silent Jsonl fallback file may be written"
     );
 }
+
+/// REQ-MCP-EXPORT-07 (uncreatable output_dir): an output directory that cannot
+/// be created yields an honest CallToolResult::error (isError:true, Spanish) —
+/// never a fake success. The directory is made uncreatable by routing it
+/// through an existing regular file, so `create_dir_all` fails inside the
+/// exporter (ExporterError::DirectoryCreation) and surfaces via process_results.
+#[tokio::test]
+async fn test_export_uncreatable_output_dir_honest_error() {
+    // Seed one result so load_results succeeds and the tool reaches the export
+    // (directory-creation) path rather than the empty-repository early return.
+    let (base_url, _handle, _container_tmp) = start_seeded_server(1).await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    // Build an output_dir that cannot be created: a path descending through an
+    // existing regular file. `create_dir_all` on this fails (NotADirectory).
+    let blocker_tmp = tempfile::TempDir::new().unwrap();
+    let blocker_file = blocker_tmp.path().join("blocker.txt");
+    std::fs::write(&blocker_file, "a regular file, not a directory").unwrap();
+    let uncreatable_dir = blocker_file.join("nested").join("output");
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_jsonl",
+        json!({ "output_dir": uncreatable_dir.to_string_lossy(), "filename": "export" }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        is_tool_error(&result),
+        "uncreatable output_dir must return isError:true, got: {}",
+        tool_text(&result)
+    );
+    let text = tool_text(&result);
+    assert!(
+        text.contains("error al exportar"),
+        "honest Spanish export error expected, got: {text}"
+    );
+    assert!(
+        !uncreatable_dir.join("export.jsonl").exists(),
+        "no file may be written to an uncreatable output_dir"
+    );
+}

--- a/tests/snapshots/mcp_behavioral_test__export_file_success.snap
+++ b/tests/snapshots/mcp_behavioral_test__export_file_success.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_mcp/../../tests/mcp_behavioral_test.rs
+expression: "redact_path(&text, out.path())"
+---
+Exportación completada: 1 documentos → [OUT_DIR]/myfile.jsonl

--- a/tests/snapshots/mcp_behavioral_test__export_jsonl_success.snap
+++ b/tests/snapshots/mcp_behavioral_test__export_jsonl_success.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_mcp/../../tests/mcp_behavioral_test.rs
+expression: "redact_path(&text, out.path())"
+---
+Exportación completada: 1 documentos → [OUT_DIR]/export.jsonl

--- a/tests/snapshots/mcp_behavioral_test__export_vector_success.snap
+++ b/tests/snapshots/mcp_behavioral_test__export_vector_success.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_mcp/../../tests/mcp_behavioral_test.rs
+expression: "redact_path(&text, out.path())"
+---
+Exportación completada: 1 documentos → [OUT_DIR]/vectors.json

--- a/tests/snapshots/mcp_behavioral_test__process_export_pipeline_success.snap
+++ b/tests/snapshots/mcp_behavioral_test__process_export_pipeline_success.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_mcp/../../tests/mcp_behavioral_test.rs
+expression: "redact_path(&text, container_tmp.path())"
+---
+Exportación completada: 1 documentos → [OUT_DIR]/export.jsonl


### PR DESCRIPTION
## Linked Issue

Closes #343

> #343 es una issue paraguas (7 tools stub en 3 slices). Este PR entrega el **slice 1** (las 4 tools de exportación). Los slices restantes quedan trackeados en: **#381** (slice 2 — AI tools) y **#382** (slice 3 — métricas). `download_assets` pertenece a #170.

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Las 4 tools de MCP que devolvían **falso éxito** sin escribir nada (`export_jsonl`, `export_vector`, `process_export_pipeline`, `export_file`) ahora hacen export **real** cableándose a la lógica existente de `webfang_core` (`export_factory::process_results` / `create_exporter`). Esto elimina la violación del Principio de Menor Sorpresa: los agentes de IA dejaban de decidir sobre efectos secundarios inexistentes.
- Cuando no hay datos (repositorio vacío / `None` / falta contenido), las tools devuelven un **error honesto** en español (`isError:true`) en lugar de un éxito falso. Formato inválido → `McpError::invalid_params` (-32602); se eliminó el fallback silencioso `unwrap_or(Jsonl)`.
- Se agregó `CrawlResultRepository::load_all()` bulk (método default en el trait + override eficiente en el impl) para alimentar los exportadores sin N+1.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/domain/repositories.rs` | `load_all()` como método default en el trait `CrawlResultRepository` |
| `crates/webfang_core/src/application/crawl_result_repository.rs` | Override eficiente de `load_all()` (single-scan reusando framing de `recover_index`) + unit tests |
| `crates/webfang_mcp/src/mcp_server/handlers/export.rs` | Cableado de las 4 tools a exportadores reales; helper `load_results_from` (seam testable); errores honestos en español; `#[instrument]` preservado |
| `crates/webfang_mcp/src/mcp_server/params.rs` | `ExportFileParams.content` ahora requerido (content-in-params) |
| `crates/webfang_mcp/src/mcp_server/mcp_protocol.rs` | Actualización por el schema break de `ExportFileParams` |
| `tests/mcp_behavioral_test.rs` | 9 tests comportamentales (seeded MCP over HTTP/JSON-RPC) + seed helper + redactor local |
| `tests/snapshots/*.snap` | 4 snapshots determinísticos (redactados) |

### Notas de diseño
- **REQ-04 (export_file):** el spec original pedía "Markdown/Text/JSON con YAML frontmatter", pero `FileExporter::save_md`/`save_txt` son **dead code** inalcanzable vía `create_exporter` (jsonl/vector/auto). Se enmendó REQ-04 para usar la superficie cableada real; si se quiere markdown+frontmatter genuino, abrir un follow-up para cablear `FileExporter::save_md`.
- `process_export_pipeline` usa `container.scraper_config.output_dir` como default (respeta DI, testeable bajo nextest paralelo).
- `export_file` construye el chunk vía `from_scraped_content` (evita agregar deps `uuid`/`chrono` a `webfang_mcp`, que sería ask-first).

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (exit 0)
- [x] `cargo nextest run` pasa (workspace 1903/1903, 0 failures)
- [x] `cargo nextest run -p webfang_mcp --features mcp` pasa (83/83)
- [x] Verificado independientemente (ciclo SDD verify): 9/9 requisitos SATISFIED, 0 CRITICAL
- [x] Sin `.unwrap()` en código de producción; sin dependencias nuevas

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed
