### PR TITLE
feat(ci): Wave 4 — CI enforcement + coverage gate + dead test detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@
 #
 # Pipeline flow:
 #   toolchain (15s) → fmt (30s) → clippy (2min) → test-core (3min) → test-full (5min)
+#   toolchain also runs dead-test detection (scripts/check_dead_tests.sh)
 #   test-core runs: unit tests (--lib) then integration/behavioral tests (--test '*')
 #   security runs in parallel with tests (no Rust compile)
+#   feature-matrix runs after clippy (cargo-hack --each-feature, catches broken feature combos)
 #   mcp smoke runs after test-full
+#   coverage runs on PRs + dispatch (llvm-cov + Codecov)
 #   release runs after all gates pass (main only)
 #   miri runs on schedule/dispatch only
 #
@@ -69,6 +72,10 @@ jobs:
             echo "ERROR: Rust $INSTALLED is below minimum $REQUIRED"
             exit 1
           fi
+      # Regression guard for Wave 3 (#402): all tests must be crate-local.
+      # Fails if anyone re-adds a .rs file under root tests/ (dead test).
+      - name: Dead test detection
+        run: bash scripts/check_dead_tests.sh
 
   # ============================================================================
   # TIER 1: FORMAT GATE (30-60 seconds)
@@ -198,6 +205,26 @@ jobs:
           RUSTDOCFLAGS: -D warnings
       - name: Doctests
         run: cargo test --doc -p webfang_core -p webfang_ai --all-features
+
+  # ============================================================================
+  # FEATURE MATRIX: cargo-hack checks each feature in isolation (Wave 4, #403).
+  # Catches broken feature combinations — e.g. a feature that fails to compile
+  # without another, or dead code behind an untested flag. Runs after clippy so
+  # already-broken code doesn't burn compute. taiki-e/install-action provides a
+  # prebuilt cargo-hack (matches the nextest/llvm-cov/deny pattern, no source build).
+  # ============================================================================
+  feature-matrix:
+    name: Feature matrix
+    needs: [clippy]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-hack
+      - name: Feature matrix check
+        run: cargo hack check --each-feature --workspace --no-dev-deps
 
   # ============================================================================
   # MCP SMOKE: After full tests pass
@@ -333,13 +360,15 @@ jobs:
           cargo miri test --lib -- --skip downloader ${{ matrix.filter }}
 
   # ============================================================================
-  # COVERAGE: Manual trigger only
+  # COVERAGE: PR gate + manual trigger
+  # Measures and reports coverage on every PR (Wave 4, #403); uploads to Codecov.
+  # fail_ci_if_error: false — coverage is informational, never blocks the PR.
   # ============================================================================
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     needs: [test-full]
     steps:
       - uses: actions/checkout@v4
@@ -348,6 +377,10 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate coverage
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info -- --skip test_mcp
+      - name: Report coverage
+        run: |
+          cargo llvm-cov report --lcov | tail -5
+          echo "Coverage report generated successfully"
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/scripts/check_dead_tests.sh
+++ b/scripts/check_dead_tests.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Detect test files that aren't discovered by cargo (dead tests)
+# With crate-local tests/ and auto-discovery, every .rs file in crates/*/tests/
+# (excluding mod.rs, common/, fixtures/) is automatically a test target.
+# This script verifies no .rs files exist in root tests/ (regression guard).
+
+DEAD=0
+
+# Check root tests/ doesn't have .rs files (they should all be crate-local now)
+if [ -d "tests" ] && [ "$(find tests -name '*.rs' 2>/dev/null | wc -l)" -gt 0 ]; then
+  echo "ERROR: Root tests/ still has .rs files — all tests must be crate-local"
+  find tests -name '*.rs'
+  DEAD=$((DEAD+1))
+fi
+
+# Check no orphan test files outside standard locations
+for f in $(find . -name "*.rs" -path "*/tests/*" -not -path "./target/*" -not -path "*/common/*" -not -path "*/fixtures*" -not -path "*/snapshots/*" -not -name "mod.rs" 2>/dev/null); do
+  # Verify the file is in a valid crate tests/ directory
+  if ! echo "$f" | grep -qE '^\./crates/[^/]+/tests/'; then
+    echo "WARNING: Test file outside crate-local tests/: $f"
+  fi
+done
+
+if [ $DEAD -gt 0 ]; then
+  echo "FAILED: $DEAD dead test issue(s) found"
+  exit 1
+fi
+
+echo "OK: No dead tests detected"
+exit 0


### PR DESCRIPTION
## Linked Issue

Closes #403

## PR Type

- [x] New feature (`type:feature`)

## Summary

Wave 4 — CI enforcement to lock in the Wave 3 (#402) test remediation and prevent regression:
- `scripts/check_dead_tests.sh` — fails CI if anyone re-adds a `.rs` file under root `tests/` (all tests must stay crate-local).
- The existing coverage job now runs on every PR (was manual-only) and prints a coverage report, in addition to the existing Codecov upload.
- New `feature-matrix` job runs `cargo hack check --each-feature` to catch broken feature combinations.

## Changes

| File | Change |
|------|--------|
| `scripts/check_dead_tests.sh` | New regression guard: errors on `.rs` files in root `tests/`, warns on test files outside `crates/*/tests/`. Force-tracked (`scripts/` is gitignored for agent scratch, same convention as `analyze-trace.sh`). |
| `.github/workflows/ci.yml` | Added a "Dead test detection" step to the Tier-0 `toolchain` gate; broadened the existing `coverage` job trigger to `pull_request` + `workflow_dispatch` and added a "Report coverage" step; added a `feature-matrix` job (`needs: [clippy]`, `taiki-e/install-action@cargo-hack`). |

### Design notes
- **No duplicate coverage job** — a `coverage` job already existed (manual-only). I enhanced it (PR trigger + report step) instead of adding a second one, reusing the proven `cargo llvm-cov --all-features ... --skip test_mcp` invocation and the existing Codecov upload (`fail_ci_if_error: false`, so coverage never blocks the PR).
- **`taiki-e/install-action@cargo-hack`** instead of `cargo install cargo-hack --locked` — prebuilt binary (~1s vs a ~1-2 min source build) and consistent with the existing nextest / llvm-cov / deny / audit pattern. The `cargo hack check --each-feature --workspace --no-dev-deps` command is unchanged.

## Done criteria

- [x] Script detects orphan test files (verified: warns on files outside `crates/*/tests/`)
- [x] CI fails if someone adds a test in root `tests/` (verified: exit 1)
- [x] Coverage is measured and reported on each PR
- [x] Feature matrix runs on each PR

## Test Plan

- [x] `bash scripts/check_dead_tests.sh` passes on the current tree (no root `tests/`)
- [x] Verified failure path: adding `tests/dead_test.rs` → exit 1
- [x] `cargo check --workspace --tests` compiles (exit 0)
- [x] `ci.yml` validated as well-formed YAML; all jobs wired (`feature-matrix needs:[clippy]`, coverage on PR + dispatch)
- [x] No Rust code touched — config-only change

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (ci.yml pipeline-flow comment updated)
