### PR TITLE
chore(infra): remove jzon-rs-serde, consolidate on serde_json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,22 +2809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jzon-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8607f9aa775c9c06d43e3cf72bb53c3eb816caf0e9a57198af18b9e4976e27"
-
-[[package]]
-name = "jzon-rs-serde"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c9e582fa60c25c556ad5f93cb9a1606f115f9f3a88d71fbcb481ebda2389b6"
-dependencies = [
- "jzon-rs",
- "serde",
-]
-
-[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6155,7 +6139,6 @@ dependencies = [
  "html-to-markdown-rs",
  "indicatif 0.17.11",
  "insta",
- "jzon-rs-serde",
  "legible",
  "lol_html",
  "mimetype-detector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ tower-http = { version = "0.6", features = ["trace"] }
 schemars = "1.0"
 
 # Competitive Features
-jzon-rs-serde = "0.3"
 crc32fast = "1"
 robotstxt = "0.3"
 secrecy = { version = "0.8", features = ["serde"] }

--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -113,7 +113,6 @@ async-compression = { workspace = true }
 # Security
 
 # Competitive Features
-jzon-rs-serde = { workspace = true }
 crc32fast = { workspace = true }
 robotstxt = { workspace = true }
 

--- a/crates/webfang_core/src/application/crawler/checkpoint.rs
+++ b/crates/webfang_core/src/application/crawler/checkpoint.rs
@@ -1,7 +1,7 @@
 //! Checkpoint persistence for crawl state — Application layer
 //!
 //! Saves and loads crawl state (visited URLs, queued URLs, pages crawled)
-//! using jzon-rs JSON serialization with CRC32 integrity checks and atomic writes.
+//! using JSON serialization with CRC32 integrity checks and atomic writes.
 //!
 //! # Design Decisions
 //!
@@ -200,7 +200,7 @@ impl From<OldCheckpointSchema> for CrawlCheckpoint {
     }
 }
 
-/// Checkpoint store using jzon-rs JSON serialization with CRC32 integrity.
+/// Checkpoint store using JSON serialization with CRC32 integrity.
 ///
 /// File format: `[4-byte CRC32][JSON payload]`
 ///
@@ -214,7 +214,7 @@ impl CheckpointStore for BincodeCheckpoint {
     #[instrument(skip(self, state), fields(path = %path.display()))]
     fn save(&self, state: &CrawlCheckpoint, path: &Path) -> Result<(), String> {
         // Serialize to JSON
-        let payload = jzon_serde::to_string(state)
+        let payload = serde_json::to_string(state)
             .map_err(|e| format!("checkpoint serialization failed: {e}"))?
             .into_bytes();
 
@@ -277,7 +277,7 @@ impl CheckpointStore for BincodeCheckpoint {
         if stored_checksum != computed_checksum {
             // CRC mismatch — try old-format fallback (pure JSON, no CRC32 header).
             // Old JSON starts with `{` (0x7B), which is never a valid CRC32+JSON combo.
-            if let Ok(old) = jzon_serde::from_slice::<OldCheckpointSchema>(&data) {
+            if let Ok(old) = serde_json::from_slice::<OldCheckpointSchema>(&data) {
                 info!(
                     "migrated old-format checkpoint: {} (visited={}, pages={})",
                     path.display(),
@@ -296,7 +296,7 @@ impl CheckpointStore for BincodeCheckpoint {
         }
 
         // Deserialize from JSON
-        match jzon_serde::from_slice::<CrawlCheckpoint>(payload) {
+        match serde_json::from_slice::<CrawlCheckpoint>(payload) {
             Ok(state) => {
                 info!(
                     "checkpoint loaded: {} (visited={}, queued={}, pages={})",

--- a/crates/webfang_core/src/application/pipeline/stages/jsonl_output.rs
+++ b/crates/webfang_core/src/application/pipeline/stages/jsonl_output.rs
@@ -51,7 +51,7 @@ impl OutputStage for JsonlOutputStage {
         item: &'a ScrapedItem,
     ) -> Pin<Box<dyn Future<Output = Result<(), OutputError>> + Send + 'a>> {
         Box::pin(async {
-            let json = jzon_serde::to_string(item)
+            let json = serde_json::to_string(item)
                 .map_err(|e| OutputError::Serialization(e.to_string()))?;
             let mut file = self
                 .file

--- a/crates/webfang_core/src/domain/pipeline_item.rs
+++ b/crates/webfang_core/src/domain/pipeline_item.rs
@@ -169,17 +169,17 @@ mod tests {
     }
 
     #[test]
-    fn test_scraped_item_jzon_roundtrip() {
+    fn test_scraped_item_json_roundtrip() {
         let item = ScrapedItem {
-            url: "https://jzon.test".into(),
+            url: "https://roundtrip.test".into(),
             raw_html: "<html></html>".into(),
             text_content: Some("content".into()),
             metadata: std::collections::HashMap::new(),
             status_code: 200,
             embeddings: Some(vec![1.0]),
         };
-        let json = jzon_serde::to_string(&item).unwrap();
-        let restored: ScrapedItem = jzon_serde::from_str(&json).unwrap();
+        let json = serde_json::to_string(&item).unwrap();
+        let restored: ScrapedItem = serde_json::from_str(&json).unwrap();
         assert_eq!(item.url, restored.url);
         assert_eq!(item.embeddings, restored.embeddings);
     }


### PR DESCRIPTION
## Linked Issue

Closes #384

## PR Type

- [x] Maintenance / tooling (`type:chore`)

## Summary

- Remove `jzon-rs-serde` (45-day-old crate, 915 downloads, SIMD never enabled) and replace all 5 call sites with identical `serde_json` equivalents
- Consolidate on a single JSON library — eliminates "which lib do I use?" ambiguity
- Full analysis of why the proposed migration in #354 was based on false premises (SIMD not active, hot paths are I/O-bound, half the files were not migrable)

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/pipeline/stages/jsonl_output.rs` | `jzon_serde::to_string` → `serde_json::to_string` |
| `crates/webfang_core/src/application/crawler/checkpoint.rs` | `jzon_serde::to_string/from_slice` → `serde_json::*`, updated doc comments |
| `crates/webfang_core/src/domain/pipeline_item.rs` | Test roundtrip migrated, renamed `test_scraped_item_json_roundtrip` |
| `Cargo.toml` | Removed `jzon-rs-serde = "0.3"` from workspace deps |
| `crates/webfang_core/Cargo.toml` | Removed `jzon-rs-serde = { workspace = true }` |
| `Cargo.lock` | Purged `jzon-rs` and `jzon-rs-serde` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (0 warnings)
- [x] `cargo nextest run` passes — 2006 tests passed (1 pre-existing flaky, unrelated)
- [x] Checkpoint format unchanged (same JSON, same `#[serde(default)]` schema evolution)

## Contributor Checklist

- [x] Linked an issue with `Closes #384`
- [x] Added exactly one `type:*` label (`type:chore`)
- [x] Conventional commit format (`chore(infra): ...`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] No behavior change — pure dependency consolidation