### PR TITLE
feat(mcp): cablear download_assets al AssetDownloader (#452)

### DIFF
--- a/crates/webfang_mcp/examples/mcp_server.rs
+++ b/crates/webfang_mcp/examples/mcp_server.rs
@@ -232,9 +232,7 @@
 //!
 //! | Tool | Description | Key params |
 //! |------|-------------|------------|
-//! | `download_assets` | Download images/docs from HTML | `html`, `base_url`, `images?`, `documents?` |
-//!
-//! **⚠️ Not yet implemented** — see #170. Returns explicit error.
+//! | `download_assets` | Download images/docs from HTML | `html`, `base_url`, `images?`, `documents?`, `output_dir?` |
 //!
 //! ### Category 8: AI Semantic (feature-gated)
 //!
@@ -298,6 +296,8 @@
 use std::net::SocketAddr;
 
 use anyhow::Result;
+use std::sync::Arc;
+use webfang_core::adapters::downloader::{DownloadConfig, Downloader};
 use webfang_core::config::Config;
 use webfang_core::di::{Container, ContainerExt};
 use webfang_mcp::mcp_server::server::{start_mcp_server, DEFAULT_MCP_ADDR};
@@ -341,7 +341,11 @@ async fn main() -> Result<()> {
         }
     };
 
-    let state = McpState::new(container);
+    // Inject a shared Downloader so `download_assets` reuses one connection
+    // pool across tool calls. The default config writes to `./downloads`
+    // relative to the working directory.
+    let state = McpState::new(container)
+        .with_downloader(Arc::new(Downloader::new(DownloadConfig::default())?));
     let addr: SocketAddr = DEFAULT_MCP_ADDR.parse()?;
     start_mcp_server(state, addr).await
 }

--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -13,11 +13,16 @@ use tracing::instrument;
 
 #[tool_router(router = tool_router_assets, vis = "pub")]
 impl McpHandler {
-    /// Download images and documents from HTML (NOT YET IMPLEMENTED — see #170)
+    /// Download images and documents from HTML into the output directory.
+    ///
+    /// The boolean toggles `images` (default: true) and `documents`
+    /// (default: false) select which asset kinds are downloaded. Files are
+    /// written with SHA-256 hashed filenames; the response reports each
+    /// downloaded asset with its local path.
     #[tool(
-        description = "NOT YET IMPLEMENTED (see #170). Download images and/or documents referenced in HTML content. Parameters 'images' and 'documents' are boolean toggles, not URL lists. Use scrape_url with download_images=true as a working alternative."
+        description = "Download images (default: true) and/or documents (default: false) referenced in HTML content into the output directory (SHA-256 hashed filenames). 'images' and 'documents' are boolean toggles, not URL lists. Returns the downloaded assets with their local paths. For a full scrape that also downloads assets, use scrape_with_options with download_images/download_documents."
     )]
-    #[instrument(skip(self), fields(base_url = %params.base_url, images = params.images.unwrap_or(true), documents = params.documents.unwrap_or(false)))]
+    #[instrument(skip(self), fields(base_url = %params.base_url, images = params.images.unwrap_or(true), documents = params.documents.unwrap_or(false), output_dir = ?params.output_dir))]
     async fn download_assets(
         &self,
         Parameters(params): Parameters<DownloadAssetsParams>,
@@ -31,16 +36,44 @@ impl McpHandler {
             )
         })?;
 
-        let download_images = params.images.unwrap_or(true);
-        let download_documents = params.documents.unwrap_or(false);
+        let mut config = webfang_core::infrastructure::config::ScraperConfig {
+            download_images: params.images.unwrap_or(true),
+            download_documents: params.documents.unwrap_or(false),
+            ..Default::default()
+        };
+        if let Some(ref output_dir) = params.output_dir {
+            config.output_dir = std::path::PathBuf::from(output_dir);
+        }
 
-        // TODO(#170): Wire up actual asset downloading via shared Downloader
-        // For now, return an explicit "not implemented" error instead of fake success
-        Ok(CallToolResult::error(vec![Content::text(format!(
-            "download_assets not yet implemented (see #170). \
-             Use scrape_url with download_images=true instead. \
-             Requested: images={download_images}, documents={download_documents}, base={base_url}"
-        ))]))
+        // Shared downloader when injected (connection pooling across calls);
+        // None falls back to a per-call Downloader built from the config.
+        let dl = self
+            .state
+            .downloader
+            .as_deref()
+            .map(|d| d as &dyn webfang_core::domain::ports::AssetDownloaderPort);
+
+        match webfang_core::application::scraper_service::download_assets_if_enabled(
+            &params.html,
+            &base_url,
+            &config,
+            dl,
+        )
+        .await
+        {
+            Ok(assets) => {
+                tracing::info!(
+                    downloaded = assets.len(),
+                    images = config.download_images,
+                    documents = config.download_documents,
+                    "assets downloaded"
+                );
+                let content = serde_json::to_string_pretty(&assets)
+                    .unwrap_or_else(|_| "failed to serialize".into());
+                Ok(CallToolResult::success(vec![Content::text(content)]))
+            },
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+        }
     }
 }
 

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -190,6 +190,13 @@ pub(crate) struct DownloadAssetsParams {
     pub images: Option<bool>,
     /// Download documents (default: false)
     pub documents: Option<bool>,
+    /// Output directory for downloaded assets.
+    ///
+    /// When omitted, defaults to the scraper output directory
+    /// (`output/` relative to the current working directory). Only used when
+    /// the server has no shared downloader injected; a shared downloader
+    /// writes to its own configured output directory.
+    pub output_dir: Option<String>,
 }
 
 // Params for tools that accept free-form JSON input

--- a/crates/webfang_mcp/tests/download_assets_test.rs
+++ b/crates/webfang_mcp/tests/download_assets_test.rs
@@ -1,0 +1,442 @@
+//! MCP `download_assets` behavioral tests
+//!
+//! Proves the tool is wired into the real `AssetDownloaderPort` infrastructure
+//! (#452): a wiremock server serves the assets, a real `Downloader` writes
+//! SHA-256 hashed files into a TempDir, and the tool returns them as JSON.
+//!
+//! Run with: cargo nextest run --test download_assets_test --features mcp
+
+#![cfg(feature = "mcp")]
+
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use wreq::Client;
+
+use webfang_core::adapters::downloader::{DownloadConfig, Downloader};
+use webfang_core::config::Config;
+use webfang_core::di::Container;
+use webfang_mcp::mcp_server::server::build_mcp_router;
+use webfang_mcp::mcp_server::state::McpState;
+
+/// Start a test MCP server on a random port. Pass `Some(downloader)` to inject
+/// a shared `AssetDownloaderPort` (the production wiring in `mcp_server.rs`);
+/// pass `None` to exercise the per-call fallback downloader built from config.
+async fn start_server(
+    downloader: Option<Arc<Downloader>>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let config = Config::default();
+    let container = Container::new(config.crawler, config.scraper)
+        .await
+        .expect("container creation failed");
+    let state = match downloader {
+        Some(d) => McpState::new(container).with_downloader(d),
+        None => McpState::new(container),
+    };
+    let app = build_mcp_router(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Wait for the server to accept TCP connections instead of a fixed sleep.
+    for _ in 0..20 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    (base_url, handle)
+}
+
+/// Build a JSON-RPC request body for MCP protocol.
+fn mcp_request(method: &str, params: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    })
+}
+
+/// Extract the first JSON-RPC object from an SSE (`data: ` prefixed) or direct
+/// JSON response body. Local copy — each integration test binary is standalone.
+fn extract_json(body: &str) -> Option<Value> {
+    if body.contains("data: ") {
+        body.lines()
+            .filter(|line| line.starts_with("data: "))
+            .filter_map(|line| {
+                let json_str = line.strip_prefix("data: ").unwrap_or(line);
+                serde_json::from_str::<Value>(json_str).ok()
+            })
+            .next()
+    } else {
+        serde_json::from_str::<Value>(body).ok()
+    }
+}
+
+/// Initialize an MCP session (initialize + notifications/initialized) and
+/// return the session ID.
+async fn init_session(client: &Client, base_url: &str) -> String {
+    let init_body = mcp_request(
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "download-assets-test", "version": "1.0.0" }
+        }),
+    );
+    let resp = client
+        .post(format!("{base_url}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&init_body)
+        .send()
+        .await
+        .expect("initialize should succeed");
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("initialize must return mcp-session-id");
+
+    let _ = client
+        .post(format!("{base_url}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&json!({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+        .send()
+        .await;
+
+    session_id
+}
+
+/// Call an MCP tool and return the parsed JSON-RPC response object.
+async fn call_tool(
+    client: &Client,
+    base_url: &str,
+    session_id: &str,
+    name: &str,
+    args: Value,
+) -> Value {
+    let body = mcp_request("tools/call", json!({ "name": name, "arguments": args }));
+    let resp = client
+        .post(format!("{base_url}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", session_id)
+        .json(&body)
+        .send()
+        .await
+        .expect("tools/call should succeed");
+    let text = resp.text().await.expect("read response body");
+    extract_json(&text).expect("response must parse as JSON-RPC")
+}
+
+/// Extract the first content text from a tool result object.
+fn tool_text(result: &Value) -> String {
+    result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|first| first.get("text"))
+        .and_then(|t| t.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Whether a tool result is flagged as an error (CallToolResult::error).
+fn is_tool_error(result: &Value) -> bool {
+    result
+        .get("isError")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Unwrap the CallToolResult object from the JSON-RPC envelope returned by
+/// `call_tool`, so helpers like `tool_text` see the `content` field.
+fn tool_result(resp: Value) -> Value {
+    resp.get("result")
+        .cloned()
+        .expect("JSON-RPC response must carry a result")
+}
+
+/// Parse the tool's JSON text payload into an array of downloaded assets.
+fn asset_array(result: &Value) -> Vec<Value> {
+    let parsed: Value = serde_json::from_str(&tool_text(result)).expect("response is JSON");
+    parsed.as_array().expect("response is an array").to_vec()
+}
+
+#[tokio::test]
+async fn download_assets_downloads_images_via_shared_downloader() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/logo.png"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "image/png")
+                .set_body_bytes(b"PNG-BYTES"),
+        )
+        .mount(&mock)
+        .await;
+
+    let out = tempfile::TempDir::new().expect("create output temp dir");
+    let dl_config = DownloadConfig {
+        output_dir: out.path().to_path_buf(),
+        ..Default::default()
+    };
+    let downloader = Arc::new(Downloader::new(dl_config).expect("build downloader"));
+    let (base_url, _handle) = start_server(Some(downloader)).await;
+
+    let client = Client::new();
+    let session = init_session(&client, &base_url).await;
+
+    let html = format!(
+        "<html><body><img src=\"{}/logo.png\"></body></html>",
+        mock.uri()
+    );
+    let result = tool_result(
+        call_tool(
+            &client,
+            &base_url,
+            &session,
+            "download_assets",
+            json!({
+                "html": html,
+                "base_url": mock.uri(),
+                "images": true,
+                "documents": false,
+            }),
+        )
+        .await,
+    );
+
+    assert!(
+        !is_tool_error(&result),
+        "expected success, got: {}",
+        tool_text(&result)
+    );
+    let assets = asset_array(&result);
+    assert_eq!(assets.len(), 1, "one image expected");
+    assert_eq!(assets[0]["asset_type"], "image");
+
+    let local_path = assets[0]["local_path"].as_str().expect("local_path");
+    let file_name = std::path::Path::new(local_path)
+        .file_name()
+        .expect("file name")
+        .to_string_lossy()
+        .to_string();
+    // SHA-256 hashed filename: <12 hex chars>.png
+    assert_eq!(file_name.len(), 16, "unexpected filename {file_name}");
+    assert!(
+        file_name[..12].chars().all(|c| c.is_ascii_hexdigit()),
+        "hash prefix must be hex, got {file_name}"
+    );
+    assert!(file_name.ends_with(".png"));
+    assert!(
+        std::path::Path::new(local_path).exists(),
+        "asset file must exist on disk"
+    );
+
+    // Deterministic snapshot of the full tool response.
+    insta::with_settings!({
+        filters => vec![
+            (out.path().to_string_lossy().as_ref(), "[OUT_DIR]"),
+            (r"127\.0\.0\.1:\d+", "127.0.0.1:[PORT]"),
+        ],
+    }, {
+        insta::assert_snapshot!("download_assets_images_response", tool_text(&result));
+    });
+}
+
+#[tokio::test]
+async fn download_assets_downloads_documents_when_enabled() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/report.pdf"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/pdf")
+                .set_body_bytes(b"%PDF-1.4 fake pdf"),
+        )
+        .mount(&mock)
+        .await;
+
+    let out = tempfile::TempDir::new().expect("create output temp dir");
+    let dl_config = DownloadConfig {
+        output_dir: out.path().to_path_buf(),
+        ..Default::default()
+    };
+    let downloader = Arc::new(Downloader::new(dl_config).expect("build downloader"));
+    let (base_url, _handle) = start_server(Some(downloader)).await;
+
+    let client = Client::new();
+    let session = init_session(&client, &base_url).await;
+
+    let html = format!(
+        "<html><body><a href=\"{}/report.pdf\">Report</a></body></html>",
+        mock.uri()
+    );
+    let result = tool_result(
+        call_tool(
+            &client,
+            &base_url,
+            &session,
+            "download_assets",
+            json!({
+                "html": html,
+                "base_url": mock.uri(),
+                "images": false,
+                "documents": true,
+            }),
+        )
+        .await,
+    );
+
+    assert!(
+        !is_tool_error(&result),
+        "expected success, got: {}",
+        tool_text(&result)
+    );
+    let assets = asset_array(&result);
+    assert_eq!(assets.len(), 1, "one document expected");
+    assert_eq!(assets[0]["asset_type"], "document");
+
+    let local_path = assets[0]["local_path"].as_str().expect("local_path");
+    let file_name = std::path::Path::new(local_path)
+        .file_name()
+        .expect("file name")
+        .to_string_lossy()
+        .to_string();
+    assert!(
+        file_name.ends_with(".pdf"),
+        "unexpected filename {file_name}"
+    );
+    assert!(
+        std::path::Path::new(local_path).exists(),
+        "asset file must exist on disk"
+    );
+}
+
+#[tokio::test]
+async fn download_assets_both_disabled_returns_empty() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/logo.png"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"PNG"))
+        .mount(&mock)
+        .await;
+
+    let out = tempfile::TempDir::new().expect("create output temp dir");
+    let dl_config = DownloadConfig {
+        output_dir: out.path().to_path_buf(),
+        ..Default::default()
+    };
+    let downloader = Arc::new(Downloader::new(dl_config).expect("build downloader"));
+    let (base_url, _handle) = start_server(Some(downloader)).await;
+
+    let client = Client::new();
+    let session = init_session(&client, &base_url).await;
+
+    let html = format!(
+        "<html><body><img src=\"{}/logo.png\"></body></html>",
+        mock.uri()
+    );
+    let result = tool_result(
+        call_tool(
+            &client,
+            &base_url,
+            &session,
+            "download_assets",
+            json!({
+                "html": html,
+                "base_url": mock.uri(),
+                "images": false,
+                "documents": false,
+            }),
+        )
+        .await,
+    );
+
+    assert!(
+        !is_tool_error(&result),
+        "expected success, got: {}",
+        tool_text(&result)
+    );
+    assert!(
+        asset_array(&result).is_empty(),
+        "no downloads expected when both toggles are false"
+    );
+}
+
+#[tokio::test]
+async fn download_assets_output_dir_param_writes_to_requested_dir() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/logo.png"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "image/png")
+                .set_body_bytes(b"PNG-BYTES"),
+        )
+        .mount(&mock)
+        .await;
+
+    // No shared downloader injected: the handler builds a per-call Downloader
+    // from config, honoring the `output_dir` parameter.
+    let (base_url, _handle) = start_server(None).await;
+
+    let client = Client::new();
+    let session = init_session(&client, &base_url).await;
+
+    let out = tempfile::TempDir::new().expect("create output temp dir");
+    let html = format!(
+        "<html><body><img src=\"{}/logo.png\"></body></html>",
+        mock.uri()
+    );
+    let result = tool_result(
+        call_tool(
+            &client,
+            &base_url,
+            &session,
+            "download_assets",
+            json!({
+                "html": html,
+                "base_url": mock.uri(),
+                "images": true,
+                "documents": false,
+                "output_dir": out.path().to_string_lossy().to_string(),
+            }),
+        )
+        .await,
+    );
+
+    assert!(
+        !is_tool_error(&result),
+        "expected success, got: {}",
+        tool_text(&result)
+    );
+    let assets = asset_array(&result);
+    assert_eq!(assets.len(), 1, "one image expected");
+
+    let local_path = assets[0]["local_path"].as_str().expect("local_path");
+    assert!(
+        local_path.starts_with(out.path().to_string_lossy().as_ref()),
+        "expected {local_path} to live under {}",
+        out.path().to_string_lossy()
+    );
+    assert!(
+        std::path::Path::new(local_path).exists(),
+        "asset file must exist on disk"
+    );
+}

