### PR TITLE
fix(observability): trace events share one correlation ID per run — no per-page correlation in trace JSONL

### DIFF
--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -170,9 +170,13 @@ pub async fn discover_urls_for_tui(
 ///
 /// # Arguments
 ///
-/// * `client` - HTTP client to use for requests
+/// * `downloader` - Downloader (fetch router in production, mock in tests)
 /// * `url` - URL to scrape
 /// * `config` - Scraper configuration
+/// * `correlation` - Per-page correlation identity, derived by the caller from
+///   the run-root identity (`root.child()` — same `trace_id`, fresh
+///   `span_id`), so every page of a run stays reconstructable under one trace
+///   (#501)
 ///
 /// # Returns
 ///
@@ -180,7 +184,7 @@ pub async fn discover_urls_for_tui(
 /// * `Err(ScraperError)` - Error during scraping
 #[instrument(
     name = "scrape_single_url",
-    skip(downloader, config, asset_downloader, engine, binary_writer),
+    skip(downloader, config, asset_downloader, engine, binary_writer, correlation),
     fields(url = %url)
 )]
 pub async fn scrape_single_url_for_tui(
@@ -190,20 +194,46 @@ pub async fn scrape_single_url_for_tui(
     asset_downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     #[allow(unused_variables)] engine: Option<&AdaptiveSelectorEngine>,
     binary_writer: Option<&dyn crate::domain::ports::BinaryWriterPort>,
+    correlation: &CorrelationId,
 ) -> ScraperResult<ScrapedContent> {
-    // Per-page identity, declared on the span at creation time (#501).
-    // FileTraceLayer snapshots span fields in `on_new_span`, so fields recorded
-    // later are invisible offline — mirror `crawl_page` (crawl_task.rs) exactly.
-    let page_correlation = CorrelationId::new();
-    let span = span!(
-        Level::DEBUG,
-        "scrape_single",
-        url = %url,
-        correlation_id = %page_correlation,
-        trace_id = %page_correlation.trace_id()
-    );
-    let _guard = span.enter();
+    scrape_single_url_for_tui_inner(
+        downloader,
+        url,
+        config,
+        asset_downloader,
+        engine,
+        binary_writer,
+        correlation.clone(),
+    )
+    .await
+}
 
+/// Inner implementation of [`scrape_single_url_for_tui`].
+///
+/// The `#[instrument]` span declares the per-page identity (`correlation_id`,
+/// `trace_id`) AT CREATION time (#501): FileTraceLayer snapshots span fields
+/// in `on_new_span`, so fields recorded later never reach the `--trace-file`
+/// JSONL. The instrumented span lifecycle is also async-safe — no `enter()`
+/// guard crosses an `.await` (#501 follow-up).
+#[instrument(
+    level = "debug",
+    name = "scrape_single",
+    skip(downloader, config, asset_downloader, engine, binary_writer, correlation),
+    fields(
+        url = %url,
+        correlation_id = %correlation,
+        trace_id = %correlation.trace_id()
+    )
+)]
+async fn scrape_single_url_for_tui_inner(
+    downloader: &dyn Downloader,
+    url: &Url,
+    config: &ScraperConfig,
+    asset_downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
+    #[allow(unused_variables)] engine: Option<&AdaptiveSelectorEngine>,
+    binary_writer: Option<&dyn crate::domain::ports::BinaryWriterPort>,
+    correlation: CorrelationId,
+) -> ScraperResult<ScrapedContent> {
     debug!("Scraping: {}", url);
 
     // Fetch the page through the injected downloader (a `FetchRouter` in
@@ -297,7 +327,7 @@ pub async fn scrape_single_url_for_tui(
             date: None,
             html: None,
             assets,
-            correlation_id: Some(page_correlation),
+            correlation_id: Some(correlation),
         });
     }
 
@@ -318,21 +348,13 @@ pub async fn scrape_single_url_for_tui(
             &chain,
             url.as_str(),
             "fetch",
-            Some(&page_correlation),
+            Some(&correlation),
             "WAF challenge detected",
         );
         return Err(ScraperError::waf_blocked(url.to_string(), chain));
     }
 
-    extract_content(
-        &html,
-        url,
-        config,
-        asset_downloader,
-        engine,
-        Some(&page_correlation),
-    )
-    .await
+    extract_content(&html, url, config, asset_downloader, engine, &correlation).await
 }
 
 /// Convert lowercased string headers into a wreq [`wreq::header::HeaderMap`]
