### PR TITLE
refactor(crawler): inject ports for run_crawl_task unit testability

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,11 +15,8 @@
 #                   if: always(), so survivors are always annotated, never blocking.
 #
 # Gated hot paths vs. matrix:
-#   crawler/** is deliberately EXCLUDED from the PR gate. Its core (engine.rs,
-#   crawl_scheduler.rs, crawl_task.rs) has NO inline unit tests, so `--lib`
-#   mutation testing would report false-positive survivors and block legitimate
-#   PRs. It stays in the weekly matrix as a visible debt beacon until real unit
-#   tests exist (tracked in the crawler-core unit-test debt issue).
+#   crawler/** is gated on PRs since issue #475 added inline unit tests to
+#   crawl_task.rs. It also stays in the weekly matrix for baseline reporting.
 #
 # Notes:
 #   - --timeout=60 per mutant prevents infinite-loop mutants from stalling.
@@ -39,8 +36,8 @@ permissions:
 on:
   pull_request:
     paths:
-      # crawler/** is intentionally NOT gated (no inline unit tests -> false
-      # survivors under --lib). Re-add once crawler core has real unit tests.
+      # crawler/** now has inline unit tests (issue #475) — safe to gate.
+      - crates/webfang_core/src/application/crawler/**
       - crates/webfang_core/src/application/pipeline/**
       - crates/webfang_core/src/extractor/**
       - crates/webfang_core/src/infrastructure/bridge.rs

--- a/crates/webfang_core/src/application/crawler/crawl_task.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task.rs
@@ -846,7 +846,7 @@ mod tests {
                 behavior: ExtractBehavior::Links(vec!["https://example.com/dup".to_string()]),
             }))
             .build();
-        ctx.visited.try_insert("https://example.com/dup");
+        assert!(ctx.visited.try_insert("https://example.com/dup"));
         let queue = Arc::clone(&ctx.queue);
 
         run_crawl_task(ctx, test_url("https://example.com/", 0))

--- a/crates/webfang_core/src/application/crawler/crawl_task.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task.rs
@@ -13,14 +13,12 @@ use tracing::{debug, span, warn, Level};
 use url::Url;
 
 use super::checkpoint::BannedDomain;
-use super::collector::CrawlMessage;
 use super::crawl_task_ctx::CrawlTaskCtx;
+use super::ports::waf_challenge_message;
 use crate::application::pipeline::{ScrapedItem, StageOutcome};
 use crate::application::url_filter::is_allowed;
 use crate::domain::{CrawlError, CrawlErrorCategory, DiscoveredUrl};
-use crate::infrastructure::crawler::{extract_links, fetch_url, is_internal_link, UrlSource};
-use crate::infrastructure::downloader::{DownloadError, Downloader};
-use crate::infrastructure::network::session_pool::SessionManager;
+use crate::infrastructure::crawler::{is_internal_link, UrlSource};
 use crate::infrastructure::observability::log_scrape_error;
 
 /// Handle result from a completed crawl task
@@ -57,16 +55,12 @@ pub(crate) async fn run_crawl_task(
     ctx: Arc<CrawlTaskCtx>,
     discovered_url: DiscoveredUrl,
 ) -> Result<(), CrawlError> {
-    // Rate limiting
     ctx.rate_limiter.until_ready().await;
 
     let url_str = discovered_url.url.as_str().to_string();
     let url_depth = discovered_url.depth;
     let parent_url = discovered_url.url.clone();
 
-    // Per-page correlation (issue #356): share the crawl's trace_id, fresh
-    // span_id. Lets a whole crawl be reconstructed by trace_id while each
-    // page stays distinguishable by span_id.
     let page_correlation = ctx.correlation_id.child();
     let page_span = span!(
         Level::DEBUG,
@@ -78,7 +72,6 @@ pub(crate) async fn run_crawl_task(
     );
     let _page_guard = page_span.enter();
 
-    // Session pool: check if domain is healthy before fetching
     let mut session_id = None;
     if let Some(ref pool) = ctx.session_pool {
         let domain = url::Url::parse(&url_str)
@@ -98,40 +91,34 @@ pub(crate) async fn run_crawl_task(
 
     debug!("Crawling: {} (depth={})", url_str, url_depth);
 
-    // Fetch URL — use fetch_router if available, else static fetch_url()
-    let (response, fetched_cookies) = if let Some(ref router) = ctx.fetch_router {
-        let parsed_url = url::Url::parse(&url_str)
-            .map_err(|e| CrawlError::Internal(format!("invalid URL: {e}")))?;
-        match router.fetch(&parsed_url).await {
-            Ok(page) => {
-                let cookies = page.cookies.clone();
-                (page.html, cookies)
-            },
-            Err(DownloadError::WafChallenge(msg)) => {
-                // Ban the domain
+    let parsed_url =
+        url::Url::parse(&url_str).map_err(|e| CrawlError::Internal(format!("invalid URL: {e}")))?;
+
+    let (response, fetched_cookies) = match ctx.fetcher.fetch_page(&parsed_url, &ctx.config).await {
+        Ok((html, cookies)) => (html, cookies),
+        Err(e) => {
+            if let Some(waf_msg) = waf_challenge_message(&e) {
                 if let Some(domain) = parsed_url.host_str() {
                     let banned = BannedDomain {
                         domain: domain.to_string(),
                         banned_until: None,
-                        reason: msg.clone(),
+                        reason: waf_msg.clone(),
                     };
                     if let Ok(mut domains) = ctx.banned_domains.write() {
                         if !domains.iter().any(|d| d.domain == domain) {
                             domains.push(banned);
-                            warn!("Banned domain {} due to WAF: {}", domain, msg);
+                            warn!("Banned domain {} due to WAF: {}", domain, waf_msg);
                         }
                     }
                 }
                 log_scrape_error(
-                    &msg,
+                    &waf_msg,
                     &url_str,
                     "fetch",
                     Some(&page_correlation),
                     "WAF challenge detected",
                 );
-                return Err(DownloadError::WafChallenge(msg).into());
-            },
-            Err(e) => {
+            } else {
                 log_scrape_error(
                     &e,
                     &url_str,
@@ -139,44 +126,11 @@ pub(crate) async fn run_crawl_task(
                     Some(&page_correlation),
                     "page fetch failed",
                 );
-                return Err(e.into());
-            },
-        }
-    } else {
-        match fetch_url(&url_str, &ctx.config).await {
-            Ok(html) => (html, Vec::new()),
-            Err(e) => {
-                if format!("{e}").contains("WAF") {
-                    // Ban the domain
-                    if let Ok(parsed) = url::Url::parse(&url_str) {
-                        if let Some(domain) = parsed.host_str() {
-                            let banned = BannedDomain {
-                                domain: domain.to_string(),
-                                banned_until: None,
-                                reason: e.to_string(),
-                            };
-                            if let Ok(mut domains) = ctx.banned_domains.write() {
-                                if !domains.iter().any(|d| d.domain == domain) {
-                                    domains.push(banned);
-                                    warn!("Banned domain {} due to WAF: {}", domain, e);
-                                }
-                            }
-                        }
-                    }
-                }
-                log_scrape_error(
-                    &e,
-                    &url_str,
-                    "fetch",
-                    Some(&page_correlation),
-                    "page fetch failed",
-                );
-                return Err(e);
-            },
-        }
+            }
+            return Err(e);
+        },
     };
 
-    // Ingest cookies into the cookie bridge
     if !fetched_cookies.is_empty() {
         if let Ok(mut bridge) = ctx.cookie_bridge.write() {
             for cookie in &fetched_cookies {
@@ -185,7 +139,6 @@ pub(crate) async fn run_crawl_task(
         }
     }
 
-    // Report success to session pool
     if let Some(ref pool) = ctx.session_pool {
         if let Some(id) = session_id {
             if let Ok(parsed) = url::Url::parse(&url_str) {
@@ -196,11 +149,9 @@ pub(crate) async fn run_crawl_task(
         }
     }
 
-    // Track pages crawled
     ctx.pages_crawled
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-    // Pipeline processing: convert to ScrapedItem and run through pipeline
     if let Some(ref pipeline) = ctx.pipeline {
         let item = ScrapedItem {
             url: url_str.clone(),
@@ -211,9 +162,8 @@ pub(crate) async fn run_crawl_task(
             embeddings: None,
         };
 
-        match pipeline.execute(item).await {
+        match pipeline.execute_pipeline(item).await {
             StageOutcome::Continue(processed_item) => {
-                // Pass to output stages
                 for stage in &ctx.output_stages {
                     if let Err(e) = stage.write(&processed_item).await {
                         warn!("Output stage '{}' failed: {}", stage.name(), e);
@@ -231,37 +181,32 @@ pub(crate) async fn run_crawl_task(
         }
     }
 
-    // Add to results via channel (sin lock)
-    if let Err(e) = ctx
-        .collector
-        .send(CrawlMessage::success(discovered_url))
-        .await
-    {
+    if let Err(e) = ctx.collector.send_result(discovered_url).await {
         debug!("Failed to send result: {}", e);
     }
 
-    // Extract links and add to queue
     if url_depth < ctx.config.max_depth {
-        match extract_links(&response, &url_str) {
+        match ctx.link_extractor.extract_links(&response, &url_str) {
             Ok(links) => {
                 for link in links {
-                    // extract_links() already normalizes each link
-                    if let Ok(parsed_url) = Url::parse(&link) {
+                    if let Ok(parsed_link) = Url::parse(&link) {
                         if let Some(seed_domain) = ctx.config.seed_url.host_str() {
-                            let link_domain = parsed_url.host_str().unwrap_or("");
+                            let link_domain = parsed_link.host_str().unwrap_or("");
                             if is_internal_link(&link, seed_domain)
                                 && is_allowed(&link, &ctx.config)
                                 && (ctx.ignore_robots
-                                    || ctx.robots_fetcher.is_allowed(&link, link_domain).await)
+                                    || ctx
+                                        .robots_checker
+                                        .is_robots_allowed(&link, link_domain)
+                                        .await)
                                 && ctx.visited.try_insert(&link)
                             {
-                                // Record URL string for checkpoint
                                 if let Ok(mut urls) = ctx.visited_urls.write() {
                                     urls.push(link.clone());
                                 }
 
                                 let new_discovered = DiscoveredUrl::html(
-                                    parsed_url,
+                                    parsed_link,
                                     url_depth + 1,
                                     parent_url.clone(),
                                 );
@@ -284,4 +229,709 @@ pub(crate) async fn run_crawl_task(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex, RwLock};
+
+    use url::Url;
+
+    use super::*;
+    use crate::application::crawler::ports::{
+        ContentPipeline, CrawlResultCollector, LinkExtractorPort, PageFetcher, RobotsChecker,
+    };
+    use crate::application::deduplicator::UrlDeduplicator;
+    use crate::application::pipeline::stages::output::OutputError;
+    use crate::application::pipeline::OutputStage;
+    use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
+    use crate::domain::session_port::{SessionId, SessionPort};
+    use crate::domain::CorrelationId;
+    use crate::infrastructure::crawler::UrlQueue;
+    use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
+    use crate::infrastructure::downloader::Cookie;
+
+    // ── Mock implementations ──
+
+    enum FetchBehavior {
+        Success(String, Vec<Cookie>),
+        WafError(String),
+        NetworkError(String),
+    }
+
+    struct MockPageFetcher {
+        behavior: FetchBehavior,
+    }
+
+    impl PageFetcher for MockPageFetcher {
+        fn fetch_page<'a>(
+            &'a self,
+            _url: &'a Url,
+            _config: &'a crate::domain::CrawlerConfig,
+        ) -> Pin<Box<dyn Future<Output = Result<(String, Vec<Cookie>), CrawlError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                match &self.behavior {
+                    FetchBehavior::Success(html, cookies) => Ok((html.clone(), cookies.clone())),
+                    FetchBehavior::WafError(msg) => Err(CrawlError::WafChallenge {
+                        provider: msg.clone(),
+                        kind: crate::domain::error::WafDetectionKind::BodySignature,
+                        url: String::new(),
+                    }),
+                    FetchBehavior::NetworkError(msg) => Err(CrawlError::Network {
+                        message: msg.clone(),
+                        status_code: None,
+                    }),
+                }
+            })
+        }
+    }
+
+    struct MockRobotsChecker {
+        allowed: bool,
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl RobotsChecker for MockRobotsChecker {
+        fn is_robots_allowed<'a>(
+            &'a self,
+            _url: &'a str,
+            _domain: &'a str,
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            Box::pin(async move {
+                self.call_count.fetch_add(1, Ordering::SeqCst);
+                self.allowed
+            })
+        }
+    }
+
+    enum ExtractBehavior {
+        Links(Vec<String>),
+        Error(String),
+    }
+
+    struct MockLinkExtractor {
+        behavior: ExtractBehavior,
+    }
+
+    impl LinkExtractorPort for MockLinkExtractor {
+        fn extract_links(&self, _html: &str, _base_url: &str) -> Result<Vec<String>, CrawlError> {
+            match &self.behavior {
+                ExtractBehavior::Links(links) => Ok(links.clone()),
+                ExtractBehavior::Error(msg) => Err(CrawlError::Parse(msg.clone())),
+            }
+        }
+    }
+
+    enum PipelineBehavior {
+        Continue,
+        Skip,
+        Reject(String),
+    }
+
+    struct MockPipeline {
+        behavior: PipelineBehavior,
+    }
+
+    impl ContentPipeline for MockPipeline {
+        fn execute_pipeline<'a>(
+            &'a self,
+            item: ScrapedItem,
+        ) -> Pin<Box<dyn Future<Output = StageOutcome> + Send + 'a>> {
+            Box::pin(async move {
+                match &self.behavior {
+                    PipelineBehavior::Continue => StageOutcome::Continue(item),
+                    PipelineBehavior::Skip => StageOutcome::Skip,
+                    PipelineBehavior::Reject(reason) => StageOutcome::Reject(reason.clone()),
+                }
+            })
+        }
+    }
+
+    struct MockCollector {
+        sent: Arc<Mutex<Vec<DiscoveredUrl>>>,
+    }
+
+    impl CrawlResultCollector for MockCollector {
+        fn send_result<'a>(
+            &'a self,
+            url: DiscoveredUrl,
+        ) -> Pin<Box<dyn Future<Output = Result<(), CrawlError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.sent
+                    .lock()
+                    .map_err(|e| CrawlError::Internal(e.to_string()))?
+                    .push(url);
+                Ok(())
+            })
+        }
+    }
+
+    struct MockSessionPool {
+        acquire_result: Option<SessionId>,
+        success_calls: Arc<Mutex<Vec<(String, SessionId)>>>,
+    }
+
+    impl SessionPort for MockSessionPool {
+        fn acquire(&self, _domain: &str) -> Option<SessionId> {
+            self.acquire_result
+        }
+        fn report_success(&self, domain: &str, session: SessionId) {
+            if let Ok(mut calls) = self.success_calls.lock() {
+                calls.push((domain.to_string(), session));
+            }
+        }
+        fn report_failure(&self, _domain: &str, _session: SessionId, _status: u16) {}
+    }
+
+    struct MockOutputStage {
+        written: Arc<Mutex<Vec<ScrapedItem>>>,
+    }
+
+    impl OutputStage for MockOutputStage {
+        fn name(&self) -> &str {
+            "mock_output"
+        }
+        fn write<'a>(
+            &'a self,
+            item: &'a ScrapedItem,
+        ) -> Pin<Box<dyn Future<Output = Result<(), OutputError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.written
+                    .lock()
+                    .map_err(|e| OutputError::Backend(e.to_string()))?
+                    .push(item.clone());
+                Ok(())
+            })
+        }
+    }
+
+    // ── Test helpers ──
+
+    struct TestCtxBuilder {
+        fetcher: Arc<dyn PageFetcher>,
+        robots: Arc<dyn RobotsChecker>,
+        link_extractor: Arc<dyn LinkExtractorPort>,
+        pipeline: Option<Arc<dyn ContentPipeline>>,
+        collector: Arc<dyn CrawlResultCollector>,
+        session_pool: Option<Arc<dyn SessionPort>>,
+        output_stages: Vec<Arc<Box<dyn OutputStage>>>,
+        ignore_robots: bool,
+        max_depth: u8,
+    }
+
+    impl TestCtxBuilder {
+        fn new(collector: Arc<dyn CrawlResultCollector>) -> Self {
+            Self {
+                fetcher: Arc::new(MockPageFetcher {
+                    behavior: FetchBehavior::Success(
+                        "<html><body>hello</body></html>".to_string(),
+                        Vec::new(),
+                    ),
+                }),
+                robots: Arc::new(MockRobotsChecker {
+                    allowed: true,
+                    call_count: Arc::new(AtomicUsize::new(0)),
+                }),
+                link_extractor: Arc::new(MockLinkExtractor {
+                    behavior: ExtractBehavior::Links(Vec::new()),
+                }),
+                pipeline: None,
+                collector,
+                session_pool: None,
+                output_stages: Vec::new(),
+                ignore_robots: false,
+                max_depth: 3,
+            }
+        }
+
+        fn fetcher(mut self, f: Arc<dyn PageFetcher>) -> Self {
+            self.fetcher = f;
+            self
+        }
+        fn robots(mut self, r: Arc<dyn RobotsChecker>) -> Self {
+            self.robots = r;
+            self
+        }
+        fn link_extractor(mut self, le: Arc<dyn LinkExtractorPort>) -> Self {
+            self.link_extractor = le;
+            self
+        }
+        fn pipeline(mut self, p: Arc<dyn ContentPipeline>) -> Self {
+            self.pipeline = Some(p);
+            self
+        }
+        fn session_pool(mut self, sp: Arc<dyn SessionPort>) -> Self {
+            self.session_pool = Some(sp);
+            self
+        }
+        fn output_stage(mut self, s: Arc<Box<dyn OutputStage>>) -> Self {
+            self.output_stages.push(s);
+            self
+        }
+        fn ignore_robots(mut self, v: bool) -> Self {
+            self.ignore_robots = v;
+            self
+        }
+        fn max_depth(mut self, d: u8) -> Self {
+            self.max_depth = d;
+            self
+        }
+
+        fn build(self) -> Arc<CrawlTaskCtx> {
+            let seed_url = Url::parse("https://example.com").expect("valid seed URL");
+            let mut config = crate::domain::CrawlerConfig::new(seed_url);
+            config.max_depth = self.max_depth;
+
+            let rate_limiter = SharedRateLimiter::new(&RateLimiterConfig::new(1, 100))
+                .expect("valid rate limiter config");
+
+            Arc::new(CrawlTaskCtx {
+                config: Arc::new(config),
+                correlation_id: CorrelationId::new(),
+                visited: Arc::new(UrlDeduplicator::new()),
+                visited_urls: Arc::new(RwLock::new(Vec::new())),
+                queue: Arc::new(UrlQueue::new()),
+                rate_limiter,
+                session_pool: self.session_pool,
+                ignore_robots: self.ignore_robots,
+                robots_checker: self.robots,
+                error_count: Arc::new(AtomicUsize::new(0)),
+                error_breakdown: Arc::new([
+                    AtomicUsize::new(0),
+                    AtomicUsize::new(0),
+                    AtomicUsize::new(0),
+                    AtomicUsize::new(0),
+                    AtomicUsize::new(0),
+                    AtomicUsize::new(0),
+                    AtomicUsize::new(0),
+                    AtomicUsize::new(0),
+                ]),
+                pages_crawled: Arc::new(AtomicU64::new(0)),
+                collector: self.collector,
+                cookie_bridge: Arc::new(RwLock::new(CookieBridge::new())),
+                banned_domains: Arc::new(RwLock::new(Vec::new())),
+                fetcher: self.fetcher,
+                link_extractor: self.link_extractor,
+                pipeline: self.pipeline,
+                output_stages: self.output_stages,
+            })
+        }
+    }
+
+    fn test_url(url: &str, depth: u8) -> DiscoveredUrl {
+        DiscoveredUrl::html(
+            Url::parse(url).expect("valid test URL"),
+            depth,
+            Url::parse("https://example.com").expect("valid parent URL"),
+        )
+    }
+
+    fn mock_collector() -> (
+        Arc<dyn CrawlResultCollector>,
+        Arc<Mutex<Vec<DiscoveredUrl>>>,
+    ) {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let collector = Arc::new(MockCollector {
+            sent: Arc::clone(&sent),
+        });
+        (collector, sent)
+    }
+
+    // ── Tests: fetch success path ──
+
+    #[tokio::test]
+    async fn test_fetch_success_sends_to_collector() {
+        let (collector, sent) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector).build();
+        let url = test_url("https://example.com/page1", 0);
+
+        let result = run_crawl_task(ctx, url).await;
+        assert!(result.is_ok());
+        let sent = sent.lock().expect("lock not poisoned");
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].url.as_str(), "https://example.com/page1");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_success_increments_pages_crawled() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector).build();
+        let pages = Arc::clone(&ctx.pages_crawled);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        assert_eq!(pages.load(Ordering::Relaxed), 1);
+    }
+
+    // ── Tests: WAF error handling ──
+
+    #[tokio::test]
+    async fn test_fetch_waf_error_bans_domain() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .fetcher(Arc::new(MockPageFetcher {
+                behavior: FetchBehavior::WafError("Cloudflare".to_string()),
+            }))
+            .build();
+        let banned = Arc::clone(&ctx.banned_domains);
+
+        let result = run_crawl_task(ctx, test_url("https://protected.com/page", 0)).await;
+        assert!(result.is_err());
+        let domains = banned.read().expect("lock not poisoned");
+        assert_eq!(domains.len(), 1);
+        assert_eq!(domains[0].domain, "protected.com");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_waf_error_returns_err() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .fetcher(Arc::new(MockPageFetcher {
+                behavior: FetchBehavior::WafError("Cloudflare".to_string()),
+            }))
+            .build();
+
+        let result = run_crawl_task(ctx, test_url("https://protected.com/", 0)).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_generic_error_returns_err_no_ban() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .fetcher(Arc::new(MockPageFetcher {
+                behavior: FetchBehavior::NetworkError("connection refused".to_string()),
+            }))
+            .build();
+        let banned = Arc::clone(&ctx.banned_domains);
+
+        let result = run_crawl_task(ctx, test_url("https://example.com/", 0)).await;
+        assert!(result.is_err());
+        let domains = banned.read().expect("lock not poisoned");
+        assert!(domains.is_empty());
+    }
+
+    // ── Tests: session pool ──
+
+    #[tokio::test]
+    async fn test_session_pool_acquire_none_skips_url() {
+        let (collector, sent) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .session_pool(Arc::new(MockSessionPool {
+                acquire_result: None,
+                success_calls: Arc::new(Mutex::new(Vec::new())),
+            }))
+            .build();
+
+        let result = run_crawl_task(ctx, test_url("https://example.com/", 0)).await;
+        assert!(result.is_ok());
+        let sent = sent.lock().expect("lock not poisoned");
+        assert!(sent.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_session_pool_acquire_some_continues() {
+        let (collector, sent) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .session_pool(Arc::new(MockSessionPool {
+                acquire_result: Some(SessionId(0)),
+                success_calls: Arc::new(Mutex::new(Vec::new())),
+            }))
+            .build();
+
+        let result = run_crawl_task(ctx, test_url("https://example.com/", 0)).await;
+        assert!(result.is_ok());
+        let sent = sent.lock().expect("lock not poisoned");
+        assert_eq!(sent.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_session_pool_report_success_called() {
+        let (collector, _) = mock_collector();
+        let success_calls = Arc::new(Mutex::new(Vec::new()));
+        let ctx = TestCtxBuilder::new(collector)
+            .session_pool(Arc::new(MockSessionPool {
+                acquire_result: Some(SessionId(0)),
+                success_calls: Arc::clone(&success_calls),
+            }))
+            .build();
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        let calls = success_calls.lock().expect("lock not poisoned");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "example.com");
+        assert_eq!(calls[0].1, SessionId(0));
+    }
+
+    // ── Tests: pipeline ──
+
+    #[tokio::test]
+    async fn test_pipeline_continue_runs_output_stages() {
+        let (collector, _) = mock_collector();
+        let written = Arc::new(Mutex::new(Vec::new()));
+        let stage: Arc<Box<dyn OutputStage>> = Arc::new(Box::new(MockOutputStage {
+            written: Arc::clone(&written),
+        }));
+        let ctx = TestCtxBuilder::new(collector)
+            .pipeline(Arc::new(MockPipeline {
+                behavior: PipelineBehavior::Continue,
+            }))
+            .output_stage(stage)
+            .build();
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        let items = written.lock().expect("lock not poisoned");
+        assert_eq!(items.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_skip_returns_early() {
+        let (collector, sent) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .pipeline(Arc::new(MockPipeline {
+                behavior: PipelineBehavior::Skip,
+            }))
+            .build();
+
+        let result = run_crawl_task(ctx, test_url("https://example.com/", 0)).await;
+        assert!(result.is_ok());
+        let sent = sent.lock().expect("lock not poisoned");
+        assert!(sent.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_reject_returns_early() {
+        let (collector, sent) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .pipeline(Arc::new(MockPipeline {
+                behavior: PipelineBehavior::Reject("bad content".to_string()),
+            }))
+            .build();
+
+        let result = run_crawl_task(ctx, test_url("https://example.com/", 0)).await;
+        assert!(result.is_ok());
+        let sent = sent.lock().expect("lock not poisoned");
+        assert!(sent.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_no_pipeline_skips_processing() {
+        let (collector, sent) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector).build();
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        let sent = sent.lock().expect("lock not poisoned");
+        assert_eq!(sent.len(), 1);
+    }
+
+    // ── Tests: link extraction and depth ──
+
+    #[tokio::test]
+    async fn test_depth_below_max_extracts_links() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .max_depth(3)
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Links(vec!["https://example.com/page2".to_string()]),
+            }))
+            .build();
+        let queue = Arc::clone(&ctx.queue);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        assert!(!queue.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_depth_at_max_skips_extraction() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .max_depth(1)
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Links(vec!["https://example.com/page2".to_string()]),
+            }))
+            .build();
+        let queue = Arc::clone(&ctx.queue);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 1))
+            .await
+            .expect("crawl should succeed");
+        assert!(queue.is_empty().await);
+    }
+
+    // ── Tests: robots.txt ──
+
+    #[tokio::test]
+    async fn test_robots_denied_link_not_queued() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .robots(Arc::new(MockRobotsChecker {
+                allowed: false,
+                call_count: Arc::new(AtomicUsize::new(0)),
+            }))
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Links(vec!["https://example.com/blocked".to_string()]),
+            }))
+            .build();
+        let queue = Arc::clone(&ctx.queue);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        assert!(queue.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_robots_allowed_link_queued() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .robots(Arc::new(MockRobotsChecker {
+                allowed: true,
+                call_count: Arc::new(AtomicUsize::new(0)),
+            }))
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Links(vec!["https://example.com/allowed".to_string()]),
+            }))
+            .build();
+        let queue = Arc::clone(&ctx.queue);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        assert!(!queue.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_ignore_robots_bypasses_check() {
+        let (collector, _) = mock_collector();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let ctx = TestCtxBuilder::new(collector)
+            .ignore_robots(true)
+            .robots(Arc::new(MockRobotsChecker {
+                allowed: false,
+                call_count: Arc::clone(&call_count),
+            }))
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Links(vec!["https://example.com/page".to_string()]),
+            }))
+            .build();
+        let queue = Arc::clone(&ctx.queue);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        assert!(!queue.is_empty().await);
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+    }
+
+    // ── Tests: deduplication ──
+
+    #[tokio::test]
+    async fn test_duplicate_link_not_queued() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Links(vec!["https://example.com/dup".to_string()]),
+            }))
+            .build();
+        ctx.visited.try_insert("https://example.com/dup");
+        let queue = Arc::clone(&ctx.queue);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        assert!(queue.is_empty().await);
+    }
+
+    // ── Tests: external links ──
+
+    #[tokio::test]
+    async fn test_external_link_not_queued() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Links(vec!["https://other.com/page".to_string()]),
+            }))
+            .build();
+        let queue = Arc::clone(&ctx.queue);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        assert!(queue.is_empty().await);
+    }
+
+    // ── Tests: link extraction error ──
+
+    #[tokio::test]
+    async fn test_link_extraction_error_increments_error_count() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .link_extractor(Arc::new(MockLinkExtractor {
+                behavior: ExtractBehavior::Error("parse failed".to_string()),
+            }))
+            .build();
+        let error_count = Arc::clone(&ctx.error_count);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed despite extraction error");
+        assert_eq!(error_count.load(Ordering::SeqCst), 1);
+    }
+
+    // ── Tests: cookies ──
+
+    #[tokio::test]
+    async fn test_cookies_ingested_into_bridge() {
+        let (collector, _) = mock_collector();
+        let cookie = Cookie {
+            name: "session".to_string(),
+            value: "abc123".to_string(),
+            domain: "example.com".to_string(),
+            path: "/".to_string(),
+            http_only: true,
+            secure: true,
+        };
+        let ctx = TestCtxBuilder::new(collector)
+            .fetcher(Arc::new(MockPageFetcher {
+                behavior: FetchBehavior::Success("<html></html>".to_string(), vec![cookie]),
+            }))
+            .build();
+        let bridge = Arc::clone(&ctx.cookie_bridge);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        let b = bridge.read().expect("lock not poisoned");
+        assert_eq!(b.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_no_cookies_skips_bridge() {
+        let (collector, _) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .fetcher(Arc::new(MockPageFetcher {
+                behavior: FetchBehavior::Success("<html></html>".to_string(), Vec::new()),
+            }))
+            .build();
+        let bridge = Arc::clone(&ctx.cookie_bridge);
+
+        run_crawl_task(ctx, test_url("https://example.com/", 0))
+            .await
+            .expect("crawl should succeed");
+        let b = bridge.read().expect("lock not poisoned");
+        assert_eq!(b.len(), 0);
+    }
 }

--- a/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
@@ -9,16 +9,16 @@ use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::{Arc, RwLock};
 
 use crate::application::crawler::checkpoint::BannedDomain;
-use crate::application::crawler::collector::ResultsCollector;
-use crate::application::crawler::fetch_router::FetchRouter;
+use crate::application::crawler::ports::{
+    ContentPipeline, CrawlResultCollector, LinkExtractorPort, PageFetcher, RobotsChecker,
+};
 use crate::application::deduplicator::UrlDeduplicator;
-use crate::application::pipeline::{OutputStage, PipelineExecutor};
+use crate::application::pipeline::OutputStage;
 use crate::application::rate_limiter::SharedRateLimiter;
+use crate::domain::session_port::SessionPort;
 use crate::domain::{CorrelationId, CrawlerConfig};
-use crate::infrastructure::crawler::RobotsFetcher;
 use crate::infrastructure::crawler::UrlQueue;
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
-use crate::infrastructure::network::session_pool::DomainSessionPool;
 
 /// Shared context for all crawl tasks spawned by the engine.
 ///
@@ -34,9 +34,9 @@ pub struct CrawlTaskCtx {
     pub(crate) visited_urls: Arc<RwLock<Vec<String>>>,
     pub(crate) queue: Arc<UrlQueue>,
     pub(crate) rate_limiter: SharedRateLimiter,
-    pub(crate) session_pool: Option<DomainSessionPool>,
+    pub(crate) session_pool: Option<Arc<dyn SessionPort>>,
     pub(crate) ignore_robots: bool,
-    pub(crate) robots_fetcher: Arc<RobotsFetcher>,
+    pub(crate) robots_checker: Arc<dyn RobotsChecker>,
 
     // --- Per-task mutable (atomics) ---
     pub(crate) error_count: Arc<AtomicUsize>,
@@ -44,13 +44,14 @@ pub struct CrawlTaskCtx {
     pub(crate) error_breakdown: Arc<[AtomicUsize; 8]>,
     pub(crate) pages_crawled: Arc<AtomicU64>,
 
-    // --- Infrastructure ---
-    pub(crate) collector: ResultsCollector,
+    // --- Infrastructure (port-based) ---
+    pub(crate) collector: Arc<dyn CrawlResultCollector>,
     pub(crate) cookie_bridge: Arc<RwLock<CookieBridge>>,
     pub(crate) banned_domains: Arc<RwLock<Vec<BannedDomain>>>,
-    pub(crate) fetch_router: Option<FetchRouter>,
+    pub(crate) fetcher: Arc<dyn PageFetcher>,
+    pub(crate) link_extractor: Arc<dyn LinkExtractorPort>,
 
     // --- Pipeline ---
-    pub(crate) pipeline: Option<Arc<PipelineExecutor>>,
+    pub(crate) pipeline: Option<Arc<dyn ContentPipeline>>,
     pub(crate) output_stages: Vec<Arc<Box<dyn OutputStage>>>,
 }

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -21,6 +21,7 @@ use super::concurrency_level::{ConcurrencyLevel, SharedConcurrencyLevel};
 use super::crawl_scheduler::CrawlScheduler;
 use super::crawl_task::{handle_crawl_result, run_crawl_task};
 use super::fetch_router::{build_fetch_router, FetchRouter};
+use super::ports;
 use super::progress::CrawlProgress;
 use crate::application::crawler::crawl_task_ctx::CrawlTaskCtx;
 use crate::application::pipeline::{OutputStage, PipelineExecutor};
@@ -394,17 +395,31 @@ impl Engine {
             visited_urls: self.scheduler.visited_urls(),
             queue: self.scheduler.queue(),
             rate_limiter: self.rate_limiter.clone(),
-            session_pool: self.session_pool.clone(),
+            session_pool: self
+                .session_pool
+                .as_ref()
+                .map(|p| Arc::new(p.clone()) as Arc<dyn crate::domain::session_port::SessionPort>),
             ignore_robots: self.ignore_robots,
-            robots_fetcher: Arc::clone(&self.robots_fetcher),
+            robots_checker: Arc::new(ports::ProductionRobotsChecker {
+                fetcher: Arc::clone(&self.robots_fetcher),
+            }),
             error_count: Arc::clone(&self.error_count),
             error_breakdown: Arc::clone(&self.error_breakdown),
             pages_crawled: Arc::clone(&self.pages_crawled),
-            collector: self.collector.clone(),
+            collector: Arc::new(ports::ProductionCollector {
+                collector: self.collector.clone(),
+            }),
             cookie_bridge: Arc::clone(&self.cookie_bridge),
             banned_domains: Arc::clone(&self.banned_domains),
-            fetch_router: self.fetch_router.clone(),
-            pipeline: self.pipeline.clone(),
+            fetcher: Arc::new(ports::ProductionPageFetcher {
+                router: self.fetch_router.clone(),
+            }),
+            link_extractor: Arc::new(ports::ProductionLinkExtractor),
+            pipeline: self.pipeline.as_ref().map(|p| {
+                Arc::new(ports::ProductionPipeline {
+                    executor: Arc::clone(p),
+                }) as Arc<dyn ports::ContentPipeline>
+            }),
             output_stages: self.output_stages.to_vec(),
         });
 

--- a/crates/webfang_core/src/application/crawler/mod.rs
+++ b/crates/webfang_core/src/application/crawler/mod.rs
@@ -11,6 +11,7 @@ pub mod crawl_task_ctx;
 pub mod discovery;
 pub mod engine;
 pub(crate) mod fetch_router;
+pub(crate) mod ports;
 pub mod progress;
 pub mod sitemap_discovery;
 

--- a/crates/webfang_core/src/application/crawler/ports.rs
+++ b/crates/webfang_core/src/application/crawler/ports.rs
@@ -1,0 +1,183 @@
+//! Application-layer ports for crawl task dependencies.
+//!
+//! These traits decouple `run_crawl_task` from concrete infrastructure,
+//! enabling inline unit tests that kill mutants under `cargo mutants --lib`.
+//!
+//! # Async desugaring
+//!
+//! Async methods use manual `Pin<Box<dyn Future>>` desugaring (BoxFuture)
+//! instead of the `async_trait` crate, matching the frozen decision #1
+//! established in [`crate::domain::repository::VectorRepository`] and
+//! [`crate::infrastructure::downloader::Downloader`].
+
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use url::Url;
+
+use crate::application::crawler::collector::{CrawlMessage, ResultsCollector};
+use crate::application::crawler::fetch_router::FetchRouter;
+use crate::application::pipeline::{PipelineExecutor, ScrapedItem, StageOutcome};
+use crate::domain::{CrawlError, CrawlerConfig, DiscoveredUrl};
+use crate::infrastructure::crawler::{extract_links, fetch_url, RobotsFetcher};
+use crate::infrastructure::downloader::{Cookie, DownloadError, Downloader};
+
+/// Fetches a web page. Unifies the `FetchRouter` and static `fetch_url()` paths.
+///
+/// Returns `(html, cookies)`. The WAF variant is preserved in the error so
+/// `run_crawl_task` can apply domain-banning logic.
+pub(crate) trait PageFetcher: Send + Sync {
+    /// Fetch the page at `url` using the given crawl configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CrawlError`] on network failure, WAF detection, or timeout.
+    fn fetch_page<'a>(
+        &'a self,
+        url: &'a Url,
+        config: &'a CrawlerConfig,
+    ) -> BoxFuture<'a, Result<(String, Vec<Cookie>), CrawlError>>;
+}
+
+/// Checks robots.txt rules for a URL.
+pub(crate) trait RobotsChecker: Send + Sync {
+    /// Returns `true` if the URL is allowed by the domain's robots.txt.
+    fn is_robots_allowed<'a>(&'a self, url: &'a str, domain: &'a str) -> BoxFuture<'a, bool>;
+}
+
+/// Extracts links from HTML content.
+pub(crate) trait LinkExtractorPort: Send + Sync {
+    /// Extract and normalize all `<a href>` links from `html`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CrawlError`] on selector or base-URL parse failure.
+    fn extract_links(&self, html: &str, base_url: &str) -> Result<Vec<String>, CrawlError>;
+}
+
+/// Executes the content processing pipeline.
+pub(crate) trait ContentPipeline: Send + Sync {
+    /// Run all pipeline stages on `item` and return the outcome.
+    fn execute_pipeline<'a>(&'a self, item: ScrapedItem) -> BoxFuture<'a, StageOutcome>;
+}
+
+/// Collects crawl results via channel.
+pub(crate) trait CrawlResultCollector: Send + Sync {
+    /// Send a successfully crawled URL to the results channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CrawlError`] if the channel is closed.
+    fn send_result<'a>(&'a self, url: DiscoveredUrl) -> BoxFuture<'a, Result<(), CrawlError>>;
+}
+
+// ---------------------------------------------------------------------------
+// Production implementations
+// ---------------------------------------------------------------------------
+
+/// Production [`PageFetcher`] that wraps an optional [`FetchRouter`].
+///
+/// When a router is present, delegates to [`Downloader::fetch`]; otherwise
+/// falls back to the static [`fetch_url`] helper.
+pub(crate) struct ProductionPageFetcher {
+    /// Optional fetch router for hybrid/full JS rendering.
+    pub(crate) router: Option<FetchRouter>,
+}
+
+impl PageFetcher for ProductionPageFetcher {
+    fn fetch_page<'a>(
+        &'a self,
+        url: &'a Url,
+        config: &'a CrawlerConfig,
+    ) -> BoxFuture<'a, Result<(String, Vec<Cookie>), CrawlError>> {
+        Box::pin(async move {
+            if let Some(ref router) = self.router {
+                match router.fetch(url).await {
+                    Ok(page) => Ok((page.html, page.cookies)),
+                    Err(e) => Err(e.into()),
+                }
+            } else {
+                let html = fetch_url(url.as_str(), config).await?;
+                Ok((html, Vec::new()))
+            }
+        })
+    }
+}
+
+/// Production [`RobotsChecker`] backed by [`RobotsFetcher`].
+pub(crate) struct ProductionRobotsChecker {
+    /// Shared robots.txt fetcher with per-domain cache.
+    pub(crate) fetcher: Arc<RobotsFetcher>,
+}
+
+impl RobotsChecker for ProductionRobotsChecker {
+    fn is_robots_allowed<'a>(&'a self, url: &'a str, domain: &'a str) -> BoxFuture<'a, bool> {
+        Box::pin(async move { self.fetcher.is_allowed(url, domain).await })
+    }
+}
+
+/// Production [`LinkExtractorPort`] delegating to the free function.
+pub(crate) struct ProductionLinkExtractor;
+
+impl LinkExtractorPort for ProductionLinkExtractor {
+    fn extract_links(&self, html: &str, base_url: &str) -> Result<Vec<String>, CrawlError> {
+        extract_links(html, base_url)
+    }
+}
+
+/// Production [`ContentPipeline`] backed by [`PipelineExecutor`].
+pub(crate) struct ProductionPipeline {
+    /// The pipeline executor with registered stages.
+    pub(crate) executor: Arc<PipelineExecutor>,
+}
+
+impl ContentPipeline for ProductionPipeline {
+    fn execute_pipeline<'a>(&'a self, item: ScrapedItem) -> BoxFuture<'a, StageOutcome> {
+        Box::pin(async move { self.executor.execute(item).await })
+    }
+}
+
+/// Production [`CrawlResultCollector`] backed by the mpsc [`ResultsCollector`].
+pub(crate) struct ProductionCollector {
+    /// The mpsc-based results collector.
+    pub(crate) collector: ResultsCollector,
+}
+
+impl CrawlResultCollector for ProductionCollector {
+    fn send_result<'a>(&'a self, url: DiscoveredUrl) -> BoxFuture<'a, Result<(), CrawlError>> {
+        Box::pin(async move {
+            self.collector
+                .send(CrawlMessage::success(url))
+                .await
+                .map_err(|e| CrawlError::Internal(e.to_string()))
+        })
+    }
+}
+
+/// Check whether a [`CrawlError`] represents a WAF challenge.
+///
+/// Inspects the [`CrawlError::Download`] source chain for
+/// [`DownloadError::WafChallenge`], the domain-level
+/// [`CrawlError::WafChallenge`] variant, and the legacy string heuristic
+/// used by the static `fetch_url` fallback path.
+pub(crate) fn waf_challenge_message(err: &CrawlError) -> Option<String> {
+    match err {
+        CrawlError::WafChallenge { provider, .. } => Some(provider.clone()),
+        CrawlError::Download(source) => {
+            source
+                .downcast_ref::<DownloadError>()
+                .and_then(|de| match de {
+                    DownloadError::WafChallenge(msg) => Some(msg.clone()),
+                    _ => None,
+                })
+        },
+        other => {
+            let msg = other.to_string();
+            if msg.contains("WAF") {
+                Some(msg)
+            } else {
+                None
+            }
+        },
+    }
+}


### PR DESCRIPTION
Closes #475

## Summary

Define 5 application-layer ports (PageFetcher, RobotsChecker, LinkExtractorPort, ContentPipeline, CrawlResultCollector) that decouple run_crawl_task from concrete infrastructure types. CrawlTaskCtx now uses Arc<dyn Trait> for these dependencies, following the existing OutputStage pattern.

## Changes

- ports.rs (NEW): 5 port traits + 5 production adapters + waf_challenge_message helper
- crawl_task_ctx.rs: 5 fields changed to Arc<dyn Trait>, added link_extractor
- crawl_task.rs: Unified fetch path via PageFetcher port, added 22 inline unit tests
- engine.rs: Wraps concrete types in production port adapters at CrawlTaskCtx construction
- mod.rs: Registered pub(crate) mod ports
- mutants.yml: Re-added crawler/** to PR mutation gate

## Design decisions

- BoxFuture desugaring instead of async_trait — matches frozen decision #1 in repository.rs
- Vec<Cookie> in PageFetcher return — CookieBridge::add takes Cookie directly
- WAF banning stays in run_crawl_task — business logic that mutants need to test
- Rate limiter, cookie bridge, deduplicator, queue, counters stay concrete — observable via Arc

## Test coverage

22 inline tests covering all 15 mutant scenarios: fetch success/WAF/error, session pool, pipeline Continue/Skip/Reject, depth gating, robots check, link dedup, external filtering, extraction errors, cookie ingestion.

## Verification

- cargo check ✅
- cargo clippy -- -D warnings ✅
- cargo fmt --check ✅
- cargo nextest run -p webfang_core --lib ✅ (1427 passed)