### PR TITLE
fix(cli): context-aware empty discovery message based on --use-sitemap

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -266,9 +266,12 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
                 return Err(CliExit::NetworkError(format!("URL discovery failed: {e}")));
             },
             Ok(urls) if urls.is_empty() => {
-                return Err(CliExit::EmptyDiscovery(
-                    "No URLs discovered from sitemaps".into(),
-                ));
+                let msg = if opts.crawl.use_sitemap {
+                    "No URLs discovered from sitemaps"
+                } else {
+                    "No URLs discovered from link extraction"
+                };
+                return Err(CliExit::EmptyDiscovery(msg.into()));
             },
             Ok(urls) => urls,
         };


### PR DESCRIPTION
## Linked Issue

Closes #490

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- The empty-discovery warning always said "No URLs discovered from sitemaps" even when `--use-sitemap` was NOT passed.
- Now the message reflects the actual discovery method: "from sitemaps" when `--use-sitemap` is active, "from link extraction" otherwise.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/orchestrator.rs` | Conditional message based on `opts.crawl.use_sitemap` in the empty-discovery error path |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (exit_code tests 11/11 — existing `contains("No URLs discovered")` assertion matches both variants)

## Contributor Checklist

- [x] Linked an issue with `Closes #490`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`fix(cli): ...`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] No docs update needed (error message fix only)