### PR TITLE
feat(mcp): real metrics in get_scrape_metrics (build ScrapeMetrics accumulator)

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -4,6 +4,7 @@
 //! crawl_with_sitemap, discover_urls, discover_sitemap, detect_spa
 
 use super::McpHandler;
+use crate::mcp_server::metrics::{domain_of, Outcome, ScrapeEvent};
 use crate::mcp_server::params::*;
 use crate::mcp_server::selector_service;
 use rmcp::handler::server::tool::ToolRouter;
@@ -11,6 +12,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::tool;
 use rmcp::tool_router;
 use rmcp::{model::CallToolResult, model::Content, ErrorData as McpError};
+use std::time::Instant;
 use tracing::instrument;
 
 #[tool_router(router = tool_router_scraping, vis = "pub")]
@@ -33,16 +35,34 @@ impl McpHandler {
             )
         })?;
 
+        let start = Instant::now();
         let client = self.state.container.http_client().as_ref();
         match webfang_core::application::scraper_service::scrape_with_readability(client, &url)
             .await
         {
             Ok(results) => {
+                let count = results.len();
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "scrape_url",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Success,
+                    count,
+                    duration: start.elapsed(),
+                });
                 let content = serde_json::to_string_pretty(&results)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "scrape_url",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Error,
+                    count: 0,
+                    duration: start.elapsed(),
+                });
+                Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
+            },
         }
     }
 
@@ -79,6 +99,7 @@ impl McpHandler {
             config.selector = sel.clone();
         }
 
+        let start = Instant::now();
         let client = self.state.container.http_client().as_ref();
         let dl = self
             .state
@@ -92,6 +113,14 @@ impl McpHandler {
         .await
         {
             Ok(outcome) => {
+                let count = outcome.results.len();
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "scrape_with_options",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Success,
+                    count,
+                    duration: start.elapsed(),
+                });
                 let response = selector_service::build_scrape_response(
                     outcome.results,
                     &outcome.extract_result,
@@ -101,7 +130,16 @@ impl McpHandler {
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "scrape_with_options",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Error,
+                    count: 0,
+                    duration: start.elapsed(),
+                });
+                Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
+            },
         }
     }
 
@@ -131,6 +169,14 @@ impl McpHandler {
             )]));
         }
 
+        let start = Instant::now();
+        let domain = urls
+            .first()
+            .and_then(|u| u.host_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| "unknown".to_string());
+        let count = urls.len();
+
         let mut config = webfang_core::infrastructure::config::ScraperConfig::default();
         if let Some(c) = params.concurrency {
             config.scraper_concurrency = c;
@@ -148,12 +194,26 @@ impl McpHandler {
         .await
         {
             Ok(results) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "scrape_batch",
+                    domain,
+                    outcome: Outcome::Success,
+                    count,
+                    duration: start.elapsed(),
+                });
                 tracing::info!("batch scrape complete: {} pages", results.len());
                 let content = serde_json::to_string_pretty(&results)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "scrape_batch",
+                    domain,
+                    outcome: Outcome::Error,
+                    count,
+                    duration: start.elapsed(),
+                });
                 tracing::error!("batch scrape failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -178,6 +238,7 @@ impl McpHandler {
             )
         })?;
 
+        let start = Instant::now();
         let crawler_config = webfang_core::domain::CrawlerConfig::builder(seed_url)
             .max_depth(params.max_depth.unwrap_or(3))
             .max_pages(params.max_pages.unwrap_or(100) as usize)
@@ -185,6 +246,14 @@ impl McpHandler {
 
         match webfang_core::application::crawler::crawl_site(crawler_config).await {
             Ok(result) => {
+                let count = result.total_pages;
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "crawl_site",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Success,
+                    count,
+                    duration: start.elapsed(),
+                });
                 let urls: Vec<String> = result.urls.iter().map(|u| u.url.to_string()).collect();
                 let json = serde_json::json!({
                     "urls": urls,
@@ -195,7 +264,16 @@ impl McpHandler {
                     serde_json::to_string_pretty(&json).unwrap(),
                 )]))
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "crawl_site",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Error,
+                    count: 0,
+                    duration: start.elapsed(),
+                });
+                Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
+            },
         }
     }
 
@@ -220,6 +298,7 @@ impl McpHandler {
                 Some(serde_json::Value::String("url".to_string())),
             )
         })?;
