### PR TITLE
refactor(core): descomponer scraper_service.rs God Module (#443)

### DIFF
--- a/crates/webfang_core/src/application/asset_download.rs
+++ b/crates/webfang_core/src/application/asset_download.rs
@@ -5,7 +5,7 @@
 //! [`download_assets_if_enabled`] is application-layer orchestration, not
 //! adapter logic: it reads [`ScraperConfig`](crate::ScraperConfig), extracts
 //! asset URLs from the HTML via [`crate::extractor`], deduplicates them, and
-//! delegates the actual transfer to the [`AssetDownloaderPort`] adapter
+//! delegates the actual transfer to the [`AssetDownloaderPort`](crate::domain::ports::AssetDownloaderPort) adapter
 //! (`adapters::downloader::Downloader` implements the port). Pushing this into
 //! the adapter would invert the Clean Architecture dependency direction
 //! (adapters implement domain ports; they do not orchestrate application

--- a/crates/webfang_core/src/application/asset_download.rs
+++ b/crates/webfang_core/src/application/asset_download.rs
@@ -1,0 +1,83 @@
+//! Asset download orchestration — application-layer glue for asset downloading.
+//!
+//! # Design note (#443)
+//!
+//! [`download_assets_if_enabled`] is application-layer orchestration, not
+//! adapter logic: it reads [`ScraperConfig`](crate::ScraperConfig), extracts
+//! asset URLs from the HTML via [`crate::extractor`], deduplicates them, and
+//! delegates the actual transfer to the [`AssetDownloaderPort`] adapter
+//! (`adapters::downloader::Downloader` implements the port). Pushing this into
+//! the adapter would invert the Clean Architecture dependency direction
+//! (adapters implement domain ports; they do not orchestrate application
+//! config), so the function lives here and delegates downward through the port.
+
+use crate::domain::DownloadedAsset;
+use crate::error::Result;
+
+/// Helper: Download assets if config has downloads enabled
+///
+/// Uses the `AssetDownloaderPort` trait for testability.
+/// Falls back to constructing a concrete `Downloader` when no trait object is provided.
+pub async fn download_assets_if_enabled(
+    _html: &str,
+    _base_url: &url::Url,
+    _config: &crate::ScraperConfig,
+    _shared_downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
+) -> Result<Vec<DownloadedAsset>> {
+    if !_config.has_downloads() {
+        return Ok(Vec::new());
+    }
+
+    #[cfg(any(feature = "images", feature = "documents"))]
+    {
+        // Use shared downloader when provided; create a fallback one otherwise
+        let owned_downloader;
+        let downloader: &dyn crate::domain::ports::AssetDownloaderPort = match _shared_downloader {
+            Some(dl) => dl,
+            None => {
+                owned_downloader =
+                    crate::adapters::downloader::Downloader::new(_config.to_download_config())?;
+                &owned_downloader
+            },
+        };
+
+        // Extract URLs from HTML
+        let mut urls: Vec<String> = Vec::new();
+        {
+            let document = scraper::Html::parse_document(_html);
+            if _config.download_images {
+                let images = crate::extractor::extract_images(&document, _base_url);
+                urls.extend(images.into_iter().map(|a| a.url));
+            }
+            if _config.download_documents {
+                let docs = crate::extractor::extract_documents(&document, _base_url);
+                urls.extend(docs.into_iter().map(|a| a.url));
+            }
+        }
+
+        if urls.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Deduplicate URLs to avoid downloading the same asset multiple times
+        // (e.g., same image referenced from multiple <img> tags).
+        use std::collections::HashSet;
+        let mut seen = HashSet::with_capacity(urls.len());
+        urls.retain(|url| seen.insert(url.clone()));
+
+        tracing::info!(
+            "📦 Downloading {} assets via adapters::Downloader",
+            urls.len()
+        );
+
+        let results = downloader.download_batch(&urls).await?;
+
+        // Trait impl already returns domain::DownloadedAsset — collect directly
+        Ok(results)
+    }
+
+    #[cfg(not(any(feature = "images", feature = "documents")))]
+    {
+        Ok(Vec::new())
+    }
+}

--- a/crates/webfang_core/src/application/diagnostic.rs
+++ b/crates/webfang_core/src/application/diagnostic.rs
@@ -1,0 +1,96 @@
+//! Selector diagnostics — build failure diagnostics for CSS selector extraction.
+//!
+//! Helper used on the extraction failure path (0 matches, invalid selector, or
+//! empty document) to attach a [`SelectorDiagnostic`] when a DOM inspector is
+//! available.
+
+use crate::domain::{DomInspectorPort, SelectorDiagnostic, SelectorErrorKind};
+
+/// Build a [`SelectorDiagnostic`] using the inspector, or return `None` if no
+/// inspector was provided.
+///
+/// This helper calls `inspector.inspect()` for the DOM structure report and
+/// `inspector.suggest()` for closest-match selector suggestions. It is only
+/// called on the failure path (0 matches or invalid selector).
+pub(crate) fn build_diagnostic(
+    inspector: Option<&dyn DomInspectorPort>,
+    document: &scraper::Html,
+    error_kind: SelectorErrorKind,
+    failed_selector: &str,
+) -> Option<SelectorDiagnostic> {
+    inspector.map(|insp| SelectorDiagnostic {
+        error_kind,
+        report: insp.inspect(document),
+        suggestions: insp.suggest(document, failed_selector),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{DomStructureReport, SelectorSuggestion};
+
+    /// Deterministic inspector stub: returns a fixed report and a single
+    /// suggestion derived from the failed selector. No infrastructure involved.
+    struct StubInspector;
+
+    impl DomInspectorPort for StubInspector {
+        fn inspect(&self, _document: &scraper::Html) -> DomStructureReport {
+            DomStructureReport {
+                element_count: 7,
+                ..DomStructureReport::default()
+            }
+        }
+
+        fn suggest(
+            &self,
+            _document: &scraper::Html,
+            failed_selector: &str,
+        ) -> Vec<SelectorSuggestion> {
+            vec![SelectorSuggestion {
+                selector: format!("suggest-{failed_selector}"),
+                score: 0.9,
+            }]
+        }
+    }
+
+    #[test]
+    fn test_no_inspector_returns_none() {
+        let document = scraper::Html::parse_document("<html><body></body></html>");
+        let result = build_diagnostic(None, &document, SelectorErrorKind::ZeroMatches, "div.x");
+        assert!(
+            result.is_none(),
+            "without an inspector no diagnostic can be produced"
+        );
+    }
+
+    #[test]
+    fn test_with_inspector_wires_report_and_suggestions() {
+        let document = scraper::Html::parse_document("<html><body><p>x</p></body></html>");
+        let result = build_diagnostic(
+            Some(&StubInspector),
+            &document,
+            SelectorErrorKind::ZeroMatches,
+            "div.missing",
+        );
+        let diagnostic = result.expect("an inspector must produce a diagnostic");
+
+        assert_eq!(diagnostic.error_kind, SelectorErrorKind::ZeroMatches);
+        assert_eq!(diagnostic.report.element_count, 7);
+        assert_eq!(diagnostic.suggestions.len(), 1);
+        assert_eq!(diagnostic.suggestions[0].selector, "suggest-div.missing");
+    }
+
+    #[test]
+    fn test_error_kind_is_preserved() {
+        let document = scraper::Html::parse_document("");
+        let result = build_diagnostic(
+            Some(&StubInspector),
+            &document,
+            SelectorErrorKind::EmptyDocument,
+            "article",
+        );
+        let diagnostic = result.expect("an inspector must produce a diagnostic");
+        assert_eq!(diagnostic.error_kind, SelectorErrorKind::EmptyDocument);
+    }
+}

--- a/crates/webfang_core/src/application/error_mapping.rs
+++ b/crates/webfang_core/src/application/error_mapping.rs
@@ -1,0 +1,175 @@
+//! Error mapping — `HttpError` to domain/scraper error conversion.
+//!
+//! This module is the application-layer half of the `HttpError` → `CrawlError`
+//! mapping; the domain half lives in `domain/error/crawl_error.rs`
+//! (`From<HttpError> for CrawlError`). The two sites MUST stay in sync — see
+//! `tests::test_request_failed_dual_site_agreement`.
+
+use crate::application::http_client::HttpError;
+use crate::error::ScraperError;
+
+/// Convert an [`HttpError`] into a domain [`CrawlError`] with the URL context.
+///
+/// This is the application-layer half of the `HttpError` → `CrawlError`
+/// mapping; the domain half lives in `domain/error/crawl_error.rs`
+/// (`From<HttpError> for CrawlError`). The two sites MUST stay in sync —
+/// see `tests::test_request_failed_dual_site_agreement`.
+fn crawl_error_from_http(err: HttpError, url: &str) -> crate::domain::error::CrawlError {
+    use crate::domain::error::CrawlError;
+    match err {
+        HttpError::ClientError(code) | HttpError::ServerError(code) => CrawlError::Http {
+            status: code,
+            url: url.to_string(),
+        },
+        HttpError::Forbidden => CrawlError::Http {
+            status: 403,
+            url: url.to_string(),
+        },
+        HttpError::RateLimited(retry_after) => CrawlError::RateLimited(retry_after),
+        HttpError::Timeout => CrawlError::Timeout,
+        HttpError::Connection(msg) => CrawlError::Connection(msg),
+        HttpError::Request(msg) => CrawlError::RequestFailed(msg),
+        HttpError::WafChallenge(provider) => CrawlError::WafChallenge {
+            provider,
+            kind: crate::domain::error::WafDetectionKind::BodySignature,
+            url: url.to_string(),
+        },
+        HttpError::DomainBanned(domain) => {
+            CrawlError::SessionPool(format!("domain banned: {domain}"))
+        },
+    }
+}
+
+/// Convert an [`HttpError`] into a [`ScraperError`] with the URL context.
+pub(crate) fn scraper_error_from_http(err: HttpError, url: &str) -> ScraperError {
+    ScraperError::from(crawl_error_from_http(err, url))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::error::CrawlError;
+    use crate::error::ErrorClass;
+
+    const URL: &str = "https://example.com";
+
+    /// EC-REQUEST-FAILED: both `HttpError::Request` conversion sites must agree.
+    ///
+    /// Site 1: `application::error_mapping::crawl_error_from_http`
+    /// Site 2: `domain/error/crawl_error.rs` `From<HttpError>`
+    ///
+    /// Both must yield `CrawlError::RequestFailed(msg)` for the same input —
+    /// no divergence between the application and domain conversion paths.
+    #[test]
+    fn test_request_failed_dual_site_agreement() {
+        let msg = "build failed";
+
+        // Site 1 (application layer)
+        let via_service =
+            crawl_error_from_http(HttpError::Request(msg.to_string()), "https://example.com");
+        // Site 2 (domain layer)
+        let via_domain: CrawlError = HttpError::Request(msg.to_string()).into();
+
+        assert!(
+            matches!(&via_service, CrawlError::RequestFailed(m) if m == msg),
+            "service site must produce RequestFailed, got: {via_service:?}"
+        );
+        assert!(
+            matches!(&via_domain, CrawlError::RequestFailed(m) if m == msg),
+            "domain site must produce RequestFailed, got: {via_domain:?}"
+        );
+
+        // Classification is preserved end-to-end: RequestFailed → Internal → InternalFatal.
+        let scraper_err = ScraperError::from(via_service);
+        assert!(
+            matches!(&scraper_err, ScraperError::Internal(m) if m == msg),
+            "RequestFailed must map to ScraperError::Internal, got: {scraper_err}"
+        );
+        assert_eq!(scraper_err.classify(), ErrorClass::InternalFatal);
+    }
+
+    #[test]
+    fn test_client_error_maps_to_http_with_status() {
+        let err = crawl_error_from_http(HttpError::ClientError(404), URL);
+        assert!(
+            matches!(&err, CrawlError::Http { status: 404, url } if url == URL),
+            "expected Http 404 with url, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_server_error_maps_to_http_with_status() {
+        let err = crawl_error_from_http(HttpError::ServerError(503), URL);
+        assert!(
+            matches!(&err, CrawlError::Http { status: 503, url } if url == URL),
+            "expected Http 503 with url, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_forbidden_maps_to_http_403() {
+        let err = crawl_error_from_http(HttpError::Forbidden, URL);
+        assert!(
+            matches!(&err, CrawlError::Http { status: 403, url } if url == URL),
+            "expected Http 403, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_rate_limited_preserves_retry_after() {
+        let err = crawl_error_from_http(HttpError::RateLimited(60), URL);
+        assert!(
+            matches!(err, CrawlError::RateLimited(60)),
+            "expected RateLimited(60), got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_timeout_maps_to_timeout() {
+        let err = crawl_error_from_http(HttpError::Timeout, URL);
+        assert!(matches!(err, CrawlError::Timeout), "got: {err:?}");
+    }
+
+    #[test]
+    fn test_connection_preserves_message() {
+        let err = crawl_error_from_http(HttpError::Connection("refused".to_string()), URL);
+        assert!(
+            matches!(&err, CrawlError::Connection(m) if m == "refused"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_waf_challenge_maps_with_body_signature_kind() {
+        use crate::domain::error::WafDetectionKind;
+        let err = crawl_error_from_http(HttpError::WafChallenge("cloudflare".to_string()), URL);
+        assert!(
+            matches!(&err, CrawlError::WafChallenge { provider, kind, url }
+                if provider == "cloudflare"
+                    && matches!(kind, WafDetectionKind::BodySignature)
+                    && url == URL),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_domain_banned_maps_to_session_pool() {
+        let err = crawl_error_from_http(HttpError::DomainBanned("example.com".to_string()), URL);
+        assert!(
+            matches!(&err, CrawlError::SessionPool(m) if m == "domain banned: example.com"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_scraper_error_from_http_wraps_domain_error() {
+        let msg = "build failed";
+        let err = scraper_error_from_http(HttpError::Request(msg.to_string()), URL);
+        // RequestFailed → ScraperError::Internal (same invariant as the dual-site test).
+        assert!(
+            matches!(&err, ScraperError::Internal(m) if m == msg),
+            "expected ScraperError::Internal, got: {err}"
+        );
+        assert_eq!(err.classify(), ErrorClass::InternalFatal);
+    }
+}

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -1,0 +1,234 @@
+//! Content extraction — CSS selector extraction and Readability entry point.
+//!
+//! Hosts the pure CSS-selector extraction logic and the thin
+//! [`scrape_with_readability`] convenience wrapper over the orchestrating
+//! `scrape_with_config` use case.
+
+use crate::application::diagnostic::build_diagnostic;
+use crate::application::http_client::HttpClientPort;
+use crate::application::scraper_service::scrape_with_config;
+use crate::domain::{DomInspectorPort, ExtractResult, ScrapedContent, SelectorErrorKind};
+use crate::error::Result;
+use crate::ScraperConfig;
+use tracing::{debug, warn};
+
+/// Extract HTML content using a CSS selector.
+///
+/// When `selector` is not "body", parses the HTML and extracts all elements
+/// matching the selector. Returns the outer HTML of matched elements wrapped
+/// in a `<div>` for Readability processing. If no elements match or the
+/// selector is invalid, returns [`ExtractResult::Fallback`] with the full
+/// HTML and an optional diagnostic (when an inspector is provided).
+///
+/// # Arguments
+/// * `html` - The HTML document to extract from
+/// * `selector` - CSS selector string (use `"body"` to skip extraction)
+/// * `inspector` - Optional DOM inspector for diagnostics on failure paths
+pub fn extract_with_selector(
+    html: &str,
+    selector: &str,
+    inspector: Option<&dyn DomInspectorPort>,
+) -> ExtractResult {
+    if selector == "body" {
+        return ExtractResult::Matched(html.to_owned());
+    }
+
+    // Early check: empty or whitespace-only HTML. `scraper::Html::parse_document("")`
+    // creates 3 implicit elements (html, head, body), so without this check the
+    // selector matching would fall through to ZeroMatches instead of
+    // EmptyDocument — leaving SelectorErrorKind::EmptyDocument as dead code.
+    if html.trim().is_empty() {
+        warn!(
+            "HTML document is empty or whitespace-only, falling back with EmptyDocument diagnostic"
+        );
+        let document = scraper::Html::parse_document(html);
+        return ExtractResult::Fallback {
+            html: html.to_owned(),
+            diagnostic: build_diagnostic(
+                inspector,
+                &document,
+                SelectorErrorKind::EmptyDocument,
+                selector,
+            ),
+        };
+    }
+
+    let document = scraper::Html::parse_document(html);
+    let sel = match scraper::Selector::parse(selector) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                "Invalid CSS selector '{}': {}, falling back to full HTML",
+                selector, e
+            );
+            return ExtractResult::Fallback {
+                html: html.to_owned(),
+                diagnostic: build_diagnostic(
+                    inspector,
+                    &document,
+                    SelectorErrorKind::InvalidSelector(e.to_string()),
+                    selector,
+                ),
+            };
+        },
+    };
+
+    let matched: Vec<String> = document.select(&sel).map(|el| el.html()).collect();
+
+    if matched.is_empty() {
+        warn!(
+            "CSS selector '{}' matched 0 elements, falling back to full HTML",
+            selector
+        );
+        return ExtractResult::Fallback {
+            html: html.to_owned(),
+            diagnostic: build_diagnostic(
+                inspector,
+                &document,
+                SelectorErrorKind::ZeroMatches,
+                selector,
+            ),
+        };
+    }
+
+    debug!(
+        "CSS selector '{}' matched {} elements",
+        selector,
+        matched.len()
+    );
+
+    ExtractResult::Matched(format!(
+        "<div id=\"selector-extracted\">{}</div>",
+        matched.join("\n")
+    ))
+}
+
+/// Scrape a URL using Readability algorithm for clean content extraction
+///
+/// This is the 2026 best practice approach — uses the same algorithm as
+/// Firefox Reader View to extract only meaningful content.
+///
+/// # Examples
+///
+/// ```no_run
+/// use webfang_core::application::{create_http_client, scrape_with_readability};
+///
+/// # #[tokio::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// let client = create_http_client()?;
+/// let url = url::Url::parse("https://example.com")?;
+/// let results = scrape_with_readability(&client, &url).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn scrape_with_readability(
+    client: &dyn HttpClientPort,
+    url: &url::Url,
+) -> Result<Vec<ScrapedContent>> {
+    let outcome =
+        scrape_with_config(client, url, &ScraperConfig::default(), None, None, None).await?;
+    Ok(outcome.results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- extract_with_selector: pure, no network (scraper::Html from a string) ---
+
+    #[test]
+    fn test_body_selector_is_passthrough() {
+        let html = "<html><body><p>keep me</p></body></html>";
+        let result = extract_with_selector(html, "body", None);
+        assert!(result.is_matched());
+        assert_eq!(
+            result.as_html(),
+            html,
+            "body selector must return HTML verbatim"
+        );
+    }
+
+    #[test]
+    fn test_matching_selector_wraps_elements() {
+        let html = "<html><body><div class=\"main\">Hello</div><aside>noise</aside></body></html>";
+        let result = extract_with_selector(html, "div.main", None);
+        assert!(result.is_matched());
+        let extracted = result.as_html();
+        assert!(
+            extracted.starts_with("<div id=\"selector-extracted\">"),
+            "matched output must be wrapped for Readability, got: {extracted}"
+        );
+        assert!(extracted.contains("Hello"));
+        assert!(
+            !extracted.contains("noise"),
+            "non-matching elements must be excluded"
+        );
+    }
+
+    #[test]
+    fn test_zero_matches_falls_back_without_inspector() {
+        let html = "<html><body><p>content</p></body></html>";
+        let result = extract_with_selector(html, "div.does-not-exist", None);
+        assert!(!result.is_matched());
+        assert_eq!(result.as_html(), html, "fallback must carry the full HTML");
+        match result {
+            ExtractResult::Fallback { diagnostic, .. } => {
+                assert!(diagnostic.is_none(), "no inspector means no diagnostic");
+            },
+            ExtractResult::Matched(_) => panic!("expected Fallback"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_selector_falls_back() {
+        let html = "<html><body><p>content</p></body></html>";
+        let result = extract_with_selector(html, ">>>not-a-selector", None);
+        assert!(!result.is_matched());
+        assert_eq!(result.as_html(), html);
+    }
+
+    #[test]
+    fn test_empty_html_falls_back() {
+        let result = extract_with_selector("   ", "div.main", None);
+        assert!(!result.is_matched(), "whitespace-only HTML must fall back");
+    }
+
+    // --- scrape_with_readability: ephemeral mock HTTP client, no real network ---
+
+    #[tokio::test]
+    async fn test_scrape_with_readability_produces_single_result() {
+        use crate::domain::http_port::HttpResponse;
+        use crate::test_fixtures::MockHttpClient;
+        use std::collections::HashMap;
+
+        let url = url::Url::parse("https://example.com").unwrap();
+        let article = "<html><head><title>Test Article</title></head><body><article>\
+             <h1>Test Article</h1>\
+             <p>This is a reasonably long paragraph of article content that should survive \
+             readability extraction without any problems at all, providing plenty of text.</p>\
+             </article></body></html>";
+        let mock = MockHttpClient::new().with_response(
+            url.as_str(),
+            Ok(HttpResponse {
+                status: 200,
+                body: article.to_string(),
+                headers: HashMap::new(),
+            }),
+        );
+
+        let results = scrape_with_readability(&mock, &url)
+            .await
+            .expect("a 200 article response must scrape successfully");
+
+        assert_eq!(results.len(), 1, "one URL must yield exactly one result");
+        assert_eq!(
+            results[0].url.as_str(),
+            url.as_str(),
+            "URL must be preserved"
+        );
+        assert!(
+            !results[0].title.is_empty(),
+            "title must resolve to non-empty"
+        );
+    }
+}

--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -3,6 +3,7 @@
 //! This layer contains the business logic that orchestrates the domain objects
 //! using infrastructure services. It depends on both domain and infrastructure.
 
+pub mod asset_download;
 pub mod batch;
 pub mod container;
 pub mod crawl_options;

--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -11,6 +11,7 @@ pub mod crawler;
 pub mod crawler_service;
 pub mod deduplicator;
 pub mod elastic_ingestion;
+pub mod error_mapping;
 pub mod export_factory;
 pub mod export_utils;
 pub mod http_client;

--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -19,6 +19,7 @@ pub mod pipeline;
 pub mod progress_observer;
 pub mod rate_limiter;
 pub mod scraper_service;
+pub mod spa_detection;
 /// Resolve extracted page titles to guaranteed non-empty strings.
 pub mod title_resolver;
 pub mod url_filter;

--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -15,6 +15,7 @@ pub mod elastic_ingestion;
 pub mod error_mapping;
 pub mod export_factory;
 pub mod export_utils;
+pub mod extraction;
 pub mod http_client;
 pub mod pipeline;
 pub mod progress_observer;

--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -10,6 +10,7 @@ pub mod crawl_result_repository;
 pub mod crawler;
 pub mod crawler_service;
 pub mod deduplicator;
+pub mod diagnostic;
 pub mod elastic_ingestion;
 pub mod error_mapping;
 pub mod export_factory;

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -11,11 +11,11 @@
 //! - **config-externalize**: Concurrency is configurable via ScraperConfig
 //! - **async-concurrency-limit**: Uses buffer_unordered for concurrency control
 
+use crate::application::diagnostic::build_diagnostic;
 use crate::application::error_mapping::scraper_error_from_http;
 use crate::application::http_client::HttpClientPort;
 use crate::domain::{
-    DomInspectorPort, DownloadedAsset, ExtractResult, ScrapedContent, SelectorDiagnostic,
-    SelectorErrorKind, ValidUrl,
+    DomInspectorPort, DownloadedAsset, ExtractResult, ScrapedContent, SelectorErrorKind, ValidUrl,
 };
 use crate::error::{Result, ScraperError};
 use crate::infrastructure::http::waf_engine::{InspectionContext, WafInspector};
@@ -131,25 +131,6 @@ pub fn extract_with_selector(
         "<div id=\"selector-extracted\">{}</div>",
         matched.join("\n")
     ))
-}
-
-/// Build a [`SelectorDiagnostic`] using the inspector, or return `None` if no
-/// inspector was provided.
-///
-/// This helper calls `inspector.inspect()` for the DOM structure report and
-/// `inspector.suggest()` for closest-match selector suggestions. It is only
-/// called on the failure path (0 matches or invalid selector).
-fn build_diagnostic(
-    inspector: Option<&dyn DomInspectorPort>,
-    document: &scraper::Html,
-    error_kind: SelectorErrorKind,
-    failed_selector: &str,
-) -> Option<SelectorDiagnostic> {
-    inspector.map(|insp| SelectorDiagnostic {
-        error_kind,
-        report: insp.inspect(document),
-        suggestions: insp.suggest(document, failed_selector),
-    })
 }
 
 /// Scrape a URL using Readability algorithm for clean content extraction

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -13,7 +13,7 @@
 
 use crate::application::error_mapping::scraper_error_from_http;
 use crate::application::http_client::HttpClientPort;
-use crate::domain::{DomInspectorPort, DownloadedAsset, ExtractResult, ScrapedContent, ValidUrl};
+use crate::domain::{DomInspectorPort, ExtractResult, ScrapedContent, ValidUrl};
 use crate::error::{Result, ScraperError};
 use crate::infrastructure::http::waf_engine::{InspectionContext, WafInspector};
 use crate::infrastructure::observability::log_scrape_error;
@@ -31,6 +31,7 @@ type AdaptiveSelectorEngine = ();
 // Re-exports preserve the historical `scraper_service::*` public paths after
 // the #443 decomposition into focused application modules. Callers (MCP
 // handlers, `crawler::discovery`, integration tests) keep resolving unchanged.
+pub use crate::application::asset_download::download_assets_if_enabled;
 pub use crate::application::extraction::{extract_with_selector, scrape_with_readability};
 pub use crate::application::spa_detection::{
     detect_spa_content, SpaDetectionResult, MIN_CONTENT_CHARS,
@@ -411,72 +412,4 @@ pub async fn scrape_multiple_with_limit(
         urls.len()
     );
     Ok(all_content)
-}
-
-/// Helper: Download assets if config has downloads enabled
-///
-/// Uses the `AssetDownloaderPort` trait for testability.
-/// Falls back to constructing a concrete `Downloader` when no trait object is provided.
-pub async fn download_assets_if_enabled(
-    _html: &str,
-    _base_url: &url::Url,
-    _config: &crate::ScraperConfig,
-    _shared_downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
-) -> Result<Vec<DownloadedAsset>> {
-    if !_config.has_downloads() {
-        return Ok(Vec::new());
-    }
-
-    #[cfg(any(feature = "images", feature = "documents"))]
-    {
-        // Use shared downloader when provided; create a fallback one otherwise
-        let owned_downloader;
-        let downloader: &dyn crate::domain::ports::AssetDownloaderPort = match _shared_downloader {
-            Some(dl) => dl,
-            None => {
-                owned_downloader =
-                    crate::adapters::downloader::Downloader::new(_config.to_download_config())?;
-                &owned_downloader
-            },
-        };
-
-        // Extract URLs from HTML
-        let mut urls: Vec<String> = Vec::new();
-        {
-            let document = scraper::Html::parse_document(_html);
-            if _config.download_images {
-                let images = crate::extractor::extract_images(&document, _base_url);
-                urls.extend(images.into_iter().map(|a| a.url));
-            }
-            if _config.download_documents {
-                let docs = crate::extractor::extract_documents(&document, _base_url);
-                urls.extend(docs.into_iter().map(|a| a.url));
-            }
-        }
-
-        if urls.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Deduplicate URLs to avoid downloading the same asset multiple times
-        // (e.g., same image referenced from multiple <img> tags).
-        use std::collections::HashSet;
-        let mut seen = HashSet::with_capacity(urls.len());
-        urls.retain(|url| seen.insert(url.clone()));
-
-        tracing::info!(
-            "📦 Downloading {} assets via adapters::Downloader",
-            urls.len()
-        );
-
-        let results = downloader.download_batch(&urls).await?;
-
-        // Trait impl already returns domain::DownloadedAsset — collect directly
-        Ok(results)
-    }
-
-    #[cfg(not(any(feature = "images", feature = "documents")))]
-    {
-        Ok(Vec::new())
-    }
 }

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -11,12 +11,9 @@
 //! - **config-externalize**: Concurrency is configurable via ScraperConfig
 //! - **async-concurrency-limit**: Uses buffer_unordered for concurrency control
 
-use crate::application::diagnostic::build_diagnostic;
 use crate::application::error_mapping::scraper_error_from_http;
 use crate::application::http_client::HttpClientPort;
-use crate::domain::{
-    DomInspectorPort, DownloadedAsset, ExtractResult, ScrapedContent, SelectorErrorKind, ValidUrl,
-};
+use crate::domain::{DomInspectorPort, DownloadedAsset, ExtractResult, ScrapedContent, ValidUrl};
 use crate::error::{Result, ScraperError};
 use crate::infrastructure::http::waf_engine::{InspectionContext, WafInspector};
 use crate::infrastructure::observability::log_scrape_error;
@@ -34,6 +31,7 @@ type AdaptiveSelectorEngine = ();
 // Re-exports preserve the historical `scraper_service::*` public paths after
 // the #443 decomposition into focused application modules. Callers (MCP
 // handlers, `crawler::discovery`, integration tests) keep resolving unchanged.
+pub use crate::application::extraction::{extract_with_selector, scrape_with_readability};
 pub use crate::application::spa_detection::{
     detect_spa_content, SpaDetectionResult, MIN_CONTENT_CHARS,
 };
@@ -41,124 +39,6 @@ pub use crate::application::spa_detection::{
 /// Maximum HTML body size to log/instrument (1MB)
 /// Bodies larger than this are skipped to avoid performance issues
 pub const MAX_INSTRUMENTED_BODY_SIZE: usize = 1_048_576;
-
-/// Extract HTML content using a CSS selector.
-///
-/// When `selector` is not "body", parses the HTML and extracts all elements
-/// matching the selector. Returns the outer HTML of matched elements wrapped
-/// in a `<div>` for Readability processing. If no elements match or the
-/// selector is invalid, returns [`ExtractResult::Fallback`] with the full
-/// HTML and an optional diagnostic (when an inspector is provided).
-///
-/// # Arguments
-/// * `html` - The HTML document to extract from
-/// * `selector` - CSS selector string (use `"body"` to skip extraction)
-/// * `inspector` - Optional DOM inspector for diagnostics on failure paths
-pub fn extract_with_selector(
-    html: &str,
-    selector: &str,
-    inspector: Option<&dyn DomInspectorPort>,
-) -> ExtractResult {
-    if selector == "body" {
-        return ExtractResult::Matched(html.to_owned());
-    }
-
-    // Early check: empty or whitespace-only HTML. `scraper::Html::parse_document("")`
-    // creates 3 implicit elements (html, head, body), so without this check the
-    // selector matching would fall through to ZeroMatches instead of
-    // EmptyDocument — leaving SelectorErrorKind::EmptyDocument as dead code.
-    if html.trim().is_empty() {
-        warn!(
-            "HTML document is empty or whitespace-only, falling back with EmptyDocument diagnostic"
-        );
-        let document = scraper::Html::parse_document(html);
-        return ExtractResult::Fallback {
-            html: html.to_owned(),
-            diagnostic: build_diagnostic(
-                inspector,
-                &document,
-                SelectorErrorKind::EmptyDocument,
-                selector,
-            ),
-        };
-    }
-
-    let document = scraper::Html::parse_document(html);
-    let sel = match scraper::Selector::parse(selector) {
-        Ok(s) => s,
-        Err(e) => {
-            warn!(
-                "Invalid CSS selector '{}': {}, falling back to full HTML",
-                selector, e
-            );
-            return ExtractResult::Fallback {
-                html: html.to_owned(),
-                diagnostic: build_diagnostic(
-                    inspector,
-                    &document,
-                    SelectorErrorKind::InvalidSelector(e.to_string()),
-                    selector,
-                ),
-            };
-        },
-    };
-
-    let matched: Vec<String> = document.select(&sel).map(|el| el.html()).collect();
-
-    if matched.is_empty() {
-        warn!(
-            "CSS selector '{}' matched 0 elements, falling back to full HTML",
-            selector
-        );
-        return ExtractResult::Fallback {
-            html: html.to_owned(),
-            diagnostic: build_diagnostic(
-                inspector,
-                &document,
-                SelectorErrorKind::ZeroMatches,
-                selector,
-            ),
-        };
-    }
-
-    debug!(
-        "CSS selector '{}' matched {} elements",
-        selector,
-        matched.len()
-    );
-
-    ExtractResult::Matched(format!(
-        "<div id=\"selector-extracted\">{}</div>",
-        matched.join("\n")
-    ))
-}
-
-/// Scrape a URL using Readability algorithm for clean content extraction
-///
-/// This is the 2026 best practice approach — uses the same algorithm as
-/// Firefox Reader View to extract only meaningful content.
-///
-/// # Examples
-///
-/// ```no_run
-/// use webfang_core::application::{create_http_client, scrape_with_readability};
-///
-/// # #[tokio::main]
-/// # async fn main() -> anyhow::Result<()> {
-/// let client = create_http_client()?;
-/// let url = url::Url::parse("https://example.com")?;
-/// let results = scrape_with_readability(&client, &url).await?;
-/// # Ok(())
-/// # }
-/// ```
-pub async fn scrape_with_readability(
-    client: &dyn HttpClientPort,
-    url: &url::Url,
-) -> Result<Vec<ScrapedContent>> {
-    let outcome =
-        scrape_with_config(client, url, &ScraperConfig::default(), None, None, None).await?;
-    Ok(outcome.results)
-}
 
 /// Outcome of a scrape operation, including selector extraction metadata.
 ///

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -31,13 +31,16 @@ use crate::application::adaptive_engine::AdaptiveSelectorEngine;
 #[cfg(not(feature = "adaptive-selectors"))]
 type AdaptiveSelectorEngine = ();
 
+// Re-exports preserve the historical `scraper_service::*` public paths after
+// the #443 decomposition into focused application modules. Callers (MCP
+// handlers, `crawler::discovery`, integration tests) keep resolving unchanged.
+pub use crate::application::spa_detection::{
+    detect_spa_content, SpaDetectionResult, MIN_CONTENT_CHARS,
+};
+
 /// Maximum HTML body size to log/instrument (1MB)
 /// Bodies larger than this are skipped to avoid performance issues
 pub const MAX_INSTRUMENTED_BODY_SIZE: usize = 1_048_576;
-
-/// Minimum character threshold for considering content "substantial".
-/// Pages below this threshold after extraction likely require JS rendering.
-pub const MIN_CONTENT_CHARS: usize = 50;
 
 /// Extract HTML content using a CSS selector.
 ///
@@ -146,63 +149,6 @@ fn build_diagnostic(
         error_kind,
         report: insp.inspect(document),
         suggestions: insp.suggest(document, failed_selector),
-    })
-}
-
-/// Result of SPA content detection analysis.
-///
-/// Contains diagnostic information about why a page was flagged
-/// as potentially requiring JavaScript rendering.
-#[derive(Debug, Clone)]
-pub struct SpaDetectionResult {
-    /// The URL that was analyzed
-    pub url: String,
-    /// Character count of the extracted content
-    pub char_count: usize,
-    /// Whether the HTML contains common SPA indicators
-    pub has_spa_markers: bool,
-}
-
-/// Detect whether a page likely requires JavaScript rendering (SPA detection).
-///
-/// Analyzes extracted content to identify pages that returned minimal content
-/// after readability/fallback extraction, which is a common symptom of
-/// Single Page Applications that render client-side.
-///
-/// # Arguments
-///
-/// * `url` - The URL that was scraped
-/// * `text_content` - The extracted text content (used for char count threshold)
-/// * `raw_html` - The raw HTML source (used for SPA marker detection)
-///
-/// # Returns
-///
-/// * `Some(SpaDetectionResult)` if the page appears to be an SPA
-/// * `None` if the content appears substantial enough
-///
-/// # Detection Heuristics
-///
-/// A page is flagged as potentially SPA-dependent when:
-/// - Extracted content is below `MIN_CONTENT_CHARS` (50 chars)
-pub fn detect_spa_content(
-    url: &str,
-    text_content: &str,
-    raw_html: &str,
-) -> Option<SpaDetectionResult> {
-    let char_count = text_content.chars().count();
-
-    if char_count >= MIN_CONTENT_CHARS {
-        return None;
-    }
-
-    // Check for common SPA mount point markers in raw HTML (not stripped text)
-    let has_spa_markers =
-        raw_html.contains("<div id=\"root\">") || raw_html.contains("<div id=\"app\">");
-
-    Some(SpaDetectionResult {
-        url: url.to_string(),
-        char_count,
-        has_spa_markers,
     })
 }
 

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -11,7 +11,8 @@
 //! - **config-externalize**: Concurrency is configurable via ScraperConfig
 //! - **async-concurrency-limit**: Uses buffer_unordered for concurrency control
 
-use crate::application::http_client::{HttpClientPort, HttpError};
+use crate::application::error_mapping::scraper_error_from_http;
+use crate::application::http_client::HttpClientPort;
 use crate::domain::{
     DomInspectorPort, DownloadedAsset, ExtractResult, ScrapedContent, SelectorDiagnostic,
     SelectorErrorKind, ValidUrl,
@@ -29,43 +30,6 @@ use crate::application::adaptive_engine::AdaptiveSelectorEngine;
 /// Placeholder when `adaptive-selectors` feature is disabled.
 #[cfg(not(feature = "adaptive-selectors"))]
 type AdaptiveSelectorEngine = ();
-
-/// Convert an [`HttpError`] into a domain [`CrawlError`] with the URL context.
-///
-/// This is the application-layer half of the `HttpError` → `CrawlError`
-/// mapping; the domain half lives in `domain/error/crawl_error.rs`
-/// (`From<HttpError> for CrawlError`). The two sites MUST stay in sync —
-/// see `tests::test_request_failed_dual_site_agreement`.
-fn crawl_error_from_http(err: HttpError, url: &str) -> crate::domain::error::CrawlError {
-    use crate::domain::error::CrawlError;
-    match err {
-        HttpError::ClientError(code) | HttpError::ServerError(code) => CrawlError::Http {
-            status: code,
-            url: url.to_string(),
-        },
-        HttpError::Forbidden => CrawlError::Http {
-            status: 403,
-            url: url.to_string(),
-        },
-        HttpError::RateLimited(retry_after) => CrawlError::RateLimited(retry_after),
-        HttpError::Timeout => CrawlError::Timeout,
-        HttpError::Connection(msg) => CrawlError::Connection(msg),
-        HttpError::Request(msg) => CrawlError::RequestFailed(msg),
-        HttpError::WafChallenge(provider) => CrawlError::WafChallenge {
-            provider,
-            kind: crate::domain::error::WafDetectionKind::BodySignature,
-            url: url.to_string(),
-        },
-        HttpError::DomainBanned(domain) => {
-            CrawlError::SessionPool(format!("domain banned: {domain}"))
-        },
-    }
-}
-
-/// Convert an [`HttpError`] into a [`ScraperError`] with the URL context.
-fn scraper_error_from_http(err: HttpError, url: &str) -> ScraperError {
-    ScraperError::from(crawl_error_from_http(err, url))
-}
 
 /// Maximum HTML body size to log/instrument (1MB)
 /// Bodies larger than this are skipped to avoid performance issues
@@ -707,47 +671,5 @@ pub async fn download_assets_if_enabled(
     #[cfg(not(any(feature = "images", feature = "documents")))]
     {
         Ok(Vec::new())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::domain::error::CrawlError;
-    use crate::error::ErrorClass;
-
-    /// EC-REQUEST-FAILED: both `HttpError::Request` conversion sites must agree.
-    ///
-    /// Site 1: `application/scraper_service.rs::crawl_error_from_http`
-    /// Site 2: `domain/error/crawl_error.rs` `From<HttpError>`
-    ///
-    /// Both must yield `CrawlError::RequestFailed(msg)` for the same input —
-    /// no divergence between the application and domain conversion paths.
-    #[test]
-    fn test_request_failed_dual_site_agreement() {
-        let msg = "build failed";
-
-        // Site 1 (application layer)
-        let via_service =
-            crawl_error_from_http(HttpError::Request(msg.to_string()), "https://example.com");
-        // Site 2 (domain layer)
-        let via_domain: CrawlError = HttpError::Request(msg.to_string()).into();
-
-        assert!(
-            matches!(&via_service, CrawlError::RequestFailed(m) if m == msg),
-            "service site must produce RequestFailed, got: {via_service:?}"
-        );
-        assert!(
-            matches!(&via_domain, CrawlError::RequestFailed(m) if m == msg),
-            "domain site must produce RequestFailed, got: {via_domain:?}"
-        );
-
-        // Classification is preserved end-to-end: RequestFailed → Internal → InternalFatal.
-        let scraper_err = ScraperError::from(via_service);
-        assert!(
-            matches!(&scraper_err, ScraperError::Internal(m) if m == msg),
-            "RequestFailed must map to ScraperError::Internal, got: {scraper_err}"
-        );
-        assert_eq!(scraper_err.classify(), ErrorClass::InternalFatal);
     }
 }

--- a/crates/webfang_core/src/application/spa_detection.rs
+++ b/crates/webfang_core/src/application/spa_detection.rs
@@ -1,0 +1,123 @@
+//! SPA detection — heuristic detection of JavaScript-rendered pages.
+//!
+//! Analyzes extracted content to identify pages that returned minimal content
+//! after readability/fallback extraction, a common symptom of Single Page
+//! Applications that render client-side.
+
+/// Minimum character threshold for considering content "substantial".
+/// Pages below this threshold after extraction likely require JS rendering.
+pub const MIN_CONTENT_CHARS: usize = 50;
+
+/// Result of SPA content detection analysis.
+///
+/// Contains diagnostic information about why a page was flagged
+/// as potentially requiring JavaScript rendering.
+#[derive(Debug, Clone)]
+pub struct SpaDetectionResult {
+    /// The URL that was analyzed
+    pub url: String,
+    /// Character count of the extracted content
+    pub char_count: usize,
+    /// Whether the HTML contains common SPA indicators
+    pub has_spa_markers: bool,
+}
+
+/// Detect whether a page likely requires JavaScript rendering (SPA detection).
+///
+/// Analyzes extracted content to identify pages that returned minimal content
+/// after readability/fallback extraction, which is a common symptom of
+/// Single Page Applications that render client-side.
+///
+/// # Arguments
+///
+/// * `url` - The URL that was scraped
+/// * `text_content` - The extracted text content (used for char count threshold)
+/// * `raw_html` - The raw HTML source (used for SPA marker detection)
+///
+/// # Returns
+///
+/// * `Some(SpaDetectionResult)` if the page appears to be an SPA
+/// * `None` if the content appears substantial enough
+///
+/// # Detection Heuristics
+///
+/// A page is flagged as potentially SPA-dependent when:
+/// - Extracted content is below `MIN_CONTENT_CHARS` (50 chars)
+pub fn detect_spa_content(
+    url: &str,
+    text_content: &str,
+    raw_html: &str,
+) -> Option<SpaDetectionResult> {
+    let char_count = text_content.chars().count();
+
+    if char_count >= MIN_CONTENT_CHARS {
+        return None;
+    }
+
+    // Check for common SPA mount point markers in raw HTML (not stripped text)
+    let has_spa_markers =
+        raw_html.contains("<div id=\"root\">") || raw_html.contains("<div id=\"app\">");
+
+    Some(SpaDetectionResult {
+        url: url.to_string(),
+        char_count,
+        has_spa_markers,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const URL: &str = "https://spa.example.com";
+
+    #[test]
+    fn test_below_threshold_without_markers_is_flagged() {
+        let result = detect_spa_content(URL, "", "<html><body></body></html>");
+        let result = result.expect("empty content must be flagged as potential SPA");
+        assert_eq!(result.url, URL);
+        assert_eq!(result.char_count, 0);
+        assert!(!result.has_spa_markers);
+    }
+
+    #[test]
+    fn test_below_threshold_with_root_marker_sets_flag() {
+        let result = detect_spa_content(URL, "loading", "<div id=\"root\"></div>")
+            .expect("short content must be flagged");
+        assert!(result.has_spa_markers, "root mount point must set marker");
+    }
+
+    #[test]
+    fn test_below_threshold_with_app_marker_sets_flag() {
+        let result = detect_spa_content(URL, "loading", "<div id=\"app\"></div>")
+            .expect("short content must be flagged");
+        assert!(result.has_spa_markers, "app mount point must set marker");
+    }
+
+    #[test]
+    fn test_at_threshold_is_not_flagged() {
+        let content = "a".repeat(MIN_CONTENT_CHARS);
+        assert_eq!(content.chars().count(), MIN_CONTENT_CHARS);
+        assert!(
+            detect_spa_content(URL, &content, "<div id=\"root\"></div>").is_none(),
+            "content at the threshold must be considered substantial"
+        );
+    }
+
+    #[test]
+    fn test_just_below_threshold_is_flagged() {
+        let content = "a".repeat(MIN_CONTENT_CHARS - 1);
+        let result = detect_spa_content(URL, &content, "<html></html>")
+            .expect("content just below threshold must be flagged");
+        assert_eq!(result.char_count, MIN_CONTENT_CHARS - 1);
+    }
+
+    #[test]
+    fn test_above_threshold_is_not_flagged() {
+        let content = "a".repeat(MIN_CONTENT_CHARS * 4);
+        assert!(
+            detect_spa_content(URL, &content, "<div id=\"root\"></div>").is_none(),
+            "substantial content must not be flagged even with SPA markers"
+        );
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #443

## PR Type

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Descompone `scraper_service.rs` (God Module de 753 líneas, 6 responsabilidades, ratio 713 prod / 40 test) en 5 módulos de aplicación enfocados, dejando en el service solo la orquestación.
- Refactoring puro: la orquestación (`scrape_with_config`, `scrape_multiple_with_limit`, `ScrapeOutcome`) queda byte-idéntica. La API pública se preserva con re-exports `pub use`, de modo que **cero call sites cambiaron** (handlers MCP, `crawler::discovery` y los tests de integración siguen resolviendo igual).
- Sube la cobertura de las unidades extraídas con tests determinísticos (error_mapping, spa_detection, diagnostic, extraction).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/error_mapping.rs` | Nuevo: `crawl_error_from_http` + `scraper_error_from_http` (+ tests de mapeo) |
| `crates/webfang_core/src/application/extraction.rs` | Nuevo: `extract_with_selector` + `scrape_with_readability` (+ tests sin red) |
| `crates/webfang_core/src/application/spa_detection.rs` | Nuevo: `detect_spa_content` + `SpaDetectionResult` + `MIN_CONTENT_CHARS` (+ tests) |
| `crates/webfang_core/src/application/diagnostic.rs` | Nuevo: `build_diagnostic` (+ tests) |
| `crates/webfang_core/src/application/asset_download.rs` | Nuevo: `download_assets_if_enabled` (verbatim; sigue orquestando vía `AssetDownloaderPort`) |
| `crates/webfang_core/src/application/mod.rs` | +5 declaraciones `pub mod` |
| `crates/webfang_core/src/application/scraper_service.rs` | 753 → 415 líneas: solo orquestación + bloque de re-exports documentado |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (1927/1927, cero diffs de snapshot)
- [x] Verificado el cambio afectado (diff estructural: las únicas líneas agregadas al service son imports + re-exports)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (n/a — refactoring sin cambio de comportamiento)
