### PR TITLE
feat(crawler): add error breakdown by category to crawl summary (#374)

### DIFF
--- a/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
@@ -40,6 +40,8 @@ pub struct CrawlTaskCtx {
 
     // --- Per-task mutable (atomics) ---
     pub(crate) error_count: Arc<AtomicUsize>,
+    /// Per-category error counters indexed by `CrawlErrorCategory::index()` (issue #374).
+    pub(crate) error_breakdown: Arc<[AtomicUsize; 8]>,
     pub(crate) pages_crawled: Arc<AtomicU64>,
 
     // --- Infrastructure ---

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -29,7 +29,8 @@ use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 use crate::application::url_filter::is_allowed;
 use crate::domain::clock::SystemClock;
 use crate::domain::{
-    CorrelationId, CrawlError, CrawlResult, CrawlerConfig, DiscoveredUrl, JsStrategy,
+    CorrelationId, CrawlError, CrawlErrorCategory, CrawlResult, CrawlerConfig, DiscoveredUrl,
+    JsStrategy,
 };
 use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::crawler::{
@@ -161,6 +162,8 @@ pub struct Engine {
     queue: Arc<UrlQueue>,
     rate_limiter: SharedRateLimiter,
     error_count: Arc<AtomicUsize>,
+    /// Per-category error counters indexed by `CrawlErrorCategory::index()` (issue #374).
+    error_breakdown: Arc<[AtomicUsize; 8]>,
     /// Checkpoint store for persistence (stateless — always available).
     checkpoint_store: BincodeCheckpoint,
     /// Loaded checkpoint state for crash recovery (`None` = fresh start).
@@ -222,6 +225,7 @@ impl Engine {
         // Results collector via mpsc channel
         let collector = ResultsCollector::new(config_clone.max_pages, Some(config_clone.max_pages));
         let error_count = Arc::new(AtomicUsize::new(0));
+        let error_breakdown = Arc::new(std::array::from_fn(|_| AtomicUsize::new(0)));
         let pages_crawled = Arc::new(AtomicU64::new(0));
         let shutdown = Arc::new(AtomicBool::new(false));
 
@@ -241,6 +245,7 @@ impl Engine {
             queue,
             rate_limiter,
             error_count,
+            error_breakdown,
             checkpoint_store: BincodeCheckpoint::new(),
             checkpoint_state: None,
             checkpoint_path: None,
@@ -543,6 +548,7 @@ impl Engine {
             ignore_robots: self.ignore_robots,
             robots_fetcher: Arc::clone(&self.robots_fetcher),
             error_count: Arc::clone(&self.error_count),
+            error_breakdown: Arc::clone(&self.error_breakdown),
             pages_crawled: Arc::clone(&self.pages_crawled),
             collector: self
                 .collector
@@ -581,7 +587,7 @@ impl Engine {
 
             // Process completed tasks FIRST (non-blocking)
             while let Some(result) = tasks.try_join_next() {
-                handle_crawl_result(result, &self.error_count);
+                handle_crawl_result(result, &self.error_count, &self.error_breakdown);
             }
 
             // Drain discovered links from the deduplicated UrlQueue
@@ -651,14 +657,14 @@ impl Engine {
                 .unwrap_or(config_clone.concurrency);
             if tasks.len() >= max_concurrent && !url_queue.is_empty() {
                 if let Some(result) = tasks.join_next().await {
-                    handle_crawl_result(result, &self.error_count);
+                    handle_crawl_result(result, &self.error_count, &self.error_breakdown);
                 }
             }
         }
 
         // Wait for remaining tasks
         while let Some(result) = tasks.join_next().await {
-            handle_crawl_result(result, &self.error_count);
+            handle_crawl_result(result, &self.error_count, &self.error_breakdown);
         }
 
         // Drop task_ctx so all cloned Senders inside CrawlTaskCtx are released.
@@ -680,7 +686,17 @@ impl Engine {
         let total_pages = collected_urls.len();
         let errors = self.error_count.load(std::sync::atomic::Ordering::SeqCst);
 
-        // Structured crawl summary (issue #356 Fase 4)
+        let breakdown: std::collections::BTreeMap<CrawlErrorCategory, usize> =
+            CrawlErrorCategory::ALL
+                .iter()
+                .filter_map(|cat| {
+                    let count =
+                        self.error_breakdown[cat.index()].load(std::sync::atomic::Ordering::SeqCst);
+                    (count > 0).then_some((*cat, count))
+                })
+                .collect();
+
+        // Structured crawl summary (issue #356 Fase 4, error breakdown #374)
         let duration = start.elapsed();
         let succeeded = total_pages.saturating_sub(errors);
         let summary_rate = if duration.as_secs_f64() > 0.0 {
@@ -692,13 +708,34 @@ impl Engine {
             total_pages = total_pages,
             succeeded = succeeded,
             errors = errors,
+            errors_waf = self.error_breakdown[CrawlErrorCategory::Waf.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
+            errors_http = self.error_breakdown[CrawlErrorCategory::Http.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
+            errors_timeout = self.error_breakdown[CrawlErrorCategory::Timeout.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
+            errors_network = self.error_breakdown[CrawlErrorCategory::Network.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
+            errors_rate_limit = self.error_breakdown[CrawlErrorCategory::RateLimit.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
+            errors_extraction = self.error_breakdown[CrawlErrorCategory::Extraction.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
+            errors_internal = self.error_breakdown[CrawlErrorCategory::Internal.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
+            errors_panic = self.error_breakdown[CrawlErrorCategory::Panic.index()]
+                .load(std::sync::atomic::Ordering::SeqCst),
             duration_secs = duration.as_secs(),
             pages_per_sec = summary_rate,
             trace_id = %self.correlation_id.trace_id(),
             "crawl completed"
         );
 
-        Ok(CrawlResult::new(collected_urls, total_pages, errors))
+        Ok(CrawlResult::new(
+            collected_urls,
+            total_pages,
+            errors,
+            breakdown,
+        ))
     }
 
     /// Graceful shutdown — drop the collector sender, receiver drains remaining items
@@ -722,18 +759,23 @@ impl Engine {
 fn handle_crawl_result(
     result: std::result::Result<Result<(), CrawlError>, tokio::task::JoinError>,
     error_count: &Arc<AtomicUsize>,
+    error_breakdown: &Arc<[AtomicUsize; 8]>,
 ) {
     match result {
         Ok(Ok(())) => {
             // Task completed successfully
         },
         Ok(Err(e)) => {
+            let category = CrawlErrorCategory::from(&e);
             warn!("Task error: {}", e);
             error_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            error_breakdown[category.index()].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         },
         Err(e) => {
             warn!("Task panicked: {}", e);
             error_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            error_breakdown[CrawlErrorCategory::Panic.index()]
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         },
     }
 }
@@ -967,6 +1009,8 @@ async fn run_crawl_task(
                 warn!("Failed to extract links from {}: {}", url_str, e);
                 ctx.error_count
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                ctx.error_breakdown[CrawlErrorCategory::Extraction.index()]
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             },
         }
     }

--- a/crates/webfang_core/src/domain/error/crawl_error_category.rs
+++ b/crates/webfang_core/src/domain/error/crawl_error_category.rs
@@ -1,0 +1,227 @@
+//! Crawl error categorization for observability (issue #374).
+//!
+//! Maps the 20+ `CrawlError` variants into a fixed set of operational
+//! categories suitable for metrics, structured logging, and dashboards.
+
+use serde::Serialize;
+
+use crate::domain::CrawlError;
+
+/// Operational category for a crawl error.
+///
+/// Reduces the full `CrawlError` variant space to a fixed set of
+/// categories that are meaningful in dashboards and alerts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CrawlErrorCategory {
+    /// WAF challenge detected (Cloudflare, AWS WAF, etc.)
+    Waf,
+    /// HTTP status errors (4xx/5xx, transient)
+    Http,
+    /// Request timeout
+    Timeout,
+    /// Network-level failures (DNS, connection, download)
+    Network,
+    /// Rate limiting (429 / retry-after)
+    RateLimit,
+    /// Content extraction / parsing failures
+    Extraction,
+    /// Internal / catch-all (storage, checkpoint, config, etc.)
+    Internal,
+    /// Task panicked (JoinError)
+    Panic,
+}
+
+impl CrawlErrorCategory {
+    /// All categories in stable order (for array indexing and iteration).
+    pub const ALL: [Self; 8] = [
+        Self::Waf,
+        Self::Http,
+        Self::Timeout,
+        Self::Network,
+        Self::RateLimit,
+        Self::Extraction,
+        Self::Internal,
+        Self::Panic,
+    ];
+
+    /// Index for array-based counting.
+    #[inline]
+    #[must_use]
+    pub const fn index(self) -> usize {
+        match self {
+            Self::Waf => 0,
+            Self::Http => 1,
+            Self::Timeout => 2,
+            Self::Network => 3,
+            Self::RateLimit => 4,
+            Self::Extraction => 5,
+            Self::Internal => 6,
+            Self::Panic => 7,
+        }
+    }
+
+    /// Tracing field name for this category.
+    #[inline]
+    #[must_use]
+    pub const fn tracing_field(self) -> &'static str {
+        match self {
+            Self::Waf => "errors_waf",
+            Self::Http => "errors_http",
+            Self::Timeout => "errors_timeout",
+            Self::Network => "errors_network",
+            Self::RateLimit => "errors_rate_limit",
+            Self::Extraction => "errors_extraction",
+            Self::Internal => "errors_internal",
+            Self::Panic => "errors_panic",
+        }
+    }
+}
+
+impl std::fmt::Display for CrawlErrorCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Waf => "waf",
+            Self::Http => "http",
+            Self::Timeout => "timeout",
+            Self::Network => "network",
+            Self::RateLimit => "rate_limit",
+            Self::Extraction => "extraction",
+            Self::Internal => "internal",
+            Self::Panic => "panic",
+        };
+        f.write_str(label)
+    }
+}
+
+impl From<&CrawlError> for CrawlErrorCategory {
+    fn from(err: &CrawlError) -> Self {
+        match err {
+            CrawlError::WafChallenge { .. } => Self::Waf,
+            CrawlError::Http { .. } | CrawlError::TransientHttp { .. } => Self::Http,
+            CrawlError::Timeout => Self::Timeout,
+            CrawlError::Network { .. } | CrawlError::Connection(..) | CrawlError::Download(..) => {
+                Self::Network
+            },
+            CrawlError::RateLimited(..) => Self::RateLimit,
+            CrawlError::Parse(..) => Self::Extraction,
+            _ => Self::Internal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::error::WafDetectionKind;
+
+    #[test]
+    fn categorize_waf() {
+        let err = CrawlError::WafChallenge {
+            provider: "Cloudflare".into(),
+            kind: WafDetectionKind::BodySignature,
+            url: "https://example.com".into(),
+        };
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Waf);
+    }
+
+    #[test]
+    fn categorize_http() {
+        let err = CrawlError::Http {
+            status: 404,
+            url: "https://example.com".into(),
+        };
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Http);
+
+        let err = CrawlError::TransientHttp {
+            status: 503,
+            url: "https://example.com".into(),
+        };
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Http);
+    }
+
+    #[test]
+    fn categorize_timeout() {
+        let err = CrawlError::Timeout;
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Timeout);
+    }
+
+    #[test]
+    fn categorize_network() {
+        let err = CrawlError::Network {
+            message: "dns failure".into(),
+            status_code: None,
+        };
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Network);
+
+        let err = CrawlError::Connection("refused".into());
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Network);
+
+        let err = CrawlError::Download(Box::new(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "reset",
+        )));
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Network);
+    }
+
+    #[test]
+    fn categorize_rate_limit() {
+        let err = CrawlError::RateLimited(60);
+        assert_eq!(
+            CrawlErrorCategory::from(&err),
+            CrawlErrorCategory::RateLimit
+        );
+    }
+
+    #[test]
+    fn categorize_parse_as_extraction() {
+        let err = CrawlError::Parse("malformed html".into());
+        assert_eq!(
+            CrawlErrorCategory::from(&err),
+            CrawlErrorCategory::Extraction
+        );
+    }
+
+    #[test]
+    fn categorize_internal_fallback() {
+        let err = CrawlError::Internal("unknown".into());
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Internal);
+
+        let err = CrawlError::Storage("corrupt".into());
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Internal);
+
+        let err = CrawlError::Checkpoint("decode failed".into());
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Internal);
+
+        let err = CrawlError::InvalidUrl("bad".into());
+        assert_eq!(CrawlErrorCategory::from(&err), CrawlErrorCategory::Internal);
+    }
+
+    #[test]
+    fn all_categories_have_unique_index() {
+        let mut seen = [false; 8];
+        for cat in CrawlErrorCategory::ALL {
+            let idx = cat.index();
+            assert!(!seen[idx], "duplicate index {idx} for {cat}");
+            seen[idx] = true;
+        }
+        assert!(seen.iter().all(|&s| s), "all indices must be covered");
+    }
+
+    #[test]
+    fn display_matches_serde_rename() {
+        for cat in CrawlErrorCategory::ALL {
+            let display = cat.to_string();
+            let tracing = cat.tracing_field();
+            assert!(
+                tracing.starts_with("errors_"),
+                "tracing_field must start with errors_: {tracing}"
+            );
+            assert!(
+                tracing.contains(&display),
+                "tracing_field {tracing} must contain display {display}"
+            );
+        }
+    }
+}

--- a/crates/webfang_core/src/domain/error/mod.rs
+++ b/crates/webfang_core/src/domain/error/mod.rs
@@ -3,7 +3,9 @@
 //! Error types for the domain layer, organized by concern.
 
 mod crawl_error;
+mod crawl_error_category;
 mod domain_error;
 
 pub use crawl_error::{CrawlError, ResourceKind, WafDetectionKind};
+pub use crawl_error_category::CrawlErrorCategory;
 pub use domain_error::DomainError;

--- a/crates/webfang_core/src/domain/mod.rs
+++ b/crates/webfang_core/src/domain/mod.rs
@@ -64,7 +64,7 @@ pub use entities::{
     DocumentChunk, DocumentChunkExported, DocumentChunkUnvalidated, DocumentChunkValidated,
     DownloadedAsset, Draft, ExportState, Exported, ScrapedContent, Validated, ValidationError,
 };
-pub use error::{CrawlError, DomainError};
+pub use error::{CrawlError, CrawlErrorCategory, DomainError};
 pub use exporter::{ExportResult, Exporter, ExporterConfig};
 pub use http_config::{HttpClientConfig, UnknownProfileError};
 pub use http_error::{HttpError, HttpResult};

--- a/crates/webfang_core/src/domain/result/crawl_result.rs
+++ b/crates/webfang_core/src/domain/result/crawl_result.rs
@@ -2,7 +2,10 @@
 //!
 //! Represents the outcome of a crawling operation.
 
+use std::collections::BTreeMap;
+
 use crate::domain::crawl_job::DiscoveredUrl;
+use crate::domain::CrawlErrorCategory;
 
 /// Crawl result containing discovered URLs
 ///
@@ -17,15 +20,23 @@ pub struct CrawlResult {
     pub total_pages: usize,
     /// Number of errors encountered
     pub errors: usize,
+    /// Error counts by category (issue #374)
+    pub error_breakdown: BTreeMap<CrawlErrorCategory, usize>,
 }
 
 impl CrawlResult {
     /// Create a new crawl result
-    pub fn new(urls: Vec<DiscoveredUrl>, total_pages: usize, errors: usize) -> Self {
+    pub fn new(
+        urls: Vec<DiscoveredUrl>,
+        total_pages: usize,
+        errors: usize,
+        error_breakdown: BTreeMap<CrawlErrorCategory, usize>,
+    ) -> Self {
         Self {
             urls,
             total_pages,
             errors,
+            error_breakdown,
         }
     }
 
@@ -53,6 +64,7 @@ mod tests {
         assert!(result.is_empty());
         assert_eq!(result.total_pages, 0);
         assert_eq!(result.errors, 0);
+        assert!(result.error_breakdown.is_empty());
     }
 
     #[test]
@@ -60,11 +72,25 @@ mod tests {
         let url = Url::parse("https://example.com").unwrap();
         let parent = Url::parse("https://example.com/").unwrap();
         let discovered = DiscoveredUrl::html(url, 0, parent);
-        let result = CrawlResult::new(vec![discovered], 1, 0);
+        let result = CrawlResult::new(vec![discovered], 1, 0, BTreeMap::new());
 
         assert!(!result.is_empty());
         assert_eq!(result.total_pages, 1);
         assert_eq!(result.errors, 0);
         assert_eq!(result.urls.len(), 1);
+        assert!(result.error_breakdown.is_empty());
+    }
+
+    #[test]
+    fn test_crawl_result_with_breakdown() {
+        let mut breakdown = BTreeMap::new();
+        breakdown.insert(CrawlErrorCategory::Waf, 3);
+        breakdown.insert(CrawlErrorCategory::Timeout, 2);
+        let result = CrawlResult::new(vec![], 10, 5, breakdown);
+
+        assert_eq!(result.errors, 5);
+        assert_eq!(result.error_breakdown.len(), 2);
+        assert_eq!(result.error_breakdown[&CrawlErrorCategory::Waf], 3);
+        assert_eq!(result.error_breakdown[&CrawlErrorCategory::Timeout], 2);
     }
 }

--- a/crates/webfang_core/src/lib.rs
+++ b/crates/webfang_core/src/lib.rs
@@ -57,8 +57,8 @@ pub(crate) mod test_fixtures;
 
 // Domain layer
 pub use domain::{
-    ContentType, CrawlError, CrawlResult, CrawlerConfig, CrawlerConfigBuilder, DiscoveredUrl,
-    DownloadedAsset, JsRenderError, JsRenderer, ScrapedContent, SessionId, ValidUrl,
+    ContentType, CrawlError, CrawlErrorCategory, CrawlResult, CrawlerConfig, CrawlerConfigBuilder,
+    DiscoveredUrl, DownloadedAsset, JsRenderError, JsRenderer, ScrapedContent, SessionId, ValidUrl,
 };
 
 // Application layer

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -259,6 +259,7 @@ impl McpHandler {
                     "urls": urls,
                     "total_pages": result.total_pages,
                     "errors": result.errors,
+                    "error_breakdown": result.error_breakdown,
                 });
                 Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&json)


