### PR TITLE
feat(ci): add Production Bug Discovery workflow (issue #401)

### DIFF
--- a/.github/workflows/bug-discovery.yml
+++ b/.github/workflows/bug-discovery.yml
@@ -1,0 +1,49 @@
+name: Production Bug Discovery
+on:
+  schedule:
+    - cron: "0 6 * * *"  # Diario 6AM
+  workflow_dispatch: {}
+  pull_request:
+    paths: ["crates/**", "tests/**"]
+
+jobs:
+  poisoned-env:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      WEBFANG_URL: "POISON_TRASH"
+      WEBFANG_OUTPUT: "POISON_TRASH"
+      WEBFANG_SINGLE_PAGE: "true"
+      WEBFANG_THRESHOLD: "0.99"
+      WEBFANG_SELECTOR: "POISON"
+      AI_MODEL_ID: "POISON"
+      WEBFANG_OBSIDIAN_WIKI_LINKS: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://poison:4317"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Run tests with poisoned environment
+        run: cargo nextest run --workspace --all-features --no-fail-fast
+      - name: Publish results
+        if: always()
+        run: |
+          echo "## Poisoned Env Results" >> $GITHUB_STEP_SUMMARY
+          echo "Tests that FAIL with poisoned env are NOT hermetic." >> $GITHUB_STEP_SUMMARY
+
+  ignored-tests:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - name: Run ignored tests (bug discovery)
+        run: cargo nextest run --workspace --all-features --run-ignored only --no-fail-fast
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Production Bug Discovery" >> $GITHUB_STEP_SUMMARY
+          echo "Failures here = potential production bugs." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes #401

## PR Type

- [ ] Bug fix (`type:bug`)
- [x] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- New CI workflow `Production Bug Discovery` — radar, not gate (both jobs `continue-on-error: true`)
- `poisoned-env`: runs the full suite with every config env var set to garbage to expose non-hermetic tests
- `ignored-tests`: runs `#[ignore]d` tests (`--run-ignored only`) to surface potential production bugs
- Triggers: daily 6AM schedule, `workflow_dispatch`, and PRs touching `crates/**` / `tests/**`

## Changes

| File | Change |
|------|--------|
| `.github/workflows/bug-discovery.yml` | new workflow (issue #401 Wave 2C) |

## Test Plan

- [x] YAML syntax validated locally
- [x] nextest install step added (`taiki-e/install-action@nextest`) matching `ci.yml` conventions — the issue draft omitted it, which would have made both jobs fail instantly
- [ ] `workflow_dispatch` triggered after merge to confirm both jobs run and publish summaries (no cargo gates apply: workflow-only change, zero Rust touched)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (n/a)