### PR TITLE
feat(ai): add EmbeddingAdapter and wire vault-search ports (#433)

### DIFF
--- a/crates/webfang_ai/src/infrastructure_ai/embedding_adapter.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/embedding_adapter.rs
@@ -1,0 +1,244 @@
+//! Embedding adapter — bridges [`InferencePool`] to the domain [`EmbeddingPort`].
+//!
+//! This is the concrete infrastructure implementation of the always-compiled
+//! domain port [`EmbeddingPort`]. It wraps the ONNX [`InferencePool`] and the
+//! HuggingFace [`MiniLmTokenizer`] to turn raw text into fixed-dimension
+//! embedding vectors, following the Adapter pattern (infrastructure adapts the
+//! domain port to the ONNX primitives).
+//!
+//! # Architecture
+//!
+//! ```text
+//! &str / &[String]
+//!     ↓
+//! [MiniLmTokenizer] text → ModelInput (token ids + masks)
+//!     ↓
+//! [InferencePool] ModelInput → Vec<f32> (dedicated worker threads)
+//!     ↓
+//! Vec<f32> / Vec<Vec<f32>>
+//! ```
+//!
+//! # Design decisions
+//!
+//! - **Batch override**: [`EmbeddingPort::embed_batch`] defaults to calling
+//!   [`EmbeddingPort::embed`] per text, re-tokenizing through the port surface
+//!   each time. This adapter overrides it to tokenize the whole batch in one
+//!   [`MiniLmTokenizer::tokenize_batch`] call, then dispatches the resulting
+//!   [`ModelInput`]s to the pool. `InferencePool` has no true batched inference
+//!   (each `infer` is one worker request), so the dispatch is sequential — the
+//!   win is avoiding per-call re-tokenization overhead, not parallel ONNX.
+//! - **Span attachment**: the port methods are synchronous fns returning a
+//!   [`BoxFuture`], so `#[instrument]` would only span the (trivial) future
+//!   construction. Per the observability contract, the span is attached to the
+//!   future itself via [`Instrument::instrument`] so it covers the actual
+//!   tokenize + infer work.
+//! - **Shared resolution**: [`EmbeddingAdapter::from_config`] reuses
+//!   [`resolve_model_assets`](crate::infrastructure_ai::semantic_cleaner_impl::resolve_model_assets),
+//!   the same hf_hub cache/download + SHA256 validation path extracted from
+//!   `SemanticCleanerImpl::new`, so both pipelines resolve models identically.
+//!
+//! # Rust-Skills Applied
+//!
+//! - `own-arc-shared`: `Arc<InferencePool>` / `Arc<MiniLmTokenizer>` shared ownership
+//! - `async-clone-before-await`: references captured before await points
+//! - `err-question-mark`: `?` propagation, no `.unwrap()` in production
+//! - `obs-instrument-spans`: spans attached to the boxed futures
+//! - `mem-with-capacity`: batch result pre-allocation
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tracing::{debug, Instrument};
+
+use crate::infrastructure_ai::inference_engine::InferencePool;
+use crate::infrastructure_ai::semantic_cleaner_impl::{resolve_model_assets, ModelConfig};
+use crate::infrastructure_ai::tokenizer::MiniLmTokenizer;
+use webfang_core::domain::embedding_port::EmbeddingPort;
+use webfang_core::error::SemanticError;
+
+/// A boxed future for dyn-compatible async trait methods.
+///
+/// Mirrors the private alias in [`webfang_core::domain::embedding_port`]; the
+/// alias there is module-private, so the adapter declares its own.
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Adapter exposing [`InferencePool`] embeddings through the domain [`EmbeddingPort`].
+///
+/// Cheap to clone-share via `Arc`: both fields are `Arc`-wrapped. Constructed
+/// either directly from existing components ([`EmbeddingAdapter::new`]) or from
+/// a [`ModelConfig`] that resolves and validates the model + tokenizer
+/// ([`EmbeddingAdapter::from_config`]).
+///
+/// # Thread Safety
+///
+/// `Send + Sync` — both `InferencePool` and `MiniLmTokenizer` are `Send + Sync`,
+/// so the adapter can be shared as `Arc<dyn EmbeddingPort>` across the MCP server
+/// and any future consumer.
+pub struct EmbeddingAdapter {
+    /// ONNX inference pool (dedicated worker threads with persistent sessions).
+    pool: Arc<InferencePool>,
+    /// HuggingFace tokenizer (text → `ModelInput`).
+    tokenizer: Arc<MiniLmTokenizer>,
+}
+
+impl EmbeddingAdapter {
+    /// Wrap an existing inference pool and tokenizer.
+    ///
+    /// Use this when the caller already holds the components (e.g. sharing the
+    /// pool built for another pipeline); otherwise prefer [`from_config`](Self::from_config).
+    #[must_use]
+    pub fn new(pool: Arc<InferencePool>, tokenizer: Arc<MiniLmTokenizer>) -> Self {
+        Self { pool, tokenizer }
+    }
+
+    /// Resolve the model + tokenizer from `config` and build the adapter.
+    ///
+    /// Mirrors `SemanticCleanerImpl::new`: resolves the model and tokenizer
+    /// through the hf_hub cache (cache-first online, strict offline), validates
+    /// the model SHA256 in memory, then loads the tokenizer and builds the
+    /// inference pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SemanticError`] when model resolution, download, SHA256
+    /// validation, tokenizer loading, or pool construction fails.
+    #[tracing::instrument(skip(config), fields(repo = %config.repo, offline_mode = config.offline_mode))]
+    pub async fn from_config(config: &ModelConfig) -> Result<Self, SemanticError> {
+        let (model_bytes, tokenizer_path) = resolve_model_assets(config).await?;
+        let tokenizer = Arc::new(MiniLmTokenizer::from_file(&tokenizer_path).await?);
+        let pool = Arc::new(InferencePool::new(model_bytes, config.model_variant)?);
+        debug!(dim = pool.embedding_dim(), "EmbeddingAdapter initialized");
+        Ok(Self { pool, tokenizer })
+    }
+}
+
+impl EmbeddingPort for EmbeddingAdapter {
+    fn embed<'a>(&'a self, text: &'a str) -> BoxFuture<'a, Result<Vec<f32>, SemanticError>> {
+        let span = tracing::debug_span!("embed", text_len = text.len(), dim = self.embedding_dim());
+        Box::pin(
+            async move {
+                let input = self.tokenizer.tokenize(text)?;
+                self.pool.infer(&input).await
+            }
+            .instrument(span),
+        )
+    }
+
+    fn embed_batch<'a>(
+        &'a self,
+        texts: &'a [String],
+    ) -> BoxFuture<'a, Result<Vec<Vec<f32>>, SemanticError>> {
+        let span = tracing::debug_span!(
+            "embed_batch",
+            count = texts.len(),
+            dim = self.embedding_dim()
+        );
+        Box::pin(
+            async move {
+                if texts.is_empty() {
+                    return Ok(Vec::new());
+                }
+                // Tokenize the whole batch once (avoids per-call re-tokenization),
+                // then dispatch each ModelInput to the pool sequentially — the pool
+                // has no batched inference, each infer is a single worker request.
+                let refs: Vec<&str> = texts.iter().map(String::as_str).collect();
+                let batch = self.tokenizer.tokenize_batch(&refs)?;
+                let inputs = batch.to_model_inputs();
+                let mut results = Vec::with_capacity(inputs.len());
+                for input in &inputs {
+                    results.push(self.pool.infer(input).await?);
+                }
+                Ok(results)
+            }
+            .instrument(span),
+        )
+    }
+
+    fn embedding_dim(&self) -> usize {
+        self.pool.embedding_dim()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure_ai::cache_config::AiModel;
+
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    /// Build a minimal in-memory WordPiece tokenizer — no tokenizer.json file
+    /// required. Only needs to EXIST for adapter construction; the embedding_dim
+    /// tests never invoke tokenization.
+    fn in_memory_tokenizer() -> tokenizers::Tokenizer {
+        use tokenizers::models::wordpiece::WordPiece;
+        // `WordPieceBuilder::vocab` accepts `Into<AHashMap>`; an array of tuples
+        // converts directly (avoids a std HashMap → AHashMap mismatch).
+        let vocab = [
+            ("[PAD]".to_string(), 0u32),
+            ("[UNK]".to_string(), 100),
+            ("[CLS]".to_string(), 101),
+            ("[SEP]".to_string(), 102),
+            ("hello".to_string(), 5),
+            ("world".to_string(), 6),
+        ];
+        let model = WordPiece::builder()
+            .vocab(vocab)
+            .unk_token("[UNK]".to_string())
+            .build()
+            .expect("wordpiece model must build from an inline vocab");
+        tokenizers::Tokenizer::new(model)
+    }
+
+    /// Adapter backed by fake model bytes (workers fail async but the pool still
+    /// reports its configured dimension) and an in-memory tokenizer — no ONNX
+    /// model download, fully deterministic.
+    fn fake_adapter() -> EmbeddingAdapter {
+        let pool = Arc::new(
+            InferencePool::new(
+                Arc::new(b"not a real onnx model".to_vec()),
+                AiModel::Granite97M,
+            )
+            .expect("pool creation must succeed even with invalid model bytes"),
+        );
+        let tokenizer = Arc::new(MiniLmTokenizer::new(in_memory_tokenizer(), 512));
+        EmbeddingAdapter::new(pool, tokenizer)
+    }
+
+    #[test]
+    fn test_embedding_adapter_is_send_sync() {
+        assert_send::<EmbeddingAdapter>();
+        assert_sync::<EmbeddingAdapter>();
+    }
+
+    #[test]
+    fn test_embedding_dim_returns_384() {
+        let adapter = fake_adapter();
+        assert_eq!(adapter.embedding_dim(), 384, "Granite-97M must report 384d");
+    }
+
+    #[test]
+    fn test_adapter_coerces_to_dyn_embedding_port() {
+        // Object-safety proof with a real instance: the adapter must coerce to
+        // the erased domain port and delegate embedding_dim through the vtable.
+        let adapter = fake_adapter();
+        let port: &dyn EmbeddingPort = &adapter;
+        assert_eq!(port.embedding_dim(), 384);
+    }
+
+    #[tokio::test]
+    async fn test_from_config_fails_offline_without_cache() {
+        // Offline mode + a bogus repo id (never present in the hf_hub cache)
+        // guarantees a deterministic resolution failure without network access,
+        // mirroring the SemanticCleanerImpl::new offline tests.
+        let config = ModelConfig::new()
+            .with_repo("nonexistent/fake-repo-for-test")
+            .with_offline_mode(true);
+        let result = EmbeddingAdapter::from_config(&config).await;
+        assert!(
+            result.is_err(),
+            "offline resolution of an uncached model must fail"
+        );
+    }
+}

