### PR TITLE
refactor: inline format args, remove uninlined_format_args allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,10 +157,6 @@ unexpected_cfgs = { level = "deny", check-cfg = ["cfg(tokio_unstable)"] }
 unsafe_code = "deny"
 
 [workspace.lints.clippy]
-# TODO: Remove this allow and inline all format args (tracking issue needed).
-# Local toolchain doesn't detect this lint but CI does — mechanical fix
-# requires CI-driven iteration or a clippy version that supports --fix for it.
-uninlined_format_args = "allow"
 
 [profile.dev]
 opt-level = 0

--- a/crates/webfang_core/src/adapters/downloader/mod.rs
+++ b/crates/webfang_core/src/adapters/downloader/mod.rs
@@ -410,7 +410,7 @@ impl Downloader {
                     if !slug_ext.is_empty() && slug_ext != name {
                         sanitize_filename(&name)
                     } else {
-                        format!("{}.{}", name, extension)
+                        format!("{name}.{extension}")
                     }
                 }
             },
@@ -752,8 +752,7 @@ mod tests {
         );
         assert!(
             filename.ends_with(".png"),
-            "Expected .png but got: {}",
-            filename
+            "Expected .png but got: {filename}"
         );
         assert!(
             filename.starts_with("abc123def456"),
@@ -764,8 +763,7 @@ mod tests {
             downloader.generate_filename("https://example.com/file", "xyz789abc123456", None, None);
         assert!(
             filename.ends_with(".bin"),
-            "Expected .bin but got: {}",
-            filename
+            "Expected .bin but got: {filename}"
         );
     }
 

--- a/crates/webfang_core/src/application/adaptive_engine.rs
+++ b/crates/webfang_core/src/application/adaptive_engine.rs
@@ -740,7 +740,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             SelectorErrorKind::RepairInconclusive(_) => {},
-            other => panic!("expected RepairInconclusive, got {:?}", other),
+            other => panic!("expected RepairInconclusive, got {other:?}"),
         }
     }
 
@@ -907,7 +907,7 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             SelectorErrorKind::RepairInconclusive(_) => {},
-            other => panic!("expected RepairInconclusive, got {:?}", other),
+            other => panic!("expected RepairInconclusive, got {other:?}"),
         }
     }
 }

--- a/crates/webfang_core/src/application/crawler/collector.rs
+++ b/crates/webfang_core/src/application/crawler/collector.rs
@@ -307,10 +307,7 @@ mod tests {
 
         for i in 0..5 {
             collector
-                .send(CrawlMessage::success(make_url(&format!(
-                    "https://{}.com",
-                    i
-                ))))
+                .send(CrawlMessage::success(make_url(&format!("https://{i}.com"))))
                 .await
                 .unwrap();
         }
@@ -330,7 +327,7 @@ mod tests {
             let collector = collector.clone();
             set.spawn(async move {
                 for j in 0..5 {
-                    let url = make_url(&format!("https://worker{}-{}.com", i, j));
+                    let url = make_url(&format!("https://worker{i}-{j}.com"));
                     collector.send(CrawlMessage::success(url)).await.ok();
                 }
             });
@@ -433,10 +430,8 @@ mod tests {
         // Rapidly fill the buffer with try_sends
         let mut filled = 0;
         for i in 0..10 {
-            let result = collector.try_send(CrawlMessage::success(make_url(&format!(
-                "https://{}.com",
-                i
-            ))));
+            let result =
+                collector.try_send(CrawlMessage::success(make_url(&format!("https://{i}.com"))));
             if result.is_ok() {
                 filled += 1;
             } else {
@@ -528,7 +523,7 @@ mod tests {
         let adapter = ResultsAdapter::new(100);
 
         for i in 0..5 {
-            let url = make_url(&format!("https://{}.com", i));
+            let url = make_url(&format!("https://{i}.com"));
             adapter.add_success(url).await.unwrap();
         }
 

--- a/crates/webfang_core/src/application/pipeline/mod.rs
+++ b/crates/webfang_core/src/application/pipeline/mod.rs
@@ -45,7 +45,7 @@ mod integration_tests {
                 assert!(item.metadata.contains_key("original_size"));
                 assert!(item.metadata.contains_key("cleaned_size"));
             },
-            other => panic!("expected Continue, got {:?}", other),
+            other => panic!("expected Continue, got {other:?}"),
         }
     }
 

--- a/crates/webfang_core/src/application/progress_observer.rs
+++ b/crates/webfang_core/src/application/progress_observer.rs
@@ -44,7 +44,7 @@ impl ProgressObserver for LiveProgressObserver {
                     url: url.to_string(),
                 });
             } else {
-                eprintln!("Status: {} [Started]", url);
+                eprintln!("Status: {url} [Started]");
             }
         })
     }
