### PR TITLE
refactor(crawler): strangler fig C — extraer CrawlScheduler del loop de run

### DIFF
--- a/crates/webfang_core/src/application/crawler/crawl_scheduler.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_scheduler.rs
@@ -1,0 +1,176 @@
+//! Crawl scheduling policy — visited tracking, work queue, and concurrency limits.
+//!
+//! Extracted from `engine.rs` (strangler fig Corte C, issue #440). Encapsulates
+//! the *scheduling decisions* that were previously inlined in `Engine::run()`:
+//! which URL to crawl next, deduplication of visited URLs, the pending-work
+//! buffer drained from the shared [`UrlQueue`], and the autoscale-aware
+//! concurrency limit.
+//!
+//! The `Engine` remains the *orchestration mechanism*: it owns the `JoinSet`,
+//! spawns tasks via the `crawl_task` module, coordinates signal-driven shutdown,
+//! and persists checkpoints. `CrawlScheduler` carries no task, shutdown, or
+//! checkpoint state.
+//!
+//! # Shared state
+//!
+//! `visited`, `visited_urls`, and `queue` are `Arc`-shared with the spawned
+//! per-page tasks (via `CrawlTaskCtx`): tasks dedup discovered links and push
+//! them onto `queue`, while the scheduler drains `queue` into its local
+//! `pending` buffer and decides what to crawl next. The scheduler owns the
+//! canonical `Arc`s and exposes accessors so the `Engine` clones them into the
+//! task context exactly once.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::{Arc, RwLock};
+
+use url::Url;
+
+use super::concurrency_level::SharedConcurrencyLevel;
+use crate::application::deduplicator::UrlDeduplicator;
+use crate::domain::DiscoveredUrl;
+use crate::infrastructure::crawler::{UrlQueue, UrlSource};
+
+/// Scheduling policy for a crawl: visited dedup, pending-work buffer, and
+/// concurrency limits.
+///
+/// Owns the canonical `Arc`s for the visited set ([`UrlDeduplicator`]), the
+/// checkpoint string mirror (`visited_urls`), and the shared discovery queue
+/// ([`UrlQueue`]). These are `Arc`-shared with the per-page tasks, which push
+/// discovered links onto `queue`; the scheduler drains that queue into a local
+/// `pending` buffer and hands out the next URL to crawl.
+pub(crate) struct CrawlScheduler {
+    /// Lock-free dedup of visited URLs (hash set).
+    visited: Arc<UrlDeduplicator>,
+    /// String mirror of visited URLs for checkpoint persistence.
+    visited_urls: Arc<RwLock<Vec<String>>>,
+    /// Shared discovery queue — tasks push discovered links here.
+    queue: Arc<UrlQueue>,
+    /// Local work buffer drained from `queue`; the scheduler pops from here.
+    pending: VecDeque<DiscoveredUrl>,
+    /// Base concurrency from `CrawlerConfig::concurrency`.
+    base_concurrency: usize,
+    /// Optional autoscale level for RAM-aware concurrency adjustment.
+    autoscale_level: Option<Arc<SharedConcurrencyLevel>>,
+}
+
+impl CrawlScheduler {
+    /// Create a scheduler with fresh scheduling state.
+    ///
+    /// Builds the visited set, its checkpoint string mirror, and the shared
+    /// discovery queue internally; these are `Arc`-shared with the per-page
+    /// tasks via the accessors below.
+    pub(crate) fn new(base_concurrency: usize) -> Self {
+        Self {
+            visited: Arc::new(UrlDeduplicator::new()),
+            visited_urls: Arc::new(RwLock::new(Vec::new())),
+            queue: Arc::new(UrlQueue::new()),
+            pending: VecDeque::new(),
+            base_concurrency,
+            autoscale_level: None,
+        }
+    }
+
+    /// Enable RAM-aware autoscaling of the concurrency limit.
+    pub(crate) fn set_autoscale(&mut self, level: Arc<SharedConcurrencyLevel>) {
+        self.autoscale_level = Some(level);
+    }
+
+    /// Clone the visited deduplicator for the shared task context.
+    pub(crate) fn visited(&self) -> Arc<UrlDeduplicator> {
+        Arc::clone(&self.visited)
+    }
+
+    /// Clone the visited-URL string mirror for the shared task context.
+    pub(crate) fn visited_urls(&self) -> Arc<RwLock<Vec<String>>> {
+        Arc::clone(&self.visited_urls)
+    }
+
+    /// Clone the discovery queue for the shared task context.
+    pub(crate) fn queue(&self) -> Arc<UrlQueue> {
+        Arc::clone(&self.queue)
+    }
+
+    /// Record a URL as visited (hash dedup + string mirror).
+    ///
+    /// Returns `true` if newly inserted, `false` if already visited.
+    pub(crate) fn record_visit(&self, url: &str) -> bool {
+        if self.visited.try_insert(url) {
+            if let Ok(mut urls) = self.visited_urls.write() {
+                urls.push(url.to_string());
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Restore visited URLs from a checkpoint (idempotent via dedup).
+    pub(crate) fn restore_visited(&self, urls: &HashSet<String>) {
+        for url in urls {
+            self.record_visit(url);
+        }
+    }
+
+    /// Snapshot the visited-URL string mirror for checkpoint persistence.
+    #[allow(clippy::expect_used)]
+    pub(crate) fn snapshot_visited(&self) -> HashSet<String> {
+        let urls = self
+            .visited_urls
+            .read()
+            .expect("visited_urls RwLock poisoned");
+        urls.iter().cloned().collect()
+    }
+
+    /// Seed the crawl: push the seed onto the discovery queue (highest priority)
+    /// and onto the local pending buffer.
+    pub(crate) async fn seed(&mut self, seed_url: &Url) {
+        let discovered = DiscoveredUrl::html(seed_url.clone(), 0, seed_url.clone());
+        self.queue
+            .push_prioritized(discovered.clone(), UrlSource::Seed)
+            .await;
+        self.pending.push_back(discovered);
+    }
+
+    /// Drain discovered links from the shared queue into the pending buffer.
+    pub(crate) async fn drain_discovered(&mut self) {
+        self.pending.append(&mut self.queue.drain_all().await);
+    }
+
+    /// Whether there are URLs left to schedule.
+    #[must_use]
+    pub(crate) fn has_pending_work(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    /// Effective concurrency limit (autoscale-aware).
+    #[must_use]
+    pub(crate) fn effective_concurrency(&self) -> usize {
+        self.autoscale_level
+            .as_ref()
+            .map(|level| level.effective_concurrency(self.base_concurrency))
+            .unwrap_or(self.base_concurrency)
+    }
+
+    /// Whether another task may be spawned given `in_flight` running tasks.
+    #[must_use]
+    pub(crate) fn can_spawn(&self, in_flight: usize) -> bool {
+        in_flight < self.effective_concurrency()
+    }
+
+    /// Next URL to crawl, or `None` if at the concurrency limit or out of work.
+    ///
+    /// Checks the concurrency limit *before* popping (so the pending buffer is
+    /// left untouched when no task may spawn), then skips already-visited URLs,
+    /// marking the returned URL as visited.
+    pub(crate) fn next_url(&mut self, in_flight: usize) -> Option<DiscoveredUrl> {
+        if !self.can_spawn(in_flight) {
+            return None;
+        }
+        while let Some(discovered) = self.pending.pop_front() {
+            if self.record_visit(discovered.url.as_str()) {
+                return Some(discovered);
+            }
+        }
+        None
+    }
+}

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -18,20 +18,18 @@ use super::checkpoint::{
 };
 use super::collector::ResultsCollector;
 use super::concurrency_level::{ConcurrencyLevel, SharedConcurrencyLevel};
+use super::crawl_scheduler::CrawlScheduler;
 use super::crawl_task::{handle_crawl_result, run_crawl_task};
 use super::fetch_router::{build_fetch_router, FetchRouter};
 use super::progress::CrawlProgress;
 use crate::application::crawler::crawl_task_ctx::CrawlTaskCtx;
-use crate::application::deduplicator::UrlDeduplicator;
 use crate::application::pipeline::{OutputStage, PipelineExecutor};
 use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
 use crate::domain::clock::SystemClock;
 use crate::domain::{
-    CorrelationId, CrawlError, CrawlErrorCategory, CrawlResult, CrawlerConfig, DiscoveredUrl,
-    JsStrategy,
+    CorrelationId, CrawlError, CrawlErrorCategory, CrawlResult, CrawlerConfig, JsStrategy,
 };
 use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
-use crate::infrastructure::crawler::{UrlQueue, UrlSource};
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
 use crate::infrastructure::downloader::resource_governor::ResourceGovernor;
 use crate::infrastructure::downloader::DownloadError;
@@ -50,10 +48,8 @@ pub struct Engine {
     /// Root correlation ID for this crawl — all pages share its `trace_id`.
     correlation_id: CorrelationId,
     collector: ResultsCollector,
-    visited: Arc<UrlDeduplicator>,
-    /// String URLs for checkpoint persistence (mirrors `visited` hashes).
-    visited_urls: Arc<RwLock<Vec<String>>>,
-    queue: Arc<UrlQueue>,
+    /// Scheduling policy — visited dedup, pending-work buffer, concurrency limits.
+    scheduler: CrawlScheduler,
     rate_limiter: SharedRateLimiter,
     error_count: Arc<AtomicUsize>,
     /// Per-category error counters indexed by `CrawlErrorCategory::index()` (issue #374).
@@ -88,8 +84,6 @@ pub struct Engine {
     pipeline: Option<Arc<PipelineExecutor>>,
     /// Output stages that receive items after pipeline processing.
     output_stages: Vec<Arc<Box<dyn OutputStage>>>,
-    /// Optional autoscale level for RAM-aware concurrency adjustment.
-    autoscale_level: Option<Arc<SharedConcurrencyLevel>>,
     /// Handle for the signal handler task — aborted on shutdown
     /// to prevent the tokio runtime from hanging waiting for it.
     signal_handle: Option<tokio::task::JoinHandle<()>>,
@@ -109,12 +103,9 @@ impl Engine {
             Err(e) => return Err(CrawlError::Internal(e.to_string())),
         };
 
-        // Create URL queue
-        let queue = Arc::new(UrlQueue::new());
-
-        // Track visited URLs — lock-free DashSet for dedup, RwLock Vec for checkpoint
-        let visited = Arc::new(UrlDeduplicator::new());
-        let visited_urls = Arc::new(RwLock::new(Vec::new()));
+        // Scheduling policy owns the visited set, its checkpoint string mirror,
+        // and the shared discovery queue (Arc-shared with the per-page tasks).
+        let scheduler = CrawlScheduler::new(config_clone.concurrency);
 
         // Results collector via mpsc channel
         let collector = ResultsCollector::new(config_clone.max_pages, Some(config_clone.max_pages));
@@ -134,9 +125,7 @@ impl Engine {
             config,
             correlation_id: CorrelationId::new(),
             collector,
-            visited,
-            visited_urls,
-            queue,
+            scheduler,
             rate_limiter,
             error_count,
             error_breakdown,
@@ -155,7 +144,6 @@ impl Engine {
             banned_domains: Arc::new(RwLock::new(Vec::new())),
             pipeline: None,
             output_stages: Vec::new(),
-            autoscale_level: None,
             signal_handle: None,
         })
     }
@@ -275,7 +263,7 @@ impl Engine {
             }
         });
 
-        self.autoscale_level = Some(level);
+        self.scheduler.set_autoscale(level);
         self
     }
 
@@ -302,14 +290,7 @@ impl Engine {
     /// Save the current checkpoint to disk (non-blocking wrapper).
     async fn save_checkpoint(&self) {
         if let Some(path) = &self.checkpoint_path {
-            let visited_set: HashSet<String> = {
-                #[allow(clippy::expect_used)]
-                let urls = self
-                    .visited_urls
-                    .read()
-                    .expect("visited_urls RwLock poisoned");
-                urls.iter().cloned().collect()
-            };
+            let visited_set: HashSet<String> = self.scheduler.snapshot_visited();
             let pages = self
                 .pages_crawled
                 .load(std::sync::atomic::Ordering::Relaxed);
@@ -374,18 +355,6 @@ impl Engine {
         })
     }
 
-    /// Record a URL as visited (both hash dedup and string tracking).
-    fn record_visit(&self, url: &str) -> bool {
-        if self.visited.try_insert(url) {
-            if let Ok(mut urls) = self.visited_urls.write() {
-                urls.push(url.to_string());
-            }
-            true
-        } else {
-            false
-        }
-    }
-
     /// Run the crawl loop until completion
     ///
     /// Returns the collected URLs and error count.
@@ -398,9 +367,7 @@ impl Engine {
         // Load checkpoint state if resuming
         if let Some(ref cp) = self.checkpoint_state {
             if !cp.visited.is_empty() {
-                for url in &cp.visited {
-                    self.record_visit(url);
-                }
+                self.scheduler.restore_visited(&cp.visited);
                 info!("Restored {} visited URLs from checkpoint", cp.visited.len());
             }
             if !cp.banned_domains.is_empty() {
@@ -414,31 +381,18 @@ impl Engine {
             }
         }
 
-        // Add seed URL to queue (highest priority)
-        let seed_discovered = DiscoveredUrl::html(
-            config_clone.seed_url.clone(),
-            0,
-            config_clone.seed_url.clone(),
-        );
-        self.queue
-            .push_prioritized(seed_discovered, UrlSource::Seed)
-            .await;
+        // Seed the scheduler (pushes onto the discovery queue and pending buffer)
+        self.scheduler.seed(&config_clone.seed_url).await;
 
         let mut tasks = tokio::task::JoinSet::new();
-        let mut url_queue = std::collections::VecDeque::new();
-        url_queue.push_back(DiscoveredUrl::html(
-            config_clone.seed_url.clone(),
-            0,
-            config_clone.seed_url.clone(),
-        ));
 
         // Build shared task context once — all spawned tasks share this Arc
         let task_ctx = Arc::new(CrawlTaskCtx {
             config: Arc::clone(&self.config),
             correlation_id: self.correlation_id.clone(),
-            visited: Arc::clone(&self.visited),
-            visited_urls: Arc::clone(&self.visited_urls),
-            queue: Arc::clone(&self.queue),
+            visited: self.scheduler.visited(),
+            visited_urls: self.scheduler.visited_urls(),
+            queue: self.scheduler.queue(),
             rate_limiter: self.rate_limiter.clone(),
             session_pool: self.session_pool.clone(),
             ignore_robots: self.ignore_robots,
@@ -458,7 +412,7 @@ impl Engine {
         let start = std::time::Instant::now();
 
         // Main crawl loop
-        while !url_queue.is_empty() || !tasks.is_empty() {
+        while self.scheduler.has_pending_work() || !tasks.is_empty() {
             // Check shutdown signal
             if self.shutdown.load(std::sync::atomic::Ordering::Relaxed) {
                 info!("Shutdown signal received — saving checkpoint and exiting");
@@ -478,7 +432,7 @@ impl Engine {
             }
 
             // Drain discovered links from the deduplicated UrlQueue
-            url_queue.append(&mut self.queue.drain_all().await);
+            self.scheduler.drain_discovered().await;
 
             // Periodic checkpoint save
             if self.checkpoint_interval > 0 {
@@ -505,44 +459,19 @@ impl Engine {
                 }
             }
 
-            // Spawn new tasks up to concurrency limit
-            while let Some(discovered_url) = url_queue.pop_front() {
-                // Check concurrency limit (autoscale-aware)
-                let max_concurrent = self
-                    .autoscale_level
-                    .as_ref()
-                    .map(|l| l.effective_concurrency(config_clone.concurrency))
-                    .unwrap_or(config_clone.concurrency);
-                if tasks.len() >= max_concurrent {
-                    url_queue.push_front(discovered_url);
-                    break;
-                }
-
-                // Check if already visited — atomic, lock-free
-                if !self.visited.try_insert(discovered_url.url.as_str()) {
-                    continue;
-                }
-                // Record URL string for checkpoint (we just inserted into hash set)
-                if let Ok(mut urls) = self.visited_urls.write() {
-                    urls.push(discovered_url.url.as_str().to_string());
-                }
-
+            // Spawn new tasks up to the (autoscale-aware) concurrency limit.
+            // The scheduler checks the limit before popping and skips URLs that
+            // were already visited, marking each handed-out URL as visited.
+            while let Some(discovered_url) = self.scheduler.next_url(tasks.len()) {
                 // Spawn task — single Arc clone instead of 18 individual clones
                 let task_ctx = Arc::clone(&task_ctx);
-                let discovered_url_task = discovered_url.clone();
                 tasks.spawn(
-                    async move { run_crawl_task(task_ctx, discovered_url_task).await }
-                        .in_current_span(),
+                    async move { run_crawl_task(task_ctx, discovered_url).await }.in_current_span(),
                 );
             }
 
-            // If no tasks can be spawned and queue is not empty, wait for one task
-            let max_concurrent = self
-                .autoscale_level
-                .as_ref()
-                .map(|l| l.effective_concurrency(config_clone.concurrency))
-                .unwrap_or(config_clone.concurrency);
-            if tasks.len() >= max_concurrent && !url_queue.is_empty() {
+            // If no tasks can be spawned and work remains, wait for one task
+            if !self.scheduler.can_spawn(tasks.len()) && self.scheduler.has_pending_work() {
                 if let Some(result) = tasks.join_next().await {
                     handle_crawl_result(result, &self.error_count, &self.error_breakdown);
                 }

--- a/crates/webfang_core/src/application/crawler/mod.rs
+++ b/crates/webfang_core/src/application/crawler/mod.rs
@@ -5,6 +5,7 @@
 pub mod checkpoint;
 pub mod collector;
 pub mod concurrency_level;
+pub(crate) mod crawl_scheduler;
 pub(crate) mod crawl_task;
 pub mod crawl_task_ctx;
 pub mod discovery;


### PR DESCRIPTION
Closes #440

⚠️ **Stacked: #467 (A) → #468 (B) → esta (C).** Mergear en orden.

## Summary

Corte C del strangler fig (#430) — la cirugía principal. Extraída la **política de scheduling** (visited dedup, pending-work buffer, concurrency limits) del loop de `Engine::run()` a un struct `CrawlScheduler`.

`run()` pasa de un loop monolítico a un orquestador de alto nivel: seed → loop { drain discovered → scheduler.next_url() → spawn via crawl_task → handle results } → drain tasks → checkpoint → collect.

## Changes

- **Nuevo** `crawl_scheduler.rs` (175 líneas): `CrawlScheduler` con interfaz `next_url()`, `can_spawn()`, `has_pending_work()`, `seed()`, `drain_discovered()`, `record_visit()`, `snapshot_visited()`
- **engine.rs**: 882 → 812 líneas (−70). `run()` delega scheduling al scheduler y tareas al módulo `crawl_task`
- **mod.rs**: `pub(crate) mod crawl_scheduler;`

## Design decisions

- Scheduler owns the canonical `Arc`s (visited/queue) — shared con `CrawlTaskCtx` via accessors. **No increase in Arc::clone count.**
- `next_url` checks concurrency limit BEFORE popping (equivalent semantics, cleaner interface)
- Signal handling + checkpoint persistence stay in Engine (cross-cutting concerns)
- Did NOT split `run` into phases — the seam is the scheduler, per issue spec

## Verification

- `cargo check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo nextest run`: **1992 passed, 0 failed** ✅

## Strangler fig complete (A→B→C)

| Corte | Issue | engine.rs | Extraído |
|:---|:---|:---|:---|
| A | #438 | 1311 → 1151 | `fetch_router.rs` (178 lines) |
| B | #439 | 1151 → 882 | `crawl_task.rs` (287 lines) |
| C | #440 | 882 → 812 | `crawl_scheduler.rs` (175 lines) |
| **Total** | | **1311 → 812 (−38%)** | 640 lines in focused modules |