### PR TITLE
fix(ci): gate extract_content tests that trigger servo_arc Tree Borrows UB

### DIFF
--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -686,8 +686,11 @@ work with when computing the document readability score.</p>
     }
 
     // ─── extract_content direct tests (no Downloader needed) ───
+    // All gated: extract_content → html_cleaner → lol_html → servo_arc
+    // triggers Tree Borrows UB in servo_arc Arc::drop (upstream, experimental model).
 
     #[tokio::test]
+    #[cfg(not(miri))]
     async fn extract_content_readability_extracts_article() {
         let html = r#"<html><head><title>Test Page</title></head><body>
             <article><h1>Hello</h1><p>This is a long enough paragraph of content that readability should be able to extract properly from the DOM structure.</p>
@@ -705,6 +708,7 @@ work with when computing the document readability score.</p>
     }
 
     #[tokio::test]
+    #[cfg(not(miri))]
     async fn extract_content_fallback_short_content_returns_error() {
         let html = "<html><body><div></div></body></html>";
         let url = Url::parse("https://example.com/tiny").unwrap();
@@ -721,6 +725,7 @@ work with when computing the document readability score.</p>
     }
 
     #[tokio::test]
+    #[cfg(not(miri))]
     async fn extract_content_with_selector_extracts_matching_content() {
         let html = r#"<html><body>
             <nav>Navigation stuff</nav>
@@ -741,6 +746,7 @@ work with when computing the document readability score.</p>
     }
 
     #[tokio::test]
+    #[cfg(not(miri))]
     async fn extract_content_populates_correlation_id_natively() {
         // Fase 1 (issue #356): correlation_id must be populated natively,
         // WITHOUT requiring the `otel` feature. Every scraped page must be


### PR DESCRIPTION
## Summary

Follow-up to #484 (merged in #485). The original fix cleared the inline-asm and attribute errors, allowing Miri to reach deeper into the test suite where it found a **Tree Borrows violation in servo_arc 0.4.3** (dependency of lol_html).

The UB is upstream — `servo_arc::Arc::drop` does a `fetch_sub` on a refcount pointer that Miri's experimental Tree Borrows model classifies as `Frozen`. This is not actionable from webfang. Fixes #487

Tracking: #487

## Changes

Gate all 4 `extract_content` tests in `discovery.rs` with `#[cfg(not(miri))]`:
- `extract_content_readability_extracts_article`
- `extract_content_fallback_short_content_returns_error`
- `extract_content_with_selector_extracts_matching_content`
- `extract_content_populates_correlation_id_natively`

All exercise `extract_content()` → `html_cleaner` → `lol_html` → `servo_arc`.

## Verification

- `cargo check -p webfang_core` — PASS
- `cargo clippy -p webfang_core -- -D warnings` — PASS
- `cargo fmt -p webfang_core -- --check` — PASS