@@ -64,7 +64,7 @@ impl ProgressObserver for LiveProgressObserver {
                     status,
                 });
             } else {
-                eprintln!("Status: {} [{:?}]", url, status);
+                eprintln!("Status: {url} [{status:?}]");
             }
         })
     }
@@ -84,7 +84,7 @@ impl ProgressObserver for LiveProgressObserver {
                     chars,
                 });
             } else {
-                eprintln!("Status: {} [Completed, {} chars]", url, chars);
+                eprintln!("Status: {url} [Completed, {chars} chars]");
             }
         })
     }
@@ -104,7 +104,7 @@ impl ProgressObserver for LiveProgressObserver {
                     error: error.clone(),
                 });
             } else {
-                eprintln!("Status: {} [Failed: {}]", url, error);
+                eprintln!("Status: {url} [Failed: {error}]");
             }
         })
     }
@@ -145,7 +145,7 @@ impl ProgressObserver for LiveProgressObserver {
                     error: ScrapeError::Other("blocked by robots.txt".into()),
                 });
             } else {
-                eprintln!("Status: {} [Blocked by robots.txt]", url);
+                eprintln!("Status: {url} [Blocked by robots.txt]");
             }
         })
     }

--- a/crates/webfang_core/src/application/rate_limiter.rs
+++ b/crates/webfang_core/src/application/rate_limiter.rs
@@ -265,8 +265,7 @@ mod tests {
         let elapsed = start.elapsed();
         assert!(
             elapsed >= std::time::Duration::from_millis(500),
-            "Rate limiter should enforce 500ms delay, got {:?}",
-            elapsed
+            "Rate limiter should enforce 500ms delay, got {elapsed:?}"
         );
     }
 
@@ -286,8 +285,7 @@ mod tests {
 
         assert!(
             elapsed >= std::time::Duration::from_millis(100),
-            "Third request should be delayed by 100ms, got {:?}",
-            elapsed
+            "Third request should be delayed by 100ms, got {elapsed:?}"
         );
     }
 

--- a/crates/webfang_core/src/cli/error.rs
+++ b/crates/webfang_core/src/cli/error.rs
@@ -308,8 +308,7 @@ mod tests {
             assert_eq!(
                 code,
                 ExitCode::from(expected_code),
-                "Expected exit code {}",
-                expected_code
+                "Expected exit code {expected_code}"
             );
         }
     }

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -453,8 +453,7 @@ mod tests {
         let state_path = store.get_state_path();
         assert!(
             state_path.starts_with(&state_dir),
-            "state path should be under custom state_dir: {:?}",
-            state_path
+            "state path should be under custom state_dir: {state_path:?}"
         );
     }
 }

--- a/crates/webfang_core/src/domain/credentials.rs
+++ b/crates/webfang_core/src/domain/credentials.rs
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn test_api_key_debug_shows_redacted() {
         let key = ApiKey::new("sk-secret123");
-        let debug_str = format!("{:?}", key);
+        let debug_str = format!("{key:?}");
         assert_eq!(debug_str, "[REDACTED]");
     }
 
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     fn test_access_token_debug_shows_redacted() {
         let token = AccessToken::new("ghp_token123");
-        let debug_str = format!("{:?}", token);
+        let debug_str = format!("{token:?}");
         assert_eq!(debug_str, "[REDACTED]");
     }
 
