### PR TITLE
refactor(ai): deduplicar cascade del adaptive_engine + JoinError→error (#445)

### DIFF
--- a/crates/webfang_core/src/application/adaptive_engine/cache.rs
+++ b/crates/webfang_core/src/application/adaptive_engine/cache.rs
@@ -1,0 +1,81 @@
+//! Cache machinery for the adaptive selector repair engine.
+//!
+//! A TTL-bounded [`DashMap`] keyed by a deterministic FNV-1a hash of the failed
+//! selector combined with the DOM structural hash. Eviction is lazy: expired
+//! entries are purged only when the cache reaches its configured capacity.
+
+use std::hash::{Hash, Hasher};
+use std::time::Instant;
+
+use super::{AdaptiveRepairOutcome, AdaptiveSelectorEngine};
+
+/// Cached repair entry with expiration.
+pub(super) struct CachedEntry {
+    outcome: AdaptiveRepairOutcome,
+    expires_at: Instant,
+}
+
+impl AdaptiveSelectorEngine {
+    /// Compute cache key from selector + structural hash.
+    pub(super) fn cache_key(&self, selector: &str, structural_hash: u64) -> u64 {
+        let mut hasher = FnvHasher::default();
+        selector.hash(&mut hasher);
+        structural_hash.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Fetch a non-expired cached outcome, if present.
+    ///
+    /// Returns a clone of the stored outcome without mutating its trace; callers
+    /// decide whether to flag the result as a cache hit.
+    pub(super) fn cache_get(&self, key: u64) -> Option<AdaptiveRepairOutcome> {
+        let entry = self.cache.get(&key)?;
+        if entry.expires_at > Instant::now() {
+            Some(entry.outcome.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Insert into cache with lazy eviction when at capacity.
+    pub(super) fn cache_insert(&self, key: u64, outcome: AdaptiveRepairOutcome) {
+        // Lazy eviction: if at capacity, remove expired entries
+        if self.cache.len() >= self.options.max_cache_entries {
+            let now = Instant::now();
+            self.cache.retain(|_, entry| entry.expires_at > now);
+        }
+
+        self.cache.insert(
+            key,
+            CachedEntry {
+                outcome,
+                expires_at: Instant::now() + self.options.cache_ttl,
+            },
+        );
+    }
+
+    /// Get the number of cached entries (for monitoring).
+    #[must_use]
+    pub fn cache_len(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+/// Minimal FNV-1a hasher for deterministic cache key computation.
+#[derive(Default)]
+pub(super) struct FnvHasher(u64);
+
+impl Hasher for FnvHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        let mut h: u64 = 0xcbf29ce484222325;
+        for &b in bytes {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        self.0 = h;
+    }
+}

--- a/crates/webfang_core/src/application/adaptive_engine/cache.rs
+++ b/crates/webfang_core/src/application/adaptive_engine/cache.rs
@@ -1,8 +1,9 @@
 //! Cache machinery for the adaptive selector repair engine.
 //!
-//! A TTL-bounded [`DashMap`] keyed by a deterministic FNV-1a hash of the failed
-//! selector combined with the DOM structural hash. Eviction is lazy: expired
-//! entries are purged only when the cache reaches its configured capacity.
+//! A TTL-bounded [`DashMap`](dashmap::DashMap) keyed by a deterministic FNV-1a
+//! hash of the failed selector combined with the DOM structural hash. Eviction
+//! is lazy: expired entries are purged only when the cache reaches its
+//! configured capacity.
 
 use std::hash::{Hash, Hasher};
 use std::time::Instant;

--- a/crates/webfang_core/src/application/adaptive_engine/mod.rs
+++ b/crates/webfang_core/src/application/adaptive_engine/mod.rs
@@ -176,7 +176,9 @@ impl AdaptiveSelectorEngine {
             hasher.finish()
         })
         .await
-        .expect("Tier 1 hash computation panicked");
+        .map_err(|e| {
+            SelectorErrorKind::BlockingTaskFailed(format!("tier1 structural hash task failed: {e}"))
+        })?;
 
         // 2. Tier 1: lexical via spawn_blocking (HTML parsing is !Sync)
         let inspector = Arc::clone(&self.inspector);
@@ -187,7 +189,9 @@ impl AdaptiveSelectorEngine {
             inspector.suggest(&document, &selector_clone)
         })
         .await
-        .expect("Tier 1 suggestion panicked");
+        .map_err(|e| {
+            SelectorErrorKind::BlockingTaskFailed(format!("tier1 suggestion task failed: {e}"))
+        })?;
 
         let best_tier1 = t1_suggestions.into_iter().max_by(|a, b| {
             a.score
@@ -212,7 +216,11 @@ impl AdaptiveSelectorEngine {
                 .collect::<Vec<_>>()
         })
         .await
-        .expect("DOM fragment extraction panicked");
+        .map_err(|e| {
+            SelectorErrorKind::BlockingTaskFailed(format!(
+                "dom fragment extraction task failed: {e}"
+            ))
+        })?;
 
         // 4. Run the shared cascade
         let ctx = SemanticContext {
@@ -301,9 +309,9 @@ impl AdaptiveSelectorEngine {
 
     /// Full async repair cascade: Tier 1 + optional Tier 2.
     ///
-    /// Thin wrapper over [`Self::cascade`]: computes the structural hash, the
-    /// Tier 1 suggestions, and the DOM fragments synchronously from the
-    /// already-parsed `document`, then delegates the shared cascade.
+    /// Thin wrapper over the private `cascade` method: computes the structural
+    /// hash, the Tier 1 suggestions, and the DOM fragments synchronously from
+    /// the already-parsed `document`, then delegates the shared cascade.
     ///
     /// # Errors
     ///

--- a/crates/webfang_core/src/application/adaptive_engine/mod.rs
+++ b/crates/webfang_core/src/application/adaptive_engine/mod.rs
@@ -178,17 +178,7 @@ impl AdaptiveSelectorEngine {
         .await
         .expect("Tier 1 hash computation panicked");
 
-        // 2. Check cache
-        let cache_key = self.cache_key(&selector, structural_hash);
-        if let Some(mut outcome) = self.cache_get(cache_key) {
-            if let Some(ref mut trace) = outcome.trace {
-                trace.cache_hit = true;
-            }
-            debug!(cache_hit = true, "returning cached repair outcome");
-            return Ok(outcome);
-        }
-
-        // 3. Tier 1: lexical via spawn_blocking (HTML parsing is !Sync)
+        // 2. Tier 1: lexical via spawn_blocking (HTML parsing is !Sync)
         let inspector = Arc::clone(&self.inspector);
         let html_for_t1 = html_raw.clone();
 
@@ -206,57 +196,8 @@ impl AdaptiveSelectorEngine {
         });
 
         let tier1_score = best_tier1.as_ref().map(|s| s.score).unwrap_or(0.0);
-        debug!(score = tier1_score, "tier1_evaluated");
 
-        // 4. Fast path: high confidence → return immediately
-        if tier1_score > self.options.lexical_threshold {
-            if let Some(best) = best_tier1 {
-                let trace = CascadeTrace {
-                    tier1_score,
-                    tier2_score: None,
-                    tier2_latency_ms: 0,
-                    cache_hit: false,
-                };
-                let outcome = AdaptiveRepairOutcome::repaired(best, trace);
-                self.cache_insert(cache_key, outcome.clone());
-                info!(new_selector = %outcome.suggestion.selector, method = "tier1_lexical", "repair_resolved");
-                return Ok(outcome);
-            }
-        }
-
-        // 5. Tier 2: semantic (if available)
-        let semantic = match &self.semantic {
-            Some(s) => s,
-            None => {
-                return self
-                    .handle_tier1_only(best_tier1, tier1_score, structural_hash, cache_key)
-                    .await;
-            },
-        };
-
-        // Check Tier 2 availability — skip if inference pool is saturated
-        let _permit = match tokio::time::timeout(
-            Duration::from_millis(100),
-            self.inference_semaphore.acquire(),
-        )
-        .await
-        {
-            Ok(Ok(permit)) => permit,
-            Ok(Err(_)) => {
-                warn!("inference semaphore closed, skipping tier2");
-                return self
-                    .handle_tier1_only(best_tier1, tier1_score, structural_hash, cache_key)
-                    .await;
-            },
-            Err(_) => {
-                warn!("tier2 inference pool saturated (semaphore timeout), skipping tier2");
-                return self
-                    .handle_tier1_only(best_tier1, tier1_score, structural_hash, cache_key)
-                    .await;
-            },
-        };
-
-        // 6. Extract DOM fragments via spawn_blocking (HTML parsing is !Sync)
+        // 3. Extract DOM fragments via spawn_blocking (HTML parsing is !Sync)
         let inspector = Arc::clone(&self.inspector);
         let html_for_fragments = html_raw.clone();
 
@@ -273,63 +214,14 @@ impl AdaptiveSelectorEngine {
         .await
         .expect("DOM fragment extraction panicked");
 
-        // 7. Build semantic context and run Tier 2
+        // 4. Run the shared cascade
         let ctx = SemanticContext {
             target_text: html_raw,
             dom_fragments,
             domain_hint: domain,
         };
-
-        let tier2_start = Instant::now();
-        let tier2_result = semantic.find_semantic_match(ctx).await;
-        let tier2_latency_ms = tier2_start.elapsed().as_millis() as u64;
-
-        match tier2_result {
-            Ok(Some(sem_match)) => {
-                debug!(confidence = sem_match.confidence, "tier2_escalated");
-
-                let trace = CascadeTrace {
-                    tier1_score,
-                    tier2_score: Some(sem_match.confidence),
-                    tier2_latency_ms,
-                    cache_hit: false,
-                };
-
-                let suggestion = SelectorSuggestion {
-                    selector: sem_match.selector,
-                    score: sem_match.confidence as f64,
-                };
-
-                let status = if sem_match.confidence >= self.options.semantic_threshold {
-                    RepairStatus::Repaired
-                } else {
-                    RepairStatus::Degraded
-                };
-
-                let outcome = AdaptiveRepairOutcome {
-                    suggestion,
-                    status,
-                    trace: Some(trace),
-                };
-                self.cache_insert(cache_key, outcome.clone());
-                info!(
-                    new_selector = %outcome.suggestion.selector,
-                    final_score = sem_match.confidence,
-                    method = "tier2_semantic",
-                    "repair_resolved"
-                );
-                Ok(outcome)
-            },
-            Ok(None) => {
-                self.handle_tier1_only(best_tier1, tier1_score, structural_hash, cache_key)
-                    .await
-            },
-            Err(e) => {
-                warn!(error = ?e, "tier2 inference failed");
-                self.handle_tier1_only(best_tier1, tier1_score, structural_hash, cache_key)
-                    .await
-            },
-        }
+        self.cascade(&selector, structural_hash, best_tier1, tier1_score, ctx)
+            .await
     }
 
     /// Compute a structural hash from DOM tag counts for cache keying.
@@ -409,6 +301,10 @@ impl AdaptiveSelectorEngine {
 
     /// Full async repair cascade: Tier 1 + optional Tier 2.
     ///
+    /// Thin wrapper over [`Self::cascade`]: computes the structural hash, the
+    /// Tier 1 suggestions, and the DOM fragments synchronously from the
+    /// already-parsed `document`, then delegates the shared cascade.
+    ///
     /// # Errors
     ///
     /// Returns `SelectorErrorKind::RepairInconclusive` if both tiers fail.
@@ -422,8 +318,53 @@ impl AdaptiveSelectorEngine {
     ) -> Result<AdaptiveRepairOutcome, SelectorErrorKind> {
         let structural_hash = self.structural_hash(document);
 
+        // Tier 1: lexical
+        let suggestions = self.inspector.suggest(document, failed_selector);
+        let best_tier1 = suggestions.into_iter().max_by(|a, b| {
+            a.score
+                .partial_cmp(&b.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let tier1_score = best_tier1.as_ref().map(|s| s.score).unwrap_or(0.0);
+
+        let dom_fragments = self.extract_dom_fragments(document);
+
+        let ctx = SemanticContext {
+            target_text: html.to_owned(),
+            dom_fragments,
+            domain_hint: domain.map(|d| d.to_owned()),
+        };
+        self.cascade(
+            failed_selector,
+            structural_hash,
+            best_tier1,
+            tier1_score,
+            ctx,
+        )
+        .await
+    }
+
+    /// Shared repair cascade: cache → fast path → semaphore-gated Tier 2 →
+    /// Tier 1 fallback.
+    ///
+    /// Both public entry points ([`Self::select_sync_aware`] and
+    /// [`Self::repair`]) precompute the Tier 1 result and the Tier 2
+    /// [`SemanticContext`] — each in its own way — and delegate the identical
+    /// cascade logic here.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SelectorErrorKind::RepairInconclusive` if both tiers fail.
+    async fn cascade(
+        &self,
+        selector: &str,
+        structural_hash: u64,
+        best_tier1: Option<SelectorSuggestion>,
+        tier1_score: f64,
+        ctx: SemanticContext,
+    ) -> Result<AdaptiveRepairOutcome, SelectorErrorKind> {
         // Check cache
-        let cache_key = self.cache_key(failed_selector, structural_hash);
+        let cache_key = self.cache_key(selector, structural_hash);
         if let Some(mut outcome) = self.cache_get(cache_key) {
             if let Some(ref mut trace) = outcome.trace {
                 trace.cache_hit = true;
@@ -432,15 +373,6 @@ impl AdaptiveSelectorEngine {
             return Ok(outcome);
         }
 
-        // Tier 1: lexical
-        let suggestions = self.inspector.suggest(document, failed_selector);
-        let best_tier1 = suggestions.into_iter().max_by(|a, b| {
-            a.score
-                .partial_cmp(&b.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        let tier1_score = best_tier1.as_ref().map(|s| s.score).unwrap_or(0.0);
         debug!(score = tier1_score, "tier1_evaluated");
 
         // Fast path: high confidence → return immediately
@@ -459,11 +391,10 @@ impl AdaptiveSelectorEngine {
             }
         }
 
-        // Tier 2: semantic (if available and in ambiguity zone)
+        // Tier 2: semantic (if available)
         let semantic = match &self.semantic {
             Some(s) => s,
             None => {
-                // No semantic provider — return Tier 1 best or fail
                 return self
                     .handle_tier1_only(best_tier1, tier1_score, structural_hash, cache_key)
                     .await;
@@ -492,13 +423,7 @@ impl AdaptiveSelectorEngine {
             },
         };
 
-        // Build semantic context
-        let ctx = SemanticContext {
-            target_text: html.to_owned(),
-            dom_fragments: self.extract_dom_fragments(document),
-            domain_hint: domain.map(|d| d.to_owned()),
-        };
-
+        // Run Tier 2 on the precomputed semantic context
         let tier2_start = Instant::now();
         let tier2_result = semantic.find_semantic_match(ctx).await;
         let tier2_latency_ms = tier2_start.elapsed().as_millis() as u64;
@@ -540,7 +465,6 @@ impl AdaptiveSelectorEngine {
                 Ok(outcome)
             },
             Ok(None) => {
-                // Tier 2 found nothing — use Tier 1 best or fail
                 self.handle_tier1_only(best_tier1, tier1_score, structural_hash, cache_key)
                     .await
             },

--- a/crates/webfang_core/src/application/adaptive_engine/mod.rs
+++ b/crates/webfang_core/src/application/adaptive_engine/mod.rs
@@ -17,6 +17,10 @@ use crate::domain::dom_inspector::{
 };
 use crate::domain::semantic_inspector::{SemanticContext, SemanticInspectorPort};
 
+mod cache;
+
+use cache::{CachedEntry, FnvHasher};
+
 /// Whether the repair succeeded and how.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RepairStatus {
@@ -100,12 +104,6 @@ impl Default for AdaptiveSelectorOptions {
     }
 }
 
-/// Cached repair entry with expiration.
-struct CachedEntry {
-    outcome: AdaptiveRepairOutcome,
-    expires_at: Instant,
-}
-
 /// 2-tier adaptive CSS selector repair engine.
 ///
 /// Combines lexical (Tier 1) and semantic (Tier 2) selector suggestions
@@ -182,15 +180,12 @@ impl AdaptiveSelectorEngine {
 
         // 2. Check cache
         let cache_key = self.cache_key(&selector, structural_hash);
-        if let Some(entry) = self.cache.get(&cache_key) {
-            if entry.expires_at > Instant::now() {
-                let mut outcome = entry.outcome.clone();
-                if let Some(ref mut trace) = outcome.trace {
-                    trace.cache_hit = true;
-                }
-                debug!(cache_hit = true, "returning cached repair outcome");
-                return Ok(outcome);
+        if let Some(mut outcome) = self.cache_get(cache_key) {
+            if let Some(ref mut trace) = outcome.trace {
+                trace.cache_hit = true;
             }
+            debug!(cache_hit = true, "returning cached repair outcome");
+            return Ok(outcome);
         }
 
         // 3. Tier 1: lexical via spawn_blocking (HTML parsing is !Sync)
@@ -373,11 +368,9 @@ impl AdaptiveSelectorEngine {
 
         // Check cache first
         let cache_key = self.cache_key(failed_selector, structural_hash);
-        if let Some(entry) = self.cache.get(&cache_key) {
-            if entry.expires_at > Instant::now() {
-                debug!(cache_hit = true, "returning cached repair outcome");
-                return Some(entry.outcome.clone());
-            }
+        if let Some(outcome) = self.cache_get(cache_key) {
+            debug!(cache_hit = true, "returning cached repair outcome");
+            return Some(outcome);
         }
 
         let suggestions = self.inspector.suggest(document, failed_selector);
@@ -431,15 +424,12 @@ impl AdaptiveSelectorEngine {
 
         // Check cache
         let cache_key = self.cache_key(failed_selector, structural_hash);
-        if let Some(entry) = self.cache.get(&cache_key) {
-            if entry.expires_at > Instant::now() {
-                let mut outcome = entry.outcome.clone();
-                if let Some(ref mut trace) = outcome.trace {
-                    trace.cache_hit = true;
-                }
-                debug!(cache_hit = true, "returning cached repair outcome");
-                return Ok(outcome);
+        if let Some(mut outcome) = self.cache_get(cache_key) {
+            if let Some(ref mut trace) = outcome.trace {
+                trace.cache_hit = true;
             }
+            debug!(cache_hit = true, "returning cached repair outcome");
+            return Ok(outcome);
         }
 
         // Tier 1: lexical
@@ -602,58 +592,6 @@ impl AdaptiveSelectorEngine {
             .map(|(class, _)| class.clone())
             .chain(report.common_ids.iter().map(|(id, _)| id.clone()))
             .collect()
-    }
-
-    /// Compute cache key from selector + structural hash.
-    fn cache_key(&self, selector: &str, structural_hash: u64) -> u64 {
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = FnvHasher::default();
-        selector.hash(&mut hasher);
-        structural_hash.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    /// Insert into cache with lazy eviction when at capacity.
-    fn cache_insert(&self, key: u64, outcome: AdaptiveRepairOutcome) {
-        // Lazy eviction: if at capacity, remove expired entries
-        if self.cache.len() >= self.options.max_cache_entries {
-            let now = Instant::now();
-            self.cache.retain(|_, entry| entry.expires_at > now);
-        }
-
-        self.cache.insert(
-            key,
-            CachedEntry {
-                outcome,
-                expires_at: Instant::now() + self.options.cache_ttl,
-            },
-        );
-    }
-
-    /// Get the number of cached entries (for monitoring).
-    #[must_use]
-    pub fn cache_len(&self) -> usize {
-        self.cache.len()
-    }
-}
-
-/// Minimal FNV-1a hasher for deterministic cache key computation.
-#[derive(Default)]
-struct FnvHasher(u64);
-
-impl std::hash::Hasher for FnvHasher {
-    fn finish(&self) -> u64 {
-        self.0
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        let mut h: u64 = 0xcbf29ce484222325;
-        for &b in bytes {
-            h ^= b as u64;
-            h = h.wrapping_mul(0x100000001b3);
-        }
-        self.0 = h;
     }
 }
 

--- a/crates/webfang_core/src/domain/dom_inspector.rs
+++ b/crates/webfang_core/src/domain/dom_inspector.rs
@@ -33,6 +33,9 @@ pub enum SelectorErrorKind {
     EmptyDocument,
     /// Both Tier 1 and Tier 2 repair failed — diagnostic details enclosed.
     RepairInconclusive(Box<RepairFailureDiagnostic>),
+    /// A blocking task (DOM parse / structural hash / suggestion) panicked or
+    /// was cancelled while running on the blocking thread pool.
+    BlockingTaskFailed(String),
 }
 
 /// A closest-match selector suggestion computed via Jaro-Winkler similarity.


### PR DESCRIPTION
## Linked Issue

Closes #445

## PR Type

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Deduplica el cascade del adaptive engine: `select_sync_aware` y `repair` eran el mismo cascade espejado (~330 líneas). Ahora un único `cascade()` privado corre cache→tier1→fast-path→semaphore→tier2→`handle_tier1_only` una sola vez; los dos entry points quedan como wrappers finos (parseo sync vía `spawn_blocking` vs `&scraper::Html` ya parseado).
- Convierte 3 `expect` sobre JoinHandles de `spawn_blocking` en errores: un panic en la tarea bloqueante ya no propaga panic al caller async; se mapea a `SelectorErrorKind::BlockingTaskFailed` (elimina panics latentes, espíritu de #429).
- Extrae la caché (`CachedEntry`, `cache_key`, `cache_insert`, `FnvHasher`) a `adaptive_engine/cache.rs`.
- **Código feature-gateado tras `adaptive-selectors`**: verificado con `--features adaptive-selectors` (nextest 2002/2002, incluye los tests `adaptive_selector_integration`).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/adaptive_engine/cache.rs` | Nuevo: maquinaria de caché extraída (items `pub(super)`, solo `cache_len` es `pub`) |
| `crates/webfang_core/src/application/adaptive_engine.rs` → `adaptive_engine/mod.rs` | `cascade()` privado unifica el cascade; `select_sync_aware`/`repair` como wrappers; 3 `expect` → `map_err`; net −76 líneas por dedup |
| `crates/webfang_core/src/domain/dom_inspector.rs` | Nuevo variant `SelectorErrorKind::BlockingTaskFailed(String)` (aditivo: el enum no tiene `Display` y todos los match usan catch-all) |

### Diseño del cascade
`cascade(&self, selector, structural_hash, best_tier1: Option<SelectorSuggestion>, tier1_score: f64, ctx: SemanticContext)` recibe el resultado Tier1 ya computado. Pasar un `SemanticContext` precomputado (en vez de 3 campos sueltos) lo mantiene bajo `clippy::too_many_arguments`. `cascade` no está `#[instrument]`-ado a propósito y `cascade_started` queda solo en `select_sync_aware`, preservando la estructura exacta de spans/eventos.

### JoinError → error
Las 3 `map_err` producen payloads de diagnóstico en inglés (convención de `granite_dom_inspector.rs`). No hay path de renderizado user-facing: `extraction.rs` convierte los errores del engine en `Fallback`.

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --features adaptive-selectors --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p webfang_core --all-features --no-deps` clean
- [x] `cargo nextest run --workspace` (default, cero diffs de snapshot)
- [x] `cargo nextest run --features adaptive-selectors` (2002/2002, cero diffs de snapshot)

## Notes

- API pública sin cambios: `select_sync_aware`, `repair`, `repair_tier1`, `new`, `cache_len` mantienen firma/visibilidad. Cero call-site churn (callers en `extraction.rs`, `scraper_service.rs`, `cli/main.rs` y el integration test compilan igual).
- El path `JoinError`→error NO se unit-testea: inducir un panic real en `spawn_blocking` de forma determinística es flaky; se documenta en vez de forzar un test. El happy path no cambia.
- Tradeoff aceptado: en `select_sync_aware` el tier1/fragments se computa antes del cache check (antes era tras adquirir el semáforo). El comportamiento observable (outcomes, orden de eventos de tracing, `cache_hit`, `cache_len`) es idéntico — probado por tests/snapshots sin cambios.

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (n/a — refactoring; docs de módulo en cache.rs)