+        let start = Instant::now();
         let config = webfang_core::domain::CrawlerConfig::new(seed_url);
         match webfang_core::application::crawler::crawl_with_sitemap(
             &params.url,
@@ -229,6 +308,14 @@ impl McpHandler {
         .await
         {
             Ok(urls) => {
+                let count = urls.len();
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "crawl_with_sitemap",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Success,
+                    count,
+                    duration: start.elapsed(),
+                });
                 tracing::info!("sitemap crawl complete: {} urls found", urls.len());
                 let url_strings: Vec<String> = urls.iter().map(|u| u.url.to_string()).collect();
                 Ok(CallToolResult::success(vec![Content::text(
@@ -236,6 +323,13 @@ impl McpHandler {
                 )]))
             },
             Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "crawl_with_sitemap",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Error,
+                    count: 0,
+                    duration: start.elapsed(),
+                });
                 tracing::error!("sitemap crawl failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -253,22 +347,49 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, scraping);
 
+        let start = Instant::now();
         let port = self.state.container.http_client();
         match port.get(&params.url).await {
             Ok(resp) => {
                 let html = resp.body;
                 match webfang_core::infrastructure::crawler::extract_links(&html, &params.url) {
                     Ok(links) => {
+                        let count = links.len();
+                        self.state.record_scrape(ScrapeEvent {
+                            tool: "discover_urls",
+                            domain: domain_of(&params.url),
+                            outcome: Outcome::Success,
+                            count,
+                            duration: start.elapsed(),
+                        });
                         let content = serde_json::to_string_pretty(&links)
                             .unwrap_or_else(|_| "failed to serialize".into());
                         Ok(CallToolResult::success(vec![Content::text(content)]))
                     },
-                    Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+                    Err(e) => {
+                        self.state.record_scrape(ScrapeEvent {
+                            tool: "discover_urls",
+                            domain: domain_of(&params.url),
+                            outcome: Outcome::Error,
+                            count: 0,
+                            duration: start.elapsed(),
+                        });
+                        Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
+                    },
                 }
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
-                "HTTP error: {e}"
-            ))])),
+            Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "discover_urls",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Error,
+                    count: 0,
+                    duration: start.elapsed(),
+                });
+                Ok(CallToolResult::error(vec![Content::text(format!(
+                    "HTTP error: {e}"
+                ))]))
+            },
         }
     }
 
@@ -289,6 +410,7 @@ impl McpHandler {
                 Some(serde_json::Value::String("url".to_string())),
             )
         })?;
+        let start = Instant::now();
         let crawler_config = webfang_core::domain::CrawlerConfig::new(seed);
 
         match webfang_core::application::crawler::crawl_with_sitemap(
@@ -299,12 +421,29 @@ impl McpHandler {
         .await
         {
             Ok(discovered) => {
+                let count = discovered.len();
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "discover_sitemap",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Success,
+                    count,
+                    duration: start.elapsed(),
+                });
                 let urls: Vec<String> = discovered.into_iter().map(|d| d.url.to_string()).collect();
                 let content = serde_json::to_string_pretty(&urls)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "discover_sitemap",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Error,
+                    count: 0,
+                    duration: start.elapsed(),
+                });
+                Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
+            },
         }
     }
 
@@ -319,9 +458,17 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, scraping);
 
+        let start = Instant::now();
         let port = self.state.container.http_client();
         match port.get(&params.url).await {
             Ok(resp) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "detect_spa",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Success,
+                    count: 1,
+                    duration: start.elapsed(),
+                });
                 let html = resp.body;
                 let text = webfang_core::infrastructure::scraper::fallback::extract_text(&html);
                 match webfang_core::application::scraper_service::detect_spa_content(
@@ -344,9 +491,18 @@ impl McpHandler {
                     )])),
                 }
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
-                "HTTP error: {e}"
-            ))])),
+            Err(e) => {
+                self.state.record_scrape(ScrapeEvent {
+                    tool: "detect_spa",
+                    domain: domain_of(&params.url),
+                    outcome: Outcome::Error,
+                    count: 0,
+                    duration: start.elapsed(),
+                });
+                Ok(CallToolResult::error(vec![Content::text(format!(
+                    "HTTP error: {e}"
+                ))]))
+            },
         }
     }
 }

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -4,6 +4,7 @@
 //! get_scrape_metrics
 
 use super::McpHandler;
+use crate::mcp_server::metrics::MetricsSnapshot;
 use crate::mcp_server::params::*;
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -101,13 +102,7 @@ impl McpHandler {
     async fn get_scrape_metrics(&self) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, security);
 
-        let metrics = serde_json::json!({
-            "message": "Metrics collection requires active scraping session",
-            "status": "available"
-        });
-        Ok(CallToolResult::success(vec![Content::text(
-            serde_json::to_string_pretty(&metrics).unwrap(),
-        )]))
+        Ok(render_metrics(&self.state.metrics_snapshot()))
     }
 }
 
@@ -153,6 +148,27 @@ fn verify_waf_verdict(
         ignore_waf: false,
     };
     WafInspector::inspect(html, &ctx)
