### PR TITLE
fix(mcp): correct url_to_file_path example and download_assets schema docs

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -13,9 +13,9 @@ use tracing::instrument;
 
 #[tool_router(router = tool_router_assets, vis = "pub")]
 impl McpHandler {
-    /// Download images and documents from HTML
+    /// Download images and documents from HTML (NOT YET IMPLEMENTED — see #170)
     #[tool(
-        description = "Download images (PNG, JPG, GIF, WEBP, SVG, BMP) and/or documents (PDF, DOCX, XLSX, PPTX) from HTML content. Uses SHA256-hashed filenames."
+        description = "NOT YET IMPLEMENTED (see #170). Download images and/or documents referenced in HTML content. Parameters 'images' and 'documents' are boolean toggles, not URL lists. Use scrape_url with download_images=true as a working alternative."
     )]
     #[instrument(skip(self), fields(base_url = %params.base_url, images = params.images.unwrap_or(true), documents = params.documents.unwrap_or(false)))]
     async fn download_assets(

--- a/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
@@ -135,7 +135,7 @@ impl McpHandler {
 
     /// Convert a URL to a domain-based file path
     #[tool(
-        description = "Convert a URL to a domain-based file path. E.g., 'https://example.com/docs/page' → 'example.com/docs/page.md'."
+        description = "Convert a URL to a domain-based file path. E.g., 'https://example.com/docs/page' → './output/example.com/docs/docs-page.md'. Path segments are flattened into the filename."
     )]
     #[instrument(skip(self), fields(url = %params.url))]
     async fn url_to_file_path(


### PR DESCRIPTION
Closes #344 (items 6+7)

## Summary
- **url_to_file_path**: Fix tool description example to match actual output format (`./output/` prefix + flattened path segments). The old example showed `example.com/docs/page.md` but actual output is `./output/example.com/docs/docs-page.md`.
- **download_assets**: Clarify that the tool is NOT YET IMPLEMENTED (#170) and that `images`/`documents` params are boolean toggles, not URL lists. Prevents callers from passing arrays and getting deserialize errors.

## Testing
- `cargo check -p webfang_mcp` ✅
- `cargo clippy -p webfang_mcp -- -D warnings` ✅
- `cargo fmt --check` ✅
- Doc-only changes, no behavioral impact.