### PR TITLE
feat(cli): add positional URL argument and fix negative threshold parsing

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -204,6 +204,13 @@ async fn __main() -> CliExit {
     };
 
     // =========================================================================
+    // 1b. Merge positional URL into --url (positional is syntactic sugar)
+    // =========================================================================
+    if let Some(pos_url) = args.positional_url.take() {
+        args.crawler.url = Some(pos_url);
+    }
+
+    // =========================================================================
     // 2. Handle subcommands (completions)
     // =========================================================================
     if let Some(Commands::Completions { shell }) = args.subcommand {

--- a/crates/webfang_core/src/cli/args/ai.rs
+++ b/crates/webfang_core/src/cli/args/ai.rs
@@ -18,7 +18,13 @@ fn parse_threshold(s: &str) -> Result<f32, String> {
 pub struct AiArgs {
     /// Relevance threshold for AI semantic filtering (0.0-1.0)
     #[cfg(feature = "ai")]
-    #[arg(long, default_value = "0.3", env = "WEBFANG_THRESHOLD", value_parser = parse_threshold)]
+    #[arg(
+        long,
+        default_value = "0.3",
+        env = "WEBFANG_THRESHOLD",
+        value_parser = parse_threshold,
+        allow_negative_numbers = true
+    )]
     #[clap(next_help_heading = "AI Settings")]
     pub threshold: f32,
 

--- a/crates/webfang_core/src/cli/args/mod.rs
+++ b/crates/webfang_core/src/cli/args/mod.rs
@@ -41,13 +41,17 @@ use clap::Parser;
 #[command(name = "webfang", version)]
 #[command(
     about = "High-performance web scraper with WAF evasion and AI-powered content cleaning",
-    after_help = "EXIT CODES:\n  0    Success\n  2    No URLs discovered\n  3    All scrapers failed\n  64   Bad CLI arguments (usage error)\n  69   WAF block or network error\n  74   I/O error\n  76   Protocol error\n  78   Configuration error\n\nEXAMPLES:\n  webfang -u https://example.com\n  webfang -u https://example.com --ai\n  webfang -u https://example.com -f jsonl\n  webfang -u https://example.com -v\n  webfang -u https://example.com -vv  # DEBUG\n  webfang --url-list urls.txt --resume"
+    after_help = "EXIT CODES:\n  0    Success\n  2    No URLs discovered\n  3    All scrapers failed\n  64   Bad CLI arguments (usage error)\n  69   WAF block or network error\n  74   I/O error\n  76   Protocol error\n  78   Configuration error\n\nEXAMPLES:\n  webfang https://example.com\n  webfang -u https://example.com\n  webfang -u https://example.com --ai\n  webfang -u https://example.com -f jsonl\n  webfang -u https://example.com -v\n  webfang -u https://example.com -vv  # DEBUG\n  webfang --url-list urls.txt --resume"
 )]
-#[command(args_conflicts_with_subcommands = true)]
+#[command(subcommand_negates_reqs = true)]
 pub struct Args {
     /// Subcommands
     #[command(subcommand)]
     pub subcommand: Option<Commands>,
+
+    /// URL to scrape (positional shorthand — equivalent to --url)
+    #[arg(value_name = "URL", conflicts_with = "url")]
+    pub positional_url: Option<String>,
 
     /// Crawler and discovery configuration.
     #[command(flatten)]
@@ -294,5 +298,58 @@ mod tests {
             opts.crawl.ignore_waf,
             "ignore_waf must propagate Args -> CrawlOptions"
         );
+    }
+
+    // ========================================================================
+    // #344 — Positional URL argument
+    // ========================================================================
+
+    #[test]
+    fn positional_url_parses() {
+        clean_env();
+        let args = Args::try_parse_from(["webfang", "https://example.com"]).expect("valid args");
+        assert_eq!(
+            args.positional_url.as_deref(),
+            Some("https://example.com"),
+            "positional URL captured"
+        );
+    }
+
+    #[test]
+    fn positional_url_with_flags() {
+        clean_env();
+        let args = Args::try_parse_from(["webfang", "https://example.com", "--max-pages", "5"])
+            .expect("valid args");
+        assert_eq!(args.positional_url.as_deref(), Some("https://example.com"));
+        assert_eq!(args.crawler.max_pages, 5);
+    }
+
+    #[test]
+    fn positional_url_conflicts_with_flag() {
+        clean_env();
+        let result =
+            Args::try_parse_from(["webfang", "https://example.com", "-u", "https://other.com"]);
+        assert!(result.is_err(), "positional + -u must conflict");
+    }
+
+    #[test]
+    fn completions_still_work() {
+        clean_env();
+        let args = Args::try_parse_from(["webfang", "completions", "bash"]).expect("valid args");
+        assert!(
+            matches!(
+                args.subcommand,
+                Some(Commands::Completions { shell: Shell::Bash })
+            ),
+            "completions subcommand parses without URL"
+        );
+    }
+
+    #[test]
+    fn no_args_no_url_is_ok() {
+        clean_env();
+        let args = Args::try_parse_from(["webfang"]).expect("valid args");
+        assert!(args.positional_url.is_none());
+        assert!(args.crawler.url.is_none());
     }
 }

