### PR TITLE
feat(mcp): wire AI tools via Container cleaner port (issue #381 slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6202,6 +6202,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "url-normalize",
+ "webfang_ai",
  "webfang_core",
  "wiremock",
  "wreq",

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -26,6 +26,7 @@ use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 use crate::domain::credentials::CredentialStore;
 use crate::domain::ports::HttpClientPort;
 use crate::domain::repository::DynVectorRepository;
+use crate::domain::semantic_cleaner::SemanticCleaner;
 use crate::domain::{repositories::CrawlResultRepository, CrawlerConfig};
 use crate::infrastructure::autotuning::ElasticConfig;
 use crate::infrastructure::bridge::CpuBridge;
@@ -77,6 +78,13 @@ pub struct Container {
     /// the SQLite repo (`persistence` feature) or the headless `StreamRepository`
     /// JSONL sink.
     pub elastic_ingestion: Option<Arc<ElasticIngestion<DynVectorRepository>>>,
+
+    // --- Optional domain ports (injected post-construction) ---
+    /// AI semantic cleaner (optional). `None` when the `ai` feature is off or
+    /// no cleaner was injected; MCP tools map this absence to an honest error.
+    /// Stored as `Arc<dyn SemanticCleaner>` — the trait is a domain port like
+    /// `HttpClientPort`, always compiled (no `#[cfg(feature = "ai")]`).
+    cleaner: Option<Arc<dyn SemanticCleaner>>,
 }
 
 impl Container {
@@ -141,6 +149,7 @@ impl Container {
             state_store: None,
             crawl_result_repo,
             elastic_ingestion: None,
+            cleaner: None,
         })
     }
 
@@ -183,6 +192,14 @@ impl Container {
         self.crawl_result_repo.clone()
     }
 
+    /// Get the semantic cleaner port, if one was injected.
+    ///
+    /// Clones the `Arc` (cheap) so callers can hold the cleaner across an
+    /// `.await` without borrowing the container (`async-clone-before-await`).
+    pub fn cleaner(&self) -> Option<Arc<dyn SemanticCleaner>> {
+        self.cleaner.clone()
+    }
+
     /// Access the elastic ingestion pipeline, if activated.
     #[must_use]
     pub fn elastic_ingestion(&self) -> Option<&ElasticIngestion<DynVectorRepository>> {
@@ -208,6 +225,16 @@ impl Container {
     /// Set a pre-configured credential store.
     pub fn with_credential_store(mut self, store: CredentialStore) -> Self {
         self.credential_store = Arc::new(store);
+        self
+    }
+
+    /// Inject an AI semantic cleaner (domain port).
+    ///
+    /// Takes `Arc<dyn SemanticCleaner>` directly — mirrors the CLI construction
+    /// `Arc::new(cleaner) as Arc<dyn SemanticCleaner>` and the
+    /// `McpState::with_inspector` precedent. Absence (`None`) stays the default.
+    pub fn with_cleaner(mut self, cleaner: Arc<dyn SemanticCleaner>) -> Self {
+        self.cleaner = Some(cleaner);
         self
     }
 
@@ -407,5 +434,64 @@ mod tests {
             container.http_client(),
             container2.http_client()
         ));
+    }
+
+    // --- Tests for the optional semantic-cleaner port (REQ-05) ---
+
+    /// In-crate fake cleaner — the defining crate may implement its own sealed
+    /// trait (`private::Sealed`), which external crates cannot. Enables a CI
+    /// test of the Container cleaner port without loading an ONNX model.
+    struct FakeCleaner;
+
+    impl crate::domain::semantic_cleaner::private::Sealed for FakeCleaner {}
+
+    impl crate::domain::semantic_cleaner::SemanticCleaner for FakeCleaner {
+        fn clean<'a>(
+            &'a self,
+            _html: &'a str,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = Result<
+                            Vec<crate::domain::DocumentChunk>,
+                            crate::error::SemanticError,
+                        >,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn max_tokens(&self) -> usize {
+            512
+        }
+
+        fn is_ready(&self) -> bool {
+            true
+        }
+    }
+
+    /// REQ-05 (absence): a freshly built container reports no cleaner.
+    #[cfg_attr(miri, ignore = "boring-sys2 FFI (wreq Client) not supported by Miri")]
+    #[tokio::test]
+    async fn cleaner_absent_by_default() {
+        let (_tmp, container) = make_test_container().await;
+        assert!(
+            container.cleaner().is_none(),
+            "cleaner() must be None when no cleaner was injected"
+        );
+    }
+
+    /// REQ-05 (injection): `with_cleaner` makes the accessor report present.
+    #[cfg_attr(miri, ignore = "boring-sys2 FFI (wreq Client) not supported by Miri")]
+    #[tokio::test]
+    async fn with_cleaner_sets_cleaner() {
+        let (_tmp, container) = make_test_container().await;
+        let container = container.with_cleaner(Arc::new(FakeCleaner));
+        assert!(
+            container.cleaner().is_some(),
+            "cleaner() must be Some after with_cleaner injection"
+        );
     }
 }