@@ -450,7 +450,7 @@ mod tests {
     #[test]
     fn test_sensitive_string_debug() {
         let sensitive = SensitiveString::new("secret-data".to_string());
-        assert_eq!(format!("{:?}", sensitive), "[REDACTED]");
+        assert_eq!(format!("{sensitive:?}"), "[REDACTED]");
     }
 
     #[test]

--- a/crates/webfang_core/src/domain/error/crawl_error.rs
+++ b/crates/webfang_core/src/domain/error/crawl_error.rs
@@ -298,8 +298,7 @@ mod tests {
         let error = CrawlError::Storage("archivo corrupto".to_string());
         assert!(
             error.to_string().contains("error de almacenamiento"),
-            "expected Storage display to contain 'error de almacenamiento', got: {}",
-            error
+            "expected Storage display to contain 'error de almacenamiento', got: {error}"
         );
         assert!(error.to_string().contains("archivo corrupto"));
     }

--- a/crates/webfang_core/src/domain/value_objects.rs
+++ b/crates/webfang_core/src/domain/value_objects.rs
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn test_valid_url_display() {
         let url = ValidUrl::parse("https://example.com").unwrap();
-        assert_eq!(format!("{}", url), "https://example.com/");
+        assert_eq!(format!("{url}"), "https://example.com/");
     }
 
     #[test]
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn test_correlation_id_display() {
         let corr = CorrelationId::new();
-        let display = format!("{}", corr);
+        let display = format!("{corr}");
 
         assert!(display.starts_with("00-"));
         assert_eq!(display, corr.to_traceparent());

--- a/crates/webfang_core/src/infrastructure/config.rs
+++ b/crates/webfang_core/src/infrastructure/config.rs
@@ -568,10 +568,10 @@ mod tests {
     #[test]
     fn test_concurrency_config_display() {
         let auto = ConcurrencyConfig::auto();
-        assert_eq!(format!("{}", auto), "auto");
+        assert_eq!(format!("{auto}"), "auto");
 
         let explicit = ConcurrencyConfig::new(5);
-        assert_eq!(format!("{}", explicit), "5");
+        assert_eq!(format!("{explicit}"), "5");
     }
 
     #[test]

--- a/crates/webfang_core/src/infrastructure/converter/html_to_markdown.rs
+++ b/crates/webfang_core/src/infrastructure/converter/html_to_markdown.rs
@@ -79,11 +79,7 @@ mod tests {
     fn test_code_block_uses_backticks() {
         let html = "<pre><code>fn main() {}</code></pre>";
         let md = convert_to_markdown(html);
-        assert!(
-            md.contains("```"),
-            "Expected fenced code blocks, got: {}",
-            md
-        );
+        assert!(md.contains("```"), "Expected fenced code blocks, got: {md}");
     }
 
     #[test]

--- a/crates/webfang_core/src/infrastructure/crawler/memory_manager.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/memory_manager.rs
@@ -189,7 +189,7 @@ mod tests {
         let manager = MemoryManager::with_disk_swap(temp_dir.path().to_path_buf());
 
         let urls: Vec<Url> = (0..15_000)
-            .map(|i| Url::parse(&format!("https://example.com/page{}", i)).unwrap())
+            .map(|i| Url::parse(&format!("https://example.com/page{i}")).unwrap())
             .collect();
 
         // Should write chunks to disk
@@ -212,7 +212,7 @@ mod tests {
                                                            // 525 URLs * 2000 bytes = 1,050,000 bytes >= 1,048,576 bytes (1MB)
         let url_count_that_exceeds = 525;
         let urls: Vec<Url> = (0..url_count_that_exceeds)
-            .map(|i| Url::parse(&format!("https://example.com/page{}", i)).unwrap())
+            .map(|i| Url::parse(&format!("https://example.com/page{i}")).unwrap())
             .collect();
 
         // Should fail due to memory limit when disk swap disabled

--- a/crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs
@@ -675,7 +675,7 @@ mod tests {
         let config = SitemapConfig::builder().max_depth(0).build();
         assert_eq!(config.max_depth, 0);
         let err = SitemapError::MaxDepthExceeded;
-        assert_eq!(format!("{}", err), "maximum recursion depth exceeded");
+        assert_eq!(format!("{err}"), "maximum recursion depth exceeded");
     }
 
     #[test]

--- a/crates/webfang_core/src/infrastructure/crawler/url_queue.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/url_queue.rs
@@ -284,13 +284,13 @@ mod tests {
     use url::Url;
 
     fn create_test_url(path: &str) -> DiscoveredUrl {
-        let url = Url::parse(&format!("https://example.com{}", path)).unwrap();
+        let url = Url::parse(&format!("https://example.com{path}")).unwrap();
         let parent = Url::parse("https://example.com/").unwrap();
         DiscoveredUrl::html(url, 0, parent)
     }
 
     fn create_test_url_with_depth(path: &str, depth: u8) -> DiscoveredUrl {
-        let url = Url::parse(&format!("https://example.com{}", path)).unwrap();
+        let url = Url::parse(&format!("https://example.com{path}")).unwrap();
         let parent = Url::parse("https://example.com/").unwrap();
         DiscoveredUrl::html(url, depth, parent)
     }
@@ -363,7 +363,7 @@ mod tests {
         let queue = UrlQueue::new();
 
         for i in 0..10 {
-            let url = create_test_url(&format!("/page{}", i));
+            let url = create_test_url(&format!("/page{i}"));
             assert!(queue.push(url).await);
         }
 

--- a/crates/webfang_core/src/infrastructure/export/vector_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/vector_exporter.rs
@@ -411,8 +411,7 @@ mod tests {
         let result = exporter.serialize_document(&doc2);
         assert!(
             result.is_ok(),
-            "dimension mismatch should serialize without embeddings, got: {:?}",
-            result
+            "dimension mismatch should serialize without embeddings, got: {result:?}"
         );
 
         let json_str = result.unwrap();

--- a/crates/webfang_core/src/infrastructure/observability/file_trace_layer.rs
+++ b/crates/webfang_core/src/infrastructure/observability/file_trace_layer.rs
@@ -216,7 +216,7 @@ where
             return format!("{:016x}", root.id().into_u64());
         }
     }
-    format!("{:016x}", seed)
+    format!("{seed:016x}")
 }
 
 /// Build a stable per-invocation seed used as the fallback `trace_id` when no

--- a/crates/webfang_core/src/infrastructure/user_agent.rs
+++ b/crates/webfang_core/src/infrastructure/user_agent.rs
@@ -271,8 +271,7 @@ mod tests {
         for agent in &agents {
             assert!(
                 agent.contains("Chrome/13") || agent.contains("Firefox/"),
-                "Agent '{}' should contain Chrome/13x or Firefox/",
-                agent
+                "Agent '{agent}' should contain Chrome/13x or Firefox/"
             );
         }
     }

--- a/crates/webfang_core/src/lib.rs
+++ b/crates/webfang_core/src/lib.rs
@@ -29,7 +29,6 @@
 #![deny(missing_docs)]
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![allow(clippy::module_name_repetitions)]
-#![allow(clippy::uninlined_format_args)]
 
 // ============================================================================
 // Modules

--- a/crates/webfang_core/tests/common/mod.rs
+++ b/crates/webfang_core/tests/common/mod.rs
@@ -155,8 +155,7 @@ impl MockVault {
 
         let vault_fs_path = vault_path.to_string_lossy();
         let obsidian_json = format!(
-            r#"{{"vault":{{"fsPath":"{}","id":"test-vault-id","name":"TestVault"}}}}"#,
-            vault_fs_path
+            r#"{{"vault":{{"fsPath":"{vault_fs_path}","id":"test-vault-id","name":"TestVault"}}}}"#
         );
         std::fs::write(obsidian_dir.join("obsidian.json"), &obsidian_json)
             .expect("failed to create obsidian.json");

--- a/crates/webfang_core/tests/orchestrator_unit_tests.rs
+++ b/crates/webfang_core/tests/orchestrator_unit_tests.rs
@@ -132,8 +132,7 @@ async fn sitemap_empty_returns_no_urls_found() {
             result,
             Err(webfang_core::infrastructure::crawler::SitemapError::NoUrlsFound)
         ),
-        "expected NoUrlsFound, got {:?}",
-        result
+        "expected NoUrlsFound, got {result:?}"
     );
 }
 

--- a/crates/webfang_core/tests/stress_test.rs
+++ b/crates/webfang_core/tests/stress_test.rs
@@ -35,24 +35,23 @@ async fn stress_test_task_starvation() {
     eprintln!("\n{}", "=".repeat(50));
     eprintln!("tokio-console STRESS TEST METRICS");
     eprintln!("{}", "=".repeat(50));
-    eprintln!("Total tasks:       {}", total_tasks);
-    eprintln!("Worker threads:  {}", worker_threads);
-    eprintln!("Duration:       {:?}", elapsed);
-    eprintln!("Throughput:     {:.2} tasks/sec", tasks_per_sec);
+    eprintln!("Total tasks:       {total_tasks}");
+    eprintln!("Worker threads:  {worker_threads}");
+    eprintln!("Duration:       {elapsed:?}");
+    eprintln!("Throughput:     {tasks_per_sec:.2} tasks/sec");
 
     // Análisis de resultados
     let successful = results.iter().filter(|r| r.is_ok()).count();
     let failed = results.iter().filter(|r| r.is_err()).count();
 
     eprintln!("\nResults:");
-    eprintln!("  Successful:    {}", successful);
-    eprintln!("  Failed:      {}", failed);
+    eprintln!("  Successful:    {successful}");
+    eprintln!("  Failed:      {failed}");
     eprintln!("{}", "=".repeat(50));
 
     assert!(
         results.iter().all(|r| r.is_ok()),
-        "Some tasks failed: {} errors",
-        failed
+        "Some tasks failed: {failed} errors"
     );
 }
 
@@ -91,17 +90,17 @@ async fn stress_test_cpu_work() {
     eprintln!("\n{}", "=".repeat(50));
     eprintln!("tokio-console CPU STRESS TEST");
     eprintln!("{}", "=".repeat(50));
-    eprintln!("Total tasks:       {}", total);
+    eprintln!("Total tasks:       {total}");
     eprintln!("Worker threads:  4");
-    eprintln!("Duration:       {:?}", elapsed);
-    eprintln!("Throughput:     {:.2} tasks/sec", tasks_per_sec);
+    eprintln!("Duration:       {elapsed:?}");
+    eprintln!("Throughput:     {tasks_per_sec:.2} tasks/sec");
     eprintln!("Completed:      {}", completed.load(Ordering::Relaxed));
     eprintln!("{}", "=".repeat(50));
 
     // Verificar que ningún task panickeara
     for (i, result) in results.iter().enumerate() {
         if let Err(e) = result {
-            eprintln!("Task {} failed: {}", i, e);
+            eprintln!("Task {i} failed: {e}");
         }
     }
 
@@ -148,17 +147,13 @@ async fn stress_test_memory() {
     eprintln!("\n{}", "=".repeat(50));
     eprintln!("tokio-console MEMORY STRESS TEST");
     eprintln!("{}", "=".repeat(50));
-    eprintln!("Total tasks:       {}", total_allocations);
+    eprintln!("Total tasks:       {total_allocations}");
     eprintln!("Worker threads:  2");
-    eprintln!("Duration:       {:?}", elapsed);
-    eprintln!("Throughput:     {:.2} tasks/sec", tasks_per_sec);
+    eprintln!("Duration:       {elapsed:?}");
+    eprintln!("Throughput:     {tasks_per_sec:.2} tasks/sec");
     eprintln!("{}", "=".repeat(50));
 
     // Este test principalmente mide que no hubo crashes por memory pressure
     // El throughput debería ser razonable
-    assert!(
-        tasks_per_sec > 100.0,
-        "Throughput too low: {}",
-        tasks_per_sec
-    );
+    assert!(tasks_per_sec > 100.0, "Throughput too low: {tasks_per_sec}");
 }


### PR DESCRIPTION
Closes #411

## Summary
- Removed workspace-wide `uninlined_format_args = "allow"` from root Cargo.toml
- Removed crate-level allow from webfang_core/src/lib.rs
- Inlined 54 format args (mostly webfang_core/src lib code that the crate-level allow was suppressing, plus 3 test files)

## Verification
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::uninlined_format_args` (CI proxy — lint fires on CI's toolchain) reports 0 warnings
- `cargo nextest run --workspace` green
- `cargo fmt --check` clean