+}
+
+/// Render a metrics snapshot as the `get_scrape_metrics` tool result.
+///
+/// Empty accumulator (`total_events == 0`, DD-12) → honest Spanish
+/// pre-condition error (`isError:true`, REQ-05). Populated → the snapshot as
+/// pretty JSON via `CallToolResult::success` (REQ-04). A serialization failure
+/// maps to an honest Spanish error, never a panic (REQ-10). Mirrors the
+/// `load_results_from` honest-error pattern in `export.rs`.
+fn render_metrics(snapshot: &MetricsSnapshot) -> CallToolResult {
+    if snapshot.total_events == 0 {
+        return CallToolResult::error(vec![Content::text(
+            "no hay métricas disponibles: todavía no se registró ninguna operación de scraping",
+        )]);
+    }
+    match serde_json::to_string_pretty(snapshot) {
+        Ok(json) => CallToolResult::success(vec![Content::text(json)]),
+        Err(e) => CallToolResult::error(vec![Content::text(format!(
+            "no se pudieron serializar las métricas: {e}"
+        ))]),
+    }
 }
 
 #[cfg(test)]
@@ -242,5 +258,91 @@ mod tests {
             Default::default(),
         );
         assert!(!verdict.is_blocked, "T2 + 200 must pass");
+    }
+
+    // ========================================================================
+    // get_scrape_metrics — render_metrics honest rendering (REQ-04/05/10)
+    // ========================================================================
+
+    /// REQ-05/REQ-10: an empty accumulator renders an honest Spanish
+    /// pre-condition error (isError:true) — NOT the legacy canned success JSON.
+    #[test]
+    fn render_metrics_empty_is_honest_spanish_error() {
+        use crate::mcp_server::metrics::ScrapeMetrics;
+
+        let snapshot = ScrapeMetrics::default().snapshot();
+        assert_eq!(snapshot.total_events, 0, "fresh accumulator is empty");
+        let result = render_metrics(&snapshot);
+
+        // Serialize exactly as the MCP transport would, then assert the honest
+        // error contract (mirrors export.rs load_results_from_none test).
+        let json = serde_json::to_value(&result).expect("CallToolResult must serialize");
+        assert_eq!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "empty metrics must set isError:true, got: {json}"
+        );
+        let text = json
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|first| first.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap_or_default();
+        assert!(
+            text.contains("no hay métricas disponibles"),
+            "honest Spanish empty-state error expected, got: {text}"
+        );
+        assert!(
+            !text.contains("Metrics collection requires active scraping session"),
+            "legacy canned text must be gone, got: {text}"
+        );
+    }
+
+    /// REQ-04: a populated snapshot renders as a JSON success (isError not
+    /// true) carrying the real counts and per-domain breakdown.
+    #[test]
+    fn render_metrics_populated_is_json_success() {
+        use crate::mcp_server::metrics::{Outcome, ScrapeEvent, ScrapeMetrics};
+        use std::time::Duration;
+
+        let mut metrics = ScrapeMetrics::default();
+        metrics.record(ScrapeEvent {
+            tool: "scrape_url",
+            domain: "example.com".to_string(),
+            outcome: Outcome::Success,
+            count: 4,
+            duration: Duration::from_millis(100),
+        });
+        let snapshot = metrics.snapshot();
+        let result = render_metrics(&snapshot);
+
+        let json = serde_json::to_value(&result).expect("CallToolResult must serialize");
+        assert_ne!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "populated metrics must not be an error, got: {json}"
+        );
+        let text = json
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|first| first.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap_or_default();
+        let parsed: serde_json::Value =
+            serde_json::from_str(text).expect("content text must be valid JSON");
+        assert_eq!(
+            parsed.get("total_events").and_then(|v| v.as_u64()),
+            Some(1),
+            "real total_events expected, got: {parsed}"
+        );
+        assert!(
+            parsed
+                .get("domains")
+                .and_then(|d| d.get("example.com"))
+                .is_some(),
+            "per-domain breakdown expected, got: {parsed}"
+        );
     }
 }