--- a/crates/webfang_mcp/Cargo.toml
+++ b/crates/webfang_mcp/Cargo.toml
@@ -11,9 +11,11 @@ homepage.workspace = true
 
 [features]
 mcp = ["webfang_core/mcp"]
+ai = ["dep:webfang_ai", "webfang_core/ai"]
 
 [dependencies]
 webfang_core = { workspace = true }
+webfang_ai = { workspace = true, optional = true }
 
 # MCP
 rmcp = { workspace = true }

--- a/crates/webfang_mcp/examples/mcp_server.rs
+++ b/crates/webfang_mcp/examples/mcp_server.rs
@@ -11,6 +11,9 @@
 //! # Build and run (release recommended — BoringSSL takes ~45s debug)
 //! cargo run --example mcp_server --release -p webfang_mcp
 //!
+//! # With AI semantic cleaning (opt-in; downloads the ONNX model on first run)
+//! WEBFANG_MCP_AI=1 cargo run --example mcp_server --release -p webfang_mcp --features ai
+//!
 //! # Verify with curl (see testing section below)
 //! ```
 //!
@@ -312,20 +315,29 @@ async fn main() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("failed to build container: {e}"))?;
 
     // REQ-07: construct and inject the AI semantic cleaner behind the `ai`
-    // feature, mirroring the CLI (main.rs). The block shadows `container` with
-    // a cleaner-backed one; with the feature off it is absent and the container
-    // carries no cleaner (honest-error paths apply). Shadowing (not `mut`)
-    // keeps the off-build warning-free.
+    // feature, mirroring the CLI (main.rs). Construction is OPT-IN via
+    // `WEBFANG_MCP_AI=1` so a plain `--all-features` smoke run (e.g. the CI
+    // MCP handshake) does not download the ~390 MB ONNX model at startup:
+    // the server binds immediately and the AI tools answer with honest
+    // feature-gated errors until a cleaner is injected. The block shadows
+    // `container` with a cleaner-backed one; shadowing (not `mut`) keeps the
+    // off-build warning-free.
     #[cfg(feature = "ai")]
     let container = {
-        let variant = webfang_ai::AiModel::from_env_or_default();
-        let model_config = webfang_ai::ModelConfig::default().with_model_variant(variant);
-        match webfang_ai::SemanticCleanerImpl::new(model_config).await {
-            Ok(cleaner) => container.with_cleaner(std::sync::Arc::new(cleaner)),
-            Err(e) => {
-                tracing::warn!("semantic cleaner unavailable, continuing without AI: {e}");
-                container
-            },
+        let ai_enabled = std::env::var("WEBFANG_MCP_AI")
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+        if ai_enabled {
+            let variant = webfang_ai::AiModel::from_env_or_default();
+            let model_config = webfang_ai::ModelConfig::default().with_model_variant(variant);
+            match webfang_ai::SemanticCleanerImpl::new(model_config).await {
+                Ok(cleaner) => container.with_cleaner(std::sync::Arc::new(cleaner)),
+                Err(e) => {
+                    tracing::warn!("semantic cleaner unavailable, continuing without AI: {e}");
+                    container
+                },
+            }
+        } else {
+            container
         }
     };
 

--- a/crates/webfang_mcp/examples/mcp_server.rs
+++ b/crates/webfang_mcp/examples/mcp_server.rs
@@ -310,6 +310,25 @@ async fn main() -> Result<()> {
     let container = Container::from_config(config)
         .await
         .map_err(|e| anyhow::anyhow!("failed to build container: {e}"))?;
+
+    // REQ-07: construct and inject the AI semantic cleaner behind the `ai`
+    // feature, mirroring the CLI (main.rs). The block shadows `container` with
+    // a cleaner-backed one; with the feature off it is absent and the container
+    // carries no cleaner (honest-error paths apply). Shadowing (not `mut`)
+    // keeps the off-build warning-free.
+    #[cfg(feature = "ai")]
+    let container = {
+        let variant = webfang_ai::AiModel::from_env_or_default();
+        let model_config = webfang_ai::ModelConfig::default().with_model_variant(variant);
+        match webfang_ai::SemanticCleanerImpl::new(model_config).await {
+            Ok(cleaner) => container.with_cleaner(std::sync::Arc::new(cleaner)),
+            Err(e) => {
+                tracing::warn!("semantic cleaner unavailable, continuing without AI: {e}");
+                container
+            },
+        }
+    };
+
     let state = McpState::new(container);
     let addr: SocketAddr = DEFAULT_MCP_ADDR.parse()?;
     start_mcp_server(state, addr).await

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -13,6 +13,7 @@ use rmcp::tool;
 use rmcp::tool_router;
 use rmcp::{model::CallToolResult, model::Content, ErrorData as McpError};
 use tracing::instrument;
+use webfang_core::domain::DocumentChunk;
 
 /// Build an honest tool error (`isError:true`) carrying a Spanish message.
 ///
@@ -21,6 +22,23 @@ use tracing::instrument;
 /// false success. Mirrors the slice-1 export handlers (see `export.rs`).
 fn honest_error(message: impl Into<String>) -> CallToolResult {
     CallToolResult::error(vec![Content::text(message.into())])
+}
+
+/// Success envelope for `semantic_cleaner` (REQ-01).
+///
+/// Embeddings are inline and full — each chunk carries its vector (truncating
+/// would violate REQ-01). The summary fields give a quick overview without
+/// scanning `documents`.
+#[derive(serde::Serialize)]
+struct SemanticCleanResponse {
+    /// The URL that was fetched and cleaned.
+    url: String,
+    /// Number of semantic chunks produced.
+    chunks: usize,
+    /// Embedding dimensionality (0 when the cleaner produced no embeddings).
+    embedding_dim: usize,
+    /// The cleaned chunks, each with its embedding populated.
+    documents: Vec<DocumentChunk>,
 }
 
 #[tool_router(router = tool_router_ai, vis = "pub")]
@@ -39,6 +57,8 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, ai);
 
+        // REQ-03: reject malformed URLs first (invalid-params), regardless of
+        // cleaner presence — no fetch, no cleaning.
         let _url = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
                 format!("URL inválida: {e}"),
@@ -46,9 +66,45 @@ impl McpHandler {
             )
         })?;
 