@@ -607,7 +629,8 @@ mod tests {
         let url = Url::parse("https://example.com/doc.pdf").expect("valid URL");
         let config = ScraperConfig::new();
 
-        let result = scrape_single_url_for_tui(&dl, &url, &config, None, None, None)
+        let corr = CorrelationId::new();
+        let result = scrape_single_url_for_tui(&dl, &url, &config, None, None, None, &corr)
             .await
             .expect("binary detection should succeed");
 
@@ -627,7 +650,8 @@ mod tests {
         let url = Url::parse("https://example.com").expect("valid URL");
         let config = ScraperConfig::new();
 
-        let err = scrape_single_url_for_tui(&dl, &url, &config, None, None, None)
+        let corr = CorrelationId::new();
+        let err = scrape_single_url_for_tui(&dl, &url, &config, None, None, None, &corr)
             .await
             .expect_err("WAF body should trigger WafBlocked");
 
@@ -652,7 +676,8 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/article").expect("valid URL");
         let config = ScraperConfig::new();
 
-        let result = scrape_single_url_for_tui(&dl, &url, &config, None, None, None)
+        let corr = CorrelationId::new();
+        let result = scrape_single_url_for_tui(&dl, &url, &config, None, None, None, &corr)
             .await
             .expect("normal HTML should scrape successfully");
 
@@ -673,7 +698,8 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com").expect("valid URL");
         let config = ScraperConfig::new();
 
-        let err = scrape_single_url_for_tui(&dl, &url, &config, None, None, None)
+        let corr = CorrelationId::new();
+        let err = scrape_single_url_for_tui(&dl, &url, &config, None, None, None, &corr)
             .await
             .expect_err("WafChallenge download error should propagate");
 
@@ -693,7 +719,8 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/missing").expect("valid URL");
         let config = ScraperConfig::new();
 
-        let err = scrape_single_url_for_tui(&dl, &url, &config, None, None, None)
+        let corr = CorrelationId::new();
+        let err = scrape_single_url_for_tui(&dl, &url, &config, None, None, None, &corr)
             .await
             .expect_err("404 status should produce an error");
 
@@ -717,7 +744,8 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/article").unwrap();
         let config = ScraperConfig::default();
 
-        let result = extract_content(html, &url, &config, None, None, None).await;
+        let corr = CorrelationId::new();
+        let result = extract_content(html, &url, &config, None, None, &corr).await;
 
         assert!(result.is_ok());
         let content = result.unwrap();
@@ -732,7 +760,8 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/tiny").unwrap();
         let config = ScraperConfig::default();
 
-        let result = extract_content(html, &url, &config, None, None, None).await;
+        let corr = CorrelationId::new();
+        let result = extract_content(html, &url, &config, None, None, &corr).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -756,7 +785,8 @@ work with when computing the document readability score.</p>
             ..Default::default()
         };
 
-        let result = extract_content(html, &url, &config, None, None, None).await;
+        let corr = CorrelationId::new();
+        let result = extract_content(html, &url, &config, None, None, &corr).await;
 
         assert!(result.is_ok());
         let content = result.unwrap();
@@ -776,7 +806,8 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/article").unwrap();
         let config = ScraperConfig::default();
 
-        let result = extract_content(html, &url, &config, None, None, None).await;
+        let corr = CorrelationId::new();
+        let result = extract_content(html, &url, &config, None, None, &corr).await;
 
         assert!(result.is_ok());
         let content = result.unwrap();
@@ -792,10 +823,11 @@ work with when computing the document readability score.</p>
     #[tokio::test]
     #[cfg(not(miri))]
     async fn extract_content_reuses_injected_correlation_id() {
-        // Issue #501: callers that own the page identity (e.g. the scrape span
-        // in `scrape_single_url_for_tui`) inject it so the exported content is
-        // correlatable with the trace's `span_fields` — exact identity, not a
-        // freshly generated one.
+        // Issue #501: callers own the page identity (e.g. the scrape span in
+        // `scrape_single_url_for_tui`) and inject it so the exported content
+        // is correlatable with the trace's `span_fields` — exact identity,
+        // not a freshly generated one. The parameter is required: identity
+        // enters through the type system or not at all.
         let html = r#"<html><head><title>Test Page</title></head><body>
             <article><h1>Hello</h1><p>This is a long enough paragraph of content that readability should be able to extract properly from the DOM structure.</p>
             <p>Second paragraph with more content to ensure readability has enough material to work with for extraction.</p></article>
@@ -804,7 +836,7 @@ work with when computing the document readability score.</p>
         let config = ScraperConfig::default();
         let injected = CorrelationId::new_with_ids(uuid::Uuid::now_v7(), 0x00AB);
 
-        let content = extract_content(html, &url, &config, None, None, Some(&injected))
+        let content = extract_content(html, &url, &config, None, None, &injected)
             .await
             .expect("extraction with an injected correlation ID must succeed");
 

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -788,4 +788,30 @@ work with when computing the document readability score.</p>
         let corr = content.correlation_id.unwrap();
         assert!(corr.to_traceparent().starts_with("00-"));
     }
+
+    #[tokio::test]
+    #[cfg(not(miri))]
+    async fn extract_content_reuses_injected_correlation_id() {
+        // Issue #501: callers that own the page identity (e.g. the scrape span
+        // in `scrape_single_url_for_tui`) inject it so the exported content is
+        // correlatable with the trace's `span_fields` — exact identity, not a
+        // freshly generated one.
+        let html = r#"<html><head><title>Test Page</title></head><body>
+            <article><h1>Hello</h1><p>This is a long enough paragraph of content that readability should be able to extract properly from the DOM structure.</p>
+            <p>Second paragraph with more content to ensure readability has enough material to work with for extraction.</p></article>
+        </body></html>"#;
+        let url = Url::parse("https://example.com/article").unwrap();
+        let config = ScraperConfig::default();
+        let injected = CorrelationId::new_with_ids(uuid::Uuid::now_v7(), 0x00AB);
+
+        let content = extract_content(html, &url, &config, None, None, Some(&injected))
+            .await
+            .expect("extraction with an injected correlation ID must succeed");
+
+        assert_eq!(
+            content.correlation_id.as_ref(),
+            Some(&injected),
+            "extract_content must reuse the injected correlation ID exactly"
+        );
+    }
 }

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -191,7 +191,17 @@ pub async fn scrape_single_url_for_tui(
     #[allow(unused_variables)] engine: Option<&AdaptiveSelectorEngine>,
     binary_writer: Option<&dyn crate::domain::ports::BinaryWriterPort>,
 ) -> ScraperResult<ScrapedContent> {
-    let span = span!(Level::DEBUG, "scrape_single", url = %url);
+    // Per-page identity, declared on the span at creation time (#501).
+    // FileTraceLayer snapshots span fields in `on_new_span`, so fields recorded
+    // later are invisible offline — mirror `crawl_page` (crawl_task.rs) exactly.
+    let page_correlation = CorrelationId::new();
+    let span = span!(
+        Level::DEBUG,
+        "scrape_single",
+        url = %url,
+        correlation_id = %page_correlation,
+        trace_id = %page_correlation.trace_id()
+    );
     let _guard = span.enter();
 
     debug!("Scraping: {}", url);
@@ -287,7 +297,7 @@ pub async fn scrape_single_url_for_tui(
             date: None,
             html: None,
             assets,
-            correlation_id: Some(CorrelationId::new()),
+            correlation_id: Some(page_correlation),
         });
     }
 
@@ -308,13 +318,21 @@ pub async fn scrape_single_url_for_tui(
             &chain,
             url.as_str(),
             "fetch",
-            None,
+            Some(&page_correlation),
             "WAF challenge detected",
         );
         return Err(ScraperError::waf_blocked(url.to_string(), chain));
     }
 
-    extract_content(&html, url, config, asset_downloader, engine).await
+    extract_content(
+        &html,
+        url,
+        config,
+        asset_downloader,
+        engine,
+        Some(&page_correlation),
+    )
+    .await
 }
 
 /// Convert lowercased string headers into a wreq [`wreq::header::HeaderMap`]
@@ -699,7 +717,7 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/article").unwrap();
         let config = ScraperConfig::default();
 
-        let result = extract_content(html, &url, &config, None, None).await;
+        let result = extract_content(html, &url, &config, None, None, None).await;
 
         assert!(result.is_ok());
         let content = result.unwrap();
@@ -714,7 +732,7 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/tiny").unwrap();
         let config = ScraperConfig::default();
 
-        let result = extract_content(html, &url, &config, None, None).await;
+        let result = extract_content(html, &url, &config, None, None, None).await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -738,7 +756,7 @@ work with when computing the document readability score.</p>
             ..Default::default()
         };
 
