### PR TITLE
fix(crawler): include seed URL in DOM discovery when no internal links (#488)

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -265,13 +265,16 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
             Err(e) => {
                 return Err(CliExit::NetworkError(format!("URL discovery failed: {e}")));
             },
-            Ok(urls) if urls.is_empty() => {
-                let msg = if opts.crawl.use_sitemap {
-                    "No URLs discovered from sitemaps"
-                } else {
-                    "No URLs discovered from link extraction"
-                };
-                return Err(CliExit::EmptyDiscovery(msg.into()));
+            // Exit 2 only when the sitemap is the source of truth. In DOM mode an
+            // empty discovery is not fatal: `plan_urls` injects the seed URL so
+            // the site itself is still scraped (#488). The message is always the
+            // sitemap one: this guard no longer fires in DOM mode (#495 made the
+            // message context-aware; the link-extraction branch is now unreachable
+            // here because an empty DOM discovery flows to `plan_urls`).
+            Ok(urls) if urls.is_empty() && opts.crawl.use_sitemap => {
+                return Err(CliExit::EmptyDiscovery(
+                    "No URLs discovered from sitemaps".into(),
+                ));
             },
             Ok(urls) => urls,
         };

--- a/crates/webfang_core/tests/exit_code_integration.rs
+++ b/crates/webfang_core/tests/exit_code_integration.rs
@@ -101,6 +101,71 @@ async fn test_empty_sitemap_returns_exit_2() {
 }
 
 // ============================================================================
+// Tests: DOM discovery with only external links → exit 0 (seed injected)
+// ============================================================================
+
+/// DOM discovery that finds no internal URLs must still scrape the seed URL:
+/// empty discovery is not fatal outside sitemap mode, so the run exits 0
+/// instead of EmptyDiscovery (exit 2) (#488).
+#[tokio::test]
+async fn test_dom_external_only_links_scrapes_seed() {
+    let mock_server = MockServer::start().await;
+
+    // The seed page links only to an external domain, so DOM discovery yields
+    // zero internal URLs.
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><h1>Seed content</h1>\
+             <a href=\"https://iana.org\">external link</a></body></html>",
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let base_url = format!("{}/", mock_server.uri());
+    let out_dir = tempfile::TempDir::new().expect("create temp output dir");
+
+    cmd()
+        .arg("--url")
+        .arg(&base_url)
+        .arg("--output")
+        .arg(out_dir.path())
+        .timeout(Duration::from_secs(30))
+        .assert()
+        .code(0);
+
+    // The seed page itself must have been fetched: DOM discovery reads it once
+    // for link extraction and the scraper reads it again for content.
+    let requests = mock_server.received_requests().await.unwrap();
+    let seed_requests = requests.iter().filter(|r| r.url.path() == "/").count();
+    assert!(
+        seed_requests >= 1,
+        "expected the seed page / to be fetched, got {seed_requests} requests"
+    );
+
+    // The seed page was saved as markdown in the output dir and contains the
+    // identifiable seed content.
+    let md_files: Vec<PathBuf> = walkdir::WalkDir::new(out_dir.path())
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    assert_eq!(
+        md_files.len(),
+        1,
+        "expected 1 .md file in output, got {}",
+        md_files.len()
+    );
+    let content = std::fs::read_to_string(&md_files[0]).expect("read .md file");
+    assert!(
+        content.contains("Seed content"),
+        "expected seed content in .md file"
+    );
+}
+
+// ============================================================================
 // Tests: Network timeout → exit 69
 // ============================================================================
 


### PR DESCRIPTION
## Linked Issue

Closes #488

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- In DOM discovery mode (no sitemap), a site whose links are all external (e.g. example.com → iana.org) yielded 0 discovered URLs, and `prepare_phase` short-circuited with `EmptyDiscovery` (exit 2) before `plan_urls` could inject the seed URL.
- The exit-2 guard is now gated on `opts.crawl.use_sitemap`: empty discovery is only fatal when the sitemap is the source of truth. In DOM mode the empty list flows to `plan_urls`, which already injects the seed (covered by the existing `plan_urls_dom_mode_empty_discovered` unit test).
- Sitemap behavior is unchanged: an empty sitemap still returns exit 2.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/orchestrator.rs` | Gate the empty-discovery exit-2 guard on `use_sitemap` so DOM mode reaches `plan_urls` (seed injection) |
| `crates/webfang_core/tests/exit_code_integration.rs` | Add `test_dom_external_only_links_scrapes_seed`: external-only links → exit 0, seed fetched, `.md` written with seed content |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (exit_code_integration 4/4, crawl_test 7/7 incl. sitemap EmptyDiscovery preserved, orchestrator units 19/19)
- [x] Manually verified the affected functionality

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed