### PR TITLE
fix(infra): use per-layer filters so FileTraceLayer runs at TRACE independently

### DIFF
--- a/crates/webfang_core/src/cli/config.rs
+++ b/crates/webfang_core/src/cli/config.rs
@@ -86,22 +86,26 @@ pub fn init_logging_dual(
 ) {
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-    let filter = if quiet {
+    // Per-layer filters (#489): the console filter respects the user's
+    // verbosity choice, while the file trace layer ALWAYS runs at TRACE
+    // level so `--trace-file` captures everything independently of `-v`/`-vv`.
+    let console_filter = if quiet {
         EnvFilter::new("webfang=warn,tokio=warn,reqwest=warn")
     } else {
         EnvFilter::new(format!("webfang={level},tokio=warn,reqwest=warn"))
     };
+    let trace_filter = EnvFilter::new("webfang=trace,tokio=warn,reqwest=warn");
 
     let fmt_layer = fmt::layer()
         .with_writer(std::io::stderr)
         .with_ansi(!no_color)
         .with_target(true)
-        .pretty();
+        .pretty()
+        .with_filter(console_filter);
 
     tracing_subscriber::registry()
-        .with(file_trace_layer)
+        .with(file_trace_layer.with_filter(trace_filter))
         .with(fmt_layer)
-        .with(filter)
         .try_init()
         .ok();
 }


### PR DESCRIPTION
## Linked Issue

Closes #489

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- The `EnvFilter` was applied as a **global registry filter**, gating ALL layers including `FileTraceLayer`. Without `-vv`, the trace file got 0 lines.
- Moved to **per-layer filters**: console respects user verbosity (`-v`/`-vv`/`--quiet`), `FileTraceLayer` always captures at TRACE level independently.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/config.rs` | Replaced global `EnvFilter` with per-layer filters: `console_filter` on fmt_layer, `trace_filter` (TRACE) on FileTraceLayer |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (cli::config 7/7, file_trace_layer 16/16)
- [x] Manually verified: `--trace-file` now produces JSONL output without `-vv`

## Contributor Checklist

- [x] Linked an issue with `Closes #489`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`fix(infra): ...`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] No docs update needed (internal behavior fix)