### PR TITLE
test(crawler): cover HybridRouter escalation gaps — L2 non-WAF error and all-layers-exhausted

### DIFF
--- a/crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs
@@ -202,6 +202,28 @@ mod tests {
     }
 
     #[test]
+    fn test_cookies_do_not_leak_cross_domain() {
+        // #511: pin cross-domain isolation — cookies accumulated across fetch
+        // layers must never be served to an unrelated domain, including the
+        // suffix-without-dot-boundary trap ("notexample.com" vs ".example.com").
+        let mut bridge = CookieBridge::new();
+        bridge.add(make_cookie("exact", "example.com", "/"));
+        bridge.add(make_cookie("wild", ".example.com", "/"));
+
+        let url: Url = "https://other.com/".parse().unwrap();
+        assert!(
+            bridge.cookies_for_url(&url).is_empty(),
+            "unrelated domain must receive no cookies"
+        );
+
+        let url: Url = "https://notexample.com/".parse().unwrap();
+        assert!(
+            bridge.cookies_for_url(&url).is_empty(),
+            "suffix without dot boundary must not match .example.com"
+        );
+    }
+
+    #[test]
     fn test_cookies_for_url_filters_by_path() {
         let mut bridge = CookieBridge::new();
         bridge.add(make_cookie("s1", "a.com", "/admin"));

--- a/crates/webfang_core/src/infrastructure/downloader/hybrid_router.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/hybrid_router.rs
@@ -268,6 +268,33 @@ mod tests {
         }
     }
 
+    /// Fails with an HTTP error — a non-WAF [`DownloadError`] that must NOT
+    /// abort escalation (distinct variant from `FailingDownloader` so tests
+    /// can pinpoint which layer produced the observed error).
+    struct HttpErrorDownloader {
+        status: u16,
+        message: String,
+    }
+
+    impl Downloader for HttpErrorDownloader {
+        fn fetch<'a>(&'a self, _url: &'a Url) -> BoxFuture<'a, Result<FetchedPage, DownloadError>> {
+            Box::pin(async move {
+                Err(DownloadError::Http {
+                    status: self.status,
+                    message: self.message.clone(),
+                })
+            })
+        }
+
+        fn supports_interactions(&self) -> bool {
+            false
+        }
+
+        fn memory_cost(&self) -> usize {
+            0
+        }
+    }
+
     // ---- Tests ---------------------------------------------------------
 
     #[tokio::test]
@@ -354,6 +381,51 @@ mod tests {
         let url: Url = "https://spa.example.com".parse().unwrap();
         let page = router.fetch(&url).await.unwrap();
         assert!(page.html.contains("Enough content"));
+    }
+
+    #[tokio::test]
+    async fn test_layer2_non_waf_error_escalates_to_layer3() {
+        // Gap #511-1: Layer 2 failing with a non-WAF DownloadError (here: HTTP
+        // 500, a distinct variant from L1/L3 Network errors) must NOT abort —
+        // the router escalates to Layer 3 (hybrid_router.rs:125-127).
+        let router = HybridRouter::new(
+            StubDownloader::spa_page(),
+            HttpErrorDownloader {
+                status: 500,
+                message: "obscura subprocess failed".into(),
+            },
+            StubDownloader::static_page().with_interactions(true),
+            false,
+        );
+        let url: Url = "https://spa.example.com".parse().unwrap();
+        let page = router.fetch(&url).await.unwrap();
+        assert!(page.html.contains("Enough content"));
+    }
+
+    #[tokio::test]
+    async fn test_all_layers_exhausted_returns_final_error() {
+        // Gap #511-2: when all three layers fail, the router returns the LAST
+        // layer's error (hybrid_router.rs:148-151). L2 fails with Http{500}
+        // and L3 with Network("chromium crashed"); asserting the Network
+        // variant + message proves the surfaced error is L3's, not L2's.
+        let router = HybridRouter::new(
+            StubDownloader::spa_page(),
+            HttpErrorDownloader {
+                status: 500,
+                message: "obscura subprocess failed".into(),
+            },
+            FailingDownloader {
+                message: "chromium crashed".into(),
+            },
+            false,
+        );
+        let url: Url = "https://spa.example.com".parse().unwrap();
+        let err = router.fetch(&url).await.unwrap_err();
+        assert!(matches!(err, DownloadError::Network(_)));
+        assert!(
+            err.to_string().contains("chromium crashed"),
+            "final error must carry Layer 3's cause, got: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Linked Issue

Closes #511

## PR Type

- [x] Maintenance / tooling (`type:chore`)

## Summary

- Close the two untested escalation branches of the three-layer HybridRouter: a non-WAF `DownloadError` from Layer 2 must escalate to Layer 3 (instead of aborting), and when all layers fail the router must surface Layer 3's final error.
- Pin CookieBridge cross-domain isolation so cookies accumulated across fetch layers never leak to unrelated domains.
- Verify ResourceGovernor RAM gating before Layer 2/3 (code inspection — no deterministic RAM-pressure injection without governor DI).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/infrastructure/downloader/hybrid_router.rs` | + `HttpErrorDownloader` stub (non-WAF variant distinguishable from Network errors), + `test_layer2_non_waf_error_escalates_to_layer3`, + `test_all_layers_exhausted_returns_final_error` |
| `crates/webfang_core/src/infrastructure/downloader/cookie_bridge.rs` | + `test_cookies_do_not_leak_cross_domain` (pins domain boundary incl. `notexample.com` vs `.example.com` trap) |

## #511 task checklist

- [x] `test_layer2_non_waf_error_escalates_to_layer3` — L2 `Http{500}` → L3 success (covers hybrid_router.rs:125-127)
- [x] `test_all_layers_exhausted_returns_final_error` — L3 `Network` error surfaces with its message, not L2's (covers :148-151)
- [x] CookieBridge cross-domain filter verified — `cookies_for_url` domain/path matching holds; new regression test pins it
- [x] ResourceGovernor gates L2/L3 by RAM — `check_resources()` called at hybrid_router.rs:107 (L2) and :133 (L3); denial returns `DownloadError::Internal`. The >=90% RAM denial path cannot be exercised deterministically without governor DI (flagged as follow-up if ever needed)

**Acceptance criterion met:** 8/8 escalation scenarios covered (6 existing + 2 new).

## GitNexus impact

`detect_changes`: 0 production symbols affected — all changes inside `#[cfg(test)]` modules. Risk: none.

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p webfang_core --all-targets -- -D warnings` clean
- [x] `cargo nextest run -p webfang_core` — **1863 passed, 0 failed** (23 skipped)
- [x] New tests verified by name: 3/3 PASS

## Contributor Checklist

- [x] Linked an issue with `Closes #511`
- [x] Added exactly one `type:*` label (`type:chore`, per issue label — no `type:test` exists)
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] No behavior change — tests only