### PR TITLE
refactor(core): eliminar anyhow residual de webfang_core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,18 @@ jobs:
       # Fails if anyone re-adds a .rs file under root tests/ (dead test).
       - name: Dead test detection
         run: bash scripts/check_dead_tests.sh
+      # Regression guard for #428: webfang_core is a LIBRARY and must use typed
+      # errors (ScraperError/CrawlError/InfraError), never anyhow. anyhow erases
+      # the error types the engine needs to distinguish a 403 from a timeout for
+      # retry/WAF decisions. Doc-comments may still mention anyhow as prose; this
+      # guard only forbids real `use anyhow` imports in library code.
+      - name: Forbid anyhow in webfang_core
+        run: |
+          if grep -rn 'use anyhow' crates/webfang_core/src/ --include='*.rs'; then
+            echo "::error::webfang_core must use typed errors, not anyhow (issue #428). See crates/webfang_core/src/error.rs"
+            exit 1
+          fi
+          echo "OK: no anyhow imports in webfang_core/src"
 
   # ============================================================================
   # TIER 1: FORMAT GATE (30-60 seconds)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6112,7 +6112,6 @@ version = "2.0.0"
 dependencies = [
  "ahash",
  "aho-corasick",
- "anyhow",
  "assert_cmd",
  "async-compression",
  "built",

--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -54,7 +54,6 @@ scraper = { workspace = true }
 lol_html = { workspace = true }
 
 # Error handling
-anyhow = { workspace = true }
 thiserror = { workspace = true }
 
 # Logging

--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -11,7 +11,7 @@
 //! use url::Url;
 //!
 //! # #[tokio::main]
-//! # async fn main() -> anyhow::Result<()> {
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let config = CrawlerConfig::new(Url::parse("https://example.com")?);
 //! let job = BatchJob::new(
 //!     "batch-1".to_string(),

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -47,7 +47,6 @@ pub use crate::infrastructure::crawler::parse_sitemap;
 /// 3. User selects which URLs to scrape
 ///
 /// Following **own-borrow-over-clone**: Accepts `&str` not `&String`.
-/// Following **err-anyhow-for-applications**: Uses anyhow::Result.
 ///
 /// # Arguments
 ///
@@ -57,7 +56,7 @@ pub use crate::infrastructure::crawler::parse_sitemap;
 /// # Returns
 ///
 /// * `Ok(Vec<Url>)` - Discovered URLs (owned)
-/// * `Err(anyhow::Error)` - Error during discovery
+/// * `Err(ScraperError)` - Error during discovery
 ///
 /// # Examples
 ///
@@ -66,7 +65,7 @@ pub use crate::infrastructure::crawler::parse_sitemap;
 /// use url::Url;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> anyhow::Result<()> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let seed = Url::parse("https://example.com")?;
 /// let config = CrawlerConfig::new(seed);
 ///
@@ -86,7 +85,7 @@ pub use crate::infrastructure::crawler::parse_sitemap;
 pub async fn discover_urls_for_tui(
     base_url: &str,
     config: &CrawlerConfig,
-) -> anyhow::Result<Vec<Url>> {
+) -> ScraperResult<Vec<Url>> {
     let span = span!(Level::INFO, "discover_urls", base_url = base_url);
     let _guard = span.enter();
 
@@ -114,11 +113,7 @@ pub async fn discover_urls_for_tui(
         let client = super::super::create_http_client_with_config(&http_config)?;
 
         info!("Fetching {} for link extraction", base_url);
-        let response = client
-            .get(base_url)
-            .send()
-            .await
-            .map_err(|e| anyhow::anyhow!("HTTP error: {e}"))?;
+        let response = client.get(base_url).send().await?;
 
         let status = response.status();
         let content_type = response
@@ -137,18 +132,14 @@ pub async fn discover_urls_for_tui(
             status, content_type, content_length
         );
 
-        let html = response
-            .text()
-            .await
-            .map_err(|e| anyhow::anyhow!("Network error: {e}"))?;
+        let html = response.text().await?;
 
         debug!("Received HTML: {} bytes", html.len());
 
-        let base = Url::parse(base_url).map_err(|e| anyhow::anyhow!("Invalid URL: {e}"))?;
+        let base = Url::parse(base_url)?;
 
         // Extract links
-        let links =
-            extract_links(&html, base_url).map_err(|e| anyhow::anyhow!("Parse error: {e}"))?;
+        let links = extract_links(&html, base_url)?;
 
         // Filter and normalize URLs
         let mut urls = Vec::new();
@@ -176,7 +167,6 @@ pub async fn discover_urls_for_tui(
 /// Scrape a single URL
 ///
 /// Following **own-borrow-over-clone**: Accepts `&Url` not `&String`.
-/// Following **err-anyhow-for-applications**: Uses anyhow::Result.
 ///
 /// # Arguments
 ///

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -1088,7 +1088,7 @@ impl Default for EngineOptions {
 /// use url::Url;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> anyhow::Result<()> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let seed = Url::parse("https://example.com")?;
 /// let config = CrawlerConfig::builder(seed)
 ///     .max_depth(2)
@@ -1162,7 +1162,7 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
 /// use url::Url;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> anyhow::Result<()> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let seed = Url::parse("https://example.com")?;
 /// let config = CrawlerConfig::builder(seed)
 ///     .max_depth(2)

--- a/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
+++ b/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
@@ -5,7 +5,6 @@
 //! were extracted from `discovery.rs` (issue #442) to separate the sitemap
 //! infrastructure concern from DOM-link discovery.
 
-use anyhow::Result;
 use tracing::{info, span, Level};
 use url::Url;
 
@@ -16,7 +15,6 @@ use crate::infrastructure::crawler::{SitemapConfig, SitemapParser};
 
 /// Crawl site using sitemap (preferred method - FASE 3)
 ///
-/// Following **err-anyhow-for-applications**: Uses anyhow::Result.
 /// Following **own-borrow-over-clone**: Accepts `&str` not `&String`.
 /// Following **api-builder-pattern**: Uses SitemapConfig builder.
 ///
@@ -39,7 +37,7 @@ use crate::infrastructure::crawler::{SitemapConfig, SitemapParser};
 /// use url::Url;
 ///
 /// # #[tokio::main]
-/// # async fn main() -> anyhow::Result<()> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let seed = Url::parse("https://example.com")?;
 /// let config = CrawlerConfig::new(seed);
 ///
@@ -65,7 +63,6 @@ pub async fn crawl_with_sitemap(
 /// The public `crawl_with_sitemap` function calls this one.
 ///
 /// Following **own-borrow-over-clone**: Accepts `&str` not `&String`.
-/// Following **err-anyhow-for-applications**: Uses Result with anyhow.
 #[allow(unused_variables)]
 async fn crawl_with_sitemap_internal(
     base_url: &str,

--- a/crates/webfang_core/src/application/export_utils.rs
+++ b/crates/webfang_core/src/application/export_utils.rs
@@ -3,6 +3,7 @@
 //! Provides helper functions for creating exporters and state stores
 //! based on CLI configuration.
 
+use crate::error::Result as ScraperResult;
 use crate::infrastructure::export::StateStore;
 use std::path::PathBuf;
 use tracing::info;
@@ -56,7 +57,7 @@ pub fn domain_from_url(url: &str) -> String {
 ///     "https://example.com"
 /// ).unwrap();
 /// ```
-pub fn create_state_store(state_dir: PathBuf, url: &str) -> anyhow::Result<StateStore> {
+pub fn create_state_store(state_dir: PathBuf, url: &str) -> ScraperResult<StateStore> {
     let domain = domain_from_url(url);
     let mut store = StateStore::new(&domain);
 

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -125,7 +125,7 @@ pub fn extract_with_selector(
 /// use webfang_core::application::{create_http_client, scrape_with_readability};
 ///
 /// # #[tokio::main]
-/// # async fn main() -> anyhow::Result<()> {
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let client = create_http_client()?;
 /// let url = url::Url::parse("https://example.com")?;
 /// let results = scrape_with_readability(&client, &url).await?;

--- a/crates/webfang_core/src/cli/url_discovery.rs
+++ b/crates/webfang_core/src/cli/url_discovery.rs
@@ -9,6 +9,7 @@ use url::Url;
 use crate::application::crawl_options::CrawlOptions;
 use crate::application::discover_urls_for_tui;
 use crate::cli::SelectedUrls;
+use crate::error::Result as ScraperResult;
 use crate::CrawlerConfig;
 
 /// Discover URLs with progress bar.
@@ -17,7 +18,7 @@ use crate::CrawlerConfig;
 pub async fn discover_urls(
     crawler_config: &CrawlerConfig,
     opts: &CrawlOptions,
-) -> anyhow::Result<Vec<Url>> {
+) -> ScraperResult<Vec<Url>> {
     let discovery_pb = if !opts.export.quiet {
         let pb = ProgressBar::new_spinner();
         pb.set_draw_target(ProgressDrawTarget::stderr());

--- a/crates/webfang_core/src/infrastructure/crawler/http_client.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/http_client.rs
@@ -10,13 +10,13 @@
 
 use std::time::Duration;
 
-use anyhow::{Context, Result};
 use tracing::debug;
 use wreq::Client;
 use wreq_util::Profile;
 
 use crate::domain::http_config::HttpClientConfig;
 use crate::domain::{CrawlError, CrawlerConfig};
+use crate::error::Result as ScraperResult;
 use crate::infrastructure::http::create_http_client_with_config;
 
 /// Create a rate-limited HTTP client
@@ -48,7 +48,7 @@ use crate::infrastructure::http::create_http_client_with_config;
 ///
 /// let client = create_rate_limited_client(500, Profile::Chrome145).unwrap();
 /// ```
-pub fn create_rate_limited_client(delay_ms: u64, tls_emulation: Profile) -> Result<Client> {
+pub fn create_rate_limited_client(delay_ms: u64, tls_emulation: Profile) -> ScraperResult<Client> {
     // The connect timeout replicates the historical 10s cap of this client; the
     // per-request timeout is applied by `fetch_url` from `CrawlerConfig`.
     let http_config = HttpClientConfig {
@@ -56,8 +56,7 @@ pub fn create_rate_limited_client(delay_ms: u64, tls_emulation: Profile) -> Resu
         connect_timeout_secs: 10,
         ..Default::default()
     };
-    let client = create_http_client_with_config(&http_config)
-        .context("failed to build rate-limited HTTP client")?;
+    let client = create_http_client_with_config(&http_config)?;
 
     debug!(
         "Created rate-limited HTTP client with delay_ms={} tls_emulation={:?}",

--- a/crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs
@@ -9,7 +9,7 @@
 //! use webfang_core::infrastructure::crawler::SitemapParser;
 //!
 //! # #[tokio::main]
-//! # async fn main() -> anyhow::Result<()> {
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let parser = SitemapParser::new()?;
 //! let urls = parser.parse_from_url("https://example.com/sitemap.xml").await?;
 //! println!("Found {} URLs", urls.len());

--- a/crates/webfang_core/src/infrastructure/export/state_store.rs
+++ b/crates/webfang_core/src/infrastructure/export/state_store.rs
@@ -177,7 +177,7 @@ impl StateStore {
     /// use webfang_core::infrastructure::export::StateStore;
     /// use webfang_core::domain::ExportState;
     ///
-    /// # fn main() -> anyhow::Result<()> {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let store = StateStore::new("example.com");
     /// let mut state = ExportState::new("example.com");
     /// state.mark_processed("https://example.com/page1");

--- a/crates/webfang_core/src/infrastructure/observability/logging.rs
+++ b/crates/webfang_core/src/infrastructure/observability/logging.rs
@@ -11,6 +11,8 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+use crate::error::Result as ScraperResult;
+
 /// Guard for JSON logging - ensures flush on drop (RAII)
 ///
 /// Dropping this guard ensures all pending log writes are flushed
@@ -94,7 +96,7 @@ pub fn init_json_logging(
     level: &str,
     log_dir: Option<&Path>,
     app_name: &str,
-) -> anyhow::Result<LogGuard> {
+) -> ScraperResult<LogGuard> {
     init_json_logging_dual(level, false, false, log_dir, app_name)
 }
 
@@ -113,7 +115,7 @@ pub fn init_json_logging_dual(
     no_color: bool,
     log_dir: Option<&Path>,
     app_name: &str,
-) -> anyhow::Result<LogGuard> {
+) -> ScraperResult<LogGuard> {
     let filter = if quiet {
         EnvFilter::new("webfang=warn,tokio=warn,reqwest=warn")
     } else {

--- a/crates/webfang_core/tests/progress_e2e_wiring.rs
+++ b/crates/webfang_core/tests/progress_e2e_wiring.rs
@@ -1,7 +1,7 @@
 //! End-to-end test for channel plumbing: observer → channel → receiver.
 
 #[tokio::test]
-async fn test_full_pipeline_event_flow() -> anyhow::Result<()> {
+async fn test_full_pipeline_event_flow() -> Result<(), Box<dyn std::error::Error>> {
     use std::sync::Arc;
     use webfang_core::application::progress_observer::LiveProgressObserver;
     use webfang_core::domain::entities::progress::{ScrapeProgress, ScrapeStatus};


### PR DESCRIPTION
Closes #428

## Summary

Eliminación completa de `anyhow` en `webfang_core` (29 refs / 12 archivos). La librería usaba `anyhow::Result` en hot paths del core, borrando los tipos exactos donde el engine necesita distinguir `403` de `timeout` para decisiones de retry/WAF.

## Changes

- **discovery.rs** (hot path): `discover_urls_for_tui` → `ScraperResult<Vec<Url>>`, 4× `anyhow!` reemplazados por `?` con `From` impls existentes. Borrada la coartada `err-anyhow-for-applications` (regla de CLI aplicada mal en library core).
- **crawler infra**: `http_client.rs`, `sitemap_parser.rs`, `sitemap_discovery.rs` → errores tipados (`ScraperResult`, `CrawlError`).
- **application layer**: `engine.rs`, `processor.rs`, `extraction.rs`, `export_utils.rs` → `ScraperResult`.
- **observability/state**: `logging.rs`, `state_store.rs`, `url_discovery.rs` → `ScraperResult`.
- **Doctests**: migrados de `anyhow::Result` a `Box<dyn Error>` (std-only).
- **Cargo.toml**: removida dependencia `anyhow` de `webfang_core`.
- **CI lint**: guard TIER-0 que falla si se reintroduce `use anyhow` en `webfang_core/src/`.

## Verification

- `cargo check --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo nextest run --workspace`: **1992 passed, 0 failed** ✅
- `cargo test --doc -p webfang_core`: 67 passed ✅
- `rg 'anyhow' crates/webfang_core/src/`: solo 5 doc-comments (documentación de migración, intencionales)

## Notes

- `scraper_service.rs` no requirió cambios (ya estaba limpio, mención stale en la issue).
- `anyhow` sigue permitido en `webfang_cli` (la aplicación).
- Cambio menor en mensajes de error de discovery: ahora renderizan como `ScraperError::Network` ("error de red: …") en vez del texto genérico de anyhow. La causa raíz de wreq se preserva.