--- a/crates/webfang_ai/src/infrastructure_ai/embedding_adapter.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/embedding_adapter.rs
@@ -1,7 +1,7 @@
-//! Embedding adapter — bridges [`InferencePool`] to the domain [`EmbeddingPort`].
+//! Embedding adapter — bridges [`InferencePool`] to the domain [`EmbeddingPort`](webfang_core::domain::embedding_port::EmbeddingPort).
 //!
 //! This is the concrete infrastructure implementation of the always-compiled
-//! domain port [`EmbeddingPort`]. It wraps the ONNX [`InferencePool`] and the
+//! domain port [`EmbeddingPort`](webfang_core::domain::embedding_port::EmbeddingPort). It wraps the ONNX [`InferencePool`] and the
 //! HuggingFace [`MiniLmTokenizer`] to turn raw text into fixed-dimension
 //! embedding vectors, following the Adapter pattern (infrastructure adapts the
 //! domain port to the ONNX primitives).
@@ -20,20 +20,20 @@
 //!
 //! # Design decisions
 //!
-//! - **Batch override**: [`EmbeddingPort::embed_batch`] defaults to calling
-//!   [`EmbeddingPort::embed`] per text, re-tokenizing through the port surface
+//! - **Batch override**: [`EmbeddingPort::embed_batch`](webfang_core::domain::embedding_port::EmbeddingPort::embed_batch) defaults to calling
+//!   [`EmbeddingPort::embed`](webfang_core::domain::embedding_port::EmbeddingPort::embed) per text, re-tokenizing through the port surface
 //!   each time. This adapter overrides it to tokenize the whole batch in one
 //!   [`MiniLmTokenizer::tokenize_batch`] call, then dispatches the resulting
 //!   [`ModelInput`]s to the pool. `InferencePool` has no true batched inference
 //!   (each `infer` is one worker request), so the dispatch is sequential — the
 //!   win is avoiding per-call re-tokenization overhead, not parallel ONNX.
 //! - **Span attachment**: the port methods are synchronous fns returning a
-//!   [`BoxFuture`], so `#[instrument]` would only span the (trivial) future
+//!   `BoxFuture`, so `#[instrument]` would only span the (trivial) future
 //!   construction. Per the observability contract, the span is attached to the
-//!   future itself via [`Instrument::instrument`] so it covers the actual
+//!   future itself via [`Instrument::instrument`](tracing::Instrument::instrument) so it covers the actual
 //!   tokenize + infer work.
 //! - **Shared resolution**: [`EmbeddingAdapter::from_config`] reuses
-//!   [`resolve_model_assets`](crate::infrastructure_ai::semantic_cleaner_impl::resolve_model_assets),
+//!   `resolve_model_assets`,
 //!   the same hf_hub cache/download + SHA256 validation path extracted from
 //!   `SemanticCleanerImpl::new`, so both pipelines resolve models identically.
 //!

--- a/crates/webfang_ai/src/infrastructure_ai/mod.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/mod.rs
@@ -74,6 +74,9 @@ pub mod cache_config;
 
 pub mod semantic_cleaner_impl;
 
+/// Adapter bridging `InferencePool` to the domain `EmbeddingPort` (#433).
+pub mod embedding_adapter;
+
 pub mod inference_engine;
 
 pub mod tokenizer;