-        Ok(CallToolResult::error(vec![Content::text(
-            "AI feature not available in webfang_mcp. Rebuild webfang_cli with --features ai instead.".to_string(),
-        )]))
+        // REQ-02: absent cleaner (ai feature off) -> honest Spanish error.
+        let Some(cleaner) = self.state.container.cleaner() else {
+            return Ok(honest_error(
+                "funcionalidad no disponible: limpieza semántica con IA. Reconstruye con --features ai para habilitarla.",
+            ));
+        };
+
+        // REQ-01: fetch the page via the existing HTTP port, then clean it.
+        // Operational failures map to honest errors — never a false success.
+        let response = match self.state.container.http_client().get(&params.url).await {
+            Ok(resp) => resp,
+            Err(e) => return Ok(honest_error(format!("no se pudo obtener la página: {e}"))),
+        };
+        let documents = match cleaner.clean(&response.body).await {
+            Ok(docs) => docs,
+            Err(e) => return Ok(honest_error(format!("error al limpiar el contenido: {e}"))),
+        };
+
+        let chunks = documents.len();
+        let embedding_dim = documents
+            .first()
+            .and_then(|doc| doc.embeddings.as_ref())
+            .map(Vec::len)
+            .unwrap_or(0);
+        let envelope = SemanticCleanResponse {
+            url: params.url.clone(),
+            chunks,
+            embedding_dim,
+            documents,
+        };
+        let payload = match serde_json::to_string(&envelope) {
+            Ok(json) => json,
+            Err(e) => {
+                return Ok(honest_error(format!(
+                    "error al serializar la respuesta: {e}"
+                )))
+            },
+        };
+        Ok(CallToolResult::success(vec![Content::text(payload)]))
     }
 
     /// Semantic search over Obsidian vault using embeddings

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -14,6 +14,15 @@ use rmcp::tool_router;
 use rmcp::{model::CallToolResult, model::Content, ErrorData as McpError};
 use tracing::instrument;
 
+/// Build an honest tool error (`isError:true`) carrying a Spanish message.
+///
+/// Shared by the AI handlers so feature-gated and operational failures are
+/// reported as `CallToolResult::error` — never an MCP protocol error, never a
+/// false success. Mirrors the slice-1 export handlers (see `export.rs`).
+fn honest_error(message: impl Into<String>) -> CallToolResult {
+    CallToolResult::error(vec![Content::text(message.into())])
+}
+
 #[tool_router(router = tool_router_ai, vis = "pub")]
 impl McpHandler {
     /// Semantic HTML cleaning with AI embeddings
@@ -32,7 +41,7 @@ impl McpHandler {
 
         let _url = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
-                format!("invalid URL: {e}"),
+                format!("URL inválida: {e}"),
                 Some(serde_json::Value::String("url".to_string())),
             )
         })?;
@@ -53,12 +62,49 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, obsidian);
 
-        Ok(CallToolResult::error(vec![Content::text(
-            "AI feature not available in webfang_mcp. Rebuild webfang_cli with --features ai instead.".to_string(),
-        )]))
+        // Deferred capability (follow-up issue #386): semantic vault search
+        // needs an embed/rank surface beyond the `SemanticCleaner` trait.
+        // Report an honest error — never a false success (REQ-04).
+        Ok(honest_error(
+            "funcionalidad no disponible: la búsqueda semántica en Obsidian aún no está implementada. Seguimiento en el issue #386.",
+        ))
     }
 }
 
 pub fn build_router() -> ToolRouter<McpHandler> {
     McpHandler::tool_router_ai()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// REQ-02/04 contract: `honest_error` produces a `CallToolResult` that
+    /// serializes with `isError:true` and carries the exact Spanish text —
+    /// never a protocol error, never a false success. Mirrors the slice-1
+    /// export-handler test (export.rs).
+    #[test]
+    fn honest_error_sets_is_error_and_spanish_text() {
+        let result = honest_error("funcionalidad no disponible: prueba");
+
+        // Serialize exactly as the MCP transport would, then assert the honest
+        // error contract: isError:true plus the Spanish message.
+        let json = serde_json::to_value(&result).expect("CallToolResult must serialize");
+        assert_eq!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "honest_error must set isError:true, got: {json}"
+        );
+        let text = json
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|first| first.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap_or_default();
+        assert!(
+            text.contains("funcionalidad no disponible"),
+            "honest Spanish error text expected, got: {text}"
+        );
+    }
 }

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -2,8 +2,10 @@
 //!
 //! Tools: semantic_cleaner, search_obsidian
 //!
-//! Tool functions are always registered. The ai feature is not available
-//! in webfang_mcp — these always return a "not implemented" error.
+//! Tool functions are always registered. `semantic_cleaner` runs when a
+//! semantic cleaner is injected into the `Container` (constructed behind the
+//! `ai` feature); without one it returns an honest feature-gated error.
+//! `search_obsidian` is not yet implemented (honest error, see issue #386).
 
 use super::McpHandler;
 use crate::mcp_server::params::*;

--- a/tests/mcp_behavioral_test.rs
+++ b/tests/mcp_behavioral_test.rs
@@ -1211,3 +1211,80 @@ async fn test_semantic_cleaner_invalid_url_is_invalid_params() {
         "invalid URL must map to JSON-RPC invalid-params (-32602), got: {error}"
     );
 }
+
+/// REQ-02: with no cleaner injected (bare container, `ai` feature off),
+/// `semantic_cleaner` returns an honest `CallToolResult::error` (isError:true,
+/// Spanish) for a valid URL — never a protocol error, never a false success,
+/// and no fetch is attempted.
+#[tokio::test]
+async fn test_semantic_cleaner_without_cleaner_is_honest_error() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "semantic_cleaner",
+        json!({ "url": "https://example.com" }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        is_tool_error(&result),
+        "absent cleaner must return isError:true, got: {}",
+        tool_text(&result)
+    );
+    let text = tool_text(&result);
+    assert!(
+        text.contains("limpieza semántica"),
+        "honest Spanish absent-cleaner error expected, got: {text}"
+    );
+}
+
+/// REQ-06: with the `ai` feature off, the MCP server still registers the AI
+/// tools (`semantic_cleaner` + `search_obsidian`). Registration is
+/// unconditional; the tools report honest errors when invoked without a cleaner.
+#[tokio::test]
+async fn test_mcp_handler_construction_without_ai() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let body = mcp_request("tools/list", json!({}));
+    let resp = client
+        .post(format!("{}/mcp", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&body)
+        .send()
+        .await
+        .expect("tools/list should succeed");
+    let text = resp.text().await.expect("read body");
+    let parsed = extract_json(&text).expect("tools/list must parse");
+
+    let tools = parsed
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(|t| t.as_array())
+        .unwrap_or_else(|| panic!("tools/list must return a tools array, got: {parsed}"));
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|t| t.get("name")?.as_str())
+        .collect();
+
+    assert!(
+        names.contains(&"semantic_cleaner"),
+        "semantic_cleaner must be registered with ai off, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"search_obsidian"),
+        "search_obsidian must be registered with ai off, got: {names:?}"
+    );
+}

