### PR TITLE
ci(sanitizers): reliable TSan job with -Zbuild-std

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -23,21 +23,53 @@ jobs:
           echo "## Miri Results" >> $GITHUB_STEP_SUMMARY
           echo "Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
+  # ThreadSanitizer with full std instrumentation (-Zbuild-std).
+  # Without -Zbuild-std, ABI mismatch between instrumented and non-instrumented
+  # crates produces unreliable warnings. With it, results are trustworthy.
+  # Phase 1: continue-on-error (advisory). Phase 2: hard gate after triage.
+  # Build time ~15 min (compiles std from source) + BoringSSL ~10 min.
   tsan:
+    name: "ThreadSanitizer (bridge + session_pool)"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Phase 1: advisory — report warnings but don't block CI
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - name: ThreadSanitizer
+      - name: Install nightly + rust-src
+        run: rustup toolchain install nightly --component rust-src
+      - name: Install cmake
+        run: sudo apt-get install -y cmake
+      - name: Run TSan on concurrency modules
         run: |
           RUSTFLAGS="-Zsanitizer=thread" \
-          cargo +nightly test -p webfang_core --target x86_64-unknown-linux-gnu -- --test-threads=4
-        continue-on-error: true
+          cargo +nightly test -Zbuild-std \
+            --target x86_64-unknown-linux-gnu \
+            -p webfang_core --lib \
+            -- infrastructure::bridge infrastructure::network::session_pool \
+            --test-threads=1 \
+            2>&1 | tee tsan-output.txt
+      - name: Check for warnings
+        if: always()
+        run: |
+          if grep -qi "WARNING: ThreadSanitizer" tsan-output.txt; then
+            echo "::warning::TSan warnings detected — review tsan-output.txt"
+            grep -c "WARNING: ThreadSanitizer" tsan-output.txt || true
+          else
+            echo "No TSan warnings — clean run."
+          fi
       - name: Publish TSan Summary
         if: always()
         run: |
-          echo "## ThreadSanitizer Results" >> $GITHUB_STEP_SUMMARY
+          echo "## ThreadSanitizer Results (-Zbuild-std)" >> $GITHUB_STEP_SUMMARY
+          echo "Scope: infrastructure::bridge + infrastructure::network::session_pool" >> $GITHUB_STEP_SUMMARY
           echo "Status: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+      - name: Upload TSan output
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tsan-output
+          path: tsan-output.txt
 
   lsan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #415

## Summary

Replaces the old TSan job (unreliable due to ABI mismatch between instrumented and non-instrumented crates) with a reliable version using `-Zbuild-std` for full std instrumentation.

## What changed

- `tsan` job in `sanitizers.yml` rewritten:
  - Installs `nightly + rust-src` (compiles std from source → no ABI mismatch)
  - Installs `cmake` (BoringSSL build requirement)
  - Scoped to `infrastructure::bridge` + `infrastructure::network::session_pool` (concurrency hot paths)
  - `--test-threads=1` for deterministic TSan output
  - `--lib` only (unit tests, no subprocess)
  - Phase 1: `continue-on-error: true` (advisory)
  - Uploads `tsan-output.txt` as artifact for triage
  - Warning detection step with GitHub annotations

## Acceptance Criteria

- [x] `tsan` job exists in sanitizers.yml
- [x] Uses `-Zbuild-std` (no ABI mismatch)
- [x] Runs on `infrastructure::bridge` + `infrastructure::network::session_pool`
- [ ] Zero unsuppressed TSan warnings OR documented suppressions — pending first CI run
- [x] Job timeout < 45 minutes

## Notes

- Miri remains blocked by rayon (unchanged).
- LSan job untouched (already passes from #406).
- First real run post-merge via `gh workflow run sanitizers.yml` or Monday schedule.