### PR TITLE
feat(mcp): add eager vault indexing with staleness detection (#435)

### DIFF
--- a/crates/webfang_core/src/application/vault_search.rs
+++ b/crates/webfang_core/src/application/vault_search.rs
@@ -10,14 +10,18 @@
 //! Injects domain ports (`EmbeddingPort`, `NoteRepository`, `TextChunker`)
 //! — no dependency on `webfang_ai` concrete types.
 
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 use crate::domain::embedding_port::EmbeddingPort;
 use crate::domain::note_repository::NoteRepository;
 use crate::domain::text_chunker::TextChunker;
 use crate::error::ScraperError;
+use crate::infrastructure::obsidian::read_vault_notes;
 
 /// A search result with relevance score and source metadata.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -32,6 +36,22 @@ pub struct VaultSearchResult {
     pub chunk_index: i64,
     /// Heading context (if available from chunking metadata).
     pub heading: Option<String>,
+}
+
+/// Summary of a vault sync operation.
+///
+/// Returned by [`VaultSearchService::sync_vault`] after reconciling
+/// the filesystem vault against the persistent index.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+pub struct SyncSummary {
+    /// Notes newly indexed (not previously in the index).
+    pub indexed: usize,
+    /// Notes re-indexed because their content hash changed.
+    pub updated: usize,
+    /// Notes removed from the index (deleted from the vault).
+    pub deleted: usize,
+    /// Notes already indexed with matching content hash (skipped).
+    pub unchanged: usize,
 }
 
 /// Semantic search service for Obsidian vault notes.