### PR DESCRIPTION
## Linked Issue

Closes #374

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Add per-category error classification (WAF, HTTP, Timeout, Network, RateLimit, Extraction, Internal, Panic) to the crawl summary log and `CrawlResult`
- Emit individual structured tracing fields (`errors_waf`, `errors_http`, etc.) in the `"crawl completed"` event for jq-queryable observability
- Expose `error_breakdown` in the MCP `crawl_site` tool JSON response

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/domain/error/crawl_error_category.rs` | NEW — `CrawlErrorCategory` enum (8 variants), `From<&CrawlError>` classification, array indexing, 9 unit tests |
| `crates/webfang_core/src/domain/error/mod.rs` | Register module + re-export |
| `crates/webfang_core/src/domain/mod.rs` | Re-export `CrawlErrorCategory` |
| `crates/webfang_core/src/lib.rs` | Public re-export |
| `crates/webfang_core/src/domain/result/crawl_result.rs` | Add `error_breakdown: BTreeMap<CrawlErrorCategory, usize>` field, update `new()` signature |
| `crates/webfang_core/src/application/crawler/crawl_task_ctx.rs` | Add `error_breakdown: Arc<[AtomicUsize; 8]>` shared counter |
| `crates/webfang_core/src/application/crawler/engine.rs` | Classify in `handle_crawl_result` + `run_crawl_task`, emit per-category fields in log, build BTreeMap for CrawlResult |
| `crates/webfang_mcp/src/mcp_server/handlers/scraping.rs` | Add `"error_breakdown"` to crawl_site JSON response |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (22/22 related tests)
- [x] Manually verified compilation across all workspace crates

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed