### PR TITLE
fix(security): neutralize Obsidian URI command injection + harden path sanitization (#446 #447 #448)

### DIFF
--- a/crates/webfang_core/src/adapters/url_path.rs
+++ b/crates/webfang_core/src/adapters/url_path.rs
@@ -178,24 +178,38 @@ impl UrlPath {
             return String::new();
         }
         let path_trimmed = self.raw.trim_start_matches('/');
-        // Find the parent directory (everything before the last /)
         if let Some(last_slash) = path_trimmed.rfind('/') {
-            format!("{}/", &path_trimmed[..last_slash])
+            let dir = &path_trimmed[..last_slash];
+            // Sanitize each component (defense in depth): neutralizes exotic chars
+            // and dot-segments so a hostile path cannot escape the output folder even
+            // if upstream URL normalization is bypassed.
+            let sanitized = dir
+                .split('/')
+                .map(|component| {
+                    if component == "." || component == ".." {
+                        "_".to_string()
+                    } else {
+                        Self::sanitize_path_segment(component)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("/");
+            format!("{sanitized}/")
         } else {
             String::new()
         }
     }
 
     fn sanitize_path_segment(s: &str) -> String {
-        const INVALID: &[char] = &['\\', ':', '*', '?', '"', '<', '>', '|', ' '];
+        // Whitelist: only alphanumeric + '-' '_' '.' survive. Everything else
+        // (including path separators '/', '\\', and shell metacharacters) maps to '_'.
+        // Defense in depth — callers also pre-replace '/', so this guards reuse.
         s.chars()
             .map(|c| {
                 if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
                     c
-                } else if INVALID.contains(&c) {
-                    '_'
                 } else {
-                    c
+                    '_'
                 }
             })
             .collect()
@@ -530,5 +544,29 @@ mod tests {
         let url2 = UrlPath::from_url_path("/config");
         let filename2 = url2.to_safe_filename();
         assert_eq!(filename2, "config.md");
+    }
+
+    #[test]
+    fn test_filename_never_contains_path_separator() {
+        for input in ["/a/b/c", "/docs/page%20x", "/con/x"] {
+            let path = UrlPath::from_url_path(input);
+            let filename = path.to_safe_filename();
+            assert!(
+                !filename.contains('/'),
+                "separator leaked for {input}: {filename}"
+            );
+            assert!(
+                !filename.contains('\\'),
+                "backslash leaked for {input}: {filename}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_directory_neutralizes_traversal() {
+        let path = UrlPath::from_url_path("/a/../b/leaf");
+        let dir = path.to_directory();
+        assert!(!dir.contains(".."), "traversal segment leaked: {dir}");
+        assert_eq!(dir, "a/_/b/");
     }
 }

--- a/crates/webfang_core/src/infrastructure/downloader/obscura_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/obscura_downloader.rs
@@ -49,6 +49,14 @@ impl ObscuraDownloader {
 
         let url_string = url.to_string();
 
+        // Defense in depth: a typed Url always carries a scheme (e.g. https://) so it can
+        // never be mistaken for an obscura flag; reject defensively anyway.
+        if url_string.starts_with('-') {
+            return Err(DownloadError::Internal(
+                "URL inválida: no puede comenzar con '-'".to_string(),
+            ));
+        }
+
         let result = timeout(
             self.timeout,
             tokio::task::spawn_blocking(move || {

--- a/crates/webfang_core/src/infrastructure/obsidian/uri.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/uri.rs
@@ -54,7 +54,7 @@ pub fn build_obsidian_uri(vault_name: &str, file_path: &str) -> String {
 
 /// Validate Obsidian URI inputs, rejecting ASCII control characters.
 ///
-/// Shell metacharacters are neutralized by [`encode_obsidian_param`] (percent-encoded),
+/// Shell metacharacters are neutralized by `encode_obsidian_param` (percent-encoded),
 /// so they are safe in the URI. Control characters (newline, null byte, etc.) have no
 /// legitimate place in a vault name or note path and are rejected outright as a signal
 /// of malformed or hostile input.

--- a/crates/webfang_core/src/infrastructure/obsidian/uri.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/uri.rs
@@ -6,27 +6,26 @@
 
 use std::path::Path;
 
-/// Minimal encoding for Obsidian URI parameters.
+/// Comprehensive percent-encoding for Obsidian URI parameters.
 ///
-/// Unlike full URL encoding, this preserves forward slashes and other
-/// characters that Obsidian expects unencoded in URI query values.
-/// Only encodes characters that would break URI parsing: `&`, `=`,
-/// `#`, `?`, `%`, `+`, space, and non-ASCII.
+/// Whitelist-based: only RFC 3986 unreserved characters (`A-Z a-z 0-9 - _ . ~`)
+/// plus `/` (Obsidian needs slashes unencoded in file paths) survive verbatim.
+/// Every other ASCII character — including all cmd.exe metacharacters
+/// (`| > < ^ ; ( ) & = # ? % + space`) — is percent-encoded so it can never be
+/// interpreted by a shell. This neutralizes shell metacharacters (Windows
+/// cmd.exe safety) while preserving `/` for Obsidian file paths. Non-ASCII
+/// characters are UTF-8 percent-encoded byte by byte.
 fn encode_obsidian_param(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for ch in input.chars() {
         match ch {
-            '&' | '=' | '#' | '?' | '%' | '+' => {
-                out.push_str(&format!("%{:02X}", ch as u32));
-            },
-            ' ' => {
-                out.push_str("%20");
-            },
-            c if c.is_ascii() => {
-                out.push(c);
-            },
+            // RFC 3986 unreserved chars + '/' (Obsidian needs slashes unencoded in file paths).
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' | '/' => out.push(ch),
+            // Every other ASCII char — including cmd.exe metacharacters | > < ^ ; ( ) & = # ? % +
+            // and space — is percent-encoded so it can never be interpreted by a shell.
+            c if c.is_ascii() => out.push_str(&format!("%{:02X}", c as u32)),
+            // Non-ASCII: UTF-8 percent-encode each byte.
             c => {
-                // Non-ASCII: UTF-8 percent-encode each byte
                 let mut buf = [0u8; 4];
                 for &byte in c.encode_utf8(&mut buf).as_bytes() {
                     out.push_str(&format!("%{byte:02X}"));
@@ -53,6 +52,27 @@ pub fn build_obsidian_uri(vault_name: &str, file_path: &str) -> String {
     )
 }
 
+/// Validate Obsidian URI inputs, rejecting ASCII control characters.
+///
+/// Shell metacharacters are neutralized by [`encode_obsidian_param`] (percent-encoded),
+/// so they are safe in the URI. Control characters (newline, null byte, etc.) have no
+/// legitimate place in a vault name or note path and are rejected outright as a signal
+/// of malformed or hostile input.
+///
+/// # Errors
+/// Returns `Err` with a user-facing (Spanish) message if either input contains an
+/// ASCII control character.
+pub fn validate_obsidian_input(vault_name: &str, file_path: &str) -> Result<(), String> {
+    for (label, value) in [("vault_name", vault_name), ("file_path", file_path)] {
+        if value.chars().any(|c| c.is_ascii_control()) {
+            return Err(format!(
+                "{label} contiene caracteres de control no permitidos"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Open a note in Obsidian using the URI protocol (fire-and-forget).
 ///
 /// Uses `xdg-open` on Linux, `open` on macOS, `start` on Windows.
@@ -64,8 +84,12 @@ pub fn build_obsidian_uri(vault_name: &str, file_path: &str) -> String {
 /// # Returns
 /// `Ok(())` on spawn, `Err(String)` if command fails to start
 pub fn open_in_obsidian(uri: &str) -> Result<(), String> {
+    // The URI is fully percent-encoded by `build_obsidian_uri` (no raw
+    // metacharacters or quotes can appear), and on Windows the empty `""`
+    // title prevents `start` from consuming the URI as a window title.
+    // Together these make `cmd /C start` safe on Windows.
     let (cmd, args) = if cfg!(target_os = "windows") {
-        ("cmd", vec!["/C", "start", uri])
+        ("cmd", vec!["/C", "start", "", uri])
     } else if cfg!(target_os = "macos") {
         ("open", vec![uri])
     } else {
@@ -121,6 +145,8 @@ pub fn open_note(vault_path: &Path, file_path: &Path) -> Result<(), String> {
         .replace('\\', "/")
         .trim_end_matches(".md")
         .to_string();
+
+    validate_obsidian_input(&vault_name, &file_str)?;
 
     let uri = build_obsidian_uri(&vault_name, &file_str);
     open_in_obsidian(&uri)
@@ -178,5 +204,43 @@ mod tests {
     #[test]
     fn test_extract_vault_name_root() {
         assert_eq!(extract_vault_name(Path::new("/")), "Unknown");
+    }
+
+    #[test]
+    fn test_encode_neutralizes_pipe_injection() {
+        let uri = build_obsidian_uri("foo|calc.exe", "note");
+        assert!(!uri.contains('|'));
+        assert!(uri.contains("vault=foo%7Ccalc.exe"));
+    }
+
+    #[test]
+    fn test_encode_neutralizes_all_cmd_metacharacters() {
+        for meta in ['|', '>', '<', '^', ';', '(', ')', '&', '"', '\n', '\r'] {
+            let input = format!("a{meta}b");
+            let uri = build_obsidian_uri(&input, "note");
+            // Isolate the encoded vault value (between `vault=` and `&file=`).
+            // The whole URI structurally contains '&' and '=' as query separators,
+            // so asserting on the full string would false-positive on those
+            // legitimate characters even though the value is correctly encoded.
+            let vault_value = uri
+                .strip_prefix("obsidian://open?vault=")
+                .and_then(|rest| rest.split("&file=").next())
+                .unwrap_or_default();
+            assert!(
+                !vault_value.contains(meta),
+                "metacharacter {meta:?} leaked into vault value: {vault_value}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_control_chars() {
+        assert!(validate_obsidian_input("vault\nname", "note").is_err());
+        assert!(validate_obsidian_input("vault", "note\0path").is_err());
+    }
+
+    #[test]
+    fn test_validate_accepts_normal_input() {
+        assert!(validate_obsidian_input("My Vault", "Folder/Subfolder/note").is_ok());
     }
 }

--- a/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
@@ -51,6 +51,13 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, obsidian);
 
+        if let Err(e) = webfang_core::infrastructure::obsidian::uri::validate_obsidian_input(
+            &params.vault_name,
+            &params.file_path,
+        ) {
+            return Ok(CallToolResult::error(vec![Content::text(e)]));
+        }
+
         let uri = webfang_core::infrastructure::obsidian::uri::build_obsidian_uri(
             &params.vault_name,
             &params.file_path,
@@ -69,12 +76,19 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, obsidian);
 
+        if let Err(e) = webfang_core::infrastructure::obsidian::uri::validate_obsidian_input(
+            &params.vault_name,
+            &params.file_path,
+        ) {
+            return Ok(CallToolResult::error(vec![Content::text(e)]));
+        }
+
         let uri = webfang_core::infrastructure::obsidian::uri::build_obsidian_uri(
             &params.vault_name,
             &params.file_path,
         );
-        match tokio::process::Command::new("open").arg(&uri).spawn() {
-            Ok(_) => Ok(CallToolResult::success(vec![Content::text(format!(
+        match webfang_core::infrastructure::obsidian::uri::open_in_obsidian(&uri) {
+            Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
                 "Opened in Obsidian: {uri}"
             ))])),
             Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(


### PR DESCRIPTION
## Linked Issue

Closes #446
Closes #447
Closes #448

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- **#446 (HIGH):** Fixed Windows command injection in `open_in_obsidian`. `encode_obsidian_param` left cmd.exe metacharacters (`| > < ^ ; ( )`) raw, so an MCP-supplied vault name like `foo|calc.exe` executed commands via `cmd /C start <uri>`. Now whitelist-based percent-encoding neutralizes every shell metacharacter, plus input validation and a safer `start ""` invocation.
- **#447 (med):** The MCP `open_in_obsidian` handler hardcoded `open` (macOS only) and duplicated `uri.rs`. It now delegates to core's cross-platform `open_in_obsidian` (Windows/macOS/Linux) and validates input first.
- **#448 (chore):** Hardened `sanitize_path_segment` (whitelist — strips `/` and exotic chars), `to_directory` (sanitizes components + neutralizes `.`/`..` traversal), and added an obscura argument-injection guard. The `--pdg` taint analysis (item 2 of #448) was deferred by maintainer decision to #455 (cost approval).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/infrastructure/obsidian/uri.rs` | Comprehensive whitelist percent-encoding; new `validate_obsidian_input`; Windows `start "" <uri>`; `open_note` validates; injection tests |
| `crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs` | `open_in_obsidian` delegates to core cross-platform handler; both handlers validate input |
| `crates/webfang_core/src/adapters/url_path.rs` | Whitelist `sanitize_path_segment`; `to_directory` sanitizes components + dot-segments; tests |
| `crates/webfang_core/src/infrastructure/downloader/obscura_downloader.rs` | Reject URL starting with `-` (argument-injection guard) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean (0 warnings)
- [x] `cargo nextest run` passes — obsidian 102, url_path 60, obscura 4, webfang_mcp 166 (0 failures)
- [x] Manually verified the affected functionality (full diff review)

> Note: `gitnexus detect_changes` hit the documented worktree false-negative (#1259 — "No changes detected" despite a dirty tree, even with the absolute repo path). Compensated with pre-edit `impact` analysis on every touched symbol + full manual diff review: only the 4 intended files/symbols changed.

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (doc comments updated on all changed functions)
