### PR TITLE
fix(crawler): crawl_site max_depth now follows internal links (#479)

### DIFF
--- a/crates/webfang_core/src/application/crawler/crawl_scheduler.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_scheduler.rs
@@ -75,16 +75,6 @@ impl CrawlScheduler {
         self.autoscale_level = Some(level);
     }
 
-    /// Clone the visited deduplicator for the shared task context.
-    pub(crate) fn visited(&self) -> Arc<UrlDeduplicator> {
-        Arc::clone(&self.visited)
-    }
-
-    /// Clone the visited-URL string mirror for the shared task context.
-    pub(crate) fn visited_urls(&self) -> Arc<RwLock<Vec<String>>> {
-        Arc::clone(&self.visited_urls)
-    }
-
     /// Clone the discovery queue for the shared task context.
     pub(crate) fn queue(&self) -> Arc<UrlQueue> {
         Arc::clone(&self.queue)

--- a/crates/webfang_core/src/application/crawler/crawl_task.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task.rs
@@ -192,6 +192,12 @@ pub(crate) async fn run_crawl_task(
                     if let Ok(parsed_link) = Url::parse(&link) {
                         if let Some(seed_domain) = ctx.config.seed_url.host_str() {
                             let link_domain = parsed_link.host_str().unwrap_or("");
+                            // Enqueue-time dedup is owned by the queue's `seen` set
+                            // inside `push_prioritized`. The `visited` set is marked
+                            // only at dispatch time (`CrawlScheduler::record_visit`),
+                            // so a freshly discovered link must NOT be pre-marked
+                            // here: doing so made `next_url` discard it as already
+                            // visited, silently dropping every internal link (#479).
                             if is_internal_link(&link, seed_domain)
                                 && is_allowed(&link, &ctx.config)
                                 && (ctx.ignore_robots
@@ -199,12 +205,7 @@ pub(crate) async fn run_crawl_task(
                                         .robots_checker
                                         .is_robots_allowed(&link, link_domain)
                                         .await)
-                                && ctx.visited.try_insert(&link)
                             {
-                                if let Ok(mut urls) = ctx.visited_urls.write() {
-                                    urls.push(link.clone());
-                                }
-
                                 let new_discovered = DiscoveredUrl::html(
                                     parsed_link,
                                     url_depth + 1,
@@ -244,7 +245,6 @@ mod tests {
     use crate::application::crawler::ports::{
         ContentPipeline, CrawlResultCollector, LinkExtractorPort, PageFetcher, RobotsChecker,
     };
-    use crate::application::deduplicator::UrlDeduplicator;
     use crate::application::pipeline::stages::output::OutputError;
     use crate::application::pipeline::OutputStage;
     use crate::application::rate_limiter::{RateLimiterConfig, SharedRateLimiter};
@@ -492,8 +492,6 @@ mod tests {
             Arc::new(CrawlTaskCtx {
                 config: Arc::new(config),
                 correlation_id: CorrelationId::new(),
-                visited: Arc::new(UrlDeduplicator::new()),
-                visited_urls: Arc::new(RwLock::new(Vec::new())),
                 queue: Arc::new(UrlQueue::new()),
                 rate_limiter,
                 session_pool: self.session_pool,
@@ -846,13 +844,23 @@ mod tests {
                 behavior: ExtractBehavior::Links(vec!["https://example.com/dup".to_string()]),
             }))
             .build();
-        assert!(ctx.visited.try_insert("https://example.com/dup"));
         let queue = Arc::clone(&ctx.queue);
+        // Pre-enqueue the URL so the queue's dedup set (`seen`) already contains
+        // it. Enqueue-time dedup lives in `push_prioritized`, not in the `visited`
+        // set (which is reserved for dispatch-time dedup — see #479).
+        let seed = test_url("https://example.com/", 0);
+        let dup = DiscoveredUrl::html(
+            Url::parse("https://example.com/dup").expect("valid test URL"),
+            1,
+            seed.url.clone(),
+        );
+        assert!(queue.push_prioritized(dup, UrlSource::Link).await);
 
-        run_crawl_task(ctx, test_url("https://example.com/", 0))
+        run_crawl_task(ctx, seed)
             .await
             .expect("crawl should succeed");
-        assert!(queue.is_empty().await);
+        // Only the pre-seeded entry remains — the task's duplicate was rejected.
+        assert_eq!(queue.len().await, 1);
     }
 
     // ── Tests: external links ──

--- a/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
@@ -12,7 +12,6 @@ use crate::application::crawler::checkpoint::BannedDomain;
 use crate::application::crawler::ports::{
     ContentPipeline, CrawlResultCollector, LinkExtractorPort, PageFetcher, RobotsChecker,
 };
-use crate::application::deduplicator::UrlDeduplicator;
 use crate::application::pipeline::OutputStage;
 use crate::application::rate_limiter::SharedRateLimiter;
 use crate::domain::session_port::SessionPort;
@@ -30,8 +29,6 @@ pub struct CrawlTaskCtx {
     /// Root correlation ID for the crawl — every task derives a child from it
     /// so all pages share one `trace_id` (issue #356).
     pub(crate) correlation_id: CorrelationId,
-    pub(crate) visited: Arc<UrlDeduplicator>,
-    pub(crate) visited_urls: Arc<RwLock<Vec<String>>>,
     pub(crate) queue: Arc<UrlQueue>,
     pub(crate) rate_limiter: SharedRateLimiter,
     pub(crate) session_pool: Option<Arc<dyn SessionPort>>,

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -391,8 +391,6 @@ impl Engine {
         let task_ctx = Arc::new(CrawlTaskCtx {
             config: Arc::clone(&self.config),
             correlation_id: self.correlation_id.clone(),
-            visited: self.scheduler.visited(),
-            visited_urls: self.scheduler.visited_urls(),
             queue: self.scheduler.queue(),
             rate_limiter: self.rate_limiter.clone(),
             session_pool: self

--- a/crates/webfang_core/src/application/url_filter.rs
+++ b/crates/webfang_core/src/application/url_filter.rs
@@ -181,9 +181,7 @@ pub fn is_allowed(url: &str, config: &CrawlerConfig) -> bool {
 #[inline]
 #[must_use]
 pub fn extract_domain(url: &str) -> Option<String> {
-    url::Url::parse(url)
-        .ok()
-        .and_then(|u| u.host_str().map(String::from))
+    crate::domain::url_validation::extract_domain(url)
 }
 
 /// Check if a URL is internal (same domain as seed)
@@ -211,9 +209,7 @@ pub fn extract_domain(url: &str) -> Option<String> {
 #[inline]
 #[must_use]
 pub fn is_internal_link(url: &str, seed_domain: &str) -> bool {
-    extract_domain(url)
-        .map(|domain| domain == seed_domain || domain.ends_with(&format!(".{seed_domain}")))
-        .unwrap_or(false)
+    crate::domain::url_validation::is_internal_link(url, seed_domain)
 }
 
 #[cfg(test)]

--- a/crates/webfang_core/src/domain/link_extractor.rs
+++ b/crates/webfang_core/src/domain/link_extractor.rs
@@ -34,20 +34,10 @@ pub struct LinkProcessor;
 impl LinkProcessor {
     /// Check if a URL is internal (same domain)
     ///
-    /// Pure function for domain checking logic.
+    /// Delegates to the canonical, port-safe
+    /// [`crate::domain::url_validation::is_internal_link`].
     pub fn is_internal_link(url: &str, domain: &str) -> bool {
-        Self::extract_domain(url)
-            .map(|url_domain| url_domain == domain || url_domain.ends_with(&format!(".{domain}")))
-            .unwrap_or(false)
-    }
-
-    /// Extract domain from URL
-    ///
-    /// Pure function for domain extraction.
-    fn extract_domain(url: &str) -> Option<&str> {
-        url.split("://")
-            .nth(1)
-            .and_then(|rest| rest.split('/').next())
+        crate::domain::url_validation::is_internal_link(url, domain)
     }
 }
 

--- a/crates/webfang_core/src/domain/url_validation.rs
+++ b/crates/webfang_core/src/domain/url_validation.rs
@@ -80,6 +80,122 @@ pub fn validate_and_parse_url(url: &str) -> Result<url::Url> {
     Ok(parsed)
 }
 
+/// Extract the host (domain) from a URL, without any port component.
+///
+/// Uses [`url::Url::host_str`] for RFC 3986 compliant parsing. Unlike naive
+/// `split(':')` approaches, this correctly returns the host WITHOUT the port:
+/// - Ports: `http://127.0.0.1:8080/page` → `127.0.0.1`
+/// - Credentials: `http://user:pass@domain.com` → `domain.com`
+/// - IPv6: `http://[::1]:8080` → `[::1]`
+///
+/// # Arguments
+///
+/// * `url` - URL to extract the host from
+///
+/// # Returns
+///
+/// The host without port, or `None` if the URL cannot be parsed or has no host.
+///
+/// # Examples
+///
+/// ```
+/// use webfang_core::domain::url_validation::extract_domain;
+///
+/// assert_eq!(extract_domain("http://127.0.0.1:8080/page"), Some("127.0.0.1".to_string()));
+/// assert_eq!(extract_domain("https://example.com/path"), Some("example.com".to_string()));
+/// assert_eq!(extract_domain("http://[::1]:8080"), Some("[::1]".to_string()));
+/// assert_eq!(extract_domain("not-a-url"), None);
+/// ```
+#[inline]
+#[must_use]
+pub fn extract_domain(url: &str) -> Option<String> {
+    url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(String::from))
+}
+
+/// Normalize a seed reference to a bare host string (no scheme, port, or path).
+///
+/// Accepts both full URLs and bare hosts:
+/// - Full URL: `https://example.com:9090/path` → `example.com` (via
+///   [`url::Url::host_str`], which drops the port).
+/// - Bare host: `example.com/path` → `example.com` (path stripped) and
+///   `example.com:8080` → `example.com` (port stripped).
+///
+/// This is the canonical seed-host normalizer shared by the crawl engine and the
+/// MCP `is_internal_link` tool, so both classify links against the same bare host.
+///
+/// # Arguments
+///
+/// * `seed` - Seed URL or bare host to normalize
+///
+/// # Returns
+///
+/// The bare host component.
+///
+/// # Examples
+///
+/// ```
+/// use webfang_core::domain::url_validation::normalize_seed_host;
+///
+/// assert_eq!(normalize_seed_host("https://example.com/path"), "example.com");
+/// assert_eq!(normalize_seed_host("example.com"), "example.com");
+/// assert_eq!(normalize_seed_host("example.com/path"), "example.com");
+/// assert_eq!(normalize_seed_host("example.com:8080"), "example.com");
+/// ```
+#[inline]
+#[must_use]
+pub fn normalize_seed_host(seed: &str) -> String {
+    if let Ok(u) = url::Url::parse(seed) {
+        if let Some(host) = u.host_str() {
+            return host.to_string();
+        }
+    }
+    // Bare host: strip any accidental path suffix, then any :port suffix.
+    let without_path = seed.split('/').next().unwrap_or(seed);
+    without_path
+        .split(':')
+        .next()
+        .unwrap_or(without_path)
+        .to_string()
+}
+
+/// Check whether a URL is internal to a seed domain (same host or subdomain).
+///
+/// Both the URL host and the seed are normalized to bare hosts (port stripped)
+/// before comparison, so URLs with an explicit port are handled correctly. This
+/// is the single canonical implementation shared by the crawl engine and the MCP
+/// `is_internal_link` tool (#479).
+///
+/// # Arguments
+///
+/// * `url` - URL to classify
+/// * `seed_domain` - Seed host or full URL to compare against
+///
+/// # Returns
+///
+/// `true` if `url`'s host equals the seed host or is a subdomain of it.
+///
+/// # Examples
+///
+/// ```
+/// use webfang_core::domain::url_validation::is_internal_link;
+///
+/// assert!(is_internal_link("https://example.com/page", "example.com"));
+/// assert!(is_internal_link("https://blog.example.com/post", "example.com"));
+/// // The port case that broke the crawl engine (#479):
+/// assert!(is_internal_link("http://127.0.0.1:8080/page", "127.0.0.1"));
+/// assert!(!is_internal_link("http://other.com:8080/x", "example.com"));
+/// ```
+#[inline]
+#[must_use]
+pub fn is_internal_link(url: &str, seed_domain: &str) -> bool {
+    let seed_host = normalize_seed_host(seed_domain);
+    extract_domain(url)
+        .map(|host| host == seed_host || host.ends_with(&format!(".{seed_host}")))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -107,5 +223,71 @@ mod tests {
         let url = validate_and_parse_url("  https://example.com  ");
         assert!(url.is_ok());
         assert_eq!(url.unwrap().host_str(), Some("example.com"));
+    }
+
+    // ========================================================================
+    // Port-safety regression tests (#479)
+    //
+    // The crawl engine seeded `seed_domain` from `Url::host_str()` (port
+    // stripped) but compared it against a host extracted with a naive
+    // `split('/')` that KEPT the port. Any URL with an explicit port (wiremock,
+    // non-standard ports) silently filtered every internal link. These tests
+    // pin the corrected, port-safe behavior of the canonical component.
+    // ========================================================================
+
+    #[test]
+    fn extract_domain_strips_port() {
+        assert_eq!(
+            extract_domain("http://127.0.0.1:8080/page"),
+            Some("127.0.0.1".to_string())
+        );
+    }
+
+    #[test]
+    fn is_internal_link_loopback_with_port_is_internal() {
+        // THE bug case: seed from host_str() has no port, URL keeps its port.
+        assert!(is_internal_link("http://127.0.0.1:8080/page", "127.0.0.1"));
+    }
+
+    #[test]
+    fn is_internal_link_localhost_with_port_is_internal() {
+        assert!(is_internal_link("http://localhost:3000/a", "localhost"));
+    }
+
+    #[test]
+    fn is_internal_link_subdomain_with_port_is_internal() {
+        assert!(is_internal_link(
+            "http://blog.example.com:8080/post",
+            "example.com"
+        ));
+    }
+
+    #[test]
+    fn is_internal_link_seed_as_full_url_different_port_is_internal() {
+        assert!(is_internal_link(
+            "http://example.com:8080/x",
+            "http://example.com:9090"
+        ));
+    }
+
+    #[test]
+    fn is_internal_link_other_host_with_port_is_external() {
+        assert!(!is_internal_link("http://other.com:8080/x", "example.com"));
+    }
+
+    #[test]
+    fn normalize_seed_host_handles_url_port_path_and_bare() {
+        assert_eq!(
+            normalize_seed_host("https://example.com/path"),
+            "example.com"
+        );
+        assert_eq!(
+            normalize_seed_host("http://example.com:9090"),
+            "example.com"
+        );
+        assert_eq!(normalize_seed_host("example.com"), "example.com");
+        assert_eq!(normalize_seed_host("example.com/path"), "example.com");
+        assert_eq!(normalize_seed_host("example.com:8080"), "example.com");
+        assert_eq!(normalize_seed_host(""), "");
     }
 }

--- a/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
@@ -100,9 +100,7 @@ pub fn extract_links(html: &str, base_url: &str) -> Result<Vec<String>, crate::d
 #[inline]
 #[must_use]
 pub fn is_internal_link(url: &str, domain: &str) -> bool {
-    extract_domain(url)
-        .map(|url_domain| url_domain == domain || url_domain.ends_with(&format!(".{domain}")))
-        .unwrap_or(false)
+    crate::domain::url_validation::is_internal_link(url, domain)
 }
 
 /// Normalize a URL (remove fragments, strip www, remove default ports, etc.)
@@ -229,26 +227,6 @@ fn collapse_index_path(url: &str) -> String {
         },
         None => url.to_string(),
     }
-}
-
-/// Extract domain from URL
-///
-/// Following **own-borrow-over-clone**: Accepts `&str`.
-/// Following **opt-inline**: Inlined for hot path.
-///
-/// # Arguments
-///
-/// * `url` - URL to extract domain from
-///
-/// # Returns
-///
-/// Domain string or None if invalid
-#[inline]
-#[must_use]
-fn extract_domain(url: &str) -> Option<&str> {
-    url.split("://")
-        .nth(1)
-        .and_then(|rest| rest.split('/').next())
 }
 
 /// HTML link extractor implementation

--- a/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
@@ -124,12 +124,10 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         let _permit = acquire_semaphore!(self, url_utils);
 
-        let seed_host = normalize_seed_host(&params.seed_domain);
-        let is_internal = url::Url::parse(&params.url)
-            .ok()
-            .and_then(|u| u.host_str().map(String::from))
-            .map(|url_host| url_host == seed_host || url_host.ends_with(&format!(".{seed_host}")))
-            .unwrap_or(false);
+        let is_internal = webfang_core::domain::url_validation::is_internal_link(
+            &params.url,
+            &params.seed_domain,
+        );
         Ok(CallToolResult::success(vec![Content::text(
             is_internal.to_string(),
         )]))
@@ -165,27 +163,13 @@ impl McpHandler {
     }
 }
 
-/// Normalize a seed domain input to a bare host string.
-///
-/// Accepts both bare domains (`example.com`) and full URLs (`https://example.com/path`).
-/// For URLs, extracts the host component. For bare domains, strips any path suffix.
-fn normalize_seed_host(seed: &str) -> String {
-    if let Ok(u) = url::Url::parse(seed) {
-        if let Some(host) = u.host_str() {
-            return host.to_string();
-        }
-    }
-    // Bare domain — strip any accidental path component
-    seed.split('/').next().unwrap_or(seed).to_string()
-}
-
 pub fn build_router() -> ToolRouter<McpHandler> {
     McpHandler::tool_router_url_utils()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use webfang_core::domain::url_validation::normalize_seed_host;
 
     #[test]
     fn normalize_seed_host_bare_domain() {
@@ -231,12 +215,7 @@ mod tests {
     // --- Integration-style tests for the classification logic ---
 
     fn classify(url: &str, seed_domain: &str) -> bool {
-        let seed_host = normalize_seed_host(seed_domain);
-        url::Url::parse(url)
-            .ok()
-            .and_then(|u| u.host_str().map(String::from))
-            .map(|url_host| url_host == seed_host || url_host.ends_with(&format!(".{seed_host}")))
-            .unwrap_or(false)
+        webfang_core::domain::url_validation::is_internal_link(url, seed_domain)
     }
 
     #[test]

--- a/crates/webfang_mcp/tests/scraping_coverage_test.rs
+++ b/crates/webfang_mcp/tests/scraping_coverage_test.rs
@@ -526,10 +526,6 @@ async fn test_crawl_site_max_depth_zero_single_page() {
 /// max_depth=1 follows internal links one level: seed + page_a + page_b, with
 /// zero errors. The `urls` array is order-independent (JoinSet concurrency).
 #[tokio::test]
-/// FIXME: This test reveals a potential crawler bug — with max_depth=1,
-/// the crawler only crawls the seed page and does not follow internal links.
-/// Investigate separately (not in scope for #450 coverage issue).
-#[ignore = "potential crawler bug: max_depth=1 does not follow internal links"]
 async fn test_crawl_site_max_depth_one_follows_internal_links() {
     let mock = MockServer::start().await;
     let index_html = r#"<html><body>


### PR DESCRIPTION
## Linked Issue

Closes #479

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- `crawl_site` with `max_depth >= 1` crawled only the seed page and silently dropped every internal link. The ignored test `test_crawl_site_max_depth_one_follows_internal_links` failed 3/3 — it was correct; this was a real production bug (any site on a non-standard port, e.g. `localhost:3000`, never followed internal links).
- Root cause was **two stacked bugs**: (1) a port mismatch in `is_internal_link`, and (2) discovered links being double-marked in the `visited` set so the scheduler discarded them at dispatch time. Both are fixed and the test is re-enabled.
- `is_internal_link` / `extract_domain` / `normalize_seed_host` are consolidated into a single canonical, port-safe, RFC 3986 component in `domain/url_validation.rs`; the three divergent copies and the MCP tool now delegate to it.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/domain/url_validation.rs` | New canonical `extract_domain` / `normalize_seed_host` / `is_internal_link` (`url::Url::host_str()`-based, port-safe) + 7 port-safety regression tests |
| `crates/webfang_core/src/application/url_filter.rs` | `extract_domain` + `is_internal_link` delegate to domain (public API unchanged) |
| `crates/webfang_core/src/infrastructure/crawler/link_extractor.rs` | `is_internal_link` delegates to domain; deleted the buggy naive `extract_domain` (kept `extract_links`/`normalize_url`) |
| `crates/webfang_core/src/domain/link_extractor.rs` | `LinkProcessor::is_internal_link` delegates to domain; deleted naive `extract_domain` |
| `crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs` | `is_internal_link` tool delegates to core; removed the duplicate local `normalize_seed_host` |
| `crates/webfang_core/src/application/crawler/crawl_task.rs` | Removed the enqueue-time `visited` pre-mark that made `next_url` discard every link (bug 2); rewrote `test_duplicate_link_not_queued` to exercise the queue `seen` dedup |
| `crates/webfang_core/src/application/crawler/crawl_task_ctx.rs` | Removed now-dead `visited` / `visited_urls` fields |
| `crates/webfang_core/src/application/crawler/crawl_scheduler.rs` | Removed now-unused `visited()` / `visited_urls()` accessors (scheduler keeps its own internal sets for `record_visit`/checkpoints) |
| `crates/webfang_core/src/application/crawler/engine.rs` | Dropped the dead `visited`/`visited_urls` task-context wiring |
| `crates/webfang_mcp/tests/scraping_coverage_test.rs` | Re-enabled `test_crawl_site_max_depth_one_follows_internal_links` (removed `#[ignore]` + FIXME) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features mcp -- -D warnings` clean
- [x] `cargo nextest run -p webfang_mcp --features mcp --test scraping_coverage_test` — 8/8 pass (incl. the re-enabled #479 test)
- [x] `cargo nextest run -p webfang_core crawler` — 250/250 pass
- [x] Manually verified via targeted instrumentation that depth-1 links are now enqueued, drained, dispatched, and crawled (`total_pages == 3`)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (doc comments on the new canonical domain functions)