--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -1,0 +1,416 @@
+//! Scrape metrics — process-lifetime accumulator for MCP scraping activity.
+//!
+//! Pure types + logic only (DD-2): no DI, no locking, fully unit-testable.
+//! Locking/tracing wiring lives on `McpState` (see `state.rs`). One structured
+//! tracing event is emitted per recorded scrape (REQ-09) INSIDE
+//! [`ScrapeMetrics::record`] (DD-3), keeping the critical section synchronous.
+//!
+//! Serialization is snapshot-safe (REQ-08): domains/tools use [`BTreeMap`] for
+//! deterministic key order (DD-6) and timing collapses to a single flat
+//! `average_duration_ms` field (DD-5) that is trivially redactable.
+
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Outcome bucket for a scrape event (A1: success/error, NOT raw HTTP codes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The underlying scraping operation returned `Ok`.
+    Success,
+    /// The underlying scraping operation returned `Err`.
+    Error,
+}
+
+impl Outcome {
+    /// Whether this outcome is a success.
+    #[must_use]
+    pub fn is_success(self) -> bool {
+        matches!(self, Self::Success)
+    }
+}
+
+/// One recorded scrape event.
+#[derive(Debug, Clone)]
+pub struct ScrapeEvent {
+    /// Handler/tool name literal (e.g. `"scrape_url"`).
+    pub tool: &'static str,
+    /// Target host (`host_str()`) or `"unknown"` when unparseable (REQ-01).
+    pub domain: String,
+    /// Success/error bucket (A1).
+    pub outcome: Outcome,
+    /// Page/result count per the per-tool mapping.
+    pub count: usize,
+    /// Wall-clock duration of the operation.
+    pub duration: Duration,
+}
+
+/// Per-domain aggregate (REQ-02).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct DomainStats {
+    /// Number of scrape events recorded for this domain.
+    pub events: usize,
+    /// Total pages/results accumulated across this domain's events.
+    pub pages: usize,
+    /// Number of error-outcome events for this domain.
+    pub errors: usize,
+}
+
+/// Process-lifetime scrape accumulator (A3: no reset).
+///
+/// NOT `Serialize` — [`ScrapeMetrics::snapshot`] is the serializable view.
+#[derive(Debug, Clone, Default)]
+pub struct ScrapeMetrics {
+    total_events: usize,
+    success_count: usize,
+    error_count: usize,
+    /// Per-domain breakdown; `BTreeMap` for deterministic order (DD-6).
+    domains: BTreeMap<String, DomainStats>,
+    /// Per-tool event counts; `BTreeMap` for deterministic order (DD-6).
+    tools: BTreeMap<String, usize>,
+    duration_sum: Duration,
+}
+
+impl ScrapeMetrics {
+    /// Record a single scrape event.
+    ///
+    /// Short synchronous critical section: emits the structured tracing event
+    /// (REQ-09) then mutates the aggregates. No `.await` here, so the lock held
+    /// by the caller is never held across an await point (REQ-07).
+    pub fn record(&mut self, event: ScrapeEvent) {
+        tracing::info!(
+            tool = %event.tool,
+            domain = %event.domain,
+            success = event.outcome.is_success(),
+            duration_ms = event.duration.as_millis() as u64,
+            pages = event.count,
+            "scrape recorded"
+        );
+
+        self.total_events += 1;
+        match event.outcome {
+            Outcome::Success => self.success_count += 1,
+            Outcome::Error => self.error_count += 1,
+        }
+
+        let domain = self.domains.entry(event.domain.clone()).or_default();
+        domain.events += 1;
+        domain.pages += event.count;
+        if event.outcome == Outcome::Error {
+            domain.errors += 1;
+        }
+
+        *self.tools.entry(event.tool.to_string()).or_default() += 1;
+        self.duration_sum += event.duration;
+    }
+
+    /// Whether any events have been recorded (DD-12: empty ≡ `total_events == 0`).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.total_events == 0
+    }
+
+    /// Produce a serializable point-in-time view (REQ-08).
+    #[must_use]
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        let average_duration_ms = if self.total_events == 0 {
+            0.0
+        } else {
+            self.duration_sum.as_millis() as f64 / self.total_events as f64
+        };
+        MetricsSnapshot {
+            total_events: self.total_events,
+            success_count: self.success_count,
+            error_count: self.error_count,
+            domains: self.domains.clone(),
+            tools: self.tools.clone(),
+            average_duration_ms,
+        }
+    }
+}
+
+/// Serializable point-in-time view of the accumulator (REQ-08).
+///
+/// Timing collapses to one flat `average_duration_ms` field (DD-5) so snapshots
+/// stay deterministic and trivially redactable.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MetricsSnapshot {
+    /// Total recorded scrape events.
+    pub total_events: usize,
+    /// Number of success-outcome events.
+    pub success_count: usize,
+    /// Number of error-outcome events.
+    pub error_count: usize,
+    /// Per-domain breakdown (sorted keys).
+    pub domains: BTreeMap<String, DomainStats>,
+    /// Per-tool event counts (sorted keys).
+    pub tools: BTreeMap<String, usize>,
+    /// Mean wall-clock duration in milliseconds across all events.
+    pub average_duration_ms: f64,
+}
+
+/// Extract the target host from a URL, falling back to `"unknown"` (REQ-01).
+#[must_use]
+pub fn domain_of(url: &str) -> String {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    /// Build the canonical fixture: 2 success events on `a.com` (counts 3, 5)
+    /// and 1 error event on `b.com` (count 0), durations 100/200/300ms, all via
+    /// the `scrape_url` tool. Mean duration = (100+200+300)/3 = 200ms.
+    fn record_fixture(m: &mut ScrapeMetrics) {
+        m.record(ScrapeEvent {
+            tool: "scrape_url",
+            domain: "a.com".to_string(),
+            outcome: Outcome::Success,
+            count: 3,
+            duration: Duration::from_millis(100),
+        });
+        m.record(ScrapeEvent {
+            tool: "scrape_url",
+            domain: "a.com".to_string(),
+            outcome: Outcome::Success,
+            count: 5,
+            duration: Duration::from_millis(200),
+        });
+        m.record(ScrapeEvent {
+            tool: "scrape_url",
+            domain: "b.com".to_string(),
+            outcome: Outcome::Error,
+            count: 0,
+            duration: Duration::from_millis(300),
+        });
+    }
+
+    /// REQ-02: aggregates accumulate exactly (counts, per-domain, timing mean).
+    #[test]
+    fn aggregates_exact_numbers() {
+        let mut m = ScrapeMetrics::default();
+        record_fixture(&mut m);
+
+        let snap = m.snapshot();
+        assert_eq!(snap.total_events, 3, "total_events");
+        assert_eq!(snap.success_count, 2, "success_count");
+        assert_eq!(snap.error_count, 1, "error_count");
+        assert_eq!(
+            snap.domains.get("a.com"),
+            Some(&DomainStats {
+                events: 2,
+                pages: 8,
+                errors: 0
+            }),
+            "domain a.com aggregate"
+        );
+        assert_eq!(
+            snap.domains.get("b.com"),
+            Some(&DomainStats {
+                events: 1,
+                pages: 0,
+                errors: 1
+            }),
+            "domain b.com aggregate"
+        );
+        assert_eq!(snap.average_duration_ms, 200.0, "average_duration_ms");
+        assert!(!m.is_empty(), "non-empty after recording");
+    }
+
+    /// REQ-01: an unparseable domain is recorded as `"unknown"` and still counted.
+    #[test]
+    fn record_unknown_domain() {
+        assert_eq!(domain_of("not a url"), "unknown", "unparseable → unknown");
+        assert_eq!(
+            domain_of("https://example.com/path?q=1"),
+            "example.com",
+            "parseable → host_str"
+        );
+
+        let mut m = ScrapeMetrics::default();
+        m.record(ScrapeEvent {
+            tool: "scrape_url",
+            domain: domain_of("not a url"),
+            outcome: Outcome::Success,
+            count: 1,
+            duration: Duration::from_millis(50),
+        });
+
+        let snap = m.snapshot();
+        assert_eq!(snap.total_events, 1, "unknown-domain event still counted");
+        assert_eq!(
+            snap.domains.get("unknown"),
+            Some(&DomainStats {
+                events: 1,
+                pages: 1,
+                errors: 0
+            }),
+            "unknown bucket present"
+        );
+    }
+
+    /// REQ-08: fixed durations serialize to an exact, byte-stable pretty JSON
+    /// string (BTreeMap sorted keys, flat `average_duration_ms`).
+    #[test]
+    fn snapshot_serialization_exact() {
+        let mut m = ScrapeMetrics::default();
+        record_fixture(&mut m);
+        let snap = m.snapshot();
+
+        let expected = [
+            "{",
+            "  \"total_events\": 3,",
+            "  \"success_count\": 2,",
+            "  \"error_count\": 1,",
+            "  \"domains\": {",
+            "    \"a.com\": {",
+            "      \"events\": 2,",
+            "      \"pages\": 8,",
+            "      \"errors\": 0",
+            "    },",
+            "    \"b.com\": {",
+            "      \"events\": 1,",
+            "      \"pages\": 0,",
+            "      \"errors\": 1",
+            "    }",
+            "  },",
+            "  \"tools\": {",
+            "    \"scrape_url\": 3",
+            "  },",
+            "  \"average_duration_ms\": 200.0",
+            "}",
+        ]
+        .join("\n");
+
+        assert_eq!(
+            serde_json::to_string_pretty(&snap).expect("snapshot must serialize"),
+            expected,
+            "serialization must be byte-stable"
+        );
+    }
+
+    /// REQ-07: 100 concurrent records lose nothing (no lost updates/deadlock).
+    #[tokio::test]
+    async fn concurrent_records_lose_nothing() {
+        let metrics = Arc::new(Mutex::new(ScrapeMetrics::default()));
+        let mut handles = Vec::with_capacity(100);
+        for _ in 0..100 {
+            let m = Arc::clone(&metrics);
+            handles.push(tokio::spawn(async move {
+                m.lock().expect("metrics mutex").record(ScrapeEvent {
+                    tool: "scrape_url",
+                    domain: "a.com".to_string(),
+                    outcome: Outcome::Success,
+                    count: 1,
+                    duration: Duration::from_millis(1),
+                });
+            }));
+        }
+        for h in handles {
+            h.await.expect("task must not panic");
+        }
+
+        let snap = metrics.lock().expect("metrics mutex").snapshot();
+        assert_eq!(snap.total_events, 100, "no lost updates under concurrency");
+    }
+
+    /// REQ-09: each record emits ONE structured tracing event carrying
+    /// tool/domain/success/duration_ms/pages (English field names/values).
+    ///
+    /// Zero new deps: a manual capturing [`Layer`] is installed via a SCOPED
+    /// `with_default` subscriber (no global state → parallel-test safe).
+    #[test]
+    fn record_emits_structured_tracing_event() {
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::layer::Layer;
+        use tracing_subscriber::prelude::*;
+
+        /// Collects `(field_name, value)` pairs as strings.
+        struct Capture(Arc<Mutex<Vec<(String, String)>>>);
+
+        impl Visit for Capture {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                self.0
+                    .lock()
+                    .expect("capture mutex")
+                    .push((field.name().to_string(), format!("{value:?}")));
+            }
+            fn record_str(&mut self, field: &Field, value: &str) {
+                self.0
+                    .lock()
+                    .expect("capture mutex")
+                    .push((field.name().to_string(), value.to_string()));
+            }
+            fn record_bool(&mut self, field: &Field, value: bool) {
+                self.0
+                    .lock()
+                    .expect("capture mutex")
+                    .push((field.name().to_string(), value.to_string()));
+            }
+            fn record_u64(&mut self, field: &Field, value: u64) {
+                self.0
+                    .lock()
+                    .expect("capture mutex")
+                    .push((field.name().to_string(), value.to_string()));
+            }
+        }
+
+        struct CaptureLayer {
+            events: Arc<Mutex<Vec<(String, String)>>>,
+        }
+
+        impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let mut visitor = Capture(Arc::clone(&self.events));
+                event.record(&mut visitor);
+            }
+        }
+
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let layer = CaptureLayer {
+            events: Arc::clone(&events),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            ScrapeMetrics::default().record(ScrapeEvent {
+                tool: "scrape_url",
+                domain: "example.com".to_string(),
+                outcome: Outcome::Success,
+                count: 3,
+                duration: Duration::from_millis(120),
+            });
+        });
+
+        let captured = events.lock().expect("capture mutex");
+        let field = |name: &str| -> Option<String> {
+            captured
+                .iter()
+                .find(|(k, _)| k == name)
+                .map(|(_, v)| v.clone())
+        };
+        assert_eq!(field("tool").as_deref(), Some("scrape_url"), "tool field");
+        assert_eq!(
+            field("domain").as_deref(),
+            Some("example.com"),
+            "domain field"
+        );
+        assert_eq!(field("success").as_deref(), Some("true"), "success field");
+        assert_eq!(
+            field("duration_ms").as_deref(),
+            Some("120"),
+            "duration_ms field"
+        );
+        assert_eq!(field("pages").as_deref(), Some("3"), "pages field");
+    }
+}