-        let result = extract_content(html, &url, &config, None, None).await;
+        let result = extract_content(html, &url, &config, None, None, None).await;
 
         assert!(result.is_ok());
         let content = result.unwrap();
@@ -758,7 +776,7 @@ work with when computing the document readability score.</p>
         let url = Url::parse("https://example.com/article").unwrap();
         let config = ScraperConfig::default();
 
-        let result = extract_content(html, &url, &config, None, None).await;
+        let result = extract_content(html, &url, &config, None, None, None).await;
 
         assert!(result.is_ok());
         let content = result.unwrap();

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -198,6 +198,13 @@ pub(crate) async fn adaptive_selector_repair(
 ///
 /// Recibe HTML ya fetchado y validado (post-WAF). No conoce el transporte.
 ///
+/// Correlation identity (#501): callers that own the per-page identity (e.g.
+/// `scrape_single_url_for_tui`, which declares it on its trace span) inject it
+/// via `correlation_id` so the exported content shares the same identity as
+/// the page's `span_fields` in the `--trace-file` JSONL. When nothing is
+/// injected, a fresh ad-hoc ID is generated — the standalone fallback that
+/// preserves the issue #356 guarantee.
+///
 /// # Errors
 ///
 /// Returns [`ScraperError::ExtractionFailed`] when fallback content is below
@@ -208,11 +215,16 @@ pub async fn extract_content(
     config: &ScraperConfig,
     asset_downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     #[allow(unused_variables)] engine: Option<&AdaptiveSelectorEngine>,
+    correlation_id: Option<&CorrelationId>,
 ) -> Result<ScrapedContent> {
     // Clean HTML boilerplate (scripts, styles, nav, sidebar, footer) BEFORE
     // Readability. This helps legible find the main content without being
     // confused by navigation elements, JavaScript bundles, and CSS.
     let cleaned_html = crate::infrastructure::converter::html_cleaner::clean_html(html);
+
+    // Page correlation identity (#501): injected by the caller so content and
+    // span share one identity; ad-hoc generation is only the standalone fallback.
+    let correlation = correlation_id.cloned().unwrap_or_else(CorrelationId::new);
 
     // Apply CSS selector extraction if a non-default selector is configured.
     let extract_result = extract_with_selector(&cleaned_html, &config.selector, None);
@@ -257,7 +269,7 @@ pub async fn extract_content(
                 // Store CLEAN HTML from Readability (not raw HTML with nav/ads/footer)
                 html: Some(article.content),
                 assets,
-                correlation_id: Some(CorrelationId::new()),
+                correlation_id: Some(correlation.clone()),
             })
         },
         Err(e) => {
@@ -277,7 +289,7 @@ pub async fn extract_content(
                     &msg,
                     url.as_str(),
                     "extract",
-                    None,
+                    Some(&correlation),
                     "content extraction failed",
                 );
                 return Err(ScraperError::ExtractionFailed {
@@ -306,7 +318,7 @@ pub async fn extract_content(
                 date: None,
                 html: Some(html.to_owned()),
                 assets,
-                correlation_id: Some(CorrelationId::new()),
+                correlation_id: Some(correlation),
             })
         },
     }

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -136,8 +136,19 @@ pub async fn scrape_with_readability(
     client: &dyn HttpClientPort,
     url: &url::Url,
 ) -> Result<Vec<ScrapedContent>> {
-    let outcome =
-        scrape_with_config(client, url, &ScraperConfig::default(), None, None, None).await?;
+    // Standalone convenience entry: this call IS the operation, so it mints
+    // its own run-root identity (#501).
+    let root_correlation = CorrelationId::new();
+    let outcome = scrape_with_config(
+        client,
+        url,
+        &ScraperConfig::default(),
+        None,
+        None,
+        None,
+        &root_correlation,
+    )
+    .await?;
     Ok(outcome.results)
 }
 