@@ -208,6 +228,112 @@ impl VaultSearchService {
     pub async fn remove_note(&self, path: &str) -> Result<(), ScraperError> {
         self.repository.delete_note(path).await
     }
+
+    /// Synchronize the vault filesystem against the persistent index.
+    ///
+    /// # Pipeline
+    ///
+    /// 1. Read all `.md` notes from the vault via [`read_vault_notes`]
+    /// 2. Load all indexed note metadata via [`NoteRepository::list_indexed_notes`]
+    /// 3. Compare content hashes:
+    ///    - **New** note (not indexed) → [`index_note`](Self::index_note)
+    ///    - **Changed** note (hash differs) → re-index
+    ///    - **Deleted** note (indexed but gone from vault) → [`remove_note`](Self::remove_note)
+    ///    - **Unchanged** → skip
+    /// 4. Return a [`SyncSummary`] with counts
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScraperError`] if vault reading, database access,
+    /// embedding, or persistence fails. Individual note indexing errors
+    /// are logged and skipped (best-effort sync).
+    #[instrument(skip(self), fields(vault_path = %vault_path.display()))]
+    pub async fn sync_vault(&self, vault_path: &Path) -> Result<SyncSummary, ScraperError> {
+        let start = Instant::now();
+
+        // Step 1: Read all notes from the vault filesystem.
+        let notes = read_vault_notes(vault_path)?;
+
+        // Step 2: Load all indexed note metadata.
+        let indexed = self.repository.list_indexed_notes().await?;
+
+        // Build lookup structures.
+        let indexed_map: HashMap<&str, &str> = indexed
+            .iter()
+            .map(|m| (m.path.as_str(), m.content_hash.as_str()))
+            .collect();
+        let vault_paths: HashSet<&str> = notes.iter().map(|n| n.path.as_str()).collect();
+
+        let mut summary = SyncSummary::default();
+
+        // Step 3a: Index new and changed notes.
+        for note in &notes {
+            match indexed_map.get(note.path.as_str()) {
+                None => {
+                    // New note — never indexed.
+                    match self
+                        .index_note(
+                            &note.path,
+                            &note.content,
+                            &note.content_hash,
+                            note.mtime_secs,
+                        )
+                        .await
+                    {
+                        Ok(_) => summary.indexed += 1,
+                        Err(e) => {
+                            warn!(path = %note.path, "failed to index note: {e}");
+                        },
+                    }
+                },
+                Some(stored_hash) if *stored_hash != note.content_hash => {
+                    // Changed note — content hash differs.
+                    match self
+                        .index_note(
+                            &note.path,
+                            &note.content,
+                            &note.content_hash,
+                            note.mtime_secs,
+                        )
+                        .await
+                    {
+                        Ok(_) => summary.updated += 1,
+                        Err(e) => {
+                            warn!(path = %note.path, "failed to re-index note: {e}");
+                        },
+                    }
+                },
+                Some(_) => {
+                    // Unchanged — hash matches.
+                    summary.unchanged += 1;
+                },
+            }
+        }
+
+        // Step 3b: Delete notes that are no longer in the vault.
+        for meta in &indexed {
+            if !vault_paths.contains(meta.path.as_str()) {
+                match self.remove_note(&meta.path).await {
+                    Ok(()) => summary.deleted += 1,
+                    Err(e) => {
+                        warn!(path = %meta.path, "failed to delete stale note: {e}");
+                    },
+                }
+            }
+        }
+
+        let duration = start.elapsed();
+        info!(
+            indexed = summary.indexed,
+            updated = summary.updated,
+            deleted = summary.deleted,
+            unchanged = summary.unchanged,
+            duration_ms = duration.as_millis() as u64,
+            "vault sync completed"
+        );
+
+        Ok(summary)
+    }
 }
 
 /// Cosine similarity between two vectors.
@@ -296,5 +422,283 @@ mod tests {
         let debug = format!("{result:?}");
         assert!(debug.contains("vault/rust.md"));
         assert!(debug.contains("0.95"));
+    }
+
+    #[test]
+    fn test_sync_summary_default() {
+        let summary = SyncSummary::default();
+        assert_eq!(summary.indexed, 0);
+        assert_eq!(summary.updated, 0);
+        assert_eq!(summary.deleted, 0);
+        assert_eq!(summary.unchanged, 0);
+    }
+
+    // --- Stub ports for sync_vault tests ---
+
+    use crate::domain::note_repository::{IndexedNoteMeta, NoteChunkVector};
+    use crate::error::SemanticError;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Mutex;
+
+    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+    /// Stub embedder: returns a fixed 3-dim vector for any input.
+    struct StubEmbedding;
+
+    impl EmbeddingPort for StubEmbedding {
+        fn embed<'a>(&'a self, _text: &'a str) -> BoxFuture<'a, Result<Vec<f32>, SemanticError>> {
+            Box::pin(async { Ok(vec![0.1, 0.2, 0.3]) })
+        }
+
+        fn embedding_dim(&self) -> usize {
+            3
+        }
+    }
+
+    /// Stub chunker: splits on newlines, one chunk per line.
+    struct StubChunker;
+
+    impl TextChunker for StubChunker {
+        fn chunk_text(&self, text: &str) -> Result<Vec<String>, SemanticError> {
+            Ok(text
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(String::from)
+                .collect())
+        }
+    }
+
+    /// In-memory note repository for testing sync logic.
+    #[derive(Default)]
+    struct InMemoryNoteRepo {
+        notes: Mutex<Vec<IndexedNoteMeta>>,
+        chunks: Mutex<Vec<NoteChunkVector>>,
+        next_id: Mutex<i64>,
+    }
+
+    impl NoteRepository for InMemoryNoteRepo {
+        fn save_note<'a>(
+            &'a self,
+            path: &'a str,
+            content_hash: &'a str,
+            mtime_secs: i64,
+        ) -> BoxFuture<'a, Result<i64, ScraperError>> {
+            Box::pin(async move {
+                let mut notes = self.notes.lock().unwrap();
+                // Update existing or insert new.
+                if let Some(existing) = notes.iter_mut().find(|n| n.path == path) {
+                    existing.content_hash = content_hash.to_owned();
+                    existing.mtime_secs = mtime_secs;
+                    return Ok(1);
+                }
+                let mut id = self.next_id.lock().unwrap();
+                *id += 1;
+                notes.push(IndexedNoteMeta {
+                    path: path.to_owned(),
+                    content_hash: content_hash.to_owned(),
+                    mtime_secs,
+                });
+                Ok(*id)
+            })
+        }
+
+        fn save_note_chunk<'a>(
+            &'a self,
+            note_id: i64,
+            chunk_index: i64,
+            content: &'a str,
+            embedding: Option<&'a [f32]>,
+        ) -> BoxFuture<'a, Result<(), ScraperError>> {
+            Box::pin(async move {
+                let _ = note_id;
+                self.chunks.lock().unwrap().push(NoteChunkVector {
+                    note_path: String::new(),
+                    content: content.to_owned(),
+                    chunk_index,
+                    embedding: embedding.unwrap_or_default().to_vec(),
+                });
+                Ok(())
+            })
+        }
+
+        fn load_all_vectors(&self) -> BoxFuture<'_, Result<Vec<NoteChunkVector>, ScraperError>> {
+            Box::pin(async { Ok(self.chunks.lock().unwrap().clone()) })
+        }
+
+        fn note_needs_reindex<'a>(
+            &'a self,
+            path: &'a str,
+            content_hash: &'a str,
+        ) -> BoxFuture<'a, Result<bool, ScraperError>> {
+            Box::pin(async move {
+                let notes = self.notes.lock().unwrap();
+                match notes.iter().find(|n| n.path == path) {
+                    Some(n) => Ok(n.content_hash != content_hash),
+                    None => Ok(true),
+                }
+            })
+        }
+
+        fn delete_note<'a>(&'a self, path: &'a str) -> BoxFuture<'a, Result<(), ScraperError>> {
+            Box::pin(async move {
+                self.notes.lock().unwrap().retain(|n| n.path != path);
+                Ok(())
+            })
+        }
+
+        fn list_indexed_notes(&self) -> BoxFuture<'_, Result<Vec<IndexedNoteMeta>, ScraperError>> {
+            Box::pin(async { Ok(self.notes.lock().unwrap().clone()) })
+        }
+    }
+
+    fn test_service(repo: Arc<InMemoryNoteRepo>) -> VaultSearchService {
+        VaultSearchService::new(Arc::new(StubEmbedding), repo, Arc::new(StubChunker))
+    }
+
+    /// Create a synthetic vault with `.obsidian/` marker and notes.
+    fn create_test_vault(tmp: &Path, notes: &[(&str, &str)]) {
+        std::fs::create_dir_all(tmp.join(".obsidian")).unwrap();
+        for (name, content) in notes {
+            if let Some(parent) = Path::new(name).parent() {
+                if !parent.as_os_str().is_empty() {
+                    std::fs::create_dir_all(tmp.join(parent)).unwrap();
+                }
+            }
+            std::fs::write(tmp.join(name), content).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_vault_indexes_new_notes() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_vault(
+            tmp.path(),
+            &[("a.md", "# A\nContent A"), ("b.md", "# B\nContent B")],
+        );
+
+        let repo = Arc::new(InMemoryNoteRepo::default());
+        let service = test_service(repo.clone());
+
+        let summary = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(summary.indexed, 2);
+        assert_eq!(summary.updated, 0);
+        assert_eq!(summary.deleted, 0);
+        assert_eq!(summary.unchanged, 0);
+
+        // Verify notes are in the repo.
+        let indexed = repo.list_indexed_notes().await.unwrap();
+        assert_eq!(indexed.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn sync_vault_skips_unchanged_notes() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_vault(tmp.path(), &[("a.md", "# A\nContent A")]);
+
+        let repo = Arc::new(InMemoryNoteRepo::default());
+        let service = test_service(repo.clone());
+
+        // First sync: indexes the note.
+        let s1 = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(s1.indexed, 1);
+
+        // Second sync: note unchanged.
+        let s2 = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(s2.indexed, 0);
+        assert_eq!(s2.updated, 0);
+        assert_eq!(s2.unchanged, 1);
+    }
+
+    #[tokio::test]
+    async fn sync_vault_detects_changed_notes() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_vault(tmp.path(), &[("a.md", "# A\nOriginal")]);
+
+        let repo = Arc::new(InMemoryNoteRepo::default());
+        let service = test_service(repo.clone());
+
+        // First sync.
+        let s1 = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(s1.indexed, 1);
+
+        // Modify the note.
+        std::fs::write(tmp.path().join("a.md"), "# A\nModified content").unwrap();
+
+        // Second sync: detects change.
+        let s2 = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(s2.indexed, 0);
+        assert_eq!(s2.updated, 1);
+        assert_eq!(s2.unchanged, 0);
+    }
+
+    #[tokio::test]
+    async fn sync_vault_deletes_removed_notes() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_vault(
+            tmp.path(),
+            &[("a.md", "# A"), ("b.md", "# B"), ("c.md", "# C")],
+        );
+
+        let repo = Arc::new(InMemoryNoteRepo::default());
+        let service = test_service(repo.clone());
+
+        // First sync: 3 notes.
+        let s1 = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(s1.indexed, 3);
+
+        // Delete one note.
+        std::fs::remove_file(tmp.path().join("b.md")).unwrap();
+
+        // Second sync: detects deletion.
+        let s2 = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(s2.deleted, 1);
+        assert_eq!(s2.unchanged, 2);
+
+        // Verify only 2 notes remain.
+        let indexed = repo.list_indexed_notes().await.unwrap();
+        assert_eq!(indexed.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn sync_vault_empty_vault() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_vault(tmp.path(), &[]);
+
+        let repo = Arc::new(InMemoryNoteRepo::default());
+        let service = test_service(repo);
+
+        let summary = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(summary, SyncSummary::default());
+    }
+
+    #[tokio::test]
+    async fn sync_vault_mixed_operations() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_vault(
+            tmp.path(),
+            &[
+                ("keep.md", "# Keep"),
+                ("change.md", "# Old"),
+                ("delete.md", "# Gone"),
+            ],
+        );
+
+        let repo = Arc::new(InMemoryNoteRepo::default());
+        let service = test_service(repo.clone());
+
+        // First sync: 3 notes.
+        service.sync_vault(tmp.path()).await.unwrap();
+
+        // Modify one, delete one, add one.
+        std::fs::write(tmp.path().join("change.md"), "# New content").unwrap();
+        std::fs::remove_file(tmp.path().join("delete.md")).unwrap();
+        std::fs::write(tmp.path().join("new.md"), "# Brand new").unwrap();
+
+        let summary = service.sync_vault(tmp.path()).await.unwrap();
+        assert_eq!(summary.indexed, 1, "new.md");
+        assert_eq!(summary.updated, 1, "change.md");
+        assert_eq!(summary.deleted, 1, "delete.md");
+        assert_eq!(summary.unchanged, 1, "keep.md");
     }
 }

--- a/crates/webfang_core/src/infrastructure/obsidian/mod.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/mod.rs
@@ -2,12 +2,14 @@
 //!
 //! This module provides Obsidian-specific functionality:
 //! - Vault auto-detection
+//! - Vault note reading
 //! - Rich metadata generation
 //! - Obsidian URI protocol support
 
 pub mod metadata;
 pub mod uri;
 pub mod vault_detector;
+pub mod vault_reader;
 
 pub use metadata::{
     compute_reading_time, compute_word_count, detect_content_type, detect_language,
@@ -15,3 +17,4 @@ pub use metadata::{
 };
 pub use uri::{build_obsidian_uri, extract_vault_name, open_in_obsidian, open_note};
 pub use vault_detector::{detect_vault, detect_vault_with_root, is_valid_vault};
+pub use vault_reader::{read_vault_notes, VaultNote};

--- a/crates/webfang_core/src/infrastructure/obsidian/vault_reader.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/vault_reader.rs
@@ -294,7 +294,7 @@ mod tests {
         create_vault(tmp.path());
         fs::write(tmp.path().join("valid.md"), "# Valid").unwrap();
         // Invalid UTF-8 sequence
-        fs::write(tmp.path().join("binary.md"), &[0xFF, 0xFE, 0x00, 0x01]).unwrap();
+        fs::write(tmp.path().join("binary.md"), [0xFF, 0xFE, 0x00, 0x01]).unwrap();
 
         let notes = read_vault_notes(tmp.path()).unwrap();
         assert_eq!(notes.len(), 1);

--- a/crates/webfang_core/src/infrastructure/obsidian/vault_reader.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/vault_reader.rs
@@ -1,0 +1,359 @@
+//! Obsidian vault note reader.
+//!
+//! Reads all Markdown notes from a detected vault directory:
+//! - Filters by `.md` extension (ignores PDFs, images, attachments)
+//! - Skips hidden directories (`.obsidian/`, `.trash/`, `.git/`, etc.)
+//! - Computes SHA-256 content hash for staleness detection
+//! - Extracts `mtime` as Unix epoch seconds
+//! - Follows symlinks (Obsidian uses them for templates)
+//! - Skips non-UTF-8 files with a tracing warning
+//!
+//! # Integration
+//!
+//! [`read_vault_notes`] receives the vault path from [`super::vault_detector`]
+//! or from the MCP `vault_path` parameter. It does NOT duplicate detection
+//! logic — the caller is responsible for providing a valid vault root.
+//!
+//! The output [`VaultNote`] fields align with
+//! [`crate::domain::IndexedNoteMeta`] so the application layer
+//! ([`crate::application::vault_search`]) can compare hashes directly
+//! for staleness detection.
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+use crate::error::ScraperError;
+
+/// A Markdown note read from an Obsidian vault.
+///
+/// Fields mirror [`crate::domain::IndexedNoteMeta`] semantics so the
+/// application layer can compare `content_hash` for staleness without
+/// conversion.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VaultNote {
+    /// Path relative to the vault root (e.g. `notes/rust.md`).
+    pub path: String,
+    /// Full UTF-8 content of the note.
+    pub content: String,
+    /// Last modification time (Unix epoch seconds).
+    pub mtime_secs: i64,
+    /// SHA-256 content hash (hex, lowercase).
+    pub content_hash: String,
+}
+
+/// Read all Markdown notes from an Obsidian vault.
+///
+/// Walks the vault directory recursively, collecting every `.md` file
+/// while skipping hidden directories (names starting with `.`).
+/// Symlinks are followed (Obsidian uses them for template folders).
+///
+/// # Arguments
+/// - `vault_path` — Root directory of the vault (should contain `.obsidian/`)
+///
+/// # Returns
+/// A vector of [`VaultNote`] for every `.md` file found.
+/// An empty vault returns `Ok(vec![])`.
+///
+/// # Errors
+/// Returns [`ScraperError::Io`] if the vault directory cannot be read
+/// or filesystem metadata is unavailable.
+pub fn read_vault_notes(vault_path: &Path) -> Result<Vec<VaultNote>, ScraperError> {
+    let mut notes = Vec::new();
+
+    let walker = WalkDir::new(vault_path)
+        .follow_links(true)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|entry| {
+            // Always include the vault root (depth 0 is excluded by min_depth,
+            // but filter_entry still sees it for pruning decisions).
+            if entry.depth() == 0 {
+                return true;
+            }
+            // Prune hidden directories entirely (`.obsidian/`, `.trash/`, `.git/`, …)
+            if entry.file_type().is_dir() {
+                if let Some(name) = entry.file_name().to_str() {
+                    return !name.starts_with('.');
+                }
+            }
+            true
+        });
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                // Symlink loops or permission errors on individual entries
+                // should not abort the entire vault read.
+                tracing::warn!("Skipping unreadable vault entry: {e}");
+                continue;
+            },
+        };
+
+        // Only process regular files with `.md` extension.
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let is_markdown = entry
+            .path()
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+        if !is_markdown {
+            continue;
+        }
+
+        let path = entry.path();
+
+        // Read raw bytes, then validate UTF-8.
+        let bytes = std::fs::read(path)?;
+        let content = match String::from_utf8(bytes) {
+            Ok(c) => c,
+            Err(_) => {
+                tracing::warn!("Skipping non-UTF-8 note: {}", path.display());
+                continue;
+            },
+        };
+
+        // mtime via filesystem metadata → Unix epoch seconds.
+        let metadata = std::fs::metadata(path)?;
+        let mtime_secs = metadata
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_secs() as i64);
+
+        let content_hash = sha256_hex(content.as_bytes());
+
+        // Store path relative to the vault root for portability.
+        let relative = path
+            .strip_prefix(vault_path)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned();
+
+        notes.push(VaultNote {
+            path: relative,
+            content,
+            mtime_secs,
+            content_hash,
+        });
+    }
+
+    tracing::debug!(
+        vault = %vault_path.display(),
+        notes = notes.len(),
+        "Vault read complete"
+    );
+
+    Ok(notes)
+}
+
+/// SHA-256 hex digest of the bytes (lowercase, dependency-free hex encoding).
+///
+/// Same pattern as `elastic_ingestion::sha256_hex` — kept module-local
+/// to avoid cross-layer coupling (infra → application).
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let hash = hasher.finalize();
+    let mut out = String::with_capacity(hash.len() * 2);
+    for b in hash {
+        use std::fmt::Write;
+        // write! into a String is infallible.
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Create a synthetic vault with `.obsidian/` marker.
+    fn create_vault(tmp: &Path) {
+        fs::create_dir_all(tmp.join(".obsidian")).unwrap();
+    }
+
+    #[test]
+    fn reads_all_md_notes() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        fs::create_dir_all(tmp.path().join("notes")).unwrap();
+        fs::write(
+            tmp.path().join("notes").join("rust.md"),
+            "# Rust\nGreat language",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("notes").join("go.md"), "# Go\nAlso great").unwrap();
+        fs::write(tmp.path().join("readme.md"), "# Readme").unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert_eq!(notes.len(), 3);
+
+        let paths: Vec<&str> = notes.iter().map(|n| n.path.as_str()).collect();
+        assert!(paths.contains(&"notes/rust.md"));
+        assert!(paths.contains(&"notes/go.md"));
+        assert!(paths.contains(&"readme.md"));
+    }
+
+    #[test]
+    fn ignores_hidden_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        fs::create_dir_all(tmp.path().join(".trash")).unwrap();
+        fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        fs::write(
+            tmp.path().join(".obsidian").join("config.md"),
+            "should be ignored",
+        )
+        .unwrap();
+        fs::write(
+            tmp.path().join(".trash").join("deleted.md"),
+            "should be ignored",
+        )
+        .unwrap();
+        fs::write(tmp.path().join(".git").join("hook.md"), "should be ignored").unwrap();
+        fs::write(tmp.path().join("visible.md"), "# Visible").unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].path, "visible.md");
+    }
+
+    #[test]
+    fn ignores_non_md_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        fs::write(tmp.path().join("note.md"), "# Note").unwrap();
+        fs::write(tmp.path().join("image.png"), b"\x89PNG").unwrap();
+        fs::write(tmp.path().join("doc.pdf"), b"%PDF").unwrap();
+        fs::create_dir_all(tmp.path().join("attachments")).unwrap();
+        fs::write(tmp.path().join("attachments").join("file.txt"), "text").unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].path, "note.md");
+    }
+
+    #[test]
+    fn empty_vault_returns_empty_vec() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn content_hash_is_correct_sha256() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        // Known SHA-256 vector: SHA-256("hello") =
+        // 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+        fs::write(tmp.path().join("hello.md"), "hello").unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(
+            notes[0].content_hash,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn content_hash_empty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        fs::write(tmp.path().join("empty.md"), "").unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert_eq!(
+            notes[0].content_hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn mtime_is_positive_epoch_seconds() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        fs::write(tmp.path().join("note.md"), "# Note").unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        // Any file created "now" should have mtime > 2020-01-01 epoch.
+        assert!(notes[0].mtime_secs > 1_577_836_800);
+    }
+
+    #[test]
+    fn skips_non_utf8_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        fs::write(tmp.path().join("valid.md"), "# Valid").unwrap();
+        // Invalid UTF-8 sequence
+        fs::write(tmp.path().join("binary.md"), &[0xFF, 0xFE, 0x00, 0x01]).unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].path, "valid.md");
+    }
+
+    #[test]
+    fn follows_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+
+        // Create a real directory outside the vault with a note
+        let external = tempfile::tempdir().unwrap();
+        fs::write(external.path().join("linked.md"), "# Linked note").unwrap();
+
+        // Symlink it into the vault
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(external.path(), tmp.path().join("templates")).unwrap();
+
+        #[cfg(unix)]
+        {
+            let notes = read_vault_notes(tmp.path()).unwrap();
+            assert_eq!(notes.len(), 1);
+            assert_eq!(notes[0].path, "templates/linked.md");
+            assert_eq!(notes[0].content, "# Linked note");
+        }
+    }
+
+    #[test]
+    fn nested_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_vault(tmp.path());
+        fs::create_dir_all(tmp.path().join("a").join("b").join("c")).unwrap();
+        fs::write(
+            tmp.path().join("a").join("b").join("c").join("deep.md"),
+            "deep",
+        )
+        .unwrap();
+        fs::write(tmp.path().join("top.md"), "top").unwrap();
+
+        let notes = read_vault_notes(tmp.path()).unwrap();
+        assert_eq!(notes.len(), 2);
+
+        let paths: Vec<&str> = notes.iter().map(|n| n.path.as_str()).collect();
+        assert!(paths.contains(&"a/b/c/deep.md"));
+        assert!(paths.contains(&"top.md"));
+    }
+
+    #[test]
+    fn vault_note_debug_and_clone() {
+        let note = VaultNote {
+            path: "test.md".to_owned(),
+            content: "# Test".to_owned(),
+            mtime_secs: 1_700_000_000,
+            content_hash: "abc123".to_owned(),
+        };
+        let cloned = note.clone();
+        assert_eq!(note, cloned);
+        let debug = format!("{note:?}");
+        assert!(debug.contains("test.md"));
+    }
+}

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -17,8 +17,9 @@ use rmcp::tool;
 use rmcp::tool_router;
 use rmcp::{model::CallToolResult, model::Content, ErrorData as McpError};
 use tracing::instrument;
-use webfang_core::application::vault_search::{VaultSearchResult, VaultSearchService};
+use webfang_core::application::vault_search::{SyncSummary, VaultSearchResult, VaultSearchService};
 use webfang_core::domain::DocumentChunk;
+use webfang_core::infrastructure::obsidian::detect_vault;
 
 /// Build an honest tool error (`isError:true`) carrying a Spanish message.
 ///
@@ -158,6 +159,40 @@ impl McpHandler {
 
         let service = VaultSearchService::new(embedding, repo, chunker);
         let limit = params.limit.unwrap_or(10);
+
+        // Lazy sync: reconcile the vault filesystem against the index
+        // before searching. Uses the explicit vault_path param or falls
+        // back to auto-detection. Sync failures are non-fatal — we
+        // proceed with whatever is already indexed.
+        let vault_path = params
+            .vault_path
+            .clone()
+            .or_else(|| detect_vault(None, None, None).map(|p| p.to_string_lossy().into_owned()));
+        if let Some(vp) = &vault_path {
+            match service.sync_vault(std::path::Path::new(vp)).await {
+                Ok(SyncSummary {
+                    indexed,
+                    updated,
+                    deleted,
+                    unchanged,
+                }) => {
+                    tracing::info!(
+                        indexed,
+                        updated,
+                        deleted,
+                        unchanged,
+                        vault_path = %vp,
+                        "lazy vault sync completed before search"
+                    );
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        vault_path = %vp,
+                        "vault sync failed, searching existing index: {e}"
+                    );
+                },
+            }
+        }
 
         match service.search(&params.query, limit).await {
             Ok(results) => {

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -173,7 +173,6 @@ pub(crate) struct SearchObsidianParams {
     /// Search query
     pub query: String,
     /// Optional vault path to search in
-    #[allow(dead_code)]
     pub vault_path: Option<String>,
     /// Maximum results (default: 10)
     pub limit: Option<usize>,


### PR DESCRIPTION
Closes #435

Stacked on #482 (VaultReader, #434).

## Summary

Eager vault indexing with staleness detection for the Obsidian vault search pipeline.

### What was built

**Application layer** (`vault_search.rs`):
- `SyncSummary` struct: `indexed`, `updated`, `deleted`, `unchanged` counts
- `VaultSearchService::sync_vault(vault_path)`: reconciles vault filesystem against the persistent index
  - Reads all `.md` notes via `read_vault_notes` (#434)
  - Compares `content_hash` with `list_indexed_notes()` for staleness
  - Indexes new/changed notes, deletes stale entries
  - Best-effort: individual note errors are logged and skipped
  - `#[instrument]` with structured tracing summary (`duration_ms`, counts)

**MCP layer** (`handlers/ai.rs`):
- Lazy sync in `search_obsidian` before every search
  - Uses `vault_path` param or auto-detects via `detect_vault`
  - Sync failures are non-fatal — proceeds with existing index
  - Removed `#[allow(dead_code)]` from `vault_path` param (now used)

### Tests

6 async unit tests with in-memory stub ports (StubEmbedding, StubChunker, InMemoryNoteRepo):
- Indexes new notes
- Skips unchanged notes (hash match)
- Detects changed notes (hash mismatch → re-index)
- Deletes removed notes
- Empty vault → zero-op
- Mixed operations (new + changed + deleted + unchanged in one sync)

### Verification

- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅ (webfang_core + webfang_mcp)
- `cargo fmt --check` ✅
- `cargo nextest run` → 76/76 vault-related tests PASS ✅