--- a/crates/webfang_mcp/src/mcp_server/mod.rs
+++ b/crates/webfang_mcp/src/mcp_server/mod.rs
@@ -12,6 +12,7 @@
 #[macro_use]
 pub mod macros;
 pub mod handlers;
+pub mod metrics;
 pub mod params;
 pub mod selector_service;
 pub mod server;

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -5,8 +5,10 @@
 //! per tool category, protecting the 8GB RAM / HDD hardware.
 
 use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::sync::Semaphore;
 
+use crate::mcp_server::metrics::{MetricsSnapshot, ScrapeEvent, ScrapeMetrics};
 use webfang_core::adapters::downloader::Downloader;
 use webfang_core::di::Container;
 use webfang_core::domain::DomInspectorPort;
@@ -64,6 +66,9 @@ pub struct McpState {
     pub downloader: Option<Arc<Downloader>>,
     /// DOM inspector for CSS selector diagnostics (None = no diagnostics)
     pub inspector: Option<Arc<dyn DomInspectorPort>>,
+    /// Process-lifetime scrape metrics, shared across all per-session clones
+    /// (REQ-06). Locked only in short synchronous sections (REQ-07).
+    pub metrics: Arc<Mutex<ScrapeMetrics>>,
 }
 
 /// Semaphore instances for each tool category.