@@ -198,12 +209,12 @@ pub(crate) async fn adaptive_selector_repair(
 ///
 /// Recibe HTML ya fetchado y validado (post-WAF). No conoce el transporte.
 ///
-/// Correlation identity (#501): callers that own the per-page identity (e.g.
-/// `scrape_single_url_for_tui`, which declares it on its trace span) inject it
-/// via `correlation_id` so the exported content shares the same identity as
-/// the page's `span_fields` in the `--trace-file` JSONL. When nothing is
-/// injected, a fresh ad-hoc ID is generated — the standalone fallback that
-/// preserves the issue #356 guarantee.
+/// Correlation identity (#501): the per-page identity is a REQUIRED input —
+/// callers own it (e.g. `scrape_single_url_for_tui` declares it on its trace
+/// span) and inject it here so the exported content shares the same identity
+/// as the page's `span_fields` in the `--trace-file` JSONL. Standalone
+/// callers mint their own root at entry. Identity enters through the type
+/// system or not at all — there is no ad-hoc fallback.
 ///
 /// # Errors
 ///
@@ -215,16 +226,12 @@ pub async fn extract_content(
     config: &ScraperConfig,
     asset_downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     #[allow(unused_variables)] engine: Option<&AdaptiveSelectorEngine>,
-    correlation_id: Option<&CorrelationId>,
+    correlation_id: &CorrelationId,
 ) -> Result<ScrapedContent> {
     // Clean HTML boilerplate (scripts, styles, nav, sidebar, footer) BEFORE
     // Readability. This helps legible find the main content without being
     // confused by navigation elements, JavaScript bundles, and CSS.
     let cleaned_html = crate::infrastructure::converter::html_cleaner::clean_html(html);
-
-    // Page correlation identity (#501): injected by the caller so content and
-    // span share one identity; ad-hoc generation is only the standalone fallback.
-    let correlation = correlation_id.cloned().unwrap_or_else(CorrelationId::new);
 
     // Apply CSS selector extraction if a non-default selector is configured.
     let extract_result = extract_with_selector(&cleaned_html, &config.selector, None);
@@ -269,7 +276,7 @@ pub async fn extract_content(
                 // Store CLEAN HTML from Readability (not raw HTML with nav/ads/footer)
                 html: Some(article.content),
                 assets,
-                correlation_id: Some(correlation.clone()),
+                correlation_id: Some(correlation_id.clone()),
             })
         },
         Err(e) => {
@@ -289,7 +296,7 @@ pub async fn extract_content(
                     &msg,
                     url.as_str(),
                     "extract",
-                    Some(&correlation),
+                    Some(correlation_id),
                     "content extraction failed",
                 );
                 return Err(ScraperError::ExtractionFailed {
@@ -318,7 +325,7 @@ pub async fn extract_content(
                 date: None,
                 html: Some(html.to_owned()),
                 assets,
-                correlation_id: Some(correlation),
+                correlation_id: Some(correlation_id.clone()),
             })
         },
     }

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -66,12 +66,18 @@ impl ScrapeOutcome {
 
 /// Scrape a URL with asset downloading configuration
 ///
+/// Correlation contract (#501): the caller owns the run-root identity
+/// (`root_correlation`); this use case derives one page child from it
+/// (same `trace_id`, fresh `span_id`) so every page of the operation stays
+/// reconstructable under a single trace while each page is distinguishable.
+///
 /// # Arguments
 /// * `client` - HTTP client
 /// * `url` - URL to scrape
 /// * `config` - Scraper configuration with download options
 /// * `downloader` - Optional asset downloader
 /// * `inspector` - Optional DOM inspector for selector diagnostics (None for non-MCP paths)
+/// * `root_correlation` - Run-root correlation identity of the enclosing operation
 ///
 /// # Returns
 /// * `ScrapeOutcome` - Scraped content results + CSS selector extraction result
@@ -86,10 +92,11 @@ pub async fn scrape_with_config(
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     inspector: Option<&dyn DomInspectorPort>,
     engine: Option<&AdaptiveSelectorEngine>,
+    root_correlation: &CorrelationId,
 ) -> Result<ScrapeOutcome> {
-    // Per-page identity created BEFORE the span so the span can declare it
-    // (`#[instrument]` only sees function parameters — #501).
-    let correlation = CorrelationId::new();
+    // Per-page identity derived from the run root BEFORE the span so the span
+    // can declare it (`#[instrument]` only sees function parameters — #501).
+    let page_correlation = root_correlation.child();
     scrape_with_config_inner(
         client,
         url,
@@ -97,7 +104,7 @@ pub async fn scrape_with_config(
         downloader,
         inspector,
         engine,
-        correlation,
+        page_correlation,
     )
     .await
 }
@@ -400,20 +407,34 @@ pub async fn scrape_multiple_with_limit(
         return Ok(Vec::new());
     }
 
+    // One run-root identity for the whole batch (#501): every
+    // `scrape_with_config` call derives its own child from it, so the trace
+    // is shared across the batch while each page span stays unique.
+    let root_correlation = CorrelationId::new();
+    info!(
+        correlation_id = %root_correlation,
+        trace_id = %root_correlation.trace_id(),
+        "scrape_multiple identity"
+    );
+
     info!(
         "🌐 Scraping {} URLs with concurrency limit {}",
         urls.len(),
         config.scraper_concurrency
     );
 
-    let results: Vec<Result<ScrapeOutcome>> = stream::iter(urls.to_vec())
-        .map(|url| {
-            let config = config.clone();
-            async move { scrape_with_config(client, &url, &config, downloader, None, None).await }
-        })
-        .buffer_unordered(config.scraper_concurrency)
-        .collect()
-        .await;
+    let results: Vec<Result<ScrapeOutcome>> =
+        stream::iter(urls.to_vec())
+            .map(|url| {
+                let config = config.clone();
+                let root = root_correlation.clone();
+                async move {
+                    scrape_with_config(client, &url, &config, downloader, None, None, &root).await
+                }
+            })
+            .buffer_unordered(config.scraper_concurrency)
+            .collect()
+            .await;
 
     let mut all_content = Vec::new();
     for result in results {

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -13,7 +13,7 @@
 
 use crate::application::error_mapping::scraper_error_from_http;
 use crate::application::http_client::HttpClientPort;
-use crate::domain::{DomInspectorPort, ExtractResult, ScrapedContent, ValidUrl};
+use crate::domain::{CorrelationId, DomInspectorPort, ExtractResult, ScrapedContent, ValidUrl};
 use crate::error::{Result, ScraperError};
 use crate::infrastructure::http::waf_engine::{InspectionContext, WafInspector};
 use crate::infrastructure::observability::log_scrape_error;
@@ -79,21 +79,47 @@ impl ScrapeOutcome {
 /// # Errors
 /// Returns `ScraperError::Http` for HTTP errors, `ScraperError::Network` for
 /// connection errors.
-#[instrument(
-    name = "scrape_with_config",
-    skip(client, config, downloader, inspector, engine),
-    fields(
-        url = %url,
-        has_downloads = config.has_downloads()
-    )
-)]
 pub async fn scrape_with_config(
     client: &dyn HttpClientPort,
     url: &url::Url,
     config: &ScraperConfig,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     inspector: Option<&dyn DomInspectorPort>,
+    engine: Option<&AdaptiveSelectorEngine>,
+) -> Result<ScrapeOutcome> {
+    // Per-page identity created BEFORE the span so the span can declare it
+    // (`#[instrument]` only sees function parameters — #501).
+    let correlation = CorrelationId::new();
+    scrape_with_config_inner(
+        client,
+        url,
+        config,
+        downloader,
+        inspector,
+        engine,
+        correlation,
+    )
+    .await
+}
+
+#[instrument(
+    name = "scrape_with_config",
+    skip(client, config, downloader, inspector, engine, correlation),
+    fields(
+        url = %url,
+        correlation_id = %correlation,
+        trace_id = %correlation.trace_id(),
+        has_downloads = config.has_downloads()
+    )
+)]
+async fn scrape_with_config_inner(
+    client: &dyn HttpClientPort,
+    url: &url::Url,
+    config: &ScraperConfig,
+    downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
+    inspector: Option<&dyn DomInspectorPort>,
     #[allow(unused_variables)] engine: Option<&AdaptiveSelectorEngine>,
+    correlation: CorrelationId,
 ) -> Result<ScrapeOutcome> {
     let mut results = Vec::new();
 
@@ -102,7 +128,13 @@ pub async fn scrape_with_config(
     let response = match client.get(url.as_str()).await {
         Ok(resp) => resp,
         Err(e) => {
-            log_scrape_error(&e, url.as_str(), "fetch", None, "HTTP request failed");
+            log_scrape_error(
+                &e,
+                url.as_str(),
+                "fetch",
+                Some(&correlation),
+                "HTTP request failed",
+            );
             return Err(scraper_error_from_http(e, url.as_str()));
         },
     };
@@ -148,7 +180,7 @@ pub async fn scrape_with_config(
             &chain,
             url.as_str(),
             "fetch",
-            None,
+            Some(&correlation),
             "WAF challenge detected",
         );
         return Err(ScraperError::waf_blocked(url.to_string(), chain));
@@ -256,7 +288,7 @@ pub async fn scrape_with_config(
                 // This is what downstream Markdown converters receive.
                 html: Some(article.content),
                 assets,
-                correlation_id: Some(crate::domain::CorrelationId::new()),
+                correlation_id: Some(correlation.clone()),
             });
         },
         Err(e) => {
@@ -309,7 +341,7 @@ pub async fn scrape_with_config(
                 date: None,
                 html: Some(html),
                 assets,
-                correlation_id: Some(crate::domain::CorrelationId::new()),
+                correlation_id: Some(correlation),
             });
         },
     }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -76,8 +76,22 @@ pub async fn run(
         return CliExit::Success;
     }
     if opts.batch.enabled {
+        // Batch mode uses the crawl Engine, which mints its own run-root
+        // identity per crawl — do not mint one here.
         return run_batch(opts).await;
     }
+
+    // Run-root correlation identity (#501): the whole operation owns ONE
+    // root; every page derives `.child()` from it. `#[instrument]` spans
+    // cannot see locals at creation, so declare it offline-visible via a
+    // structured event (lands in the JSONL `.fields`).
+    let root_correlation = domain::CorrelationId::new();
+    info!(
+        correlation_id = %root_correlation,
+        trace_id = %root_correlation.trace_id(),
+        "run identity"
+    );
+
     let prepare = match prepare_phase(&opts).await {
         Err(e) => return e,
         Ok(p) => p,
@@ -126,6 +140,7 @@ pub async fn run(
             .as_deref()
             .map(|d| d as &dyn crate::domain::ports::AssetDownloaderPort),
         engine_ref,
+        &root_correlation,
     )
     .await
     {
@@ -352,6 +367,7 @@ async fn scrape_phase(
     observer: &dyn crate::application::progress_observer::ProgressObserver,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     engine: Option<&AdaptiveSelectorEngine>,
+    root_correlation: &domain::CorrelationId,
 ) -> Result<
     (
         Vec<domain::ScrapedContent>,
@@ -359,7 +375,16 @@ async fn scrape_phase(
     ),
     crate::error::ScraperError,
 > {
-    scrape_urls(urls, scraper_config, opts, observer, downloader, engine).await
+    scrape_urls(
+        urls,
+        scraper_config,
+        opts,
+        observer,
+        downloader,
+        engine,
+        root_correlation,
+    )
+    .await
 }
 
 /// Build the user-facing failure line for a single URL.

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -11,7 +11,7 @@ use crate::application::progress_observer::ProgressObserver;
 use crate::application::scrape_single_url_for_tui;
 use crate::cli::error::CliExit;
 use crate::domain::entities::progress::{ScrapeError, ScrapeStatus};
-use crate::domain::ScrapedContent;
+use crate::domain::{CorrelationId, ScrapedContent};
 use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
 use crate::infrastructure::export::state_store::StateStore;
@@ -107,6 +107,10 @@ pub async fn apply_resume_mode(
 
 /// Scrape all URLs, reporting progress via the provided observer.
 ///
+/// Correlation contract (#501): `root_correlation` is the run-root identity
+/// owned by the orchestrator; each page derives `.child()` from it — one
+/// shared `trace_id` for the whole run, a fresh `span_id` per page.
+///
 /// The observer handles quiet/channel logic internally — callers pass
 /// `&NoopObserver` for dry-run or `&LiveProgressObserver` for live output.
 ///
@@ -123,6 +127,7 @@ pub async fn scrape_urls(
     observer: &dyn ProgressObserver,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     engine: Option<&AdaptiveSelectorEngine>,
+    root_correlation: &CorrelationId,
 ) -> Result<
     (
         Vec<ScrapedContent>,
@@ -192,8 +197,20 @@ pub async fn scrape_urls(
             .on_status_changed(url_str, ScrapeStatus::Fetching)
             .await;
 
-        match scrape_single_url_for_tui(&router, &url, scraper_config, downloader, engine, None)
-            .await
+        // Per-page identity: child of the run root — shared trace_id, fresh
+        // span_id (#501).
+        let page_correlation = root_correlation.child();
+
+        match scrape_single_url_for_tui(
+            &router,
+            &url,
+            scraper_config,
+            downloader,
+            engine,
+            None,
+            &page_correlation,
+        )
+        .await
         {
             Ok(content) => {
                 observer

--- a/crates/webfang_core/src/infrastructure/observability/file_trace_layer.rs
+++ b/crates/webfang_core/src/infrastructure/observability/file_trace_layer.rs
@@ -635,6 +635,54 @@ mod tests {
         );
     }
 
+    /// Issue #501 regression: correlation identity declared at span creation
+    /// (the exact pattern of `scrape_single` / `crawl_page` /
+    /// `scrape_with_config`) must surface as `span_fields.correlation_id` and
+    /// `span_fields.trace_id` on every event inside the span. FileTraceLayer
+    /// snapshots fields in `on_new_span`, so anything not declared at creation
+    /// time is invisible offline — this test pins that contract.
+    #[test]
+    fn contract_captures_correlation_identity_declared_at_span_creation() {
+        use crate::domain::value_objects::CorrelationId;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("trace.jsonl");
+        let layer = FileTraceLayer::new(path.clone()).unwrap();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = tracing::Dispatch::new(subscriber);
+
+        // Fixed IDs keep the assertions exact-equality and deterministic.
+        let trace_id = uuid::Uuid::parse_str("01949e0e-8b8e-7000-8000-000000000001").unwrap();
+        let correlation = CorrelationId::new_with_ids(trace_id, 0x0000_0000_0000_0042);
+        let expected_traceparent = correlation.to_string();
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            let span = tracing::info_span!(
+                "scrape_single",
+                url = "https://example.com/page",
+                correlation_id = %correlation,
+                trace_id = %correlation.trace_id()
+            );
+            let _enter = span.enter();
+            tracing::info!("fetching page");
+        });
+
+        let parsed = parse_single_event(&path);
+        let span_fields = parsed["span_fields"]
+            .as_object()
+            .expect("span_fields must be present for spans declaring identity");
+        assert_eq!(
+            span_fields["correlation_id"],
+            json!(expected_traceparent),
+            "correlation_id must equal the W3C traceparent declared at span creation"
+        );
+        assert_eq!(
+            span_fields["trace_id"],
+            json!(trace_id.to_string()),
+            "trace_id must equal the correlation's UUID declared at span creation"
+        );
+    }
+
     #[test]
     fn contract_span_field_absent_outside_span() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/webfang_core/tests/behavioral/cli/mod.rs
+++ b/crates/webfang_core/tests/behavioral/cli/mod.rs
@@ -11,5 +11,6 @@ mod resume_test;
 mod robots_test;
 mod single_page_test;
 mod sitemap_test;
+mod trace_correlation_test;
 mod user_agent_test;
 mod waf_gauntlet_test;

--- a/crates/webfang_core/tests/behavioral/cli/trace_correlation_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/trace_correlation_test.rs
@@ -1,0 +1,150 @@
+//! End-to-end trace correlation (issue #501).
+//!
+//! Acceptance criterion from the issue: a multi-page scrape with
+//! `--trace-file` must emit per-page `correlation_id` values in
+//! `span_fields` (one distinct identity per page), and the identities
+//! exported to the RAG vector export must match them — proving the trace
+//! JSONL and the exported content are correlatable.
+
+use crate::cmd;
+use crate::BehavioralTest;
+use std::collections::BTreeSet;
+use std::io::{BufRead, BufReader};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+/// Two scrapeable pages listed in the sitemap, plus an allow-all robots.txt.
+async fn mount_two_page_site(server: &wiremock::MockServer) -> String {
+    let base = server.uri();
+
+    crate::common::mock_robots(server, "User-agent: *\n").await;
+
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>{base}/page-a</loc></url>
+    <url><loc>{base}/page-b</loc></url>
+</urlset>"#
+    );
+    crate::common::mock_sitemap(server, &format!("{base}/sitemap.xml"), &sitemap_xml).await;
+
+    // Sitemap discovery probes fallback locations with HEAD before parsing
+    // them with GET (sitemap_discovery.rs), so the probe needs its own mock.
+    Mock::given(method("HEAD"))
+        .and(path("/sitemap.xml"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(server)
+        .await;
+
+    for (page_path, title) in [("/page-a", "Page A"), ("/page-b", "Page B")] {
+        Mock::given(method("GET"))
+            .and(path(page_path))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                "<html><body><article><h1>{title}</h1></article></body></html>"
+            )))
+            .mount(server)
+            .await;
+    }
+
+    base
+}
+
+/// A sitemap scrape of two pages with `--trace-file` + vector export must:
+/// (a) carry distinct `span_fields.correlation_id` values, one per page, and
+/// (b) export the same identities in the vector JSON documents.
+#[tokio::test]
+async fn scrape_trace_and_vector_export_share_per_page_correlation() {
+    let t = BehavioralTest::new().await;
+    let base = mount_two_page_site(&t.server).await;
+
+    let trace_path = t.out.path().join("trace.jsonl");
+
+    let output = cmd()
+        .arg("--url")
+        .arg(&base)
+        .arg("--use-sitemap")
+        .arg("--export-format")
+        .arg("vector")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--trace-file")
+        .arg(&trace_path)
+        .arg("--quiet")
+        .output()
+        .expect("run webfang binary");
+
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // --- Parse the JSONL trace ---
+    let file = std::fs::File::open(&trace_path)
+        .unwrap_or_else(|e| panic!("trace file must exist at {}: {e}", trace_path.display()));
+    let lines: Vec<serde_json::Value> = BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(&line)
+                .unwrap_or_else(|e| panic!("trace line should be valid JSON: {e}\n{line}"))
+        })
+        .collect();
+    assert!(!lines.is_empty(), "trace must contain events");
+
+    // --- (a) Per-page correlation IDs declared on the scrape spans ---
+    let span_correlations: BTreeSet<String> = lines
+        .iter()
+        .filter_map(|v| {
+            v["span_fields"]["correlation_id"]
+                .as_str()
+                .map(str::to_owned)
+        })
+        .collect();
+    assert!(
+        span_correlations.len() >= 2,
+        "each scraped page must declare its own correlation_id at span creation (#501); \
+         got {} distinct value(s): {span_correlations:?}",
+        span_correlations.len()
+    );
+
+    // --- (b) The vector export carries the same identities ---
+    let vector_files = t.find_files("json");
+    assert!(
+        !vector_files.is_empty(),
+        "vector export must produce a .json file"
+    );
+    let export_json: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&vector_files[0]).expect("read vector export"),
+    )
+    .expect("vector export must be valid JSON");
+    let documents = export_json["documents"]
+        .as_array()
+        .expect("vector export must contain documents");
+    assert_eq!(
+        documents.len(),
+        2,
+        "both sitemap pages must be exported, got {}",
+        documents.len()
+    );
+
+    let mut exported: BTreeSet<String> = BTreeSet::new();
+    for doc in documents {
+        let corr = doc["correlation_id"]
+            .as_str()
+            .expect("every exported document must carry a correlation_id");
+        assert!(
+            span_correlations.contains(corr),
+            "exported correlation_id {corr} must appear in the trace span_fields \
+             ({span_correlations:?})"
+        );
+        exported.insert(corr.to_owned());
+    }
+    assert_eq!(
+        exported.len(),
+        2,
+        "each page must keep its own identity in the export; got {exported:?}"
+    );
+}