@@ -103,6 +106,8 @@ pub use cache_config::{
 };
 
 pub use semantic_cleaner_impl::{ModelConfig, SemanticCleanerImpl};
+
+pub use embedding_adapter::EmbeddingAdapter;
 
 pub use inference_engine::InferencePool;
 

--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -270,74 +270,10 @@ impl SemanticCleanerImpl {
             "Initializing semantic cleaner with full RAG pipeline"
         );
 
-        // Resolve model + tokenizer paths through the hf_hub cache.
-        // Offline mode resolves strictly from the local cache (no network) and
-        // fails fast with `OfflineMode` when either asset is missing. Online
-        // mode is cache-first: hf_hub returns the cached path when present and
-        // transparently downloads missing assets otherwise.
-        let (model_path, tokenizer_path) = if config.offline_mode {
-            let cache = HfCache::from_env();
-            let cache_repo = cache.repo(Repo::new(config.repo.clone(), RepoType::Model));
-
-            let model_path =
-                cache_repo
-                    .get(&config.model_file)
-                    .ok_or_else(|| SemanticError::OfflineMode {
-                        repo: config.repo.clone(),
-                    })?;
-            let tokenizer_path =
-                cache_repo
-                    .get("tokenizer.json")
-                    .ok_or_else(|| SemanticError::OfflineMode {
-                        repo: config.repo.clone(),
-                    })?;
-
-            debug!("Resolved model and tokenizer from offline cache");
-            (model_path, tokenizer_path)
-        } else {
-            let api = ApiBuilder::from_env()
-                .with_progress(true)
-                .build()
-                .map_err(|e| SemanticError::Download {
-                    repo: config.repo.clone(),
-                    cause: format!("Failed to build HuggingFace API client: {e}"),
-                })?;
-
-            let repo = api.model(config.repo.clone());
-
-            // Resolve both assets concurrently (cache-first, downloads if missing).
-            // `with_progress(true)` surfaces hf_hub's built-in progress bar so the
-            // first download (~390MB) is not perceived as a hang; the span makes
-            // the download phase observable in the trace file.
-            let (model_path, tokenizer_path) =
-                try_join(repo.get(&config.model_file), repo.get("tokenizer.json"))
-                    .instrument(tracing::info_span!(
-                        "download_model_assets",
-                        repo = %config.repo
-                    ))
-                    .await
-                    .map_err(|e| SemanticError::Download {
-                        repo: config.repo.clone(),
-                        cause: format!("HuggingFace API error: {e}"),
-                    })?;
-
-            debug!("Resolved model and tokenizer via hf_hub (cache-first)");
-            (model_path, tokenizer_path)
-        };
-
-        // Load the model bytes once and validate SHA256 on the in-memory buffer
-        // (zero extra I/O — the same bytes feed the inference pool below).
-        let model_bytes = Arc::new(
-            tokio::fs::read(&model_path)
-                .await
-                .map_err(SemanticError::ModelLoad)?,
-        );
-
-        validate_model_hash(
-            model_bytes.as_slice(),
-            config.model_variant.sha256(),
-            &config.repo,
-        )?;
+        // Resolve and validate model + tokenizer assets (hf_hub cache-first,
+        // in-memory SHA256 integrity check). Shared with `EmbeddingAdapter::from_config`
+        // so both pipelines resolve and validate models identically.
+        let (model_bytes, tokenizer_path) = resolve_model_assets(&config).await?;
 
         // Initialize all pipeline components.
         let tokenizer = MiniLmTokenizer::from_file(&tokenizer_path).await?;
@@ -614,6 +550,103 @@ impl SemanticCleanerImpl {
 
         Ok(result)
     }
+}
+
+/// Resolve and validate model assets from the hf_hub cache.
+///
+/// Resolves the model and tokenizer paths through the hf_hub cache — offline
+/// mode resolves strictly from the local cache (no network) and fails fast with
+/// [`SemanticError::OfflineMode`] when either asset is missing; online mode is
+/// cache-first (hf_hub returns the cached path when present and transparently
+/// downloads missing assets otherwise). Then loads the model bytes once and
+/// validates their SHA256 in memory.
+///
+/// Extracted from [`SemanticCleanerImpl::new`] so
+/// [`crate::infrastructure_ai::embedding_adapter::EmbeddingAdapter::from_config`]
+/// reuses the identical resolution + integrity-validation logic without
+/// duplicating the hf_hub plumbing.
+///
+/// # Returns
+///
+/// `(model_bytes, tokenizer_path)` — SHA256-validated model bytes and the path
+/// to `tokenizer.json`.
+///
+/// # Errors
+///
+/// Returns [`SemanticError::OfflineMode`] when offline and an asset is uncached,
+/// [`SemanticError::Download`] on hf_hub client/API failure,
+/// [`SemanticError::ModelLoad`] on read failure, or
+/// [`SemanticError::CacheValidation`] on SHA256 mismatch.
+#[tracing::instrument(skip(config), fields(repo = %config.repo, model_file = %config.model_file, offline_mode = config.offline_mode))]
+pub(crate) async fn resolve_model_assets(
+    config: &ModelConfig,
+) -> Result<(Arc<Vec<u8>>, std::path::PathBuf), SemanticError> {
+    // Resolve model + tokenizer paths through the hf_hub cache.
+    let (model_path, tokenizer_path) = if config.offline_mode {
+        let cache = HfCache::from_env();
+        let cache_repo = cache.repo(Repo::new(config.repo.clone(), RepoType::Model));
+
+        let model_path =
+            cache_repo
+                .get(&config.model_file)
+                .ok_or_else(|| SemanticError::OfflineMode {
+                    repo: config.repo.clone(),
+                })?;
+        let tokenizer_path =
+            cache_repo
+                .get("tokenizer.json")
+                .ok_or_else(|| SemanticError::OfflineMode {
+                    repo: config.repo.clone(),
+                })?;
+
+        debug!("Resolved model and tokenizer from offline cache");
+        (model_path, tokenizer_path)
+    } else {
+        let api = ApiBuilder::from_env()
+            .with_progress(true)
+            .build()
+            .map_err(|e| SemanticError::Download {
+                repo: config.repo.clone(),
+                cause: format!("Failed to build HuggingFace API client: {e}"),
+            })?;
+
+        let repo = api.model(config.repo.clone());
+
+        // Resolve both assets concurrently (cache-first, downloads if missing).
+        // `with_progress(true)` surfaces hf_hub's built-in progress bar so the
+        // first download (~390MB) is not perceived as a hang; the span makes
+        // the download phase observable in the trace file.
+        let (model_path, tokenizer_path) =
+            try_join(repo.get(&config.model_file), repo.get("tokenizer.json"))
+                .instrument(tracing::info_span!(
+                    "download_model_assets",
+                    repo = %config.repo
+                ))
+                .await
+                .map_err(|e| SemanticError::Download {
+                    repo: config.repo.clone(),
+                    cause: format!("HuggingFace API error: {e}"),
+                })?;
+
+        debug!("Resolved model and tokenizer via hf_hub (cache-first)");
+        (model_path, tokenizer_path)
+    };
+
+    // Load the model bytes once and validate SHA256 on the in-memory buffer
+    // (zero extra I/O — the same bytes feed the caller's inference pool).
+    let model_bytes = Arc::new(
+        tokio::fs::read(&model_path)
+            .await
+            .map_err(SemanticError::ModelLoad)?,
+    );
+
+    validate_model_hash(
+        model_bytes.as_slice(),
+        config.model_variant.sha256(),
+        &config.repo,
+    )?;
+
+    Ok((model_bytes, tokenizer_path))
 }
 
 /// Validate the SHA256 hash of in-memory model bytes against an expected value.