@@ -90,6 +95,7 @@ impl McpState {
             semaphores,
             downloader: None,
             inspector: None,
+            metrics: Arc::new(Mutex::new(ScrapeMetrics::default())),
         }
     }
 
@@ -103,6 +109,7 @@ impl McpState {
             semaphores,
             downloader: None,
             inspector: None,
+            metrics: Arc::new(Mutex::new(ScrapeMetrics::default())),
         }
     }
 
@@ -122,6 +129,31 @@ impl McpState {
     pub fn with_inspector(mut self, inspector: Arc<dyn DomInspectorPort>) -> Self {
         self.inspector = Some(inspector);
         self
+    }
+
+    /// Record a scrape event into the shared accumulator.
+    ///
+    /// REQ-07: short synchronous critical section — the lock is acquired and
+    /// dropped entirely within this call (the tracing event emitted inside
+    /// `record` is synchronous), so it is never held across an `.await`.
+    /// REQ-10: a poisoned mutex is recovered via `into_inner`, never a panic.
+    pub fn record_scrape(&self, event: ScrapeEvent) {
+        self.metrics
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .record(event);
+    }
+
+    /// Produce a point-in-time metrics snapshot from the shared accumulator.
+    ///
+    /// REQ-07: lock → clone snapshot → release. REQ-10: poison recovery, never
+    /// a panic.
+    #[must_use]
+    pub fn metrics_snapshot(&self) -> MetricsSnapshot {
+        self.metrics
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .snapshot()
     }
 }
 