--- a/crates/webfang_core/tests/behavioral/cli/trace_correlation_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/trace_correlation_test.rs
@@ -50,8 +50,10 @@ async fn mount_two_page_site(server: &wiremock::MockServer) -> String {
 }
 
 /// A sitemap scrape of two pages with `--trace-file` + vector export must:
-/// (a) carry distinct `span_fields.correlation_id` values, one per page, and
-/// (b) export the same identities in the vector JSON documents.
+/// (a) carry distinct `span_fields.correlation_id` values, one per page,
+/// (b) share exactly ONE run-root `span_fields.trace_id` across all page
+///     spans, with every traceparent embedding that same trace UUID, and
+/// (c) export the same identities in the vector JSON documents.
 #[tokio::test]
 async fn scrape_trace_and_vector_export_share_per_page_correlation() {
     let t = BehavioralTest::new().await;
@@ -110,7 +112,52 @@ async fn scrape_trace_and_vector_export_share_per_page_correlation() {
         span_correlations.len()
     );
 
-    // --- (b) The vector export carries the same identities ---
+    // --- (b) All page spans share ONE run-root trace_id (#501 follow-up) ---
+    let span_traces: BTreeSet<String> = lines
+        .iter()
+        .filter_map(|v| v["span_fields"]["trace_id"].as_str().map(str::to_owned))
+        .collect();
+    assert_eq!(
+        span_traces.len(),
+        1,
+        "every page span of a run must share the run-root trace_id (causality); \
+         got {} distinct value(s): {span_traces:?}",
+        span_traces.len()
+    );
+    let run_trace = span_traces
+        .first()
+        .expect("trace set asserted non-empty above");
+
+    // Every per-page traceparent `00-{32hex trace}-{16hex span}-01` must embed
+    // that same run-root trace UUID (without dashes) as its trace part.
+    let run_trace_hex = run_trace.replace('-', "");
+    for corr in &span_correlations {
+        let parts: Vec<&str> = corr.split('-').collect();
+        assert_eq!(
+            parts.len(),
+            4,
+            "correlation_id must be a W3C traceparent `00-<trace>-<span>-01`, got: {corr}"
+        );
+        assert_eq!(parts[0], "00", "traceparent version must be 00: {corr}");
+        assert_eq!(parts[3], "01", "traceparent flags must be 01: {corr}");
+        assert_eq!(
+            parts[1].len(),
+            32,
+            "traceparent trace part must be 32 hex chars: {corr}"
+        );
+        assert_eq!(
+            parts[2].len(),
+            16,
+            "traceparent span part must be 16 hex chars: {corr}"
+        );
+        assert_eq!(
+            parts[1], run_trace_hex,
+            "traceparent trace part must equal the shared run-root trace_id \
+             ({run_trace}); page identity drifted: {corr}"
+        );
+    }
+
+    // --- (c) The vector export carries the same identities ---
     let vector_files = t.find_files("json");
     assert!(
         !vector_files.is_empty(),

--- a/crates/webfang_core/tests/scraper_service_test.rs
+++ b/crates/webfang_core/tests/scraper_service_test.rs
@@ -5,7 +5,7 @@ use webfang_core::application::scraper_service::{
     detect_spa_content, extract_with_selector, scrape_multiple_with_limit, scrape_with_config,
     scrape_with_readability, MAX_INSTRUMENTED_BODY_SIZE, MIN_CONTENT_CHARS,
 };
-use webfang_core::domain::{DomInspectorPort, ExtractResult, SelectorErrorKind};
+use webfang_core::domain::{CorrelationId, DomInspectorPort, ExtractResult, SelectorErrorKind};
 use webfang_core::{ScraperConfig, ScraperError};
 
 // --- Shared mock HTTP client (tests/common/mock_http.rs, Item 2 Tier-2) ---
@@ -27,7 +27,8 @@ async fn test_scrape_with_config_invalid_url() {
         Err(HttpError::Connection("no route to host".into())),
     );
 
-    let result = scrape_with_config(&mock, &url, &config, None, None, None).await;
+    let root = CorrelationId::new();
+    let result = scrape_with_config(&mock, &url, &config, None, None, None, &root).await;
     assert!(result.is_err(), "connection error should propagate as Err");
 }
 
@@ -49,7 +50,8 @@ async fn test_scrape_with_config_returns_outcome() {
     let mock = MockHttpClient::new().with_ok_response(url.as_str(), html);
     let config = ScraperConfig::default();
 
-    let outcome = scrape_with_config(&mock, &url, &config, None, None, None)
+    let root = CorrelationId::new();
+    let outcome = scrape_with_config(&mock, &url, &config, None, None, None, &root)
         .await
         .expect("mock HTML should succeed");
     assert!(

--- a/crates/webfang_core/tests/scraper_service_test.rs
+++ b/crates/webfang_core/tests/scraper_service_test.rs
@@ -68,6 +68,59 @@ async fn test_scrape_with_config_returns_outcome() {
     );
 }
 
+/// Lineage contract (#501): `scrape_with_config` derives the page identity
+/// from the caller-owned run root — the exported `ScrapedContent` must keep
+/// the root's `trace_id` (operation causality) while getting a fresh
+/// `span_id` (`.child()` semantics). Guards against a regression back to an
+/// ad-hoc `CorrelationId::new()` inside the use case.
+#[cfg_attr(miri, ignore)] // legible/servo_arc Tree-Borrows UB
+#[tokio::test]
+async fn test_scrape_with_config_derives_child_from_run_root() {
+    let html = r#"<!DOCTYPE html>
+<html>
+<head><title>Lineage Page</title></head>
+<body>
+<article>
+<h1>Main Heading</h1>
+<p>This is the content of the article. It has enough text to be extracted by Readability.</p>
+</article>
+</body>
+</html>"#;
+
+    let url = url::Url::parse("https://example.com/lineage").unwrap();
+    let mock = MockHttpClient::new().with_ok_response(url.as_str(), html);
+    let config = ScraperConfig::default();
+
+    // Deterministic root: fixed UUID v7 + span_id keep the assertions exact.
+    let root_trace = uuid::Uuid::parse_str("01949e0e-8b8e-7000-8000-000000000001")
+        .expect("valid fixed UUID for the test root");
+    let root = CorrelationId::new_with_ids(root_trace, 0x0000_0000_0000_0001);
+
+    let outcome = scrape_with_config(&mock, &url, &config, None, None, None, &root)
+        .await
+        .expect("mock HTML should scrape");
+
+    let page = outcome
+        .results
+        .first()
+        .expect("one scraped result expected");
+    let page_correlation = page
+        .correlation_id
+        .as_ref()
+        .expect("scraped content must carry the page correlation identity");
+
+    assert_eq!(
+        page_correlation.trace_id(),
+        root.trace_id(),
+        "page identity must stay under the run-root trace_id (operation causality)"
+    );
+    assert_ne!(
+        page_correlation.span_id(),
+        root.span_id(),
+        "page identity must derive a fresh span_id via .child(), not reuse the root's"
+    );
+}
+
 // =====================================================================
 // ScraperConfig tests
 // =====================================================================

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -107,8 +107,17 @@ impl McpHandler {
             .as_deref()
             .map(|d| d as &dyn webfang_core::domain::ports::AssetDownloaderPort);
         let inspector = self.state.inspector.as_deref();
+        // An MCP tool call IS an operation (#501): mint the run-root identity
+        // at the handler entry; the use case derives the page child from it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         match webfang_core::application::scraper_service::scrape_with_config(
-            client, &url, &config, dl, inspector, None,
+            client,
+            &url,
+            &config,
+            dl,
+            inspector,
+            None,
+            &root_correlation,
         )
         .await
         {

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -139,8 +139,25 @@ jq -r 'select(.level == "ERROR") | .fields.url // empty' debug.jsonl | sort -u
 | `execute` | `pipeline::PipelineExecutor` | `url`, `stages` |
 | `pipeline_stage` | `pipeline::PipelineExecutor` | `stage`, `url` |
 | `export_batch` | `JsonlExporter` / `VectorExporter` / `FileExporter` | `exporter`, `documents` |
-| `scrape_with_config` | `scraper_service` | `url`, `has_downloads` |
+| `scrape_single_url` → `scrape_single` | `crawler::discovery::scrape_single_url_for_tui` | `url` (outer), `correlation_id`, `trace_id`, `url` (inner, #501) |
+| `scrape_with_config` | `scraper_service` | `url`, `correlation_id`, `trace_id`, `has_downloads` |
 | `scrape_multiple_with_limit` | `scraper_service` | `urls`, `concurrency` |
+
+Per-page identity is declared **at span creation time** (`correlation_id` =
+W3C traceparent, `trace_id` = the correlation's UUID) because
+FileTraceLayer snapshots span fields in `on_new_span` — fields recorded
+later never reach the JSONL. `ScrapedContent` and the RAG exports carry the
+same identity, so an exported document's `correlation_id` matches its page's
+`span_fields.correlation_id`:
+
+```bash
+# Every page identity present in the trace
+jq -r '.span_fields.correlation_id // empty' debug.jsonl | sort -u
+
+# Reconstruct one page's scrape by its correlation_id
+CID=00-01949e0e8b8e70008000000000000001-0000000000000042-01
+jq -c "select(.span_fields.correlation_id? == \"$CID\")" debug.jsonl
+```
 
 Events (not spans): `crawl progress`, `crawl completed`, and any
 `log_scrape_error(...)` error carrying `error`, `url`, `stage`, `trace_id`.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -143,14 +143,32 @@ jq -r 'select(.level == "ERROR") | .fields.url // empty' debug.jsonl | sort -u
 | `scrape_with_config` | `scraper_service` | `url`, `correlation_id`, `trace_id`, `has_downloads` |
 | `scrape_multiple_with_limit` | `scraper_service` | `urls`, `concurrency` |
 
-Per-page identity is declared **at span creation time** (`correlation_id` =
-W3C traceparent, `trace_id` = the correlation's UUID) because
-FileTraceLayer snapshots span fields in `on_new_span` — fields recorded
-later never reach the JSONL. `ScrapedContent` and the RAG exports carry the
-same identity, so an exported document's `correlation_id` matches its page's
+Identity follows the root-child contract: the OPERATION owns one root
+`CorrelationId`, and every unit of work derives `.child()` from it — same
+`trace_id`, fresh `span_id`. In a CLI run the orchestrator mints the root
+and announces it with a `run identity` event (`correlation_id`, `trace_id`
+in `.fields`); `scrape_multiple_with_limit` does the same with a
+`scrape_multiple identity` event. So in a multi-page scrape:
+
+- `span_fields.trace_id` is the **shared run-root UUID** across all page
+  spans — the whole run is reconstructable by it.
+- `span_fields.correlation_id` (full W3C traceparent) is **unique per
+  page**; its trace part is the run-root UUID without dashes.
+
+Identity is declared **at span creation time** because FileTraceLayer
+snapshots span fields in `on_new_span` — fields recorded later never reach
+the JSONL. `ScrapedContent` and the RAG exports carry the same identity, so
+an exported document's `correlation_id` matches its page's
 `span_fields.correlation_id`:
 
 ```bash
+# Reconstruct an entire run by the shared run-root trace_id
+ROOT=01949e0e-8b8e-7000-8000-000000000001
+jq -c "select(.span_fields.trace_id == \"$ROOT\")" debug.jsonl
+
+# The run-root identity (the `run identity` event carries it in .fields)
+jq -c 'select(.message? == "run identity") | .fields' debug.jsonl
+
 # Every page identity present in the trace
 jq -r '.span_fields.correlation_id // empty' debug.jsonl | sort -u
 
@@ -159,8 +177,9 @@ CID=00-01949e0e8b8e70008000000000000001-0000000000000042-01
 jq -c "select(.span_fields.correlation_id? == \"$CID\")" debug.jsonl
 ```
 
-Events (not spans): `crawl progress`, `crawl completed`, and any
-`log_scrape_error(...)` error carrying `error`, `url`, `stage`, `trace_id`.
+Events (not spans): `run identity`, `scrape_multiple identity`,
+`crawl progress`, `crawl completed`, and any `log_scrape_error(...)` error
+carrying `error`, `url`, `stage`, `trace_id`.
 
 ---
 


### PR DESCRIPTION
## Linked Issue

Fixes #493
Fixes #501

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Multi-page crawls emitted trace JSONL where every span inherited a single run-scoped correlation ID, and no span declared `correlation_id` at all (jq over `span_fields.correlation_id` returned 0 matches). Root cause: per-page `CorrelationId` was generated ad-hoc at the *end* of the scrape pipeline, while `FileTraceLayer` only captures fields declared at span creation (`on_new_span`).
- Fix follows the mandated identity-at-origin pattern (same as `crawl_page` in `crawl_task.rs`): the page `CorrelationId` is created before span creation, declared directly in the `span!`/`#[instrument]` fields so the layer snapshots it, and the same identity is threaded into `ScrapedContent`/exported JSON — trace and export now agree at span granularity.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/crawler/discovery.rs` | `scrape_single_url_for_tui` creates `page_correlation` up front; `scrape_single` span now declares `correlation_id` + `trace_id`; binary path and `extract_content` call reuse the same identity; new fidelity test |
| `crates/webfang_core/src/application/extraction.rs` | `extract_content` takes `correlation_id: Option<&CorrelationId>`; uses the injected identity when present (ad-hoc fallback kept for standalone callers); extraction errors now logged with correlation |
| `crates/webfang_core/src/application/scraper_service.rs` | `scrape_with_config` split into wrapper + inner instrumented fn so `correlation_id` + `trace_id` are declared in the `scrape_with_config` span (public signature/name/behavior unchanged); both `ScrapedContent` constructions reuse the page identity |
| `crates/webfang_core/src/infrastructure/observability/file_trace_layer.rs` | Regression contract test: correlation declared at span creation appears verbatim in `span_fields` |
| `crates/webfang_core/tests/behavioral/cli/trace_correlation_test.rs` | E2E acceptance test (wiremock, 2 pages): trace JSONL carries ≥1 distinct `span_fields.correlation_id` per page and every vector-export `correlation_id` appears in trace `span_fields` |
| `docs/debugging.md` | Span contract table: `scrape_single` and `scrape_with_config` now carry `correlation_id` + `trace_id` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (full workspace: 2088 passed, 0 failed, 23 skipped)
- [x] Manually verified the affected functionality (behavioral E2E asserts trace JSONL ↔ export correlation match end-to-end)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed

