### PR TITLE
test(infra): add failure-path tests for #393 (state_store, checkpoint, config)

### DIFF
--- a/crates/webfang_core/src/application/crawler/checkpoint.rs
+++ b/crates/webfang_core/src/application/crawler/checkpoint.rs
@@ -646,4 +646,28 @@ mod tests {
         cp_path.ensure_dir().unwrap();
         assert!(nested.exists());
     }
+
+    /// `ensure_dir` must surface a filesystem failure as `Err` instead of
+    /// panicking, so `Engine::with_checkpoint` can disable checkpointing and
+    /// keep crawling (#393). Here the base directory sits *under a regular
+    /// file*, a location that can never be created as a directory.
+    #[test]
+    fn test_ensure_dir_returns_err_when_base_dir_is_under_a_file() {
+        // Arrange: a regular file where a directory component would need to be.
+        let tmp = TempDir::new().expect("tempdir should be created");
+        let blocker = tmp.path().join("not_a_dir");
+        fs::write(&blocker, "i am a file, not a directory")
+            .expect("blocker file should be written");
+
+        // Act: try to ensure a directory nested under the file.
+        let cp_path = CheckpointPath::new(blocker.join("nested"));
+        let result = cp_path.ensure_dir();
+
+        // Assert: the failure is reported as Err (not a panic), with context.
+        let err = result.expect_err("ensure_dir must fail when the path is under a regular file");
+        assert!(
+            err.contains("failed to create checkpoint dir"),
+            "error should carry creation context, got: {err}"
+        );
+    }
 }

--- a/crates/webfang_core/src/application/export_factory.rs
+++ b/crates/webfang_core/src/application/export_factory.rs
@@ -563,4 +563,37 @@ mod tests {
 
         assert_eq!(processed.len(), 1);
     }
+
+    // =========================================================================
+    // create_state_store failure-path characterization (#393)
+    // =========================================================================
+
+    /// Pins the current contract of [`create_state_store`]: it is lazy and
+    /// infallible. `StateStore::new` and `set_cache_dir` perform no I/O, so the
+    /// store is created successfully even when `state_dir` is a regular file
+    /// where no directory could ever be created.
+    ///
+    /// Consequence: the `CliExit::IoError` branch in `apply_resume_mode`
+    /// (`cli/scrape_flow.rs`) is currently unreachable dead code, because the
+    /// state directory is only created later, on `StateStore::save`. If
+    /// `create_state_store` is ever made eager (e.g. `create_dir_all` up front),
+    /// this test must be updated and the `IoError` path becomes coverable.
+    #[test]
+    fn test_create_state_store_returns_ok_even_when_state_dir_is_a_file() {
+        // Arrange: a regular file where a state directory would need to be —
+        // an impossible location for any real directory creation.
+        let temp_dir = TempDir::new().expect("tempdir should be created");
+        let blocker = temp_dir.path().join("not_a_dir");
+        std::fs::write(&blocker, "i am a file, not a directory")
+            .expect("blocker file should be written");
+
+        // Act
+        let result = create_state_store(blocker, "example.com");
+
+        // Assert: creation is lazy/infallible — no I/O is attempted yet.
+        assert!(
+            result.is_ok(),
+            "create_state_store must be infallible (lazy): it performs no I/O at creation time"
+        );
+    }
 }

--- a/crates/webfang_core/src/cli/config.rs
+++ b/crates/webfang_core/src/cli/config.rs
@@ -163,4 +163,60 @@ max_pages = 20
     fn test_should_emit_emoji_default() {
         assert!(should_emit_emoji());
     }
+
+    /// A malformed TOML file must not crash the CLI: `ConfigDefaults::load`
+    /// logs an `error!` and falls back to all-default settings (#393). Because
+    /// the user's entire configuration is silently lost on a parse failure, the
+    /// fallback to defaults — not the parse error itself — is the behavioral
+    /// invariant this test pins.
+    #[test]
+    fn test_load_malformed_toml_falls_back_to_defaults() {
+        // Arrange: an existing file whose contents are not valid TOML.
+        let tmp = tempfile::tempdir().expect("tempdir should be created");
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "this is [[[ not valid toml")
+            .expect("config file should be written");
+
+        // Act
+        let config = ConfigDefaults::load(&config_path);
+
+        // Assert: every field falls back to its default (None); nothing crashes.
+        assert!(config.format.is_none(), "format must fall back to default");
+        assert!(
+            config.export_format.is_none(),
+            "export_format must fall back to default"
+        );
+        assert!(
+            config.concurrency.is_none(),
+            "concurrency must fall back to default"
+        );
+        assert!(
+            config.selector.is_none(),
+            "selector must fall back to default"
+        );
+        assert!(
+            config.max_pages.is_none(),
+            "max_pages must fall back to default"
+        );
+        assert!(
+            config.delay_ms.is_none(),
+            "delay_ms must fall back to default"
+        );
+        assert!(
+            config.log_level.is_none(),
+            "log_level must fall back to default"
+        );
+        assert!(
+            config.use_sitemap.is_none(),
+            "use_sitemap must fall back to default"
+        );
+        assert!(
+            config.ignore_waf.is_none(),
+            "ignore_waf must fall back to default"
+        );
+        assert!(
+            config.vault_path.is_none(),
+            "vault_path must fall back to default"
+        );
+    }
 }


### PR DESCRIPTION
Closes #393

## Summary

Adds 3 failure-path tests for the residual items of #393 (post mega-plan audit):

- **export_factory**: characterization test pinning `create_state_store` as infallible — the `CliExit::IoError` branch in `scrape_flow.rs` is unreachable dead code (state dir is created lazily on `save()`, never at construction)
- **checkpoint**: `ensure_dir` returns `Err` when base dir sits under a regular file (trigger for engine checkpoint disable)
- **cli/config**: malformed TOML falls back to defaults without crashing

## Key finding

`create_state_store` cannot fail — `StateStore::new` returns `Self`, not `Result`. Decision: keep lazy design; the characterization test documents the real contract.

## Verification

- `cargo check -p webfang_core` ✅
- `cargo clippy -p webfang_core --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo nextest run -p webfang_core` ✅ (41 tests in affected modules, 0 failures)
- `cargo fmt` ✅

## Residual

Only the anti-degradation convention documentation remains (CI gates already exist via #413, #419).