### PR TITLE
refactor(http): deduplicar loops de retry 429/5xx en client.rs (#444)

### DIFF
--- a/crates/webfang_core/src/application/http_client/client.rs
+++ b/crates/webfang_core/src/application/http_client/client.rs
@@ -2,6 +2,7 @@
 //!
 //! Wraps `wreq::Client` with retry logic, UA rotation, and WAF detection.
 
+use super::retry::{retry_with_backoff, RetryPolicy};
 use crate::domain::http_config::HttpClientConfig;
 use crate::domain::http_error::{HttpError, HttpResult};
 use crate::domain::session_port::{SessionId, SessionPort};
@@ -195,7 +196,6 @@ impl HttpClient {
 
     async fn get_inner(&self, url: &str) -> HttpResult<String> {
         let mut ua_index = 0;
-        let max_attempts = self.config.max_retries;
 
         loop {
             if ua_index >= self.user_agents.len() && ua_index > 0 {
@@ -288,55 +288,19 @@ impl HttpClient {
 
                     debug!("429 Rate Limited, retry after {}s", retry_after);
 
-                    let mut attempt = 0;
-                    let ua_for_retry = ua.clone();
-                    while attempt < max_attempts {
-                        attempt += 1;
-
-                        let delay_ms = if retry_after > 0 {
-                            retry_after * 1000
-                        } else {
-                            let exponent = attempt.saturating_sub(1);
-                            let delay = self.config.backoff_base_ms * (2_u64.pow(exponent));
-                            delay.min(self.config.backoff_max_ms)
-                        };
-
-                        debug!("429 retry attempt {} after {}ms", attempt, delay_ms);
-                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-
-                        let request = self
-                            .client
-                            .get(url)
-                            .header("Accept-Language", &self.config.accept_language)
-                            .header("Accept", &self.config.accept)
-                            .header("Referer", &self.config.referer)
-                            .header("Cache-Control", &self.config.cache_control)
-                            .header("User-Agent", &ua_for_retry);
-
-                        match request.send().await {
-                            Ok(resp) => {
-                                if resp.status().is_success() {
-                                    return resp
-                                        .text()
-                                        .await
-                                        .map_err(|e| HttpError::Request(e.to_string()));
-                                } else if resp.status().as_u16() == 429
-                                    || resp.status().is_server_error()
-                                {
-                                    continue;
-                                } else {
-                                    return Err(HttpError::ClientError(resp.status().as_u16()));
-                                }
-                            },
-                            Err(e) => {
-                                if e.is_timeout() {
-                                    return Err(HttpError::Timeout);
-                                }
-                                continue;
-                            },
-                        }
-                    }
-                    return Err(HttpError::RateLimited(retry_after));
+                    return retry_with_backoff(
+                        &self.client,
+                        url,
+                        &self.config,
+                        &ua,
+                        RetryPolicy {
+                            retry_after_secs: Some(retry_after),
+                            retryable: |code: u16| code == 429 || (500..=599).contains(&code),
+                            exhausted: HttpError::RateLimited(retry_after),
+                            label: "429",
+                        },
+                    )
+                    .await;
                 },
                 500..=599 => {
                     debug!("{} from {}", status, url);
@@ -375,49 +339,19 @@ impl HttpClient {
                         return Err(HttpError::WafChallenge(verdict.evidence_chain()));
                     }
 
-                    let mut attempt = 0;
-                    let ua_for_retry = ua.clone();
-                    while attempt < max_attempts {
-                        attempt += 1;
-
-                        let exponent = attempt.saturating_sub(1);
-                        let delay = self.config.backoff_base_ms * (2_u64.pow(exponent));
-                        let delay_ms = delay.min(self.config.backoff_max_ms);
-
-                        debug!("5xx retry attempt {} after {}ms", attempt, delay_ms);
-                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-
-                        let request = self
-                            .client
-                            .get(url)
-                            .header("Accept-Language", &self.config.accept_language)
-                            .header("Accept", &self.config.accept)
-                            .header("Referer", &self.config.referer)
-                            .header("Cache-Control", &self.config.cache_control)
-                            .header("User-Agent", &ua_for_retry);
-
-                        match request.send().await {
-                            Ok(resp) => {
-                                if resp.status().is_success() {
-                                    return resp
-                                        .text()
-                                        .await
-                                        .map_err(|e| HttpError::Request(e.to_string()));
-                                } else if resp.status().is_server_error() {
-                                    continue;
-                                } else {
-                                    return Err(HttpError::ClientError(resp.status().as_u16()));
-                                }
-                            },
-                            Err(e) => {
-                                if e.is_timeout() {
-                                    return Err(HttpError::Timeout);
-                                }
-                                continue;
-                            },
-                        }
-                    }
-                    return Err(HttpError::ServerError(status.as_u16()));
+                    return retry_with_backoff(
+                        &self.client,
+                        url,
+                        &self.config,
+                        &ua,
+                        RetryPolicy {
+                            retry_after_secs: None,
+                            retryable: |code: u16| (500..=599).contains(&code),
+                            exhausted: HttpError::ServerError(status.as_u16()),
+                            label: "5xx",
+                        },
+                    )
+                    .await;
                 },
                 code if (400..=499).contains(&code) => {
                     return Err(HttpError::ClientError(code));

--- a/crates/webfang_core/src/application/http_client/client.rs
+++ b/crates/webfang_core/src/application/http_client/client.rs
@@ -381,6 +381,36 @@ fn inspection_context(status: u16, headers: &HeaderMap, ignore_waf: bool) -> Ins
 // HttpClientPort implementation for HttpClient
 // ============================================================================
 
+/// Raw, single-shot [`HttpClientPort`] implementation for [`HttpClient`].
+///
+/// # Why this path is deliberately raw
+///
+/// [`HttpClient`] exposes two request paths with different contracts, and they
+/// are intentionally **not** unified:
+///
+/// - The hardened path — `HttpClient::get` / `get_inner` — returns only the
+///   response body as a `String`, after applying rate limiting, per-domain
+///   session gating, status-specific retries (429 / 5xx), user-agent rotation
+///   on 403, and WAF/CAPTCHA inspection. Non-2xx outcomes are surfaced as
+///   [`HttpError`] variants.
+/// - This port implementation returns a full [`HttpResponse`]
+///   (`status` + `headers` + `body`) for a **single** GET with no retry, no
+///   user-agent rotation and no WAF inspection, reporting non-2xx as data in
+///   `status` rather than as an error. It exists for callers that depend on the
+///   domain port and manage their own request lifecycle.
+///
+/// Routing this impl through the hardened path would change its observable
+/// behavior — it would start retrying, rotating user agents, and turning
+/// 5xx/429 responses into [`HttpError`]s instead of returning the status — so
+/// the divergence is preserved and documented here rather than collapsed
+/// (see #444). The bare-client factories (e.g. [`create_http_client`]) are raw
+/// for the same reason.
+///
+/// [`HttpClientPort`]: crate::domain::http_port::HttpClientPort
+/// [`HttpClient`]: crate::application::http_client::HttpClient
+/// [`HttpResponse`]: crate::domain::http_port::HttpResponse
+/// [`HttpError`]: crate::domain::http_error::HttpError
+/// [`create_http_client`]: crate::application::http_client::create_http_client
 impl crate::domain::http_port::HttpClientPort for HttpClient {
     fn get(
         &self,

--- a/crates/webfang_core/src/application/http_client/client.rs
+++ b/crates/webfang_core/src/application/http_client/client.rs
@@ -2,6 +2,7 @@
 //!
 //! Wraps `wreq::Client` with retry logic, UA rotation, and WAF detection.
 
+use super::factory::build_wreq_client;
 use super::retry::{retry_with_backoff, RetryPolicy};
 use crate::domain::http_config::HttpClientConfig;
 use crate::domain::http_error::{HttpError, HttpResult};
@@ -12,22 +13,16 @@ use crate::infrastructure::user_agent::UserAgentCache;
 use governor::clock::DefaultClock;
 use governor::state::{InMemoryState, NotKeyed};
 use governor::{Quota, RateLimiter};
-use rand;
 use std::num::NonZeroU32;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{debug, warn};
 use url::Url;
-
-use wreq::header::{HeaderMap, HeaderName, HeaderValue};
+use wreq::header::HeaderMap;
 use wreq::Client;
 
-/// Client Hints headers for Chrome 145 (2026 Standard)
-/// These headers must match the TLS fingerprint to avoid "Headless Spoofing" detection
-const CLIENT_HINTS_SEC_CH_UA: &str =
-    "\"Google Chrome\";v=\"145\", \"Chromium\";v=\"145\", \"Not=A?Brand\";v=\"99\"";
-const CLIENT_HINTS_SEC_CH_UA_MOBILE: &str = "?0";
-const CLIENT_HINTS_SEC_CH_UA_PLATFORM: &str = "\"Linux\"";
+pub use super::factory::{
+    create_http_client, create_http_client_with_config, get_random_user_agent_from_pool,
+};
 
 /// HTTP client wrapper with configurable retry behavior
 ///
@@ -380,130 +375,6 @@ fn inspection_context(status: u16, headers: &HeaderMap, ignore_waf: bool) -> Ins
         headers: headers.clone(),
         ignore_waf,
     }
-}
-
-/// Build the inner `wreq::Client` shared by `HttpClient::new` and the
-/// bare-client factories.
-///
-/// Applies the Chrome Client Hints + Sec-Fetch default headers (these MUST
-/// match the TLS fingerprint to avoid "Headless Spoofing" detection), the
-/// resolved H2/TLS profile, request/connect timeouts, connection-pool tuning,
-/// compression, cookie storage, and a bounded redirect policy.
-///
-/// When `user_agent` is `Some`, it is set as the build-time `User-Agent`;
-/// when `None`, no build-time UA is applied (callers such as `HttpClient`
-/// set the UA per request instead).
-///
-/// # Errors
-///
-/// Returns `ScraperError::Config` if the underlying client fails to build.
-fn build_wreq_client(
-    config: &HttpClientConfig,
-    user_agent: Option<String>,
-) -> Result<Client, ScraperError> {
-    let pool_size = std::cmp::max(6, num_cpus::get() - 1);
-
-    // Build Client Hints headers for Chrome 145 (2026 Standard)
-    // These MUST match the TLS fingerprint to avoid "Headless Spoofing" detection
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        HeaderName::from_static("sec-ch-ua"),
-        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA),
-    );
-    headers.insert(
-        HeaderName::from_static("sec-ch-ua-mobile"),
-        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_MOBILE),
-    );
-    headers.insert(
-        HeaderName::from_static("sec-ch-ua-platform"),
-        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_PLATFORM),
-    );
-    // Additional security headers (Sec-Fetch)
-    headers.insert(
-        HeaderName::from_static("sec-fetch-dest"),
-        HeaderValue::from_static("document"),
-    );
-    headers.insert(
-        HeaderName::from_static("sec-fetch-mode"),
-        HeaderValue::from_static("navigate"),
-    );
-    headers.insert(
-        HeaderName::from_static("sec-fetch-site"),
-        HeaderValue::from_static("none"),
-    );
-    headers.insert(
-        HeaderName::from_static("sec-fetch-user"),
-        HeaderValue::from_static("?1"),
-    );
-    headers.insert(
-        HeaderName::from_static("upgrade-insecure-requests"),
-        HeaderValue::from_static("1"),
-    );
-
-    let mut builder = Client::builder()
-        .emulation(config.tls_emulation)
-        .default_headers(headers)
-        .timeout(Duration::from_secs(config.timeout_secs))
-        .connect_timeout(Duration::from_secs(config.connect_timeout_secs))
-        .pool_max_idle_per_host(pool_size)
-        .pool_idle_timeout(Duration::from_secs(60))
-        .gzip(true)
-        .brotli(true)
-        .cookie_store(true)
-        .redirect(wreq::redirect::Policy::limited(10));
-
-    if let Some(ua) = user_agent {
-        builder = builder.user_agent(ua);
-    }
-
-    builder
-        .build()
-        .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))
-}
-
-/// Create a bare `wreq::Client` that honors the given domain config.
-///
-/// This is the config-driven counterpart of `HttpClient::new`: it returns the
-/// raw inner client (no retry middleware) for callers that manage requests
-/// themselves, while still applying the Chrome Client Hints headers, the
-/// resolved H2/TLS profile, request/connect timeouts, and pool tuning from
-/// `config`.
-///
-/// User-agent resolution: `config.user_agent` is used when set; otherwise a
-/// random agent is drawn from the fallback pool, preserving the historical
-/// rotation behavior of `create_http_client`.
-///
-/// # Errors
-///
-/// Returns `ScraperError::Config` if the underlying client fails to build.
-pub fn create_http_client_with_config(config: &HttpClientConfig) -> Result<Client, ScraperError> {
-    let user_agent = match config.user_agent.clone() {
-        Some(ua) => ua,
-        None => get_random_user_agent_from_pool(&UserAgentCache::fallback_agents()),
-    };
-
-    tracing::debug!("Using user agent: {}", user_agent);
-
-    build_wreq_client(config, Some(user_agent))
-}
-
-// Legacy function - simplified, returns wreq::Client directly
-/// Create configured HTTP client
-///
-/// Equivalent to `create_http_client_with_config(&HttpClientConfig::default())`:
-/// a Chrome145 client with a random pooled user agent, a 30s request timeout,
-/// and a 10s connect timeout, plus the Chrome Client Hints default headers.
-/// For more control, use `HttpClient::new()` with `HttpClientConfig`.
-pub fn create_http_client() -> Result<Client, ScraperError> {
-    create_http_client_with_config(&HttpClientConfig::default())
-}
-
-/// Get random user agent from pool (legacy function)
-pub fn get_random_user_agent_from_pool(pool: &[String]) -> String {
-    use rand::Rng;
-    let mut rng = rand::rng();
-    let index = rng.random_range(0..pool.len());
-    pool[index].clone()
 }
 
 // ============================================================================

--- a/crates/webfang_core/src/application/http_client/factory.rs
+++ b/crates/webfang_core/src/application/http_client/factory.rs
@@ -1,0 +1,152 @@
+//! Bare `wreq::Client` factories shared across the crate.
+//!
+//! These factories build the raw inner [`Client`] — Chrome Client Hints +
+//! Sec-Fetch default headers, the resolved H2/TLS profile, request/connect
+//! timeouts, connection-pool tuning, compression, cookie storage and a bounded
+//! redirect policy — **without** the retry / UA-rotation / WAF middleware that
+//! [`HttpClient`](crate::application::http_client::HttpClient) layers on top.
+//! Callers that manage requests themselves (the crawler, sitemap discovery,
+//! URL validation, preflight) use these; callers that want the hardened,
+//! retrying behavior use [`HttpClient::new`](crate::application::http_client::HttpClient::new).
+//!
+//! [`build_wreq_client`] is the single construction point shared by
+//! [`HttpClient::new`](crate::application::http_client::HttpClient::new) and
+//! the bare-client factories here, so both paths build an identical stack.
+
+use crate::domain::http_config::HttpClientConfig;
+use crate::error::ScraperError;
+use crate::infrastructure::user_agent::UserAgentCache;
+use std::time::Duration;
+use wreq::header::{HeaderMap, HeaderName, HeaderValue};
+use wreq::Client;
+
+/// Client Hints headers for Chrome 145 (2026 Standard)
+/// These headers must match the TLS fingerprint to avoid "Headless Spoofing" detection
+const CLIENT_HINTS_SEC_CH_UA: &str =
+    "\"Google Chrome\";v=\"145\", \"Chromium\";v=\"145\", \"Not=A?Brand\";v=\"99\"";
+const CLIENT_HINTS_SEC_CH_UA_MOBILE: &str = "?0";
+const CLIENT_HINTS_SEC_CH_UA_PLATFORM: &str = "\"Linux\"";
+
+/// Build the inner `wreq::Client` shared by `HttpClient::new` and the
+/// bare-client factories.
+///
+/// Applies the Chrome Client Hints + Sec-Fetch default headers (these MUST
+/// match the TLS fingerprint to avoid "Headless Spoofing" detection), the
+/// resolved H2/TLS profile, request/connect timeouts, connection-pool tuning,
+/// compression, cookie storage, and a bounded redirect policy.
+///
+/// When `user_agent` is `Some`, it is set as the build-time `User-Agent`;
+/// when `None`, no build-time UA is applied (callers such as `HttpClient`
+/// set the UA per request instead).
+///
+/// # Errors
+///
+/// Returns `ScraperError::Config` if the underlying client fails to build.
+pub(super) fn build_wreq_client(
+    config: &HttpClientConfig,
+    user_agent: Option<String>,
+) -> Result<Client, ScraperError> {
+    let pool_size = std::cmp::max(6, num_cpus::get() - 1);
+
+    // Build Client Hints headers for Chrome 145 (2026 Standard)
+    // These MUST match the TLS fingerprint to avoid "Headless Spoofing" detection
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua"),
+        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua-mobile"),
+        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_MOBILE),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-ch-ua-platform"),
+        HeaderValue::from_static(CLIENT_HINTS_SEC_CH_UA_PLATFORM),
+    );
+    // Additional security headers (Sec-Fetch)
+    headers.insert(
+        HeaderName::from_static("sec-fetch-dest"),
+        HeaderValue::from_static("document"),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-fetch-mode"),
+        HeaderValue::from_static("navigate"),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-fetch-site"),
+        HeaderValue::from_static("none"),
+    );
+    headers.insert(
+        HeaderName::from_static("sec-fetch-user"),
+        HeaderValue::from_static("?1"),
+    );
+    headers.insert(
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
+    );
+
+    let mut builder = Client::builder()
+        .emulation(config.tls_emulation)
+        .default_headers(headers)
+        .timeout(Duration::from_secs(config.timeout_secs))
+        .connect_timeout(Duration::from_secs(config.connect_timeout_secs))
+        .pool_max_idle_per_host(pool_size)
+        .pool_idle_timeout(Duration::from_secs(60))
+        .gzip(true)
+        .brotli(true)
+        .cookie_store(true)
+        .redirect(wreq::redirect::Policy::limited(10));
+
+    if let Some(ua) = user_agent {
+        builder = builder.user_agent(ua);
+    }
+
+    builder
+        .build()
+        .map_err(|e| ScraperError::Config(format!("failed to create http client: {e}")))
+}
+
+/// Create a bare `wreq::Client` that honors the given domain config.
+///
+/// This is the config-driven counterpart of `HttpClient::new`: it returns the
+/// raw inner client (no retry middleware) for callers that manage requests
+/// themselves, while still applying the Chrome Client Hints headers, the
+/// resolved H2/TLS profile, request/connect timeouts, and pool tuning from
+/// `config`.
+///
+/// User-agent resolution: `config.user_agent` is used when set; otherwise a
+/// random agent is drawn from the fallback pool, preserving the historical
+/// rotation behavior of `create_http_client`.
+///
+/// # Errors
+///
+/// Returns `ScraperError::Config` if the underlying client fails to build.
+pub fn create_http_client_with_config(config: &HttpClientConfig) -> Result<Client, ScraperError> {
+    let user_agent = match config.user_agent.clone() {
+        Some(ua) => ua,
+        None => get_random_user_agent_from_pool(&UserAgentCache::fallback_agents()),
+    };
+
+    tracing::debug!("Using user agent: {}", user_agent);
+
+    build_wreq_client(config, Some(user_agent))
+}
+
+// Legacy function - simplified, returns wreq::Client directly
+/// Create configured HTTP client
+///
+/// Equivalent to `create_http_client_with_config(&HttpClientConfig::default())`:
+/// a Chrome145 client with a random pooled user agent, a 30s request timeout,
+/// and a 10s connect timeout, plus the Chrome Client Hints default headers.
+/// For more control, use `HttpClient::new()` with `HttpClientConfig`.
+pub fn create_http_client() -> Result<Client, ScraperError> {
+    create_http_client_with_config(&HttpClientConfig::default())
+}
+
+/// Get random user agent from pool (legacy function)
+pub fn get_random_user_agent_from_pool(pool: &[String]) -> String {
+    use rand::Rng;
+    let mut rng = rand::rng();
+    let index = rng.random_range(0..pool.len());
+    pool[index].clone()
+}