--- a/crates/webfang_core/tests/args_test.rs
+++ b/crates/webfang_core/tests/args_test.rs
@@ -75,6 +75,7 @@ fn test_ram_budget_accepts_plain_bytes_and_suffixes() {
 fn args_with_all_fields_set() -> Args {
     Args {
         subcommand: None,
+        positional_url: None,
 
         crawler: CrawlerArgs {
             url: Some("https://example.com/test".into()),
@@ -459,6 +460,7 @@ proptest! {
     ) {
         let args = Args {
             subcommand: None,
+            positional_url: None,
             crawler: CrawlerArgs {
                 url: Some("https://example.com/prop".into()),
                 selector: "body".into(),
@@ -565,6 +567,7 @@ proptest! {
     ) {
         let args = Args {
             subcommand: None,
+            positional_url: None,
             crawler: CrawlerArgs {
                 url: Some("https://example.com/prop".into()),
                 selector: "body".into(),
@@ -650,6 +653,7 @@ proptest! {
 
         let args = Args {
             subcommand: None,
+            positional_url: None,
             crawler: CrawlerArgs {
                 url: Some("https://example.com/prop".into()),
                 selector,
@@ -729,6 +733,7 @@ proptest! {
     ) {
         let args = Args {
             subcommand: None,
+            positional_url: None,
             crawler: CrawlerArgs {
                 url: Some("https://example.com/prop".into()),
                 selector: "body".into(),
@@ -812,6 +817,7 @@ proptest! {
 
         let args = Args {
             subcommand: None,
+            positional_url: None,
             crawler: CrawlerArgs {
                 url: Some("https://example.com/prop".into()),
                 selector: "body".into(),
@@ -887,6 +893,7 @@ proptest! {
     ) {
         let args = Args {
             subcommand: None,
+            positional_url: None,
             crawler: CrawlerArgs {
                 url: Some("https://example.com/prop".into()),
                 selector: "body".into(),
@@ -960,6 +967,7 @@ proptest! {
 
         let args = Args {
             subcommand: None,
+            positional_url: None,
             crawler: CrawlerArgs {
                 url: Some("https://example.com/prop".into()),
                 selector: "body".into(),

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__help.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__help.snap
@@ -14,12 +14,16 @@ let args = Args::parse_from([ "webfang", "--url", "https://example.com", "--outp
 
 assert_eq!(args.crawler.url.as_deref(), Some("https://example.com")); ```
 
-Usage: webfang [OPTIONS]
-       webfang <COMMAND>
+Usage: webfang [OPTIONS] [URL]
+       webfang [OPTIONS] [URL] <COMMAND>
 
 Commands:
   completions  Generate shell completion scripts
   help         Print this message or the help of the given subcommand(s)
+
+Arguments:
+  [URL]
+          URL to scrape (positional shorthand — equivalent to --url)
 
 Options:
   -u, --url <URL>
@@ -420,6 +424,7 @@ EXIT CODES:
   78   Configuration error
 
 EXAMPLES:
+  webfang https://example.com
   webfang -u https://example.com
   webfang -u https://example.com --ai
   webfang -u https://example.com -f jsonl

--- a/crates/webfang_core/tests/snapshots/cli_binary_test__test_help_contains_scraper.snap
+++ b/crates/webfang_core/tests/snapshots/cli_binary_test__test_help_contains_scraper.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/webfang_core/../../tests/cli_binary_test.rs
+source: crates/webfang_core/tests/cli_binary_test.rs
 expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stdout)"
 ---
 CLI Arguments for the webfang binary.
@@ -14,12 +14,16 @@ let args = Args::parse_from([ "webfang", "--url", "https://example.com", "--outp
 
 assert_eq!(args.crawler.url.as_deref(), Some("https://example.com")); ```
 
-Usage: webfang [OPTIONS]
-       webfang <COMMAND>
+Usage: webfang [OPTIONS] [URL]
+       webfang [OPTIONS] [URL] <COMMAND>
 
 Commands:
   completions  Generate shell completion scripts
   help         Print this message or the help of the given subcommand(s)
+
+Arguments:
+  [URL]
+          URL to scrape (positional shorthand — equivalent to --url)
 
 Options:
   -u, --url <URL>
@@ -420,6 +424,7 @@ EXIT CODES:
   78   Configuration error
 
 EXAMPLES:
+  webfang https://example.com
   webfang -u https://example.com
   webfang -u https://example.com --ai
   webfang -u https://example.com -f jsonl


### PR DESCRIPTION
Closes #344 (items 1+5)

## Summary

### Item 1: Positional URL
`webfang https://example.com` now works as shorthand for `webfang -u https://example.com`.

- Replaced `args_conflicts_with_subcommands = true` with `subcommand_negates_reqs = true` (clap 4 idiom, matches ripgrep/fd pattern)
- Added `positional_url: Option<String>` with `conflicts_with = "url"` to prevent ambiguity when both positional and `-u` are provided
- Merge logic in `__main`: positional is copied into `crawler.url` before any URL-handling logic
- Subcommands still work: `webfang completions bash` parses correctly without requiring a URL

### Item 5: Negative threshold
`--threshold -0.1` now reaches the range validator instead of being intercepted by clap as a flag (exit 64).

- Added `allow_negative_numbers = true` to the `--threshold` arg attribute
- `parse_threshold()` already validates 0.0..=1.0 with a clean Spanish error: `'-0.1' está fuera de rango (rango válido: 0.0 a 1.0)`
- Did NOT use `allow_hyphen_values` (dangerous — would treat `-config` as a value)

## Testing
- 5 new tests: positional parses, positional + flags, positional conflicts with -u, completions still work, no-args parses OK
- `cargo nextest run -- args`: 13/13 ✅
- `cargo nextest run -- cli`: 193/193 ✅
- `cargo clippy -- -D warnings` ✅
- Note: `--features ai` build not tested (heavy ONNX/BoringSSL); the threshold fix is a surgical clap attribute

## Files changed
- `crates/webfang_core/src/cli/args/mod.rs` — subcommand_negates_reqs, positional_url field, examples, tests
- `crates/webfang_core/src/cli/args/ai.rs` — allow_negative_numbers
- `crates/webfang_cli/src/main.rs` — positional → crawler.url merge
- `crates/webfang_core/tests/args_test.rs` — compile fix for new field