### PR TITLE
chore(core): deny clippy::expect_used + disallowed_types anyhow barrier

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+# Clippy configuration for the WebFang workspace.
+#
+# `disallowed-types` is enforced ONLY where the corresponding
+# `deny(clippy::disallowed_types)` attribute is active (webfang_core).
+# Crates that do not deny the lint (e.g. webfang_cli, which legitimately
+# uses anyhow as its application-layer error type) are unaffected.
+
+disallowed-types = [
+    { path = "anyhow::Error", reason = "webfang_core uses typed errors (ScraperError / DomainError / AppError / InfraError) — see error stratification in AGENTS.md" },
+]

--- a/crates/webfang_ai/src/lib.rs
+++ b/crates/webfang_ai/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![cfg_attr(not(test), deny(clippy::expect_used))]
 //! WebFang AI — ONNX-based semantic cleaning
 //!
 //! Provides AI-powered content cleaning using sentence-transformers models.

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![cfg_attr(not(test), deny(clippy::expect_used))]
 //! WebFang - Production-ready web scraper with Clean Architecture
 //!
 //! Extracts clean, structured content from web pages using readability algorithm.

--- a/crates/webfang_core/src/infrastructure/stream/mod.rs
+++ b/crates/webfang_core/src/infrastructure/stream/mod.rs
@@ -153,10 +153,11 @@ impl VectorRepository for StreamRepository {
     ) -> Pin<Box<dyn Future<Output = Result<String, ScraperError>> + Send + 'a>> {
         Box::pin(async move {
             if !title.is_empty() {
-                self.titles
-                    .lock()
-                    .expect("title cache poisoned")
-                    .insert(url.to_string(), title.to_string());
+                // Invariant: a poisoned Mutex means another thread panicked while
+                // holding the lock — process state is undefined; panic is correct.
+                #[allow(clippy::expect_used)]
+                let mut cache = self.titles.lock().expect("title cache poisoned");
+                cache.insert(url.to_string(), title.to_string());
             }
             Ok(url.to_string())
         })
@@ -183,6 +184,8 @@ impl VectorRepository for StreamRepository {
             // first '-' (a SHA-256 hex string contains no '-').
             let sha256_hex = id.split('-').next().unwrap_or(id).to_string();
 
+            // Invariant: poisoned Mutex — see save_resource.
+            #[allow(clippy::expect_used)]
             let title = self
                 .titles
                 .lock()
@@ -203,6 +206,8 @@ impl VectorRepository for StreamRepository {
             let line = serde_json::to_string(&record)?;
             // D2: a broken pipe / WriteZero must surface as a fatal Io error so
             // the crawl aborts. `?` converts io::Error → ScraperError::Io.
+            // Invariant: poisoned RwLock — see save_resource.
+            #[allow(clippy::expect_used)]
             let mut writer = self.writer.lock().expect("vector stream poisoned");
             writer.write_all(line.as_bytes())?;
             writer.write_all(b"\n")?;

--- a/crates/webfang_core/src/lib.rs
+++ b/crates/webfang_core/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![cfg_attr(not(test), deny(clippy::expect_used))]
+#![cfg_attr(not(test), deny(clippy::disallowed_types))]
 //! WebFang Core — Core scraping library
 //!
 //! Contains domain, application, and infrastructure layers for web scraping.

--- a/crates/webfang_mcp/src/lib.rs
+++ b/crates/webfang_mcp/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![cfg_attr(not(test), deny(clippy::expect_used))]
 //! WebFang MCP — Model Context Protocol server
 //!
 //! Exposes scraper tools to AI agents via MCP protocol.

--- a/crates/webfang_tui/src/lib.rs
+++ b/crates/webfang_tui/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![cfg_attr(not(test), deny(clippy::expect_used))]
 //! WebFang TUI — Terminal User Interface
 //!
 //! Provides the interactive TUI for configuration and URL selection.


### PR DESCRIPTION
Closes #437

## Summary

Anti-regression barrier for panic-free production code. Completes the fix-then-deny cycle started in Wave 1 (#428/#429).

### Changes

- **`deny(clippy::expect_used)`** via `cfg_attr(not(test))` in all 5 crates (core, ai, tui, mcp, cli), matching the existing `unwrap_used` pattern. Test code is unaffected.
- **`#[allow(clippy::expect_used)]`** with invariant comments on the 3 remaining production expects — all Mutex/RwLock poisoned in `stream/mod.rs`. The other 37 legitimate expects already had allows from Wave 1.
- **`deny(clippy::disallowed_types)`** in `webfang_core` + workspace `clippy.toml` disallowing `anyhow::Error`, preventing regression after the #428 migration. `webfang_cli` keeps anyhow (application-layer convention).

### Scope note

The issue estimated ~40 production expects. Actual count: **3** (clippy ground truth with `cfg_attr(not(test))`). The remaining 293 `\.expect()` calls are all inside `#[cfg(test)]` modules. Wave 1 (#428/#429/#431) already placed 37 `#[allow]` annotations on the legitimate production invariants.

### Verification

```
cargo clippy --all-targets --all-features -- -D warnings  # 0 warnings, all 5 crates
cargo fmt --check                                          # clean
```