### PR TITLE
test(core): fix flaky connect-timeout assertion and decouple snapshots from source location

### DIFF
--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -517,8 +517,10 @@ mod tests {
         assert!(
             msg.contains("client error (connect)")
                 || msg.contains("connection")
-                || msg.contains("connect"),
-            "expected connect-failure message, got: {msg}"
+                || msg.contains("connect")
+                || msg.contains("timed out")
+                || msg.contains("timeout"),
+            "expected connect-failure or timeout message, got: {msg}"
         );
     }
 

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -1,9 +1,9 @@
 ---
-source: crates/webfang_core/../../tests/behavioral/main.rs
+source: crates/webfang_core/tests/behavioral/main.rs
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
-    at crates/webfang_core/src/cli/scrape_flow.rs:<LINE>
+  <TIMESTAMP>  WARN <MODULE>: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
+    at <FILE>.rs:<LINE>
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
 No pages were successfully scraped

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__unknown_h2_profile_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__unknown_h2_profile_stderr.snap
@@ -1,8 +1,8 @@
 ---
-source: crates/webfang_core/../../tests/behavioral/main.rs
+source: crates/webfang_core/tests/behavioral/main.rs
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::cli::orchestrator: Unknown asset H2 profile 'Firefox', falling back to Chrome145. Run `cargo doc -p wreq-util` to see all available profiles.
-    at crates/webfang_core/src/cli/orchestrator.rs:<LINE>
+  <TIMESTAMP>  WARN <MODULE>: Unknown asset H2 profile 'Firefox', falling back to Chrome145. Run `cargo doc -p wreq-util` to see all available profiles.
+    at <FILE>.rs:<LINE>
 
 Error: Error de configuración: Perfil TLS desconocido: 'Firefox'. Opciones válidas: Chrome100, Chrome101, Chrome104, Chrome105, Chrome106, Chrome107, Chrome108, Chrome109, Chrome110, Chrome114, Chrome116, Chrome117, Chrome118, Chrome119, Chrome120, Chrome123, Chrome124, Chrome126, Chrome127, Chrome128, Chrome129, Chrome130, Chrome131, Chrome132, Chrome133, Chrome134, Chrome135, Chrome136, Chrome137, Chrome138, Chrome139, Chrome140, Chrome141, Chrome142, Chrome143, Chrome144, Chrome145, Chrome146, Chrome147, Chrome148, Chrome149, Edge101, Edge122, Edge127, Edge131, Edge134, Edge135, Edge136, Edge137, Edge138, Edge139, Edge140, Edge141, Edge142, Edge143, Edge144, Edge145, Edge146, Edge147, Edge148, Opera116, Opera117, Opera118, Opera119, Opera120, Opera121, Opera122, Opera123, Opera124, Opera125, Opera126, Opera127, Opera128, Opera129, Opera130, Opera131, Firefox109, Firefox117, Firefox128, Firefox133, Firefox135, FirefoxPrivate135, FirefoxAndroid135, Firefox136, FirefoxPrivate136, Firefox139, Firefox142, Firefox143, Firefox144, Firefox145, Firefox146, Firefox147, Firefox148, Firefox149, Firefox150, Firefox151, SafariIos17_2, SafariIos17_4_1, SafariIos16_5, Safari15_3, Safari15_5, Safari15_6_1, Safari16, Safari16_5, Safari17_0, Safari17_2_1, Safari17_4_1, Safari17_5, Safari17_6, Safari18, SafariIPad18, Safari18_2, SafariIos18_1_1, Safari18_3, Safari18_3_1, Safari18_5, Safari26, Safari26_1, Safari26_2, Safari26_3, Safari26_4, SafariIPad26, SafariIpad26_2, SafariIos26, SafariIos26_2, OkHttp3_9, OkHttp3_11, OkHttp3_13, OkHttp3_14, OkHttp4_9, OkHttp4_10, OkHttp4_12, OkHttp5

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -1,12 +1,12 @@
 ---
-source: crates/webfang_core/../../tests/behavioral/main.rs
+source: crates/webfang_core/tests/behavioral/main.rs
 expression: redacted
 ---