--- a/crates/webfang_core/src/application/http_client/mod.rs
+++ b/crates/webfang_core/src/application/http_client/mod.rs
@@ -37,6 +37,7 @@
 //! ```
 
 mod client;
+mod factory;
 pub mod port;
 mod retry;
 

--- a/crates/webfang_core/src/application/http_client/mod.rs
+++ b/crates/webfang_core/src/application/http_client/mod.rs
@@ -38,6 +38,7 @@
 
 mod client;
 pub mod port;
+mod retry;
 
 pub use crate::domain::http_config::HttpClientConfig;
 pub use crate::domain::http_error::{HttpError, HttpResult};

--- a/crates/webfang_core/src/application/http_client/retry.rs
+++ b/crates/webfang_core/src/application/http_client/retry.rs
@@ -1,0 +1,202 @@
+//! Status-specific retry loops for the hardened HTTP client.
+//!
+//! The hardened client's `get_inner` (see [`HttpClient`]) handles a request's
+//! first response inline; when that response is a `429` or a `5xx`, it
+//! delegates the bounded retry loop to [`retry_with_backoff`] in this module.
+//!
+//! The two historical loops (one for `429`, one for `5xx`) were near-identical
+//! but differed in four load-bearing ways, captured by [`RetryPolicy`].
+//! [`retry_with_backoff`] reproduces both exactly by varying only that policy:
+//!
+//! | Difference | `429` path | `5xx` path |
+//! |---|---|---|
+//! | Delay strategy | honors `Retry-After` (constant `secs * 1000` ms) when `> 0`, else exponential | always exponential backoff |
+//! | Retryable status | `429` **or** any `5xx` | any `5xx` only |
+//! | Exhaustion error | [`HttpError::RateLimited`] | [`HttpError::ServerError`] |
+//! | Tracing label | `"429"` | `"5xx"` |
+//!
+//! Everything else — the attempt counter, request headers, success
+//! short-circuit, non-retryable `ClientError`, and timeout handling — is
+//! identical and lives here once. The 5xx path's pre-loop WAF inspection stays
+//! in `get_inner` because it runs on the initial response, before any retry.
+//!
+//! [`HttpClient`]: crate::application::http_client::HttpClient
+//! [`HttpError::RateLimited`]: crate::domain::http_error::HttpError::RateLimited
+//! [`HttpError::ServerError`]: crate::domain::http_error::HttpError::ServerError
+
+use crate::domain::http_config::HttpClientConfig;
+use crate::domain::http_error::{HttpError, HttpResult};
+use std::time::Duration;
+use tracing::debug;
+use wreq::Client;
+
+/// The four load-bearing differences between the `429` and `5xx` retry loops.
+///
+/// Every other aspect of the two loops is identical and lives in
+/// [`retry_with_backoff`]; this policy carries only what varies between them so
+/// the shared loop can reproduce both behaviors exactly.
+pub(super) struct RetryPolicy {
+    /// `Retry-After` seconds honored by the `429` path (`Some`); `None` for the
+    /// `5xx` path, which always uses exponential backoff.
+    pub(super) retry_after_secs: Option<u64>,
+    /// Predicate deciding whether a received status code triggers another
+    /// retry: the `429` path retries on `429` **or** any `5xx`, the `5xx` path
+    /// retries on any `5xx` only.
+    pub(super) retryable: fn(u16) -> bool,
+    /// Error returned once `max_retries` attempts are exhausted:
+    /// [`HttpError::RateLimited`] for the `429` path, [`HttpError::ServerError`]
+    /// for the `5xx` path.
+    ///
+    /// [`HttpError::RateLimited`]: crate::domain::http_error::HttpError::RateLimited
+    /// [`HttpError::ServerError`]: crate::domain::http_error::HttpError::ServerError
+    pub(super) exhausted: HttpError,
+    /// Label tagging the tracing debug messages (`"429"` / `"5xx"`).
+    pub(super) label: &'static str,
+}
+
+/// Run the bounded retry loop shared by the `429` and `5xx` handling paths.
+///
+/// Performs up to `config.max_retries` attempts. Each attempt sleeps for
+/// [`compute_backoff_delay`], re-sends the GET with the same headers the
+/// hardened client uses (Accept-Language, Accept, Referer, Cache-Control and
+/// the pinned `user_agent`), then inspects the outcome:
+///
+/// - a success status returns the body immediately;
+/// - a status satisfying `policy.retryable` continues to the next attempt;
+/// - any other status returns [`HttpError::ClientError`];
+/// - a transport error returns [`HttpError::Timeout`] when it is a timeout and
+///   otherwise continues to the next attempt.
+///
+/// When every attempt is exhausted, `policy.exhausted` is returned. The `429`
+/// caller passes a policy with `Some(retry_after)` and
+/// [`HttpError::RateLimited`]; the `5xx` caller passes `None` (pure exponential
+/// backoff) and [`HttpError::ServerError`].
+///
+/// # Errors
+///
+/// Returns the body on success, or the first terminal [`HttpError`] (a client
+/// error, a timeout, or `policy.exhausted` once retries run out).
+///
+/// [`HttpError::ClientError`]: crate::domain::http_error::HttpError::ClientError
+/// [`HttpError::Timeout`]: crate::domain::http_error::HttpError::Timeout
+/// [`HttpError::RateLimited`]: crate::domain::http_error::HttpError::RateLimited
+/// [`HttpError::ServerError`]: crate::domain::http_error::HttpError::ServerError
+pub(super) async fn retry_with_backoff(
+    client: &Client,
+    url: &str,
+    config: &HttpClientConfig,
+    user_agent: &str,
+    policy: RetryPolicy,
+) -> HttpResult<String> {
+    let mut attempt = 0;
+    while attempt < config.max_retries {
+        attempt += 1;
+
+        let delay_ms = compute_backoff_delay(
+            attempt,
+            policy.retry_after_secs,
+            config.backoff_base_ms,
+            config.backoff_max_ms,
+        );
+
+        debug!(
+            "{} retry attempt {} after {}ms",
+            policy.label, attempt, delay_ms
+        );
+        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+
+        let request = client
+            .get(url)
+            .header("Accept-Language", &config.accept_language)
+            .header("Accept", &config.accept)
+            .header("Referer", &config.referer)
+            .header("Cache-Control", &config.cache_control)
+            .header("User-Agent", user_agent);
+
+        match request.send().await {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    return resp
+                        .text()
+                        .await
+                        .map_err(|e| HttpError::Request(e.to_string()));
+                } else if (policy.retryable)(resp.status().as_u16()) {
+                    continue;
+                } else {
+                    return Err(HttpError::ClientError(resp.status().as_u16()));
+                }
+            },
+            Err(e) => {
+                if e.is_timeout() {
+                    return Err(HttpError::Timeout);
+                }
+                continue;
+            },
+        }
+    }
+    Err(policy.exhausted)
+}
+
+/// Compute the delay in milliseconds before retry attempt `attempt` (1-based).
+///
+/// When `retry_after_secs` is `Some(secs)` with `secs > 0` — the `429` path
+/// honoring a `Retry-After` header — the delay is the constant
+/// `secs * 1000` ms. In every other case (the `5xx` path's `None`, or a `429`
+/// carrying `Retry-After: 0`) the delay is exponential backoff
+/// `base_ms * 2^(attempt - 1)` capped at `max_ms`.
+fn compute_backoff_delay(
+    attempt: u32,
+    retry_after_secs: Option<u64>,
+    base_ms: u64,
+    max_ms: u64,
+) -> u64 {
+    match retry_after_secs {
+        Some(secs) if secs > 0 => secs * 1000,
+        _ => {
+            let exponent = attempt.saturating_sub(1);
+            let delay = base_ms * 2_u64.pow(exponent);
+            delay.min(max_ms)
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_after_honored_as_constant_delay() {
+        // 429 path with Retry-After: 2 → constant 2000ms regardless of attempt.
+        assert_eq!(compute_backoff_delay(1, Some(2), 10, 50), 2000);
+        assert_eq!(compute_backoff_delay(2, Some(2), 10, 50), 2000);
+        assert_eq!(compute_backoff_delay(3, Some(2), 10, 50), 2000);
+    }
+
+    #[test]
+    fn retry_after_zero_falls_back_to_exponential() {
+        // 429 path with Retry-After: 0 → exponential backoff like the 5xx path.
+        assert_eq!(compute_backoff_delay(1, Some(0), 10, 50), 10);
+        assert_eq!(compute_backoff_delay(2, Some(0), 10, 50), 20);
+        assert_eq!(compute_backoff_delay(3, Some(0), 10, 50), 40);
+    }
+
+    #[test]
+    fn no_retry_after_uses_exponential_backoff() {
+        // 5xx path (None) → base * 2^(attempt-1).
+        assert_eq!(compute_backoff_delay(1, None, 10, 10_000), 10);
+        assert_eq!(compute_backoff_delay(2, None, 10, 10_000), 20);
+        assert_eq!(compute_backoff_delay(3, None, 10, 10_000), 40);
+        assert_eq!(compute_backoff_delay(4, None, 10, 10_000), 80);
+    }
+
+    #[test]
+    fn exponential_backoff_is_capped_at_max() {
+        // base 1000, max 10000 (production defaults): 1s, 2s, 4s, 8s, then capped.
+        assert_eq!(compute_backoff_delay(1, None, 1000, 10_000), 1000);
+        assert_eq!(compute_backoff_delay(2, None, 1000, 10_000), 2000);
+        assert_eq!(compute_backoff_delay(3, None, 1000, 10_000), 4000);
+        assert_eq!(compute_backoff_delay(4, None, 1000, 10_000), 8000);
+        assert_eq!(compute_backoff_delay(5, None, 1000, 10_000), 10_000);
+        assert_eq!(compute_backoff_delay(6, None, 1000, 10_000), 10_000);
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #444

## PR Type

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [x] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Deduplica los loops de retry 429 y 5xx de `get_inner` (~234 líneas espejadas) en un único `retry_with_backoff` (`retry.rs`), preservando **todas** las diferencias de comportamiento entre ambos casos.
- Extrae las factorías de cliente a `factory.rs` (`create_http_client`, `create_http_client_with_config`, `get_random_user_agent_from_pool`, `build_wreq_client`, consts `CLIENT_HINTS_*`).
- Documenta la divergencia raw-vs-hardened del `impl HttpClientPort` (decisión: documentar, no unificar, para preservar comportamiento).
- Refactoring puro: cero diffs de snapshot, nextest 1992/0, guards de retry (429 con `Retry-After`, 500, 503 WAF) intactos.

## Preservación de las diferencias 429 vs 5xx

| Diferencia | 429 | 5xx | Cómo se preserva |
|---|---|---|---|
| Delay | honra `Retry-After` (constante `secs*1000` ms si `>0`, si no exponential) | siempre exponential `base*2^(attempt-1)` con tope `backoff_max_ms` | `RetryPolicy.retry_after_secs: Option<u64>` + fn pura `compute_backoff_delay` (reproduce los 3 casos) |
| Status reintentable | `429 \|\| 5xx` | solo `5xx` | `RetryPolicy.retryable: fn(u16)->bool` |
| Error al agotar | `RateLimited(retry_after)` | `ServerError(status)` | `RetryPolicy.exhausted: HttpError` (construido por el caller) |
| Label de tracing | `"429 retry attempt…"` | `"5xx retry attempt…"` | `RetryPolicy.label: &'static str` → salida idéntica |
| Inspección WAF pre-loop | no | inspecciona la respuesta 5xx inicial antes de reintentar | Se deja verbatim en `get_inner` (no es parte del loop) |

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/http_client/retry.rs` | Nuevo: `retry_with_backoff` + `RetryPolicy` + `compute_backoff_delay` (pura) + 4 tests determinísticos |
| `crates/webfang_core/src/application/http_client/factory.rs` | Nuevo: factorías de cliente + user-agent pool + consts `CLIENT_HINTS_*` |
| `crates/webfang_core/src/application/http_client/client.rs` | `get_inner` rewired a `retry_with_backoff`; factories movidas; doc de la divergencia del port; −227 neto |
| `crates/webfang_core/src/application/http_client/mod.rs` | `+mod factory; +mod retry;` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p webfang_core --all-features --no-deps` clean
- [x] `cargo nextest run --workspace` (1992 passed / 0 failed, cero diffs de snapshot)
- [x] Tests de http_client (54/54) incluyendo `test_429_returns_error` (preserva el sleep de `Retry-After`), `test_500_*`, paths 503 de WAF y `session_pool`

## Notes

- El `expect` legítimo de `NonZeroU32` ("rpm > 0 ya validado") se conserva.
- API pública preservada con re-exports (`crate::application::http_client::*`, `crate::create_http_client*`); cero call-site churn.
- `RetryPolicy` es un struct (no 8 args sueltos) por `clippy::too_many_arguments`; el predicado stateless coerciona a `fn(u16)->bool`.
- La divergencia del `impl HttpClientPort` (raw, sin retry/WAF, devuelve `HttpResponse` completo) se DOCUMENTA; unificarla cambiaría su comportamiento observable. Hay dos impls del port (`for wreq::Client` y `for HttpClient`), ambos documentados.
- Fuera de scope (documentado): el duplicado de `get_random_user_agent_from_pool` en `infrastructure/user_agent.rs` no se tocó.

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (doc de módulo en retry.rs/factory.rs + doc de divergencia del port)