@@ -210,5 +242,36 @@ mod tests {
             state.inspector.is_none(),
             "inspector must default to None in with_limits"
         );
+    }
+
+    /// REQ-06: the metrics accumulator is shared across per-session clones
+    /// (`server.rs` clones `McpState` per session). Mirrors the `Arc::ptr_eq`
+    /// pattern from `server.rs::test_mcp_state_with_downloader`.
+    #[tokio::test]
+    async fn metrics_shared_across_clones() {
+        use crate::mcp_server::metrics::Outcome;
+        use std::time::Duration;
+
+        let (_tmp, container) = test_container().await;
+        let state = McpState::new(container);
+        let state2 = state.clone();
+
+        assert!(
+            Arc::ptr_eq(&state.metrics, &state2.metrics),
+            "cloned McpState must share the same metrics Arc"
+        );
+
+        // A scrape recorded through one clone is visible from the other.
+        state.record_scrape(ScrapeEvent {
+            tool: "scrape_url",
+            domain: "a.com".to_string(),
+            outcome: Outcome::Success,
+            count: 2,
+            duration: Duration::from_millis(10),
+        });
+
+        let snap = state2.metrics_snapshot();
+        assert_eq!(snap.total_events, 1, "record-through-clone is visible");
+        assert_eq!(snap.success_count, 1, "success bucket recorded");
     }
 }

--- a/tests/mcp_behavioral_test.rs
+++ b/tests/mcp_behavioral_test.rs
@@ -990,3 +990,153 @@ async fn test_export_uncreatable_output_dir_honest_error() {
         "no file may be written to an uncreatable output_dir"
     );
 }
+
+// ============================================================================
+// 5. Scrape metrics — real accumulated metrics (issue #382, mcp-real-metrics)
+// ============================================================================
+
+/// Minimal article HTML that Readability extracts deterministically (mirrors
+/// `tests/scraper_service_test.rs`), so `scrape_url` records a success event.
+const METRICS_ARTICLE_HTML: &str = r#"<!DOCTYPE html>
+<html>
+<head><title>Test Page</title></head>
+<body>
+<article>
+<h1>Main Heading</h1>
+<p>This is the content of the article. It has enough text to be extracted by Readability.</p>
+</article>
+</body>
+</html>"#;
+
+/// REQ-04/06/08: a scrape recorded through ONE session is visible via
+/// `get_scrape_metrics` from a DIFFERENT session (shared `Arc` accumulator),
+/// returning real JSON — `total_events`, the scraped domain, and a timing field.
+#[tokio::test]
+async fn test_scrape_then_metrics_reflects_it_cross_session() {
+    // Arrange: wiremock answers GET / with article HTML Readability can extract.
+    let mock = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(METRICS_ARTICLE_HTML))
+        .mount(&mock)
+        .await;
+
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+
+    // Session A performs the scrape (records one event after instrumentation).
+    let session_a = init_session(&client, &base_url).await;
+    let scrape_resp = call_tool(
+        &client,
+        &base_url,
+        &session_a,
+        "scrape_url",
+        json!({ "url": mock.uri() }),
+    )
+    .await;
+    let scrape_result = scrape_resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected scrape result, got: {scrape_resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&scrape_result),
+        "scrape_url should succeed against wiremock: {}",
+        tool_text(&scrape_result)
+    );
+
+    // Session B (DIFFERENT) reads the metrics — the accumulator is shared (REQ-06).
+    let session_b = init_session(&client, &base_url).await;
+    assert_ne!(session_a, session_b, "sessions must be distinct");
+    let metrics_resp = call_tool(
+        &client,
+        &base_url,
+        &session_b,
+        "get_scrape_metrics",
+        json!({}),
+    )
+    .await;
+    let metrics_result = metrics_resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected metrics result, got: {metrics_resp}"))
+        .clone();
+
+    // REQ-04: populated read is a success (isError not true) with real JSON.
+    assert!(
+        !is_tool_error(&metrics_result),
+        "get_scrape_metrics must succeed after a scrape: {}",
+        tool_text(&metrics_result)
+    );
+    let text = tool_text(&metrics_result);
+    let parsed: Value = serde_json::from_str(&text).expect("metrics must be valid JSON");
+
+    let total = parsed
+        .get("total_events")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    assert!(
+        total >= 1,
+        "total_events must reflect the scrape, got: {text}"
+    );
+
+    // host_str() strips the wiremock port → stable "127.0.0.1" domain key.
+    let domains = parsed
+        .get("domains")
+        .and_then(|v| v.as_object())
+        .expect("domains object present");
+    assert!(
+        domains.contains_key("127.0.0.1"),
+        "domains must contain the scraped host 127.0.0.1, got: {text}"
+    );
+    assert!(
+        parsed.get("average_duration_ms").is_some(),
+        "average_duration_ms must be present, got: {text}"
+    );
+
+    // REQ-08: the redacted snapshot is byte-stable across runs.
+    insta::with_settings!({
+        filters => vec![
+            (r#""average_duration_ms":\s*[\d.]+"#, "[DURATION]"),
+            (r"127\.0\.0\.1:\d+", "127.0.0.1:[PORT]"),
+        ],
+    }, {
+        insta::assert_snapshot!("scrape_metrics_cross_session", &text);
+    });
+}
+
+/// REQ-05: a fresh server with NO recorded scrapes returns an honest Spanish
+/// pre-condition error (isError:true) — never the legacy canned success JSON.
+#[tokio::test]
+async fn test_metrics_empty_state_honest_error() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    // Read metrics FIRST, before any scrape, on a fresh server.
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "get_scrape_metrics",
+        json!({}),
+    )
+    .await;
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+
+    assert!(
+        is_tool_error(&result),
+        "empty metrics must return isError:true, got: {}",
+        tool_text(&result)
+    );
+    let text = tool_text(&result);
+    assert!(
+        text.contains("no hay métricas disponibles"),
+        "honest Spanish empty-state error expected, got: {text}"
+    );
+    assert!(
+        !text.contains("Metrics collection requires active scraping session"),
+        "legacy canned text must NOT appear, got: {text}"
+    );
+}

--- a/tests/snapshots/mcp_behavioral_test__scrape_metrics_cross_session.snap
+++ b/tests/snapshots/mcp_behavioral_test__scrape_metrics_cross_session.snap
@@ -1,0 +1,20 @@
+---
+source: crates/webfang_mcp/../../tests/mcp_behavioral_test.rs
+expression: "&text"
+---
+{
+  "total_events": 1,
+  "success_count": 1,
+  "error_count": 0,
+  "domains": {
+    "127.0.0.1": {
+      "events": 1,
+      "pages": 1,
+      "errors": 0
+    }
+  },
+  "tools": {
+    "scrape_url": 1
+  },
+  [DURATION]
+}


### PR DESCRIPTION
## Linked Issue

Closes #382

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Replace the canned `get_scrape_metrics` MCP tool — which always returned a fake success JSON via `.unwrap()` regardless of activity — with a truthful process-lifetime `ScrapeMetrics` accumulator.
- Instrument all 8 scraping handlers (one event on both the success and operation-failure arms) recording tool, domain, outcome (success/error buckets), page count, and timing; rewire the tool to return real JSON when populated, or an honest Spanish pre-condition error (`isError:true`) when empty.
- Slice 3 of 3 of #343 (follow-up; slice 1 export merged in #383, slice 2 AI is #381). Entirely within `webfang_mcp`: zero `webfang_core` changes, zero new dependencies. Observability via a structured `tracing` event per scrape (no new metrics backend).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_mcp/src/mcp_server/metrics.rs` | New: `ScrapeMetrics` accumulator (`Outcome`/`ScrapeEvent`/`DomainStats`/`MetricsSnapshot`, `domain_of`), `tracing::info!` per record, deterministic `BTreeMap` serialization, unit tests |
| `crates/webfang_mcp/src/mcp_server/state.rs` | `pub metrics: Arc<Mutex<ScrapeMetrics>>` field on `McpState` (init in both `new()` and `with_limits()`) + `record_scrape`/`metrics_snapshot` with Mutex poison recovery |
| `crates/webfang_mcp/src/mcp_server/handlers/security.rs` | Rewire `get_scrape_metrics` to a free `render_metrics` fn; honest Spanish pre-condition error when empty; remove canned JSON + `.unwrap()` |
| `crates/webfang_mcp/src/mcp_server/handlers/scraping.rs` | Instrument 8 handlers (`Instant` timing after pre-validation + record on success/error arms); return payloads unchanged (additive side-effect) |
| `crates/webfang_mcp/src/mcp_server/mod.rs` | Register `metrics` module |
| `tests/mcp_behavioral_test.rs` | Cross-session scrape→metrics behavioral test + empty-state honest-error guard (redacted `average_duration_ms` snapshot) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p webfang_mcp --features mcp --all-targets -- -D warnings` clean (0 warnings)
- [x] `cargo nextest run -p webfang_mcp --features mcp` passes (100/100 — 82 unit + 18 behavioral)
- [x] Manually verified via SDD verify phase: 11/11 requirements PASS, 0 CRITICAL / 0 WARNING

> ⚠️ Reviewer note: tests are `#![cfg(feature = "mcp")]` with no default feature. Running plain `cargo nextest -p webfang_mcp` reports only 82 unit tests and silently skips the 18 behavioral tests — use `--features mcp` for the real suite.
>
> 📏 Size note: ~944 changed lines, but production logic is ≈300 (the rest is design-mandated tests ≈373 and convention doc comments). Maintainer accepted the size for this slice.

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (N/A — public tool description unchanged)