--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -199,8 +199,9 @@ pub struct SemanticCleanerImpl {
     // Phase 2: Core inference
     /// ONNX inference pool (dedicated worker threads with persistent sessions)
     inference_pool: Arc<InferencePool>,
-    /// HuggingFace tokenizer
-    tokenizer: MiniLmTokenizer,
+    /// HuggingFace tokenizer (`Arc`-shared with the embedding adapter via
+    /// [`shared_inference`](Self::shared_inference))
+    tokenizer: Arc<MiniLmTokenizer>,
 
     // Phase 3: Chunking + scoring
     /// Semantic HTML chunker with arena allocator
@@ -275,8 +276,9 @@ impl SemanticCleanerImpl {
         // so both pipelines resolve and validate models identically.
         let (model_bytes, tokenizer_path) = resolve_model_assets(&config).await?;
 
-        // Initialize all pipeline components.
-        let tokenizer = MiniLmTokenizer::from_file(&tokenizer_path).await?;
+        // Initialize all pipeline components. The tokenizer is `Arc`-wrapped so
+        // `shared_inference` can hand the SAME instance to the embedding adapter.
+        let tokenizer = Arc::new(MiniLmTokenizer::from_file(&tokenizer_path).await?);
         let inference_pool = Arc::new(InferencePool::new(
             Arc::clone(&model_bytes),
             config.model_variant,
@@ -306,6 +308,24 @@ impl SemanticCleanerImpl {
     #[must_use]
     pub fn relevance_threshold(&self) -> f32 {
         self.config.relevance_threshold
+    }
+
+    /// Share the inference pool and tokenizer with another pipeline.
+    ///
+    /// Returns cheap `Arc` clones of the ONNX [`InferencePool`] and the
+    /// [`MiniLmTokenizer`] this cleaner was built with, so a second consumer
+    /// (e.g. the
+    /// [`EmbeddingAdapter`](crate::infrastructure_ai::embedding_adapter::EmbeddingAdapter))
+    /// can reuse the SAME model + tokenizer instead of resolving and loading a
+    /// second copy. This is what lets the `--ai` path load the ONNX model
+    /// exactly once across the semantic cleaner and the vault-search embedding
+    /// adapter — one `resolve_model_assets` call, one `InferencePool`.
+    #[must_use]
+    pub fn shared_inference(&self) -> (Arc<InferencePool>, Arc<MiniLmTokenizer>) {
+        (
+            Arc::clone(&self.inference_pool),
+            Arc::clone(&self.tokenizer),
+        )
     }
 
     /// Set the relevance threshold

--- a/crates/webfang_ai/src/lib.rs
+++ b/crates/webfang_ai/src/lib.rs
@@ -21,7 +21,7 @@ pub use webfang_core::error::SemanticError;
 // Re-export key AI types for convenience
 #[cfg(feature = "ai")]
 pub use infrastructure_ai::{
-    AiModel, ChunkId, ContentPruner, HtmlChunker, InferencePool, LegibleContentPruner,
-    MarkdownChunker, MiniLmTokenizer, ModelConfig, RelevanceScorer, SemanticCleanerImpl,
-    SentenceSplitter, ThresholdConfig, TokenBatch,
+    AiModel, ChunkId, ContentPruner, EmbeddingAdapter, HtmlChunker, InferencePool,
+    LegibleContentPruner, MarkdownChunker, MiniLmTokenizer, ModelConfig, RelevanceScorer,
+    SemanticCleanerImpl, SentenceSplitter, ThresholdConfig, TokenBatch,
 };

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -408,12 +408,15 @@ async fn __main() -> CliExit {
             });
 
         match model_config {
-            Ok(config) => match SemanticCleanerImpl::new(config.clone()).await {
+            Ok(config) => match SemanticCleanerImpl::new(config).await {
                 Ok(cleaner) => {
+                    // Share the cleaner's ONNX pool + tokenizer (#433) so the
+                    // vault-search embedding adapter reuses the SAME model — one
+                    // `resolve_model_assets` call, one `InferencePool` on `--ai`.
+                    // Extracted before type-erasing the cleaner behind the trait.
+                    let (pool, tokenizer) = cleaner.shared_inference();
                     let cleaner: Option<Arc<dyn SemanticCleaner>> = Some(Arc::new(cleaner));
-                    // Assemble the vault-search ports (#433) from the same config so
-                    // the elastic Container can embed / segment / persist notes.
-                    let ports = build_vault_ports(&config).await;
+                    let ports = build_vault_ports(pool, tokenizer).await;
                     (cleaner, ports)
                 },
                 Err(e) => {
@@ -451,30 +454,30 @@ async fn __main() -> CliExit {
     result
 }
 
-/// Assemble the vault-search AI ports (#433) from a resolved model config.
+/// Assemble the vault-search AI ports (#433) from the cleaner's shared model.
 ///
-/// Builds the ONNX embedding adapter + Markdown chunker (always under `ai`) and
-/// the SQLite note repository (under `persistence`). Every construction failure
-/// degrades gracefully — the affected port stays `None` and the corresponding
-/// capability answers with an honest error rather than aborting the run.
+/// Builds the ONNX embedding adapter + Markdown chunker (always under `ai`) from
+/// the semantic cleaner's shared inference pool + tokenizer — so the `--ai` path
+/// loads the ONNX model exactly once — plus the SQLite note repository (under
+/// `persistence`). Embedding + chunker assembly is infallible (the components are
+/// already valid); only the note repository can fail, and it degrades gracefully
+/// — the port stays `None` and the capability answers with an honest error rather
+/// than aborting the run.
 #[cfg(feature = "ai")]
 async fn build_vault_ports(
-    config: &ModelConfig,
+    pool: Arc<webfang_ai::InferencePool>,
+    tokenizer: Arc<webfang_ai::MiniLmTokenizer>,
 ) -> webfang_core::application::container::VaultAiPorts {
     use webfang_core::application::container::VaultAiPorts;
 
     let mut ports = VaultAiPorts::default();
 
-    match webfang_ai::EmbeddingAdapter::from_config(config).await {
-        Ok(adapter) => {
-            ports.embedding_port = Some(Arc::new(adapter));
-            ports.text_chunker = Some(Arc::new(webfang_ai::MarkdownChunker::new()));
-        },
-        Err(e) => {
-            tracing::warn!("embedding port unavailable, vault search disabled: {e}");
-            return ports;
-        },
-    }
+    // Assemble the embedding adapter from the cleaner's shared pool + tokenizer.
+    // Infallible — no model resolution happens here (that already happened once
+    // inside `SemanticCleanerImpl::new`), so there is nothing to degrade around.
+    let adapter = webfang_ai::EmbeddingAdapter::new(pool, tokenizer);
+    ports.embedding_port = Some(Arc::new(adapter));
+    ports.text_chunker = Some(Arc::new(webfang_ai::MarkdownChunker::new()));
 
     #[cfg(feature = "persistence")]
     {
@@ -485,16 +488,22 @@ async fn build_vault_ports(
 
         let db_path = resolve_db_path(None, env_db_path());
         match create_pool(&db_path, 4) {
-            Ok(pool) => match setup_schema(&pool).await {
+            Ok(db_pool) => match setup_schema(&db_pool).await {
                 Ok(()) => {
-                    ports.note_repository = Some(Arc::new(SqliteVectorRepository::new(pool)));
+                    ports.note_repository = Some(Arc::new(SqliteVectorRepository::new(db_pool)));
                 },
                 Err(e) => {
-                    tracing::warn!("note repository schema init failed, persistence disabled: {e}");
+                    tracing::warn!(
+                        error = %e,
+                        "note repository schema init failed, persistence disabled"
+                    );
                 },
             },
             Err(e) => {
-                tracing::warn!("note repository pool creation failed, persistence disabled: {e}");
+                tracing::warn!(
+                    error = %e,
+                    "note repository pool creation failed, persistence disabled"
+                );
             },
         }
     }

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -383,7 +383,10 @@ async fn __main() -> CliExit {
     };
 
     #[cfg(feature = "ai")]
-    let ai_cleaner: Option<Arc<dyn SemanticCleaner>> = if opts.ai && !opts.export.dry_run {
+    let (ai_cleaner, vault_ports): (
+        Option<Arc<dyn SemanticCleaner>>,
+        webfang_core::application::container::VaultAiPorts,
+    ) = if opts.ai && !opts.export.dry_run {
         // Resolve model variant: CLI flag takes precedence over AI_MODEL_ID env var
         let model_variant = if opts.ai_config.model.is_empty() {
             webfang_ai::AiModel::from_env_or_default()
@@ -405,8 +408,14 @@ async fn __main() -> CliExit {
             });
 
         match model_config {
-            Ok(config) => match SemanticCleanerImpl::new(config).await {
-                Ok(cleaner) => Some(Arc::new(cleaner) as Arc<dyn SemanticCleaner>),
+            Ok(config) => match SemanticCleanerImpl::new(config.clone()).await {
+                Ok(cleaner) => {
+                    let cleaner: Option<Arc<dyn SemanticCleaner>> = Some(Arc::new(cleaner));
+                    // Assemble the vault-search ports (#433) from the same config so
+                    // the elastic Container can embed / segment / persist notes.
+                    let ports = build_vault_ports(&config).await;
+                    (cleaner, ports)
+                },
                 Err(e) => {
                     let msg = format!("No se pudo inicializar el limpiador semántico AI: {e}");
                     return match e {
@@ -420,19 +429,75 @@ async fn __main() -> CliExit {
             },
         }
     } else {
-        None
+        (
+            None,
+            webfang_core::application::container::VaultAiPorts::default(),
+        )
     };
+    #[cfg(not(feature = "ai"))]
+    let vault_ports = webfang_core::application::container::VaultAiPorts::default();
 
     // Dispatch to the orchestrator. The argument list depends on which optional
     // features are compiled in, so each combination is spelled out explicitly.
     #[cfg(all(feature = "ai", feature = "adaptive-selectors"))]
-    let result = orchestrator::run(opts, ai_cleaner, adaptive_engine).await;
+    let result = orchestrator::run(opts, ai_cleaner, adaptive_engine, vault_ports).await;
     #[cfg(all(feature = "ai", not(feature = "adaptive-selectors")))]
-    let result = orchestrator::run(opts, ai_cleaner).await;
+    let result = orchestrator::run(opts, ai_cleaner, vault_ports).await;
     #[cfg(all(not(feature = "ai"), feature = "adaptive-selectors"))]
-    let result = orchestrator::run(opts, adaptive_engine).await;
+    let result = orchestrator::run(opts, adaptive_engine, vault_ports).await;
     #[cfg(all(not(feature = "ai"), not(feature = "adaptive-selectors")))]
-    let result = orchestrator::run(opts).await;
+    let result = orchestrator::run(opts, vault_ports).await;
 
     result
+}
+
+/// Assemble the vault-search AI ports (#433) from a resolved model config.
+///
+/// Builds the ONNX embedding adapter + Markdown chunker (always under `ai`) and
+/// the SQLite note repository (under `persistence`). Every construction failure
+/// degrades gracefully — the affected port stays `None` and the corresponding
+/// capability answers with an honest error rather than aborting the run.
+#[cfg(feature = "ai")]
+async fn build_vault_ports(
+    config: &ModelConfig,
+) -> webfang_core::application::container::VaultAiPorts {
+    use webfang_core::application::container::VaultAiPorts;
+
+    let mut ports = VaultAiPorts::default();
+
+    match webfang_ai::EmbeddingAdapter::from_config(config).await {
+        Ok(adapter) => {
+            ports.embedding_port = Some(Arc::new(adapter));
+            ports.text_chunker = Some(Arc::new(webfang_ai::MarkdownChunker::new()));
+        },
+        Err(e) => {
+            tracing::warn!("embedding port unavailable, vault search disabled: {e}");
+            return ports;
+        },
+    }
+
+    #[cfg(feature = "persistence")]
+    {
+        use webfang_core::infrastructure::autotuning::{env_db_path, resolve_db_path};
+        use webfang_core::infrastructure::persistence::{
+            create_pool, setup_schema, SqliteVectorRepository,
+        };
+
+        let db_path = resolve_db_path(None, env_db_path());
+        match create_pool(&db_path, 4) {
+            Ok(pool) => match setup_schema(&pool).await {
+                Ok(()) => {
+                    ports.note_repository = Some(Arc::new(SqliteVectorRepository::new(pool)));
+                },
+                Err(e) => {
+                    tracing::warn!("note repository schema init failed, persistence disabled: {e}");
+                },
+            },
+            Err(e) => {
+                tracing::warn!("note repository pool creation failed, persistence disabled: {e}");
+            },
+        }
+    }
+
+    ports
 }

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -102,6 +102,24 @@ pub struct Container {
     text_chunker: Option<Arc<dyn TextChunker>>,
 }
 
+/// Vault-search AI ports (#433), constructed in the binary layer (CLI/MCP) and
+/// injected into the [`Container`] in one shot.
+///
+/// Fields are domain trait objects so the dependency direction (`ai → core`) is
+/// respected: `webfang_core` never names the concrete adapters, which live in
+/// `webfang_ai` / the persistence layer and are assembled by the binary crate.
+/// An empty bundle (the [`Default`]) wires nothing — used by builds without the
+/// `ai` feature.
+#[derive(Clone, Default)]
+pub struct VaultAiPorts {
+    /// Embedding port for query/chunk vectorization.
+    pub embedding_port: Option<Arc<dyn EmbeddingPort>>,
+    /// Note repository for vault search persistence.
+    pub note_repository: Option<Arc<dyn NoteRepository>>,
+    /// Text chunker for Markdown segmentation.
+    pub text_chunker: Option<Arc<dyn TextChunker>>,
+}
+
 impl Container {
     /// Create a new container with the given configurations.
     ///
@@ -292,6 +310,27 @@ impl Container {
     /// Inject a text chunker for Markdown segmentation (#386).
     pub fn with_text_chunker(mut self, chunker: Arc<dyn TextChunker>) -> Self {
         self.text_chunker = Some(chunker);
+        self
+    }
+
+    /// Inject the vault-search AI ports that are present in `ports` (#433).
+    ///
+    /// Each field is wired independently; `None` fields leave the corresponding
+    /// port untouched. Convenience wrapper over [`with_embedding_port`](Self::with_embedding_port),
+    /// [`with_note_repository`](Self::with_note_repository) and
+    /// [`with_text_chunker`](Self::with_text_chunker) for the binary composition
+    /// roots (CLI/MCP) that assemble the whole bundle at once.
+    #[must_use]
+    pub fn with_vault_ports(mut self, ports: VaultAiPorts) -> Self {
+        if let Some(port) = ports.embedding_port {
+            self.embedding_port = Some(port);
+        }
+        if let Some(repo) = ports.note_repository {
+            self.note_repository = Some(repo);
+        }
+        if let Some(chunker) = ports.text_chunker {
+            self.text_chunker = Some(chunker);
+        }
         self
     }
 

--- a/crates/webfang_core/src/cli/elastic.rs
+++ b/crates/webfang_core/src/cli/elastic.rs
@@ -73,8 +73,13 @@ pub(super) async fn run_elastic_ingestion(
 /// - `--output-vectors <path|->` → dependency-free `StreamRepository` JSONL sink
 ///   (available in every build, including the lightweight core binary).
 /// - otherwise → `None` (no ingestion).
+///
+/// `vault_ports` (#433) carries the optional vault-search AI ports assembled by
+/// the binary layer; whichever are present are injected into the container so
+/// the ingestion's `Container` is complete. An empty bundle wires nothing.
 pub(super) async fn build_elastic_ingestion(
     opts: &CrawlOptions,
+    vault_ports: crate::application::container::VaultAiPorts,
 ) -> Result<
     Option<
         std::sync::Arc<
@@ -89,7 +94,7 @@ pub(super) async fn build_elastic_ingestion(
     )
     .await
     {
-        Ok(c) => c,
+        Ok(c) => c.with_vault_ports(vault_ports),
         Err(e) => {
             if opts.elastic.enabled || opts.elastic.output_vectors.is_some() {
                 return Err(CliExit::IoError(format!(

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -61,13 +61,14 @@ pub fn prepare_progress_channel(
 /// 2. Scraping with progress
 /// 3. Export results
 /// 4. Report failures + exit code
-#[instrument(level = "info", skip(opts, ai_cleaner, adaptive_engine), fields(url = %opts.url))]
+#[instrument(level = "info", skip(opts, ai_cleaner, adaptive_engine, vault_ports), fields(url = %opts.url))]
 pub async fn run(
     opts: CrawlOptions,
     #[cfg(feature = "ai")] ai_cleaner: Option<std::sync::Arc<dyn SemanticCleaner>>,
     #[cfg(feature = "adaptive-selectors")] adaptive_engine: Option<
         std::sync::Arc<AdaptiveSelectorEngine>,
     >,
+    vault_ports: crate::application::container::VaultAiPorts,
 ) -> CliExit {
     if opts.export.dry_run {
         println!("Dry-run: 1 URL(s) would be scraped:");
@@ -88,7 +89,7 @@ pub async fn run(
             Err(e) => return e,
         };
 
-    let elastic_ingestion = match build_elastic_ingestion(&opts).await {
+    let elastic_ingestion = match build_elastic_ingestion(&opts, vault_ports).await {
         Ok(v) => v,
         Err(e) => return e,
     };
@@ -706,7 +707,11 @@ mod tests {
     #[tokio::test]
     async fn build_elastic_ingestion_none_when_no_options() {
         let opts = CrawlOptions::default();
-        let result = build_elastic_ingestion(&opts).await;
+        let result = build_elastic_ingestion(
+            &opts,
+            crate::application::container::VaultAiPorts::default(),
+        )
+        .await;
         assert!(result.is_ok(), "should not error: {:?}", result.err());
         assert!(
             result.unwrap().is_none(),
@@ -722,7 +727,11 @@ mod tests {
     async fn build_elastic_ingestion_some_when_output_vectors() {
         let mut opts = CrawlOptions::default();
         opts.elastic.output_vectors = Some("/tmp/test.jsonl".to_string());
-        let result = build_elastic_ingestion(&opts).await;
+        let result = build_elastic_ingestion(
+            &opts,
+            crate::application::container::VaultAiPorts::default(),
+        )
+        .await;
         assert!(result.is_ok(), "should not error: {:?}", result.err());
     }
 
@@ -734,7 +743,11 @@ mod tests {
     async fn build_elastic_ingestion_some_when_elastic_enabled() {
         let mut opts = CrawlOptions::default();
         opts.elastic.enabled = true;
-        let result = build_elastic_ingestion(&opts).await;
+        let result = build_elastic_ingestion(
+            &opts,
+            crate::application::container::VaultAiPorts::default(),
+        )
+        .await;
         // May be Ok(None) or Ok(Some) depending on persistence feature
         assert!(result.is_ok(), "should not error: {:?}", result.err());
     }

--- a/crates/webfang_mcp/Cargo.toml
+++ b/crates/webfang_mcp/Cargo.toml
@@ -11,7 +11,11 @@ homepage.workspace = true
 
 [features]
 mcp = ["webfang_core/mcp"]
+# Vault search (#433): ONNX embedding adapter + Markdown chunker.
+# Note: the SQLite note repository requires `persistence` SEPARATELY —
+# the consumer (CLI binary, MCP example) opts in with `--features ai,persistence`.
 ai = ["dep:webfang_ai", "webfang_ai/ai", "webfang_core/ai"]
+persistence = ["webfang_core/persistence"]
 
 [dependencies]
 webfang_core = { workspace = true }

--- a/crates/webfang_mcp/examples/mcp_server.rs
+++ b/crates/webfang_mcp/examples/mcp_server.rs
@@ -329,17 +329,22 @@ async fn main() -> Result<()> {
         if ai_enabled {
             let variant = webfang_ai::AiModel::from_env_or_default();
             let model_config = webfang_ai::ModelConfig::default().with_model_variant(variant);
-            // Wire the semantic cleaner (clean_html / semantic_cleaner tools).
-            let container = match webfang_ai::SemanticCleanerImpl::new(model_config.clone()).await {
-                Ok(cleaner) => container.with_cleaner(std::sync::Arc::new(cleaner)),
+            // Wire the semantic cleaner (clean_html / semantic_cleaner tools), then
+            // share its ONNX pool + tokenizer with the vault-search ports (#433) so
+            // the model is loaded exactly once. The vault ports are wired only when
+            // the cleaner succeeds — they reuse the components it resolved.
+            match webfang_ai::SemanticCleanerImpl::new(model_config).await {
+                Ok(cleaner) => {
+                    let (pool, tokenizer) = cleaner.shared_inference();
+                    let container = container.with_cleaner(std::sync::Arc::new(cleaner));
+                    webfang_mcp::mcp_server::ai_wiring::wire_ai_ports(container, pool, tokenizer)
+                        .await
+                },
                 Err(e) => {
                     tracing::warn!("semantic cleaner unavailable, continuing without AI: {e}");
                     container
                 },
-            };
-            // Wire the vault-search ports (#433): embedding + chunker + note
-            // repository, so `search_obsidian` becomes functional.
-            webfang_mcp::mcp_server::ai_wiring::wire_ai_ports(container, &model_config).await
+            }
         } else {
             container
         }

--- a/crates/webfang_mcp/examples/mcp_server.rs
+++ b/crates/webfang_mcp/examples/mcp_server.rs
@@ -329,13 +329,17 @@ async fn main() -> Result<()> {
         if ai_enabled {
             let variant = webfang_ai::AiModel::from_env_or_default();
             let model_config = webfang_ai::ModelConfig::default().with_model_variant(variant);
-            match webfang_ai::SemanticCleanerImpl::new(model_config).await {
+            // Wire the semantic cleaner (clean_html / semantic_cleaner tools).
+            let container = match webfang_ai::SemanticCleanerImpl::new(model_config.clone()).await {
                 Ok(cleaner) => container.with_cleaner(std::sync::Arc::new(cleaner)),
                 Err(e) => {
                     tracing::warn!("semantic cleaner unavailable, continuing without AI: {e}");
                     container
                 },
-            }
+            };
+            // Wire the vault-search ports (#433): embedding + chunker + note
+            // repository, so `search_obsidian` becomes functional.
+            webfang_mcp::mcp_server::ai_wiring::wire_ai_ports(container, &model_config).await
         } else {
             container
         }

--- a/crates/webfang_mcp/src/mcp_server/ai_wiring.rs
+++ b/crates/webfang_mcp/src/mcp_server/ai_wiring.rs
@@ -1,0 +1,108 @@
+//! AI port wiring for the MCP server (#433).
+//!
+//! Constructs the concrete vault-search ports — the ONNX embedding adapter and
+//! the Markdown chunker — behind the `ai` feature and injects them into the
+//! [`Container`]. The SQLite note repository is wired ONLY when the consumer
+//! explicitly enables the `persistence` feature (`--features ai,persistence`),
+//! keeping the `ai` feature free of database dependencies.
+//!
+//! Mirrors the semantic-cleaner wiring precedent in `examples/mcp_server.rs`:
+//! construction failures degrade gracefully (a warning is logged and the server
+//! keeps running) so the affected tools answer with honest feature-gated errors
+//! instead of the server failing to boot.
+//!
+//! When `persistence` is enabled, the note repository reuses the elastic
+//! pipeline's SQLite database (resolved via
+//! [`resolve_db_path`](webfang_core::infrastructure::autotuning::resolve_db_path)
+//! / [`env_db_path`](webfang_core::infrastructure::autotuning::env_db_path),
+//! default `~/.webfang/crawl.db`, overridable with `WEBFANG_DB_PATH`). The frozen
+//! schema already carries the `notes` and `note_chunks` tables alongside the
+//! elastic `chunks` table, so one database serves both pipelines.
+
+use std::sync::Arc;
+
+use webfang_core::application::container::Container;
+use webfang_core::domain::embedding_port::EmbeddingPort;
+
+/// Wire the vault-search AI ports into `container`.
+///
+/// Injects, in order: the ONNX [`EmbeddingAdapter`](webfang_ai::EmbeddingAdapter),
+/// a [`MarkdownChunker`](webfang_ai::MarkdownChunker), and a SQLite-backed
+/// [`NoteRepository`]. Degradation is incremental: if the embedding adapter
+/// cannot be built the container is returned unchanged (vault search requires
+/// all three ports); if only the note repository fails, the embedding port and
+/// chunker remain wired.
+///
+/// # Errors
+///
+/// Never fails — every construction error is logged and degraded around, so the
+/// caller always receives a usable [`Container`].
+#[must_use]
+pub async fn wire_ai_ports(
+    mut container: Container,
+    model_config: &webfang_ai::ModelConfig,
+) -> Container {
+    // 1. Embedding port (ONNX adapter) — the hard dependency for vault search.
+    let adapter = match webfang_ai::EmbeddingAdapter::from_config(model_config).await {
+        Ok(adapter) => adapter,
+        Err(e) => {
+            tracing::warn!("embedding port unavailable, continuing without vault search: {e}");
+            return container;
+        },
+    };
+    let dim = adapter.embedding_dim();
+    container = container.with_embedding_port(Arc::new(adapter));
+
+    // 2. Text chunker (Markdown segmentation).
+    container = container.with_text_chunker(Arc::new(webfang_ai::MarkdownChunker::new()));
+
+    // 3. Note repository (SQLite persistence) — only when the consumer
+    //    explicitly enables the `persistence` feature. Without it, vault
+    //    search degrades to an honest "not available" error at call time.
+    #[cfg(feature = "persistence")]
+    {
+        match build_note_repository().await {
+            Ok(repo) => {
+                container = container.with_note_repository(repo);
+                tracing::info!(
+                    dim,
+                    "vault-search AI ports wired (embedding + chunker + notes)"
+                );
+            },
+            Err(e) => {
+                tracing::warn!("note repository unavailable, vault search persistence disabled: {e}");
+            },
+        }
+    }
+    #[cfg(not(feature = "persistence"))]
+    {
+        tracing::info!(
+            dim,
+            "vault-search AI ports wired (embedding + chunker); enable `persistence` for note storage"
+        );
+    }
+
+    container
+}
+
+/// Build the SQLite-backed note repository on the elastic pipeline's database.
+///
+/// Resolves the DB path via the hardware-autotuning convention (CLI > env >
+/// `~/.webfang/crawl.db`), opens a WAL-mode pool, and runs the idempotent schema
+/// setup (creating the `notes`/`note_chunks` tables if missing).
+///
+/// Only compiled when the `persistence` feature is explicitly enabled — the
+/// consumer opts in with `--features ai,persistence`.
+#[cfg(feature = "persistence")]
+async fn build_note_repository(
+) -> Result<Arc<dyn webfang_core::domain::note_repository::NoteRepository>, Box<dyn std::error::Error + Send + Sync>> {
+    use webfang_core::infrastructure::autotuning::{env_db_path, resolve_db_path};
+    use webfang_core::infrastructure::persistence::{
+        create_pool, setup_schema, SqliteVectorRepository,
+    };
+
+    let db_path = resolve_db_path(None, env_db_path());
+    let pool = create_pool(&db_path, 4)?;
+    setup_schema(&pool).await?;
+    Ok(Arc::new(SqliteVectorRepository::new(pool)))
+}

--- a/crates/webfang_mcp/src/mcp_server/ai_wiring.rs
+++ b/crates/webfang_mcp/src/mcp_server/ai_wiring.rs
@@ -26,30 +26,28 @@ use webfang_core::domain::embedding_port::EmbeddingPort;
 
 /// Wire the vault-search AI ports into `container`.
 ///
-/// Injects, in order: the ONNX [`EmbeddingAdapter`](webfang_ai::EmbeddingAdapter),
-/// a [`MarkdownChunker`](webfang_ai::MarkdownChunker), and a SQLite-backed
-/// [`NoteRepository`]. Degradation is incremental: if the embedding adapter
-/// cannot be built the container is returned unchanged (vault search requires
-/// all three ports); if only the note repository fails, the embedding port and
-/// chunker remain wired.
+/// Injects, in order: the ONNX [`EmbeddingAdapter`](webfang_ai::EmbeddingAdapter)
+/// — assembled from the semantic cleaner's shared inference pool + tokenizer, so
+/// the ONNX model is loaded exactly once — a
+/// [`MarkdownChunker`](webfang_ai::MarkdownChunker), and a SQLite-backed
+/// [`NoteRepository`]. Embedding + chunker assembly is infallible (the components
+/// are already valid); only the note repository can fail, in which case the
+/// embedding port and chunker remain wired and vault search degrades to an honest
+/// "not available" error at call time.
 ///
 /// # Errors
 ///
-/// Never fails — every construction error is logged and degraded around, so the
-/// caller always receives a usable [`Container`].
+/// Never fails — the note-repository construction error is logged and degraded
+/// around, so the caller always receives a usable [`Container`].
 #[must_use]
 pub async fn wire_ai_ports(
     mut container: Container,
-    model_config: &webfang_ai::ModelConfig,
+    pool: Arc<webfang_ai::InferencePool>,
+    tokenizer: Arc<webfang_ai::MiniLmTokenizer>,
 ) -> Container {
-    // 1. Embedding port (ONNX adapter) — the hard dependency for vault search.
-    let adapter = match webfang_ai::EmbeddingAdapter::from_config(model_config).await {
-        Ok(adapter) => adapter,
-        Err(e) => {
-            tracing::warn!("embedding port unavailable, continuing without vault search: {e}");
-            return container;
-        },
-    };
+    // 1. Embedding port (ONNX adapter) — shares the cleaner's pool + tokenizer,
+    //    so this is infallible (no model resolution happens here).
+    let adapter = webfang_ai::EmbeddingAdapter::new(pool, tokenizer);
     let dim = adapter.embedding_dim();
     container = container.with_embedding_port(Arc::new(adapter));
 
@@ -70,7 +68,10 @@ pub async fn wire_ai_ports(
                 );
             },
             Err(e) => {
-                tracing::warn!("note repository unavailable, vault search persistence disabled: {e}");
+                tracing::warn!(
+                    error = %e,
+                    "note repository unavailable, vault search persistence disabled"
+                );
             },
         }
     }
@@ -94,8 +95,10 @@ pub async fn wire_ai_ports(
 /// Only compiled when the `persistence` feature is explicitly enabled — the
 /// consumer opts in with `--features ai,persistence`.
 #[cfg(feature = "persistence")]
-async fn build_note_repository(
-) -> Result<Arc<dyn webfang_core::domain::note_repository::NoteRepository>, Box<dyn std::error::Error + Send + Sync>> {
+async fn build_note_repository() -> Result<
+    Arc<dyn webfang_core::domain::note_repository::NoteRepository>,
+    Box<dyn std::error::Error + Send + Sync>,
+> {
     use webfang_core::infrastructure::autotuning::{env_db_path, resolve_db_path};
     use webfang_core::infrastructure::persistence::{
         create_pool, setup_schema, SqliteVectorRepository,

--- a/crates/webfang_mcp/src/mcp_server/mod.rs
+++ b/crates/webfang_mcp/src/mcp_server/mod.rs
@@ -18,6 +18,10 @@ pub mod selector_service;
 pub mod server;
 pub mod state;
 
+/// Vault-search AI port wiring (#433) — only compiled with the `ai` feature.
+#[cfg(feature = "ai")]
+pub mod ai_wiring;
+
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{CallToolResult, ListToolsResult, ServerCapabilities, ServerInfo, Tool};

--- a/crates/webfang_mcp/tests/mcp_behavioral_test.rs
+++ b/crates/webfang_mcp/tests/mcp_behavioral_test.rs
@@ -1146,10 +1146,13 @@ async fn test_metrics_empty_state_honest_error() {
 // ============================================================================
 
 /// REQ-04: search_obsidian returns an honest `CallToolResult::error`
-/// (isError:true, Spanish) stating the capability is not yet implemented and
-/// Without `--features ai`, the embedding/note/chunker ports are absent.
-/// `search_obsidian` must return an honest Spanish error explaining the
-/// missing capability — never a false success, never a protocol error.
+/// (isError:true, Spanish) when the vault-search ports are absent.
+///
+/// `start_test_server` builds a bare `Container` and never wires the
+/// embedding/note/chunker ports (the production wiring lives in the
+/// `mcp_server` example behind `WEBFANG_MCP_AI`, #433), so this asserts the
+/// permanent "ports absent → honest error" contract: never a false success,
+/// never a protocol error — independent of whether `--features ai` is compiled.
 #[tokio::test]
 async fn test_search_obsidian_not_implemented_is_honest_error() {
     let (base_url, _handle) = start_test_server().await;


### PR DESCRIPTION
Closes #433

## Summary

Concrete adapter connecting `InferencePool` (webfang_ai) to the domain `EmbeddingPort`, plus production wiring of all three vault-search ports in CLI and MCP.

### What's new

- **`EmbeddingAdapter`** (`webfang_ai/src/infrastructure_ai/embedding_adapter.rs`): wraps `Arc<InferencePool>` + `Arc<MiniLmTokenizer>`, implements `EmbeddingPort` with span-instrumented `embed`/`embed_batch` and a `from_config()` constructor that reuses the extracted `resolve_model_assets` (DRY with SemanticCleanerImpl).
- **`ai_wiring.rs`** (`webfang_mcp/src/mcp_server/`): composition helper that wires embedding + chunker (+ note repo when `persistence` is explicitly enabled) with graceful degradation.
- **`VaultAiPorts`** bundle + `Container::with_vault_ports()` in core.
- **CLI wiring**: `build_vault_ports()` under `#[cfg(feature = "ai")]` in main.rs.
- **MCP example**: calls `wire_ai_ports` after the cleaner.

### Feature stratification

`ai` and `persistence` are **independent** features in `webfang_mcp`:
- `--features ai` → embedding adapter + Markdown chunker (no SQLite dependency)
- `--features ai,persistence` → full RAG stack with SQLite note repository
- No features → honest error in `search_obsidian` (existing behavior preserved)

### Verification

- `cargo check --features ai` ✅
- `cargo clippy --features ai -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo nextest run --features ai -p webfang_ai` → 125+ tests pass ✅
- Feature combos: default (no ai), ai, ai+persistence, workspace --features ai ✅