### PR TITLE
fix(infra): propagate user-requested init errors instead of silent degradation

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -383,9 +383,7 @@ async fn __main() -> CliExit {
             match opts.ai_config.model.parse::<webfang_ai::AiModel>() {
                 Ok(variant) => variant,
                 Err(e) => {
-                    return CliExit::UsageError(format!(
-                        "Modelo AI inválido para --ai-model: {e}"
-                    ));
+                    return CliExit::UsageError(format!("Modelo AI inválido para --ai-model: {e}"));
                 },
             }
         };

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -383,8 +383,9 @@ async fn __main() -> CliExit {
             match opts.ai_config.model.parse::<webfang_ai::AiModel>() {
                 Ok(variant) => variant,
                 Err(e) => {
-                    tracing::warn!("Parsing error para --ai-model: {}", e);
-                    webfang_ai::AiModel::from_env_or_default()
+                    return CliExit::UsageError(format!(
+                        "Modelo AI inválido para --ai-model: {e}"
+                    ));
                 },
             }
         };

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -271,10 +271,19 @@ impl Engine {
     }
 
     /// Enable checkpoint persistence with the given interval and base directory.
+    ///
+    /// If the checkpoint directory cannot be created, checkpointing is disabled
+    /// and an error is logged — the engine will NOT silently pretend to
+    /// checkpoint while every save fails.
     pub fn with_checkpoint(mut self, interval: u64, base_dir: PathBuf) -> Self {
         let cp_path = CheckpointPath::new(&base_dir);
         if let Err(e) = cp_path.ensure_dir() {
-            warn!("Failed to create checkpoint dir: {e}");
+            tracing::error!(
+                error = %e,
+                path = %base_dir.display(),
+                "checkpoint dir creation failed — disabling checkpoint"
+            );
+            return self;
         }
 
         match self.checkpoint_store.load(&cp_path.file()) {
@@ -417,9 +426,20 @@ impl Engine {
             // Save on blocking thread to avoid blocking the event loop
             let store = BincodeCheckpoint::new();
             let path = path.clone();
-            let _ = tokio::task::spawn_blocking(move || store.save(&state, &path))
+            match tokio::task::spawn_blocking(move || store.save(&state, &path))
                 .in_current_span()
-                .await;
+                .await
+            {
+                Ok(Ok(())) => {
+                    tracing::debug!("checkpoint saved successfully");
+                },
+                Ok(Err(e)) => {
+                    tracing::error!(error = %e, "checkpoint save failed");
+                },
+                Err(join_err) => {
+                    tracing::error!(error = %join_err, "checkpoint save task panicked");
+                },
+            }
         }
     }
 

--- a/crates/webfang_core/src/cli/commands.rs
+++ b/crates/webfang_core/src/cli/commands.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 use crate::application::crawl_options::CrawlOptions;
 use crate::cli::error::CliExit;
-use crate::infrastructure::obsidian::detect_vault;
+use crate::infrastructure::obsidian::{detect_vault, is_valid_vault};
 
 /// Common preflight checks for all commands
 #[allow(dead_code)] // pub(crate) Phase 0 triage — internal API surface
@@ -39,6 +39,16 @@ pub async fn preflight(opts: &CrawlOptions) -> Result<PreflightContext, CliExit>
 
     // Vault detection
     let config_defaults = crate::cli::config::ConfigDefaults::load(&config_path);
+
+    // Explicit --vault must be valid; cascade only applies when no flag is set
+    if let Some(ref explicit_vault) = opts.export.obsidian_vault {
+        if !is_valid_vault(explicit_vault) {
+            return Err(CliExit::UsageError(format!(
+                "La ruta de vault indicada con --vault no es válida (debe ser un directorio con .obsidian/): {}",
+                explicit_vault.display()
+            )));
+        }
+    }
 
     let vault_path = detect_vault(
         opts.export.obsidian_vault.as_deref(),

--- a/crates/webfang_core/src/cli/config.rs
+++ b/crates/webfang_core/src/cli/config.rs
@@ -4,8 +4,6 @@
 
 use std::path::Path;
 
-use tracing::warn;
-
 /// Default configuration values that can be overridden by a TOML file.
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(default)]
@@ -41,13 +39,15 @@ pub struct ConfigDefaults {
 impl ConfigDefaults {
     /// Load configuration from a TOML file, falling back to defaults.
     ///
-    /// Returns defaults if the file doesn't exist or can't be parsed.
+    /// Returns defaults if the file doesn't exist (normal — no config yet).
+    /// A malformed existing file logs `error!` and falls back to defaults —
+    /// the user's entire configuration is silently lost, so this must be loud.
     pub fn load(path: &Path) -> Self {
         let Ok(content) = std::fs::read_to_string(path) else {
             return Self::default();
         };
         toml::from_str(&content).unwrap_or_else(|e| {
-            warn!(path = %path.display(), error = %e, "Failed to parse config, using defaults");
+            tracing::error!(path = %path.display(), error = %e, "Malformed config file — all settings ignored, using defaults");
             Self::default()
         })
     }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -96,7 +96,10 @@ pub async fn run(
     };
 
     let (urls_to_scrape, state_store) =
-        apply_resume_mode(prepare.urls_to_scrape, &opts, opts.url.as_str()).await;
+        match apply_resume_mode(prepare.urls_to_scrape, &opts, opts.url.as_str()).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
 
     let elastic_ingestion = match build_elastic_ingestion(&opts).await {
         Ok(v) => v,

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -7,6 +7,7 @@ use url::Url;
 use crate::application::crawl_options::CrawlOptions;
 use crate::application::crawler::build_fetch_router;
 use crate::application::export_factory;
+use crate::cli::error::CliExit;
 use crate::application::progress_observer::ProgressObserver;
 use crate::application::scrape_single_url_for_tui;
 use crate::domain::entities::progress::{ScrapeError, ScrapeStatus};
@@ -25,11 +26,17 @@ use crate::application::adaptive_engine::AdaptiveSelectorEngine;
 type AdaptiveSelectorEngine = ();
 
 /// Apply resume mode filtering.
+///
+/// # Errors
+///
+/// Returns `CliExit::IoError` when `--resume` is active and the state store
+/// cannot be created. Without a working store the crawl would silently
+/// re-scrape every URL, defeating the purpose of resume mode.
 pub async fn apply_resume_mode(
     urls_to_scrape: Vec<Url>,
     opts: &CrawlOptions,
     target_url: &str,
-) -> (Vec<Url>, Option<StateStore>) {
+) -> Result<(Vec<Url>, Option<StateStore>), CliExit> {
     let state_store: Option<StateStore> = if opts.crawl.resume {
         info!("Resume mode enabled - tracking processed URLs");
         let state_dir = opts.crawl.state_dir.clone().unwrap_or_else(|| {
@@ -48,8 +55,10 @@ pub async fn apply_resume_mode(
         match export_factory::create_state_store(state_dir, &domain) {
             Ok(store) => Some(store),
             Err(e) => {
-                warn!("Failed to create state store: {}", e);
-                None
+                tracing::error!(error = %e, "state store creation failed with --resume active");
+                return Err(CliExit::IoError(format!(
+                    "No se pudo crear el almacén de estado para --resume: {e}"
+                )));
             },
         }
     } else {
@@ -93,7 +102,7 @@ pub async fn apply_resume_mode(
         urls_to_scrape
     };
 
-    (filtered, state_store)
+    Ok((filtered, state_store))
 }
 
 /// Scrape all URLs, reporting progress via the provided observer.
@@ -326,7 +335,9 @@ mod tests {
         };
 
         let (filtered, state_store) =
-            apply_resume_mode(urls.clone(), &opts, "https://example.com").await;
+            apply_resume_mode(urls.clone(), &opts, "https://example.com")
+                .await
+                .expect("resume disabled should not fail");
 
         assert_eq!(filtered.len(), 2);
         assert!(state_store.is_none());
@@ -359,7 +370,9 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com").await;
+        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com")
+            .await
+            .expect("valid state dir should not fail");
 
         // URL "a" was already processed, should be skipped
         assert_eq!(filtered.len(), 2, "should skip 1 already-processed URL");
@@ -399,7 +412,9 @@ mod tests {
         };
 
         let (filtered, state_store) =
-            apply_resume_mode(urls.clone(), &opts, "https://example.com").await;
+            apply_resume_mode(urls.clone(), &opts, "https://example.com")
+                .await
+                .expect("corrupted state file should not prevent store creation");
 
         // Corrupted state → fallback to all URLs (graceful degradation)
         assert_eq!(
@@ -426,7 +441,9 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com").await;
+        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com")
+            .await
+            .expect("custom state dir should not fail");
 
         assert_eq!(filtered.len(), 1);
         assert!(

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -7,9 +7,9 @@ use url::Url;
 use crate::application::crawl_options::CrawlOptions;
 use crate::application::crawler::build_fetch_router;
 use crate::application::export_factory;
-use crate::cli::error::CliExit;
 use crate::application::progress_observer::ProgressObserver;
 use crate::application::scrape_single_url_for_tui;
+use crate::cli::error::CliExit;
 use crate::domain::entities::progress::{ScrapeError, ScrapeStatus};
 use crate::domain::ScrapedContent;
 use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
@@ -334,10 +334,9 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) =
-            apply_resume_mode(urls.clone(), &opts, "https://example.com")
-                .await
-                .expect("resume disabled should not fail");
+        let (filtered, state_store) = apply_resume_mode(urls.clone(), &opts, "https://example.com")
+            .await
+            .expect("resume disabled should not fail");
 
         assert_eq!(filtered.len(), 2);
         assert!(state_store.is_none());
@@ -411,10 +410,9 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) =
-            apply_resume_mode(urls.clone(), &opts, "https://example.com")
-                .await
-                .expect("corrupted state file should not prevent store creation");
+        let (filtered, state_store) = apply_resume_mode(urls.clone(), &opts, "https://example.com")
+            .await
+            .expect("corrupted state file should not prevent store creation");
 
         // Corrupted state → fallback to all URLs (graceful degradation)
         assert_eq!(

--- a/crates/webfang_core/src/infrastructure/export/vector_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/vector_exporter.rs
@@ -179,11 +179,12 @@ impl VectorExporter {
             let mut dim_guard = self.dimensions.lock().expect("lock poisoned");
             if let Some(exp) = *dim_guard {
                 if embeddings.len() != exp {
-                    // Log warning and serialize without embeddings
-                    tracing::warn!(
+                    // Dimension mismatch: the document is degraded (no embeddings in output).
+                    // error! because --output-vectors implies embeddings are the point.
+                    tracing::error!(
                         expected_dimensions = exp,
                         actual_dimensions = embeddings.len(),
-                        "Dimension mismatch detected — serializing without embeddings"
+                        "Dimension mismatch — document serialized WITHOUT embeddings"
                     );
                     // Create a copy without embeddings
                     let mut doc_without_embeddings = doc.clone();

--- a/crates/webfang_core/src/infrastructure/obsidian/mod.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/mod.rs
@@ -14,4 +14,4 @@ pub use metadata::{
     ObsidianRichMetadata,
 };
 pub use uri::{build_obsidian_uri, extract_vault_name, open_in_obsidian, open_note};
-pub use vault_detector::detect_vault;
+pub use vault_detector::{detect_vault, is_valid_vault};

--- a/crates/webfang_core/src/infrastructure/obsidian/vault_detector.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/vault_detector.rs
@@ -76,7 +76,9 @@ pub fn detect_vault(
 }
 
 /// Check if a path is a valid Obsidian vault (contains `.obsidian/` directory).
-fn is_valid_vault(path: &Path) -> bool {
+/// Check whether a path is a valid Obsidian vault (directory with `.obsidian/` marker).
+#[must_use]
+pub fn is_valid_vault(path: &Path) -> bool {
     path.is_dir() && path.join(".obsidian").is_dir()
 }
 


### PR DESCRIPTION
Closes #361

## Summary

Fixes 6 instances where fallible initialization operations silently swallowed errors when the user **explicitly requested** the feature via CLI flag. The pattern: `match ... { Err(e) => { warn!(...); None/default } }` — the feature degrades without the user knowing.

## Changes by priority

### P0 — Data integrity (Alta)
- **`scrape_flow.rs`**: `--resume` + `create_state_store` failure → `CliExit::IoError` instead of warn+None. Prevents silent full re-scrape of the entire site.
- **`engine.rs`**: checkpoint `ensure_dir` failure → `error!` + disable checkpoint honestly (early return). `store.save()` Result inspected instead of `let _ =` — failures now logged with `error!`.

### P1 — Misleading output (Media)
- **`main.rs`**: invalid `--ai-model` → `CliExit::UsageError` instead of warn+fallback to env/default. User never silently runs a different model.
- **`vault_detector.rs` + `commands.rs`**: invalid explicit `--vault` → `CliExit::UsageError` instead of cascading to auto-detection. Prevents writing notes to a different vault. `is_valid_vault` made public; validation in caller (no `detect_vault` signature change — 33 dependents untouched).

### P2 — Loud degradation (Baja/borderline)
- **`config.rs`**: malformed config file → `error!` instead of `warn!` (fallback to defaults preserved; missing file stays silent).
- **`vector_exporter.rs`**: embedding dimension mismatch → `error!` instead of `warn!` (document still serialized without embeddings, but degradation is loud).

## Design decision

No generic `requested_or_fail` helper — each instance has a different flag pattern (bool, Option<String>, Option<PathBuf>). The convention is: **if the user asked for it explicitly, fail hard; if it's best-effort/optional, degrade with `error!`**.

## Verification

- `cargo check` + `cargo clippy -- -D warnings` + `cargo fmt`: clean
- `cargo nextest run`: **2020 passed, 0 failed**, 15 skipped (pre-existing)
- Instance A (AI threshold, `main.rs:400-414`) already fixed by PR #355 — confirmed no overlap
- Instance B (`container.rs` repo None) verified as acceptable: MCP consumer errors honestly

## Not addressed (follow-up)

- Adding a marker field in vector export output for degraded documents (requires struct change + consumer updates)
- Tests for failure paths (current tests cover happy paths; failure injection needs mock infrastructure)