--- a/tests/mcp_behavioral_test.rs
+++ b/tests/mcp_behavioral_test.rs
@@ -1140,3 +1140,74 @@ async fn test_metrics_empty_state_honest_error() {
         "legacy canned text must NOT appear, got: {text}"
     );
 }
+
+// ============================================================================
+// 6. AI tools — honest errors (issue #381 slice 2)
+// ============================================================================
+
+/// REQ-04: search_obsidian returns an honest `CallToolResult::error`
+/// (isError:true, Spanish) stating the capability is not yet implemented and
+/// referencing the follow-up issue — never a false success, never a protocol
+/// error.
+#[tokio::test]
+async fn test_search_obsidian_not_implemented_is_honest_error() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "search_obsidian",
+        json!({ "query": "rust async patterns" }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        is_tool_error(&result),
+        "search_obsidian must return isError:true, got: {}",
+        tool_text(&result)
+    );
+    let text = tool_text(&result);
+    assert!(
+        text.contains("búsqueda semántica"),
+        "honest Spanish not-implemented error expected, got: {text}"
+    );
+    assert!(
+        text.contains("issue #386"),
+        "error must reference the follow-up issue, got: {text}"
+    );
+}
+
+/// REQ-03: semantic_cleaner rejects a malformed URL with a JSON-RPC
+/// invalid-params error (-32602), regardless of cleaner state — no fetch, no
+/// cleaning. Mirrors `test_export_invalid_format_hard_error`.
+#[tokio::test]
+async fn test_semantic_cleaner_invalid_url_is_invalid_params() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "semantic_cleaner",
+        json!({ "url": "not a valid url" }),
+    )
+    .await;
+
+    let error = resp
+        .get("error")
+        .unwrap_or_else(|| panic!("invalid URL must return a JSON-RPC error, got: {resp}"));
+    let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+    assert_eq!(
+        code, -32602,
+        "invalid URL must map to JSON-RPC invalid-params (-32602), got: {error}"
+    );
+}


### PR DESCRIPTION
## Linked Issue

Closes #381

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Slice 2 of #343 (of 3): wire the MCP `semantic_cleaner` tool to the real AI cleaner through a new optional `Container` port (`Option<Arc<dyn SemanticCleaner>>`), behind a new `ai` cargo feature on `webfang_mcp`.
- `semantic_cleaner` becomes functional (fetch → `clean()` → JSON envelope with full inline embeddings) when a cleaner is injected; otherwise it returns an honest Spanish `FeatureGated` error. `search_obsidian` is upgraded from a generic stub to an honest not-implemented error pointing to #386 (the deferred semantic vault-search capability).
- The `webfang_mcp` lib stays AI-infra-free when `ai` is off (handlers reference only the always-compiled core trait); the cleaner is constructed and injected in the `mcp_server` example behind `#[cfg(feature="ai")]`.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/container.rs` | Optional cleaner port + `with_cleaner()`/`cleaner()` + unit tests (in-crate `FakeCleaner`) |
| `crates/webfang_mcp/Cargo.toml` | `ai = ["dep:webfang_ai","webfang_core/ai"]` feature + optional `webfang_ai` dep |
| `crates/webfang_mcp/src/mcp_server/handlers/ai.rs` | `honest_error` helper; wire `semantic_cleaner` (fetch→clean→envelope); honest `search_obsidian` error (#386); Spanish `URL inválida` |
| `crates/webfang_mcp/examples/mcp_server.rs` | `#[cfg(feature="ai")]` cleaner construction + injection |
| `tests/mcp_behavioral_test.rs` | 4 behavioral tests (search_obsidian honest, invalid URL, cleaner-absent honest, construction/registration) |
| `Cargo.lock` | `webfang_ai` dep for `webfang_mcp` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p webfang_core -p webfang_mcp --features mcp --tests -- -D warnings` clean
- [x] `cargo nextest run` passes — core cleaner 2/2, mcp lib 48/48, mcp behavioral 17/17
- [x] `cargo check -p webfang_mcp` passes with and without `--features ai` (lib builds with/without ONNX)
- [x] `cargo build -p webfang_mcp --example mcp_server --features mcp,ai` passes
- [ ] REQ-01 happy path (chunks + embeddings over a real ONNX model) is manual/model-gated by design (sealed trait blocks mocks)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed
