### PR TITLE
fix(http): pin --user-agent on the wreq layer so the flag reaches the wire

### DIFF
--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -226,6 +226,9 @@ impl Engine {
             tls_emulation,
             Arc::clone(&self.cookie_bridge),
             ignore_waf,
+            // #503: the Engine path keeps today's rotating default behavior —
+            // `CrawlerConfig.user_agent` is a separate dead field, out of scope.
+            None,
         )?;
         self.js_strategy = strategy;
         self.fetch_router = Some(router);

--- a/crates/webfang_core/src/application/crawler/fetch_router.rs
+++ b/crates/webfang_core/src/application/crawler/fetch_router.rs
@@ -50,8 +50,10 @@ pub enum FetchRouter {
 /// `timeout_secs` drives the wreq request timeout (connect timeout is clamped
 /// to 10s); `tls_emulation` is the TLS/HTTP2 fingerprint profile applied to the
 /// wreq layer; `cookie_bridge` is shared with the Chromiumoxide layer for
-/// cookie injection. `ignore_waf` bypasses WAF classification on the hybrid
-/// spa-detection path (REQ-WAF-07).
+/// cookie injection; `ignore_waf` bypasses WAF classification on the hybrid
+/// spa-detection path (REQ-WAF-07); `user_agent` pins the User-Agent on the
+/// wreq layer (Static and Hybrid L1) so `--user-agent` reaches the wire —
+/// `None` keeps the emulation-default + 403-rotation behavior (#503).
 ///
 /// # Errors
 ///
@@ -62,6 +64,7 @@ pub fn build_fetch_router(
     tls_emulation: Profile,
     cookie_bridge: Arc<RwLock<CookieBridge>>,
     ignore_waf: bool,
+    user_agent: Option<String>,
 ) -> Result<FetchRouter, DownloadError> {
     let connect_timeout = timeout_secs.min(10);
     Ok(match strategy {
@@ -69,9 +72,10 @@ pub fn build_fetch_router(
             timeout_secs,
             connect_timeout,
             tls_emulation,
+            user_agent,
         )?)),
         JsStrategy::Hybrid => {
-            let l1 = WreqDownloader::new(timeout_secs, connect_timeout, tls_emulation)?;
+            let l1 = WreqDownloader::new(timeout_secs, connect_timeout, tls_emulation, user_agent)?;
             let l2 = ObscuraDownloader::new(timeout_secs);
             let l3 = ChromiumoxideDownloader::new(cookie_bridge);
             FetchRouter::Hybrid(Arc::new(HybridRouter::new(l1, l2, l3, ignore_waf)))
@@ -136,6 +140,7 @@ mod router_tests {
             Profile::Chrome145,
             test_cookie_bridge(),
             false,
+            None,
         )
         .expect("static router must build");
         assert!(
@@ -152,6 +157,7 @@ mod router_tests {
             Profile::Chrome145,
             test_cookie_bridge(),
             false,
+            None,
         )
         .expect("hybrid router must build");
         assert!(
@@ -168,6 +174,7 @@ mod router_tests {
             Profile::Chrome145,
             test_cookie_bridge(),
             false,
+            None,
         )
         .expect("full router must build");
         assert!(

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -139,6 +139,10 @@ pub async fn scrape_urls(
         http_config.tls_emulation,
         cookie_bridge,
         opts.crawl.ignore_waf,
+        // #503: move the operator's --user-agent into the wreq layer instead
+        // of dropping it on the floor. `http_config` stays usable below —
+        // only this field moves out.
+        http_config.user_agent,
     )?;
 
     let _total_urls = urls.len();

--- a/crates/webfang_core/src/infrastructure/downloader/mod.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/mod.rs
@@ -40,7 +40,7 @@ use url::Url;
 /// use webfang_core::infrastructure::downloader::wreq_downloader::WreqDownloader;
 /// use webfang_core::infrastructure::downloader::Downloader;
 ///
-/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145).unwrap();
+/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145, None).unwrap();
 /// let page = downloader.fetch(&"https://example.com".parse().unwrap()).await.unwrap();
 /// assert!(!page.html.is_empty());
 /// ```

--- a/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
@@ -35,13 +35,19 @@ const WREQ_MEMORY_COST: usize = 1_024 * 1_024; // ~1 MB
 /// use webfang_core::infrastructure::downloader::wreq_downloader::WreqDownloader;
 /// use webfang_core::infrastructure::downloader::Downloader;
 ///
-/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145).unwrap();
+/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145, None).unwrap();
 /// let page = downloader.fetch(&"https://example.com".parse().unwrap()).await.unwrap();
 /// assert_eq!(page.status, 200);
 /// ```
 pub struct WreqDownloader {
     client: Arc<Client>,
     timeout_secs: u64,
+    /// User-Agent pinned by the operator (`--user-agent`, #503).
+    ///
+    /// Applied once at client-build time so every request — first fetch and
+    /// all retries — carries it. When set, the 403 pool-rotation retry is
+    /// disabled: the operator asked to be identified exactly as configured.
+    pinned_ua: Option<String>,
 }
 
 impl WreqDownloader {
@@ -55,6 +61,10 @@ impl WreqDownloader {
     /// * `timeout_secs` - Request timeout in seconds
     /// * `connect_timeout_secs` - Connection timeout in seconds
     /// * `tls_emulation` - TLS/HTTP2 fingerprint profile applied to the client
+    /// * `user_agent` - Optional pinned User-Agent (#503). Applied at client
+    ///   build time via the builder's `user_agent` API, AFTER the emulation
+    ///   profile, so it wins over the profile-default UA on the wire. When
+    ///   set, the 403 pool-rotation retry is disabled.
     ///
     /// # Errors
     ///
@@ -63,11 +73,19 @@ impl WreqDownloader {
         timeout_secs: u64,
         connect_timeout_secs: u64,
         tls_emulation: Profile,
+        user_agent: Option<String>,
     ) -> Result<Self, DownloadError> {
         let pool_size = std::cmp::max(6, num_cpus::get() - 1);
 
-        let client = Client::builder()
-            .emulation(tls_emulation)
+        // `.emulation(profile)` installs the profile-default headers (including
+        // a browser UA) via `default_headers`; a pinned UA must be set AFTER
+        // it so `HeaderMap::insert` replaces the profile value (#503).
+        let builder = Client::builder().emulation(tls_emulation);
+        let builder = match user_agent.as_deref() {
+            Some(ua) => builder.user_agent(ua),
+            None => builder,
+        };
+        let client = builder
             .timeout(Duration::from_secs(timeout_secs))
             .connect_timeout(Duration::from_secs(connect_timeout_secs))
             .pool_max_idle_per_host(pool_size)
@@ -80,13 +98,17 @@ impl WreqDownloader {
             .map_err(|e| DownloadError::Internal(format!("failed to build wreq client: {e}")))?;
 
         debug!(
-            "WreqDownloader created: pool_size={}, timeout={}s, connect_timeout={}s",
-            pool_size, timeout_secs, connect_timeout_secs
+            pool_size = pool_size,
+            timeout_secs = timeout_secs,
+            connect_timeout_secs = connect_timeout_secs,
+            ua = user_agent.as_deref().unwrap_or("emulation-default"),
+            "WreqDownloader created"
         );
 
         Ok(Self {
             client: Arc::new(client),
             timeout_secs,
+            pinned_ua: user_agent,
         })
     }
 
@@ -97,6 +119,7 @@ impl WreqDownloader {
         Self {
             client: Arc::new(client),
             timeout_secs,
+            pinned_ua: None,
         }
     }
 
@@ -196,7 +219,16 @@ fn parse_retry_after_ms(response: &wreq::Response) -> u64 {
 }
 
 impl WreqDownloader {
-    #[instrument(skip(self), fields(url = %url))]
+    /// Describe the effective User-Agent of a request for tracing (#503):
+    /// the request-level override (403 rotation), else the pinned value,
+    /// else the emulation-profile default.
+    fn effective_ua<'a>(&'a self, request_ua: Option<&'a str>) -> &'a str {
+        request_ua
+            .or(self.pinned_ua.as_deref())
+            .unwrap_or("emulation-default")
+    }
+
+    #[instrument(skip(self), fields(url = %url, ua = %self.effective_ua(user_agent)))]
     async fn send_request(
         &self,
         url: &Url,
@@ -233,7 +265,10 @@ impl WreqDownloader {
         let mut status = response.status().as_u16();
 
         // 403: one implicit retry with rotated User-Agent (mirrors HttpClient).
-        if status == 403 {
+        // Pinned UA (#503): the operator asked to be identified exactly as
+        // configured ("--user-agent QA-Bot/9.9" means QA-Bot or fail), so pool
+        // rotation is skipped and the 403 falls through to normal error handling.
+        if status == 403 && self.pinned_ua.is_none() {
             warn!("403 Forbidden from {url} — retrying with rotated User-Agent");
             let agents = UserAgentCache::fallback_agents();
             let rotated_ua = agents.get(1).map(String::as_str);
@@ -333,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_wreq_downloader_creation() {
-        let downloader = WreqDownloader::new(30, 10, Profile::Chrome145).unwrap();
+        let downloader = WreqDownloader::new(30, 10, Profile::Chrome145, None).unwrap();
         assert!(!downloader.supports_interactions());
         assert_eq!(downloader.memory_cost(), WREQ_MEMORY_COST);
     }
@@ -344,7 +379,7 @@ mod tests {
         // with it (triangulation: the parameter reaches the builder instead of
         // a hardcoded default).
         for profile in [Profile::Chrome145, Profile::Chrome131, Profile::Firefox135] {
-            let downloader = WreqDownloader::new(30, 10, profile)
+            let downloader = WreqDownloader::new(30, 10, profile, None)
                 .unwrap_or_else(|e| panic!("client must build for profile {profile:?}: {e}"));
             assert!(!downloader.supports_interactions());
         }
@@ -411,7 +446,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires network — wiremock tests below cover same scenario"]
     async fn test_fetch_example_com() {
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145).unwrap();
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
         let url: Url = "https://example.com".parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -428,8 +463,8 @@ mod tests {
 #[cfg(not(miri))]
 mod wiremock_tests {
     use super::*;
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Match, Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
     async fn test_fetch_200_returns_body() {
@@ -442,7 +477,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145).unwrap();
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
         let url: Url = mock_server.uri().parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -463,7 +498,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145).unwrap();
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
         let url: Url = format!("{}/notfound", mock_server.uri()).parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -488,7 +523,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145).unwrap();
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
         let url: Url = mock_server.uri().parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -520,7 +555,7 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145).unwrap();
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
         let url: Url = format!("{}/redirect", mock_server.uri()).parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -528,5 +563,176 @@ mod wiremock_tests {
 
         let page = result.unwrap();
         assert!(page.url.as_str().contains("/target"));
+    }
+
+    // ------------------------------------------------------------------
+    // Pinned User-Agent (#503)
+    // ------------------------------------------------------------------
+
+    /// Wire-level proof that a pinned UA wins over the emulation-profile
+    /// default UA: the TLS/HTTP2 fingerprint (Chrome145) is fully enabled,
+    /// yet the server receives exactly the pinned value. The mock only
+    /// matches `QA-Bot/9.9` — if the profile UA leaked onto the wire the
+    /// request would 404 and the fetch would fail.
+    #[tokio::test]
+    async fn pinned_user_agent_beats_emulation_profile_on_the_wire() {
+        const PINNED_UA: &str = "QA-Bot/9.9";
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(header("User-Agent", PINNED_UA))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html></html>"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let downloader =
+            WreqDownloader::new(10, 5, Profile::Chrome145, Some(PINNED_UA.to_string())).unwrap();
+        let url: Url = mock_server.uri().parse().unwrap();
+
+        let page = downloader
+            .fetch(&url)
+            .await
+            .expect("fetch succeeds only if the pinned UA matched on the wire");
+        assert_eq!(page.status, 200);
+
+        // Second proof: the server-side record shows exactly the pinned UA.
+        let requests = mock_server
+            .received_requests()
+            .await
+            .expect("server records requests");
+        let ua = requests
+            .first()
+            .expect("one request recorded")
+            .headers
+            .get("user-agent")
+            .expect("User-Agent header present");
+        assert_eq!(
+            ua.to_str().expect("User-Agent must be valid ASCII"),
+            PINNED_UA
+        );
+    }
+
+    /// Exact-match matcher for a single raw header value.
+    ///
+    /// Unlike `wiremock::matchers::header`, it does NOT comma-split the
+    /// received value: the fallback pool agents embed commas
+    /// ("(KHTML, like Gecko)"), which the built-in exact matcher splits into
+    /// two values and therefore never matches.
+    struct RawHeaderEquals {
+        name: &'static str,
+        value: String,
+    }
+
+    impl Match for RawHeaderEquals {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            request
+                .headers
+                .get_all(self.name)
+                .iter()
+                .any(|v| v.to_str().is_ok_and(|s| s == self.value))
+        }
+    }
+
+    /// Issue #503 policy: a pinned UA disables the 403 pool-agent rotation.
+    /// The first 403 surfaces as a terminal error (no retry under a rotated
+    /// identity), and the next fetch still carries the pinned UA.
+    #[tokio::test]
+    async fn pinned_user_agent_disables_403_rotation() {
+        const PINNED_UA: &str = "QA-Bot/9.9";
+        let mock_server = MockServer::start().await;
+        let pool_agent = UserAgentCache::fallback_agents().swap_remove(1);
+
+        // First hit: 403 for the pinned UA (consumed once, then falls through).
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(header("User-Agent", PINNED_UA))
+            .respond_with(ResponseTemplate::new(403))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        // Catches a rotated retry — must remain unmatched (expect(0)).
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(RawHeaderEquals {
+                name: "user-agent",
+                value: pool_agent,
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>rotated</html>"))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        // Second hit: 200, but only for the pinned UA.
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(header("User-Agent", PINNED_UA))
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>still pinned</html>"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let downloader =
+            WreqDownloader::new(10, 5, Profile::Chrome145, Some(PINNED_UA.to_string())).unwrap();
+        let url: Url = mock_server.uri().parse().unwrap();
+
+        // First fetch: 403 is terminal — rotation is disabled when pinned.
+        let err = downloader
+            .fetch(&url)
+            .await
+            .expect_err("403 must surface as an error when the UA is pinned");
+        assert!(
+            matches!(err, DownloadError::Http { status: 403, .. }),
+            "expected terminal Http 403, got: {err:?}"
+        );
+
+        // Second fetch: still carries the pinned UA (only the pinned mock
+        // answers now), proving no identity drift after the 403.
+        let page = downloader
+            .fetch(&url)
+            .await
+            .expect("second fetch succeeds with the pinned UA");
+        assert_eq!(page.status, 200);
+        assert_eq!(page.html, "<html>still pinned</html>");
+    }
+
+    /// Unpinned baseline: the pre-#503 rotation behavior is preserved —
+    /// a 403 triggers one retry with the pool agent and succeeds.
+    #[tokio::test]
+    async fn unpinned_user_agent_rotates_pool_agent_on_403() {
+        let mock_server = MockServer::start().await;
+        let pool_agent = UserAgentCache::fallback_agents().swap_remove(1);
+
+        // First hit: 403 regardless of UA (consumed once).
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(403))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        // The rotated retry must arrive with the pool agent.
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(RawHeaderEquals {
+                name: "user-agent",
+                value: pool_agent,
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_string("<html>rotated</html>"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
+        let url: Url = mock_server.uri().parse().unwrap();
+
+        let page = downloader
+            .fetch(&url)
+            .await
+            .expect("rotated retry succeeds for unpinned downloads");
+        assert_eq!(page.status, 200);
+        assert_eq!(page.html, "<html>rotated</html>");
     }
 }

--- a/crates/webfang_core/tests/behavioral/cli/mod.rs
+++ b/crates/webfang_core/tests/behavioral/cli/mod.rs
@@ -11,4 +11,5 @@ mod resume_test;
 mod robots_test;
 mod single_page_test;
 mod sitemap_test;
+mod user_agent_test;
 mod waf_gauntlet_test;

--- a/crates/webfang_core/tests/behavioral/cli/user_agent_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/user_agent_test.rs
@@ -1,0 +1,43 @@
+//! `--user-agent` pinning: the CLI flag reaches the wire (#503).
+//!
+//! Before the fix, `--user-agent` stopped at `HttpClientConfig` and never
+//! reached the wreq layer — the server saw the emulation-profile default UA.
+//! The mock below answers ONLY when the request carries exactly the pinned
+//! UA, so a successful scrape proves the flag is on the wire end-to-end.
+
+use crate::BehavioralTest;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+const SEED_HTML: &str = r#"
+<html><head><title>User Agent Pin Test</title></head>
+<body><main><article>
+<h1>Pinned Identity</h1>
+<p>This content is only served when the pinned User-Agent arrives on the wire.</p>
+<p>More paragraphs ensure readability can extract a proper document.</p>
+</article></main></body></html>
+"#;
+
+#[tokio::test]
+async fn user_agent_flag_reaches_the_wire() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .and(header("User-Agent", "QA-Bot/9.9"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SEED_HTML))
+        .expect(1)
+        .mount(&t.server)
+        .await;
+
+    t.scraper_cmd()
+        .arg("--single-page")
+        .arg("--user-agent")
+        .arg("QA-Bot/9.9")
+        .arg("--quiet")
+        .assert()
+        .success();
+
+    let content = t.read_md_content();
+    crate::assert_snapshot_redacted("user_agent_flag_reaches_the_wire", t.out.path(), content);
+}

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__user_agent_flag_reaches_the_wire.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__user_agent_flag_reaches_the_wire.snap
@@ -1,0 +1,16 @@
+---
+source: crates/webfang_core/tests/behavioral/main.rs
+expression: redacted
+---
+---
+title: User Agent Pin Test
+url: http://127.0.0.1:<PORT>/
+date: [DATE]
+excerpt: This content is only served when the pinned User-Agent arrives on the wire.
+---
+
+## Pinned Identity
+
+This content is only served when the pinned User-Agent arrives on the wire.
+
+More paragraphs ensure readability can extract a proper document.

--- a/crates/webfang_core/tests/downloader_headers_test.rs
+++ b/crates/webfang_core/tests/downloader_headers_test.rs
@@ -29,7 +29,7 @@ async fn wreq_downloader_populates_response_headers() {
         .mount(&server)
         .await;
 
-    let downloader = WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation)
+    let downloader = WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
         .expect("downloader builds");
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 
@@ -71,7 +71,7 @@ async fn wreq_downloader_headers_keys_are_lowercased() {
         .mount(&server)
         .await;
 
-    let downloader = WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation)
+    let downloader = WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
         .expect("downloader builds");
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 


### PR DESCRIPTION
## Linked Issue

Closes #503

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- `--user-agent` reached `HttpClientConfig` but was silently dropped at the `build_fetch_router` call site — the scrape page-fetch path never saw it. This threads the configured UA into the wreq layer so it is the exact identity on the wire.
- The pinned UA is applied once at client-build time (after `.emulation()`), so first fetch and every retry (429 backoff) carry it; with a pinned UA the 403 pool-rotation retry is disabled (operator asked to be identified exactly as configured, per issue expected behavior).
- Discovery paths (`discovery.rs`, `sitemap_discovery.rs`) intentionally untouched — they keep rotating pool agents by design. The Engine path keeps today's behavior (`None`) with a comment; `CrawlerConfig.user_agent` remains a separate dead field, out of scope.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs` | `pinned_ua` field + constructor param; builder-level `.user_agent()` after `.emulation()` so the pin wins over the profile UA; 403 rotation gated on `pinned_ua.is_none()`; `ua` tracing field on `send_request` (effective UA now visible in `--trace-file`); 3 wire-level wiremock tests |
| `crates/webfang_core/src/application/crawler/fetch_router.rs` | `user_agent: Option<String>` param threaded into Static + Hybrid L1; 3 unit tests updated |
| `crates/webfang_core/src/cli/scrape_flow.rs` | Moves `http_config.user_agent` into `build_fetch_router` (was dropped on the floor) |
| `crates/webfang_core/src/application/crawler/engine.rs` | Passes `None` with `#503` comment (keeps current Engine behavior) |
| `crates/webfang_core/src/infrastructure/downloader/mod.rs` | Doc-example signature update |
| `crates/webfang_core/tests/downloader_headers_test.rs` | Call-site updates |
| `crates/webfang_core/tests/behavioral/cli/user_agent_test.rs` | New end-to-end behavioral test: wiremock answers only to the exact pinned UA through the real CLI binary + snapshot |
| `crates/webfang_core/tests/behavioral/snapshots/behavioral__user_agent_flag_reaches_the_wire.snap` | Accepted deterministic snapshot |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes — 2095/2095
- [x] Wire-level proof: mock answering only to `User-Agent: QA-Bot/9.9` with `Profile::Chrome145` emulation enabled — pinned UA wins over profile default on the wire
- [x] 403 policy proof: rotated pool agent mock stays at `expect(0)`, pinned fetch after a 403 still carries the pinned identity

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers