### PR TITLE
feat(testing): add webfang_test_utils crate with EnvGuard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6204,6 +6204,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "webfang_test_utils"
+version = "2.0.0"
+dependencies = [
+ "regex",
+ "tempfile",
+]
+
+[[package]]
 name = "webfang_tui"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/webfang_tui",
     "crates/webfang_mcp",
     "crates/webfang_cli",
+    "crates/webfang_test_utils",
 ]
 exclude = ["fuzz"]
 
@@ -25,6 +26,7 @@ webfang_ai = { path = "crates/webfang_ai" }
 webfang_tui = { path = "crates/webfang_tui" }
 webfang_mcp = { path = "crates/webfang_mcp" }
 webfang_cli = { path = "crates/webfang_cli" }
+webfang_test_utils = { path = "crates/webfang_test_utils" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/webfang_test_utils/Cargo.toml
+++ b/crates/webfang_test_utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "webfang_test_utils"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+tempfile = { workspace = true }
+regex = { workspace = true }

--- a/crates/webfang_test_utils/src/lib.rs
+++ b/crates/webfang_test_utils/src/lib.rs
@@ -1,0 +1,262 @@
+//! Shared test utilities for the webfang workspace.
+//!
+//! Provides RAII environment isolation, output redaction for deterministic
+//! snapshots, and binary path resolution for integration tests.
+
+use regex::Regex;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII guard that isolates environment variable mutations in tests.
+///
+/// Acquires a global lock on construction and restores all modified variables
+/// to their original state on drop. This guarantees serial access to the
+/// process environment across concurrent test threads.
+pub struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    original_vars: Vec<(String, Option<String>)>,
+}
+
+impl EnvGuard {
+    /// Remove the given variables from the environment, saving originals for
+    /// restoration on drop.
+    #[must_use]
+    pub fn clean(vars: &[&str]) -> Self {
+        let lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut original_vars = Vec::with_capacity(vars.len());
+        for &var in vars {
+            let original = env::var(var).ok();
+            original_vars.push((var.to_owned(), original));
+            // SAFETY: Exclusividad garantizada por ENV_LOCK. Ningún otro hilo
+            // puede acceder al entorno mientras este guard vive.
+            unsafe {
+                env::remove_var(var);
+            }
+        }
+        Self {
+            _lock: lock,
+            original_vars,
+        }
+    }
+
+    /// Set the given variables in the environment, saving originals for
+    /// restoration on drop.
+    #[must_use]
+    pub fn with(vars: &[(&str, &str)]) -> Self {
+        let lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut original_vars = Vec::with_capacity(vars.len());
+        for &(var, val) in vars {
+            let original = env::var(var).ok();
+            original_vars.push((var.to_owned(), original));
+            // SAFETY: Exclusividad garantizada por ENV_LOCK. Ningún otro hilo
+            // puede acceder al entorno mientras este guard vive.
+            unsafe {
+                env::set_var(var, val);
+            }
+        }
+        Self {
+            _lock: lock,
+            original_vars,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (var, original) in &self.original_vars {
+            // SAFETY: Exclusividad garantizada por ENV_LOCK. Ningún otro hilo
+            // puede acceder al entorno mientras este guard vive.
+            unsafe {
+                match original {
+                    Some(val) => env::set_var(var, val),
+                    None => env::remove_var(var),
+                }
+            }
+        }
+    }
+}
+
+/// Redact the per-run temp-dir path so snapshots stay stable across machines.
+#[must_use]
+pub fn redact_temp_path(dir: &Path, text: &str) -> String {
+    text.replace(dir.to_string_lossy().as_ref(), "<OUT_DIR>")
+}
+
+/// Redact common non-deterministic output so snapshots are stable run-to-run:
+/// the temp dir, ISO-8601 log timestamps, dynamic wiremock ports, ANSI color
+/// escape sequences, environment-specific error suffixes, and source line
+/// numbers in tracing spans.
+#[must_use]
+pub fn redact_nondeterministic(dir: &Path, text: &str) -> String {
+    let text = redact_temp_path(dir, text);
+    let ansi = Regex::new(r"\x1b\[[0-9;]*m").expect("valid ANSI regex");
+    let text = ansi.replace_all(&text, "").into_owned();
+    let env_suffix = Regex::new(r" \(CI mode\)| \(interactive prompt requires --features ui\)")
+        .expect("valid env suffix regex");
+    let text = env_suffix.replace_all(&text, "").into_owned();
+    let ts = Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:?\d{2}|Z)")
+        .expect("valid timestamp regex");
+    let text = ts.replace_all(&text, "<TIMESTAMP>").into_owned();
+    let port = Regex::new(r"127\.0\.0\.1:\d+").expect("valid port regex");
+    let text = port.replace_all(&text, "127.0.0.1:<PORT>").into_owned();
+    let line_no = Regex::new(r"(\.rs:)\d+").expect("valid line number regex");
+    line_no.replace_all(&text, "$1<LINE>").into_owned()
+}
+
+/// Resolve the path to the `webfang` binary, building it on demand.
+///
+/// `webfang` is built by the `webfang_cli` crate (a workspace sibling),
+/// so `CARGO_BIN_EXE_webfang` is only set for the crate that owns the binary.
+/// This function falls back to building it via `cargo build`.
+#[must_use]
+pub fn webfang_path() -> PathBuf {
+    if let Ok(p) = env::var("CARGO_BIN_EXE_webfang") {
+        return PathBuf::from(p);
+    }
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/webfang_test_utils -> crates -> workspace root (three levels up)
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .expect("resolve workspace root");
+    let cargo = option_env!("CARGO").unwrap_or("cargo");
+    let mut built = workspace_root.join("target").join("debug").join("webfang");
+    if cfg!(windows) {
+        built.set_extension("exe");
+    }
+    let status = std::process::Command::new(cargo)
+        .args(["build", "-p", "webfang_cli", "--bin", "webfang", "--quiet"])
+        .current_dir(workspace_root)
+        .status()
+        .expect("spawn cargo to build webfang");
+    assert!(status.success(), "cargo build --bin webfang failed");
+    built
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn env_guard_with_sets_and_restores() {
+        const VAR: &str = "WEBFANG_TEST_VAR_1";
+        env::remove_var(VAR);
+
+        {
+            let _guard = EnvGuard::with(&[(VAR, "hello")]);
+            assert_eq!(env::var(VAR).unwrap(), "hello");
+        }
+
+        assert!(env::var(VAR).is_err());
+    }
+
+    #[test]
+    fn env_guard_with_restores_preexisting_value() {
+        const VAR: &str = "WEBFANG_TEST_VAR_2";
+        // SAFETY: test-only, serial access not needed for setup before guard
+        unsafe {
+            env::set_var(VAR, "original");
+        }
+
+        {
+            let _guard = EnvGuard::with(&[(VAR, "modified")]);
+            assert_eq!(env::var(VAR).unwrap(), "modified");
+        }
+
+        assert_eq!(env::var(VAR).unwrap(), "original");
+        // SAFETY: cleanup
+        unsafe {
+            env::remove_var(VAR);
+        }
+    }
+
+    #[test]
+    fn env_guard_clean_removes_and_restores() {
+        const VAR: &str = "WEBFANG_TEST_VAR_3";
+        // SAFETY: test-only setup
+        unsafe {
+            env::set_var(VAR, "present");
+        }
+
+        {
+            let _guard = EnvGuard::clean(&[VAR]);
+            assert!(env::var(VAR).is_err());
+        }
+
+        assert_eq!(env::var(VAR).unwrap(), "present");
+        // SAFETY: cleanup
+        unsafe {
+            env::remove_var(VAR);
+        }
+    }
+
+    #[test]
+    fn sequential_guards_do_not_interfere() {
+        const VAR_A: &str = "WEBFANG_TEST_VAR_4";
+        const VAR_B: &str = "WEBFANG_TEST_VAR_5";
+        env::remove_var(VAR_A);
+        env::remove_var(VAR_B);
+
+        {
+            let _guard = EnvGuard::with(&[(VAR_A, "a")]);
+            assert_eq!(env::var(VAR_A).unwrap(), "a");
+        }
+        assert!(env::var(VAR_A).is_err());
+
+        {
+            let _guard = EnvGuard::with(&[(VAR_B, "b")]);
+            assert_eq!(env::var(VAR_B).unwrap(), "b");
+            assert!(env::var(VAR_A).is_err());
+        }
+        assert!(env::var(VAR_B).is_err());
+    }
+
+    #[test]
+    fn redact_nondeterministic_normalizes_timestamps() {
+        let dir = Path::new("/tmp/test");
+        let input = "at 2024-03-15T10:30:00.123+01:00 done";
+        let result = redact_nondeterministic(dir, input);
+        assert_eq!(result, "at <TIMESTAMP> done");
+    }
+
+    #[test]
+    fn redact_nondeterministic_normalizes_ports() {
+        let dir = Path::new("/tmp/test");
+        let input = "server at 127.0.0.1:8080 started";
+        let result = redact_nondeterministic(dir, input);
+        assert_eq!(result, "server at 127.0.0.1:<PORT> started");
+    }
+
+    #[test]
+    fn redact_nondeterministic_strips_ansi() {
+        let dir = Path::new("/tmp/test");
+        let input = "\x1b[31merror\x1b[0m: something failed";
+        let result = redact_nondeterministic(dir, input);
+        assert_eq!(result, "error: something failed");
+    }
+
+    #[test]
+    fn redact_nondeterministic_replaces_temp_path() {
+        let dir = Path::new("/tmp/.tmpABC123");
+        let input = "wrote /tmp/.tmpABC123/output.md";
+        let result = redact_nondeterministic(dir, input);
+        assert_eq!(result, "wrote <OUT_DIR>/output.md");
+    }
+
+    #[test]
+    fn redact_nondeterministic_normalizes_line_numbers() {
+        let dir = Path::new("/tmp/test");
+        let input = "at scrape_flow.rs:193 in module";
+        let result = redact_nondeterministic(dir, input);
+        assert_eq!(result, "at scrape_flow.rs:<LINE> in module");
+    }
+}


### PR DESCRIPTION
Closes #396

## Summary
- New `crates/webfang_test_utils/` crate with reusable test infrastructure
- `EnvGuard`: RAII environment variable isolation (Mutex-based exclusivity, unsafe SAFETY comments)
- `redact_nondeterministic` / `redact_temp_path`: centralized snapshot sanitization helpers
- `webfang_path`: binary resolver adapted for the test-utils crate location
- 9 unit tests covering guard lifecycle, sequential isolation, and redaction patterns

## Verification
- `cargo check -p webfang_test_utils` ✅
- `cargo clippy -p webfang_test_utils -- -D warnings` ✅
- `cargo nextest run -p webfang_test_utils` ✅ (9/9)

## Scope
- Only touches root `Cargo.toml` (workspace members + deps) and the new crate
- Does NOT modify `tests/`, `[workspace.lints]`, or `.github/` (separate issues)