### PR TITLE
test(crawler): replace httpbin.org with wiremock in url_validator tests

### DIFF
--- a/crates/webfang_core/src/infrastructure/crawler/url_validator.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/url_validator.rs
@@ -236,30 +236,54 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "depends on external httpbin.org service, flaky in CI/CD"]
     async fn test_validate_http_status_200() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
         let validator = UrlValidator::new().unwrap();
-        let url = Url::parse("https://httpbin.org/status/200").unwrap();
+        let url = Url::parse(&server.uri()).unwrap();
 
         let result = validator.validate_http_status_inner(&url).await;
         assert!(matches!(result, Ok(ValidationResult::Valid)));
     }
 
     #[tokio::test]
-    #[ignore = "depends on external httpbin.org service, flaky in CI/CD"]
     async fn test_validate_http_status_404() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
         let validator = UrlValidator::new().unwrap();
-        let url = Url::parse("https://httpbin.org/status/404").unwrap();
+        let url = Url::parse(&server.uri()).unwrap();
 
         let result = validator.validate_http_status_inner(&url).await;
         assert!(matches!(result, Ok(ValidationResult::Invalid(_))));
     }
 
     #[tokio::test]
-    #[ignore = "depends on external httpbin.org service, flaky in CI/CD"]
     async fn test_validate_http_status_500() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
         let validator = UrlValidator::new().unwrap();
-        let url = Url::parse("https://httpbin.org/status/500").unwrap();
+        let url = Url::parse(&server.uri()).unwrap();
 
         let result = validator.validate_http_status_inner(&url).await;
         assert!(matches!(result, Ok(ValidationResult::Invalid(_))));


### PR DESCRIPTION
Closes #456

## Summary
- Remove `#[ignore]` from 3 HTTP status validation tests in `url_validator.rs`
- Replace external `httpbin.org` dependency with local `wiremock::MockServer`
- Tests go from 108s+ (flaky, network-dependent) to 0.015s (deterministic, isolated)

## Why
The `ignored-tests` CI job was permanently red because httpbin.org is unreliable in CI runners. This normalized red CI and masked real bug discoveries.

## Testing
- `cargo nextest run -p webfang_core -E 'test(test_validate_http_status)'` → 3/3 PASS
- `cargo clippy -p webfang_core -- -D warnings` → clean
- `cargo fmt --check` → clean