--- a/crates/webfang_mcp/tests/snapshots/download_assets_test__download_assets_images_response.snap
+++ b/crates/webfang_mcp/tests/snapshots/download_assets_test__download_assets_images_response.snap
@@ -1,0 +1,12 @@
+---
+source: crates/webfang_mcp/tests/download_assets_test.rs
+expression: tool_text(&result)
+---
+[
+  {
+    "url": "http://127.0.0.1:[PORT]/logo.png",
+    "local_path": "[OUT_DIR]/images/71a5d2aaa19f.png",
+    "asset_type": "image",
+    "size": 9
+  }
+]


### PR DESCRIPTION
Closes #452

## Summary
`download_assets` era un stub no funcional: publicitaba descarga de imágenes/documentos pero SIEMPRE devolvía error `not implemented (see #170)` — y #170 está MERGED (issue de UX, sin relación). La infraestructura real ya existía y estaba testeada (`AssetDownloaderPort` + `download_assets_if_enabled`); solo faltaba cablearla.

### Cambios
- **`handlers/assets.rs`**: el tool ahora construye un `ScraperConfig` desde los params (`images` default true, `documents` default false, `output_dir` opcional), lee el downloader compartido de `McpState` (con fallback per-call si es None) y delega en `download_assets_if_enabled`. Devuelve los assets descargados como JSON (paths locales, nombres SHA-256). Docstring corregido (la alternativa real es `scrape_with_options`, no `scrape_url`); referencia #170 eliminada.
- **`params.rs`**: `DownloadAssetsParams` gana `output_dir: Option<String>`.
- **`examples/mcp_server.rs`**: inyecta un `Downloader` compartido en `McpState` (pooling real; antes era None en runtime).
- **`tests/download_assets_test.rs`** (nuevo, 4 tests E2E + snapshot insta determinista): wiremock sirviendo HTML con assets, TempDir como destino; cubre imágenes, documentos, y el caso ambos-false → vacío sin error.

### Gates
- `cargo check --workspace --tests --all-features` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo nextest run -p webfang_mcp --all-features` 109/109 ✅
- `rg 170` en webfang_mcp → cero ✅

## Impacto
5 archivos: 514 insertions, 16 deletions.