### PR TITLE
fix(cli): --sitemap-url implies --use-sitemap

### DIFF
--- a/crates/webfang_core/src/cli/args/crawler.rs
+++ b/crates/webfang_core/src/cli/args/crawler.rs
@@ -72,7 +72,7 @@ pub struct CrawlerArgs {
     pub use_sitemap: bool,
 
     /// Explicit sitemap URL
-    #[arg(long, requires = "use_sitemap", env = "WEBFANG_SITEMAP_URL")]
+    #[arg(long, env = "WEBFANG_SITEMAP_URL")]
     #[clap(next_help_heading = "Discovery")]
     pub sitemap_url: Option<String>,
 

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -586,7 +586,10 @@ mod tests {
         opts.crawl.sitemap_url = Some("https://example.com/sitemap.xml".into());
         let config = ConfigDefaults::default();
         let merged = apply_config_defaults(opts, &config);
-        assert!(merged.crawl.use_sitemap, "sitemap_url must imply use_sitemap");
+        assert!(
+            merged.crawl.use_sitemap,
+            "sitemap_url must imply use_sitemap"
+        );
     }
 
     #[test]

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -73,6 +73,12 @@ pub fn apply_config_defaults(mut opts: CrawlOptions, config: &ConfigDefaults) ->
         }
     }
 
+    // --sitemap-url implies --use-sitemap (#491): an explicit sitemap URL
+    // logically enables sitemap discovery, so the user shouldn't need both flags.
+    if opts.crawl.sitemap_url.is_some() {
+        opts.crawl.use_sitemap = true;
+    }
+
     if let Some(v) = config.ignore_waf {
         if !opts.crawl.ignore_waf && v {
             opts.crawl.ignore_waf = v;

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -574,4 +574,26 @@ mod tests {
         let merged = apply_config_defaults(opts, &config);
         assert!(!merged.crawl.ignore_waf);
     }
+
+    // ========================================================================
+    // #491 — --sitemap-url implies --use-sitemap
+    // ========================================================================
+
+    #[test]
+    fn sitemap_url_implies_use_sitemap() {
+        let mut opts = CrawlOptions::default();
+        assert!(!opts.crawl.use_sitemap);
+        opts.crawl.sitemap_url = Some("https://example.com/sitemap.xml".into());
+        let config = ConfigDefaults::default();
+        let merged = apply_config_defaults(opts, &config);
+        assert!(merged.crawl.use_sitemap, "sitemap_url must imply use_sitemap");
+    }
+
+    #[test]
+    fn no_sitemap_url_leaves_use_sitemap_false() {
+        let opts = CrawlOptions::default();
+        let config = ConfigDefaults::default();
+        let merged = apply_config_defaults(opts, &config);
+        assert!(!merged.crawl.use_sitemap);
+    }
 }


### PR DESCRIPTION
Closes #491

## Summary
- Removed `requires = "use_sitemap"` constraint from `--sitemap-url` clap arg
- Added normalization in `preflight.rs`: `sitemap_url.is_some()` → `use_sitemap = true`

## Rationale
An explicit sitemap URL logically enables sitemap discovery. Requiring both `--sitemap-url` and `--use-sitemap` was redundant and confusing (exit 64).

## Verification
- `cargo clippy -- -D warnings` clean
- `webfang https://blog.rust-lang.org --sitemap-url .../sitemap.xml --dry-run` → discovers URLs via sitemap (previously: exit 64)
- `--use-sitemap` alone still works for auto-discovery
- Both flags together still works