-  <TIMESTAMP>  WARN webfang_core::infrastructure::crawler::robots_utils: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (http://127.0.0.1:<PORT>/robots.txt): client error (Connect)
-    at crates/webfang_core/src/infrastructure/crawler/robots_utils.rs:<LINE>
+  <TIMESTAMP>  WARN <MODULE>: Failed to fetch robots.txt for 127.0.0.1: error sending request for uri (http://127.0.0.1:<PORT>/robots.txt): client error (Connect)
+    at <FILE>.rs:<LINE>
 
-  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/: error de red: network error: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
-    at crates/webfang_core/src/cli/scrape_flow.rs:<LINE>
+  <TIMESTAMP>  WARN <MODULE>: Failed to scrape http://127.0.0.1:<PORT>/: error de red: network error: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
+    at <FILE>.rs:<LINE>
 
 Failed to scrape http://127.0.0.1:<PORT>/: error de red: network error: error sending request for uri (http://127.0.0.1:<PORT>/): client error (Connect)
 No pages were successfully scraped

--- a/crates/webfang_core/tests/common/cli_harness.rs
+++ b/crates/webfang_core/tests/common/cli_harness.rs
@@ -254,5 +254,13 @@ pub(crate) fn redact_nondeterministic(dir: &Path, text: &str) -> String {
     // Normalize source line numbers in tracing spans (e.g. "scrape_flow.rs:193").
     // These shift with #[cfg(feature = "...")] blocks and differ across feature sets.
     let line_no = Regex::new(r"(\.rs:)\d+").unwrap();
-    line_no.replace_all(&text, "$1<LINE>").into_owned()
+    let text = line_no.replace_all(&text, "$1<LINE>").into_owned();
+    // Normalize tracing module paths (e.g. "WARN webfang_core::cli::orchestrator:")
+    // so snapshots decouple from source location and survive function moves (#462).
+    let module = Regex::new(r"((?:WARN|INFO|ERROR|DEBUG|TRACE)\s+)\w+(?:::\w+)+").unwrap();
+    let text = module.replace_all(&text, "$1<MODULE>").into_owned();
+    // Normalize tracing source file paths (e.g. "at crates/.../orchestrator.rs:<LINE>")
+    // so moving a function between files does not break snapshots (#462).
+    let file_path = Regex::new(r"(at\s+)\S+\.rs").unwrap();
+    file_path.replace_all(&text, "$1<FILE>.rs").into_owned()
 }

--- a/crates/webfang_core/tests/snapshots/cli_binary_test__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/crates/webfang_core/tests/snapshots/cli_binary_test__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -1,9 +1,9 @@
 ---
-source: crates/webfang_core/../../tests/cli_binary_test.rs
+source: crates/webfang_core/tests/cli_binary_test.rs
 expression: "redact_nondeterministic(output_dir.path(), &stderr)"
 ---
-  <TIMESTAMP>  WARN webfang_core::cli::scrape_flow: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
-    at crates/webfang_core/src/cli/scrape_flow.rs:<LINE>
+  <TIMESTAMP>  WARN <MODULE>: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
+    at <FILE>.rs:<LINE>
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
 No pages were successfully scraped

--- a/crates/webfang_test_utils/src/lib.rs
+++ b/crates/webfang_test_utils/src/lib.rs
@@ -107,7 +107,16 @@ pub fn redact_nondeterministic(dir: &Path, text: &str) -> String {
     let port = Regex::new(r"127\.0\.0\.1:\d+").expect("valid port regex");
     let text = port.replace_all(&text, "127.0.0.1:<PORT>").into_owned();
     let line_no = Regex::new(r"(\.rs:)\d+").expect("valid line number regex");
-    line_no.replace_all(&text, "$1<LINE>").into_owned()
+    let text = line_no.replace_all(&text, "$1<LINE>").into_owned();
+    // Normalize tracing module paths (e.g. "WARN webfang_core::cli::orchestrator:")
+    // so snapshots decouple from source location and survive function moves (#462).
+    let module = Regex::new(r"((?:WARN|INFO|ERROR|DEBUG|TRACE)\s+)\w+(?:::\w+)+")
+        .expect("valid module regex");
+    let text = module.replace_all(&text, "$1<MODULE>").into_owned();
+    // Normalize tracing source file paths (e.g. "at crates/.../orchestrator.rs:<LINE>")
+    // so moving a function between files does not break snapshots (#462).
+    let file_path = Regex::new(r"(at\s+)\S+\.rs").expect("valid file path regex");
+    file_path.replace_all(&text, "$1<FILE>.rs").into_owned()
 }
 
 /// Resolve the path to the `webfang` binary, building it on demand.
@@ -255,8 +264,25 @@ mod tests {
     #[test]
     fn redact_nondeterministic_normalizes_line_numbers() {
         let dir = Path::new("/tmp/test");
-        let input = "at scrape_flow.rs:193 in module";
+        let input = "see scrape_flow.rs:193 for details";
         let result = redact_nondeterministic(dir, input);
-        assert_eq!(result, "at scrape_flow.rs:<LINE> in module");
+        assert_eq!(result, "see scrape_flow.rs:<LINE> for details");
+    }
+
+    #[test]
+    fn redact_nondeterministic_normalizes_tracing_module_paths() {
+        let dir = Path::new("/tmp/test");
+        let input =
+            "  2024-03-15T10:30:00+01:00  WARN webfang_core::cli::orchestrator: Unknown profile";
+        let result = redact_nondeterministic(dir, input);
+        assert_eq!(result, "  <TIMESTAMP>  WARN <MODULE>: Unknown profile");
+    }
+
+    #[test]
+    fn redact_nondeterministic_normalizes_tracing_file_paths() {
+        let dir = Path::new("/tmp/test");
+        let input = "    at crates/webfang_core/src/cli/orchestrator.rs:42";
+        let result = redact_nondeterministic(dir, input);
+        assert_eq!(result, "    at <FILE>.rs:<LINE>");
     }
 }


### PR DESCRIPTION
Closes #462

## Summary

Two test-determinism fixes detected during the Phase 1 debt campaign (#442/#449):

### A. Flaky test: `test_discover_urls_for_tui_respects_connect_timeout`

Relaxed the message assertion to accept timeout wordings (`timed out` / `timeout`) in addition to connect-failure wordings. The real behavioral invariant (elapsed < 6s) was already verified by the timing assertion; the text assertion was over-specific and failed under llvm-cov instrumentation where the network stack reports `operation timed out` instead of `client error (connect)`.

### B. Snapshot decoupled from source location

Added tracing module-path and source-file-path redaction to `redact_nondeterministic` (both `webfang_test_utils` and `cli_harness` copies):
- Module paths (`webfang_core::cli::orchestrator`) → `<MODULE>`
- File paths (`crates/.../orchestrator.rs`) → `<FILE>.rs`

Snapshots are now coupled to behavior, not source location. This unblocks the #449 function-move seam.

### Changed files (7)

- `crates/webfang_core/src/application/crawler/discovery.rs` — relaxed assertion
- `crates/webfang_test_utils/src/lib.rs` — new redaction regexes + 2 unit tests
- `crates/webfang_core/tests/common/cli_harness.rs` — mirrored redaction
- 4 snapshot files updated to use `<MODULE>` / `<FILE>.rs` placeholders