### PR TITLE
feat(crawler): engine cancellation token with bounded worker drain (#509)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6164,6 +6164,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ webfang_test_utils = { path = "crates/webfang_test_utils" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 
 # HTTP & Networking
 wreq = { version = "6.0.0-rc.28", features = ["gzip", "brotli", "stream", "json", "cookies", "prefix-symbols"] }

--- a/crates/webfang_core/Cargo.toml
+++ b/crates/webfang_core/Cargo.toml
@@ -34,6 +34,7 @@ pathdiff = "0.2"
 
 # Async runtime
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 
 # HTTP & Networking
 wreq = { workspace = true }

--- a/crates/webfang_core/src/application/crawler/crawl_task.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task.rs
@@ -31,11 +31,21 @@ pub(crate) fn handle_crawl_result(
         Ok(Ok(())) => {
             // Task completed successfully
         },
+        Ok(Err(CrawlError::Cancelled)) => {
+            // Shutdown control signal (#509) — not an operational failure,
+            // so it must not inflate the crawl error counters.
+            debug!("Task cancelled by engine shutdown");
+        },
         Ok(Err(e)) => {
             let category = CrawlErrorCategory::from(&e);
             warn!("Task error: {}", e);
             error_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             error_breakdown[category.index()].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        },
+        Err(e) if e.is_cancelled() => {
+            // JoinSet abort (shutdown drain timeout, #509) — logged once at
+            // the drain site; not counted as a panic.
+            debug!("Task aborted during shutdown drain");
         },
         Err(e) => {
             warn!("Task panicked: {}", e);
@@ -55,7 +65,17 @@ pub(crate) async fn run_crawl_task(
     ctx: Arc<CrawlTaskCtx>,
     discovered_url: DiscoveredUrl,
 ) -> Result<(), CrawlError> {
-    ctx.rate_limiter.until_ready().await;
+    match ctx
+        .rate_limiter
+        .until_ready_or_cancel(&ctx.cancel_token)
+        .await
+    {
+        Ok(()) => {},
+        Err(_cancelled) => {
+            debug!("Rate limit wait cancelled by engine shutdown");
+            return Err(CrawlError::Cancelled);
+        },
+    }
 
     let url_str = discovered_url.url.as_str().to_string();
     let url_depth = discovered_url.depth;
@@ -238,6 +258,7 @@ mod tests {
     use std::pin::Pin;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex, RwLock};
+    use std::time::Duration;
 
     use url::Url;
 
@@ -253,6 +274,7 @@ mod tests {
     use crate::infrastructure::crawler::UrlQueue;
     use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
     use crate::infrastructure::downloader::Cookie;
+    use tokio_util::sync::CancellationToken;
 
     // ── Mock implementations ──
 
@@ -419,6 +441,8 @@ mod tests {
         collector: Arc<dyn CrawlResultCollector>,
         session_pool: Option<Arc<dyn SessionPort>>,
         output_stages: Vec<Arc<Box<dyn OutputStage>>>,
+        rate_limiter: Option<SharedRateLimiter>,
+        cancel_token: CancellationToken,
         ignore_robots: bool,
         max_depth: u8,
     }
@@ -443,6 +467,8 @@ mod tests {
                 collector,
                 session_pool: None,
                 output_stages: Vec::new(),
+                rate_limiter: None,
+                cancel_token: CancellationToken::new(),
                 ignore_robots: false,
                 max_depth: 3,
             }
@@ -472,6 +498,14 @@ mod tests {
             self.output_stages.push(s);
             self
         }
+        fn rate_limiter(mut self, rl: SharedRateLimiter) -> Self {
+            self.rate_limiter = Some(rl);
+            self
+        }
+        fn cancel_token(mut self, token: CancellationToken) -> Self {
+            self.cancel_token = token;
+            self
+        }
         fn ignore_robots(mut self, v: bool) -> Self {
             self.ignore_robots = v;
             self
@@ -486,14 +520,17 @@ mod tests {
             let mut config = crate::domain::CrawlerConfig::new(seed_url);
             config.max_depth = self.max_depth;
 
-            let rate_limiter = SharedRateLimiter::new(&RateLimiterConfig::new(1, 100))
-                .expect("valid rate limiter config");
+            let rate_limiter = self.rate_limiter.unwrap_or_else(|| {
+                SharedRateLimiter::new(&RateLimiterConfig::new(1, 100))
+                    .expect("valid rate limiter config")
+            });
 
             Arc::new(CrawlTaskCtx {
                 config: Arc::new(config),
                 correlation_id: CorrelationId::new(),
                 queue: Arc::new(UrlQueue::new()),
                 rate_limiter,
+                cancel_token: self.cancel_token,
                 session_pool: self.session_pool,
                 ignore_robots: self.ignore_robots,
                 robots_checker: self.robots,
@@ -1011,5 +1048,70 @@ mod tests {
                 assert_eq!(breakdown[cat.index()].load(Ordering::SeqCst), 0);
             }
         }
+    }
+
+    // ========================================================================
+    // Cancellation tests (#509)
+    // ========================================================================
+
+    #[test]
+    fn cancelled_result_is_not_counted_as_error() {
+        let (error_count, breakdown) = counters();
+        handle_crawl_result(Ok(Err(CrawlError::Cancelled)), &error_count, &breakdown);
+        assert_eq!(
+            error_count.load(Ordering::SeqCst),
+            0,
+            "shutdown cancellation must not inflate the error count"
+        );
+        assert!(breakdown.iter().all(|c| c.load(Ordering::SeqCst) == 0));
+    }
+
+    #[tokio::test]
+    async fn aborted_join_result_is_not_counted_as_panic() {
+        let (error_count, breakdown) = counters();
+        let handle = tokio::spawn(std::future::pending::<Result<(), CrawlError>>());
+        handle.abort();
+        let join_err = handle.await.unwrap_err();
+        assert!(join_err.is_cancelled());
+
+        handle_crawl_result(Err(join_err), &error_count, &breakdown);
+        assert_eq!(
+            error_count.load(Ordering::SeqCst),
+            0,
+            "drain-time aborts are a control signal, not panics"
+        );
+        assert!(breakdown.iter().all(|c| c.load(Ordering::SeqCst) == 0));
+    }
+
+    #[tokio::test]
+    async fn run_crawl_task_cancelled_during_rate_limit_wait() {
+        // 60s refill with burst 1: consuming the burst forces the task into
+        // the rate-limit wait, where only cancellation can free it.
+        let limiter = SharedRateLimiter::new(&RateLimiterConfig::new(60_000, 1))
+            .expect("valid rate limiter config");
+        limiter.until_ready().await;
+
+        let cancel = CancellationToken::new();
+        let (collector, sent) = mock_collector();
+        let ctx = TestCtxBuilder::new(collector)
+            .rate_limiter(limiter)
+            .cancel_token(cancel.clone())
+            .build();
+
+        cancel.cancel();
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            run_crawl_task(ctx, test_url("https://example.com/page", 0)),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Ok(Err(CrawlError::Cancelled))),
+            "worker parked on the rate limiter must abort within the bound"
+        );
+        assert!(
+            sent.lock().map(|s| s.is_empty()).unwrap_or(false),
+            "cancelled task must not emit results"
+        );
     }
 }

--- a/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
@@ -8,6 +8,8 @@
 use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::{Arc, RwLock};
 
+use tokio_util::sync::CancellationToken;
+
 use crate::application::crawler::checkpoint::BannedDomain;
 use crate::application::crawler::ports::{
     ContentPipeline, CrawlResultCollector, LinkExtractorPort, PageFetcher, RobotsChecker,
@@ -31,6 +33,9 @@ pub struct CrawlTaskCtx {
     pub(crate) correlation_id: CorrelationId,
     pub(crate) queue: Arc<UrlQueue>,
     pub(crate) rate_limiter: SharedRateLimiter,
+    /// Engine-wide cancellation token (#509) — fired on shutdown so tasks
+    /// blocked on rate-limit or resource waits abort promptly.
+    pub(crate) cancel_token: CancellationToken,
     pub(crate) session_pool: Option<Arc<dyn SessionPort>>,
     pub(crate) ignore_robots: bool,
     pub(crate) robots_checker: Arc<dyn RobotsChecker>,

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, instrument, span, warn, Instrument, Level};
 use wreq_util::Profile;
 
@@ -38,6 +39,13 @@ use crate::infrastructure::network::session_pool::{DomainSessionPool, SessionPoo
 
 /// Shared shutdown signal — set to `true` when SIGINT/SIGTERM received.
 type ShutdownSignal = Arc<AtomicBool>;
+
+/// Grace added to the longest legitimate worker wait when bounding joins (#509).
+///
+/// The longest legitimate wait is a fetch (`config.timeout_secs`) or a
+/// rate-limit token (`config.delay_ms`); anything beyond that plus this grace
+/// is treated as a hung worker.
+const SHUTDOWN_GRACE_SECS: u64 = 10;
 
 /// Crawl engine — orchestrates URL fetching with concurrency control
 ///
@@ -73,6 +81,9 @@ pub struct Engine {
     pages_crawled: Arc<AtomicU64>,
     /// Shared shutdown signal for graceful termination.
     shutdown: ShutdownSignal,
+    /// Engine-wide cancellation token (#509) — fired on shutdown so workers
+    /// blocked on rate-limit or resource-governor waits abort promptly.
+    cancel_token: CancellationToken,
     /// JavaScript rendering strategy.
     js_strategy: JsStrategy,
     /// Optional fetch router for hybrid/full JS rendering.
@@ -139,6 +150,7 @@ impl Engine {
             session_pool: None,
             pages_crawled,
             shutdown,
+            cancel_token: CancellationToken::new(),
             js_strategy: JsStrategy::default(),
             fetch_router: None,
             cookie_bridge: Arc::new(RwLock::new(CookieBridge::new())),
@@ -229,6 +241,9 @@ impl Engine {
             // #503: the Engine path keeps today's rotating default behavior —
             // `CrawlerConfig.user_agent` is a separate dead field, out of scope.
             None,
+            // #509: the Full strategy's governor shares the engine token so
+            // permit waits abort on shutdown.
+            self.cancel_token.clone(),
         )?;
         self.js_strategy = strategy;
         self.fetch_router = Some(router);
@@ -332,7 +347,13 @@ impl Engine {
     }
 
     /// Spawn a signal handler that sets the shutdown flag on SIGINT/SIGTERM.
-    fn spawn_signal_handler(shutdown: ShutdownSignal) -> tokio::task::JoinHandle<()> {
+    ///
+    /// Also fires the cancellation token (#509) so workers blocked on
+    /// rate-limit or resource-governor waits abort instead of hanging.
+    fn spawn_signal_handler(
+        shutdown: ShutdownSignal,
+        cancel: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let ctrl_c = tokio::signal::ctrl_c();
             #[cfg(unix)]
@@ -356,7 +377,18 @@ impl Engine {
                 info!("Received interrupt — initiating graceful shutdown");
             }
             shutdown.store(true, std::sync::atomic::Ordering::SeqCst);
+            cancel.cancel();
         })
+    }
+
+    /// Clone of the engine's cancellation token (#509).
+    ///
+    /// Fire it to abort workers blocked on rate-limit or resource-governor
+    /// waits and unblock [`run`](Self::run)'s drain — the same effect as a
+    /// signal-driven shutdown, without an OS signal.
+    #[must_use]
+    pub fn cancel_handle(&self) -> CancellationToken {
+        self.cancel_token.clone()
     }
 
     /// Run the crawl loop until completion
@@ -366,7 +398,10 @@ impl Engine {
         let config_clone = Arc::clone(&self.config);
 
         // Spawn signal handler for graceful shutdown
-        self.signal_handle = Some(Self::spawn_signal_handler(Arc::clone(&self.shutdown)));
+        self.signal_handle = Some(Self::spawn_signal_handler(
+            Arc::clone(&self.shutdown),
+            self.cancel_token.clone(),
+        ));
 
         // Load checkpoint state if resuming
         if let Some(ref cp) = self.checkpoint_state {
@@ -396,6 +431,7 @@ impl Engine {
             correlation_id: self.correlation_id.clone(),
             queue: self.scheduler.queue(),
             rate_limiter: self.rate_limiter.clone(),
+            cancel_token: self.cancel_token.clone(),
             session_pool: self
                 .session_pool
                 .as_ref()
@@ -427,11 +463,23 @@ impl Engine {
         // Progress tracking start (issue #356 Fase 4)
         let start = std::time::Instant::now();
 
+        // Bound every worker wait (#509): the longest legitimate wait is a
+        // fetch (timeout_secs) or a rate-limit token (delay_ms), plus grace.
+        let worker_wait_bound = Duration::from_secs(
+            config_clone
+                .timeout_secs
+                .max(config_clone.delay_ms / 1000)
+                .saturating_add(SHUTDOWN_GRACE_SECS),
+        );
+
         // Main crawl loop
         while self.scheduler.has_pending_work() || !tasks.is_empty() {
             // Check shutdown signal
             if self.shutdown.load(std::sync::atomic::Ordering::Relaxed) {
                 info!("Shutdown signal received — saving checkpoint and exiting");
+                // Unblock workers parked on rate-limit/governor waits (#509)
+                // before saving state; cancel() is idempotent.
+                self.cancel_token.cancel();
                 self.save_checkpoint().await;
                 break;
             }
@@ -486,18 +534,34 @@ impl Engine {
                 );
             }
 
-            // If no tasks can be spawned and work remains, wait for one task
+            // If no tasks can be spawned and work remains, wait for one task.
+            // The wait is bounded (#509): on expiry we re-check engine state
+            // instead of hanging on a wedged worker.
             if !self.scheduler.can_spawn(tasks.len()) && self.scheduler.has_pending_work() {
-                if let Some(result) = tasks.join_next().await {
-                    handle_crawl_result(result, &self.error_count, &self.error_breakdown);
+                match tokio::time::timeout(worker_wait_bound, tasks.join_next()).await {
+                    Ok(Some(result)) => {
+                        handle_crawl_result(result, &self.error_count, &self.error_breakdown);
+                    },
+                    Ok(None) => {},
+                    Err(_elapsed) => {
+                        warn!(
+                            bound_secs = worker_wait_bound.as_secs(),
+                            "worker wait exceeded bound — re-checking engine state"
+                        );
+                    },
                 }
             }
         }
 
-        // Wait for remaining tasks
-        while let Some(result) = tasks.join_next().await {
-            handle_crawl_result(result, &self.error_count, &self.error_breakdown);
-        }
+        // Wait for remaining tasks — bounded, then abort stragglers, so a
+        // shutdown can never hang on a blocked worker (#509).
+        Self::drain_tasks(
+            &mut tasks,
+            &self.error_count,
+            &self.error_breakdown,
+            worker_wait_bound,
+        )
+        .await;
 
         // Drop task_ctx so all cloned Senders inside CrawlTaskCtx are released.
         // Without this, collect() hangs forever — the mpsc channel stays open
@@ -565,8 +629,46 @@ impl Engine {
         ))
     }
 
+    /// Drain spawned tasks with a bounded wait, aborting any stragglers so a
+    /// shutdown can never hang on a blocked worker (#509).
+    ///
+    /// Graceful path: cancellation fires upstream, workers parked on
+    /// rate-limit/governor waits return [`CrawlError::Cancelled`] promptly,
+    /// and the drain finishes well within `bound`. `bound` only bites when a
+    /// worker is genuinely wedged (e.g. a fetch ignoring its own timeout).
+    async fn drain_tasks(
+        tasks: &mut tokio::task::JoinSet<Result<(), CrawlError>>,
+        error_count: &Arc<AtomicUsize>,
+        error_breakdown: &Arc<[AtomicUsize; 8]>,
+        bound: Duration,
+    ) {
+        let drained = tokio::time::timeout(bound, async {
+            while let Some(result) = tasks.join_next().await {
+                handle_crawl_result(result, error_count, error_breakdown);
+            }
+        })
+        .await
+        .is_ok();
+
+        if !drained {
+            let remaining = tasks.len();
+            warn!(
+                remaining_tasks = remaining,
+                bound_secs = bound.as_secs(),
+                "task drain timed out — aborting remaining workers"
+            );
+            tasks.abort_all();
+            while let Some(result) = tasks.join_next().await {
+                handle_crawl_result(result, error_count, error_breakdown);
+            }
+        }
+    }
+
     /// Graceful shutdown — drop the collector sender, receiver drains remaining items
     pub async fn shutdown(mut self) {
+        // Unblock any worker still parked on a rate-limit/governor wait (#509).
+        self.cancel_token.cancel();
+
         // Abort signal handler to prevent the runtime from hanging
         if let Some(handle) = self.signal_handle.take() {
             handle.abort();
@@ -809,4 +911,92 @@ pub async fn crawl_site_with_options(
     let result = engine.run().await;
     engine.shutdown().await;
     result
+}
+
+#[cfg(test)]
+#[cfg(not(miri))] // wiremock + wreq use boring-sys2 FFI (unsupported by Miri)
+mod tests {
+    use super::*;
+    use url::Url;
+    use wiremock::matchers::path;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Shutdown while a worker waits: cancellation must abort the parked
+    /// worker and `run()` must return within seconds, not after the 60s
+    /// rate-limit refill (#509 acceptance).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancellation_aborts_rate_blocked_worker_and_run_returns_within_bound() {
+        let server = MockServer::start().await;
+        let port = server.address().port();
+        Mock::given(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                "<html><body><a href=\"http://127.0.0.1:{port}/linked\">next</a></body></html>"
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(path("/linked"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("<html><body>linked</body></html>"),
+            )
+            .mount(&server)
+            .await;
+
+        let seed = Url::parse(&format!("http://127.0.0.1:{port}/")).expect("valid seed URL");
+        let config = CrawlerConfig::builder(seed)
+            .max_depth(1)
+            .max_pages(10)
+            .concurrency(1)
+            .delay_ms(60_000) // 60s refill: without cancellation run() hangs ~1 min
+            .timeout_secs(5)
+            .ignore_robots(true)
+            .build();
+
+        let mut engine = Engine::new(config, true).expect("engine must build");
+        let cancel = engine.cancel_handle();
+
+        let run_handle = tokio::spawn(async move { engine.run().await });
+
+        // Wait until the seed fetch lands; its discovered /linked task is then
+        // dispatched into the rate-limit wait (burst already consumed). Even if
+        // cancellation wins that race, the task still returns Cancelled without
+        // fetching — both orderings must satisfy the assertions below.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let seed_received = server
+                .received_requests()
+                .await
+                .map(|reqs| reqs.iter().any(|r| r.url.path() == "/"))
+                .unwrap_or(false);
+            if seed_received {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "seed request never arrived"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(10), run_handle)
+            .await
+            .expect("run() must return within the bound after cancellation")
+            .expect("spawned run task must not panic");
+        let crawl = result.expect("cancelled crawl must still return a result");
+
+        assert_eq!(crawl.total_pages, 1, "only the seed was fetched");
+        assert_eq!(crawl.errors, 0, "cancelled tasks are control signals");
+
+        let requested_linked = server
+            .received_requests()
+            .await
+            .map(|reqs| reqs.iter().any(|r| r.url.path() == "/linked"))
+            .unwrap_or(true);
+        assert!(
+            !requested_linked,
+            "rate-blocked worker must be cancelled before fetching"
+        );
+    }
 }

--- a/crates/webfang_core/src/application/crawler/fetch_router.rs
+++ b/crates/webfang_core/src/application/crawler/fetch_router.rs
@@ -11,6 +11,7 @@ use url::Url;
 use wreq_util::Profile;
 
 use futures::future::BoxFuture;
+use tokio_util::sync::CancellationToken;
 
 use crate::domain::JsStrategy;
 use crate::infrastructure::downloader::chromiumoxide_downloader::ChromiumoxideDownloader;
@@ -53,7 +54,10 @@ pub enum FetchRouter {
 /// cookie injection; `ignore_waf` bypasses WAF classification on the hybrid
 /// spa-detection path (REQ-WAF-07); `user_agent` pins the User-Agent on the
 /// wreq layer (Static and Hybrid L1) so `--user-agent` reaches the wire —
-/// `None` keeps the emulation-default + 403-rotation behavior (#503).
+/// `None` keeps the emulation-default + 403-rotation behavior (#503);
+/// `cancel_token` is injected into the Full strategy's
+/// [`ResourceGovernor`] so permit waits abort on shutdown (#509) — pass an
+/// inert token where no cancellation policy exists.
 ///
 /// # Errors
 ///
@@ -65,6 +69,7 @@ pub fn build_fetch_router(
     cookie_bridge: Arc<RwLock<CookieBridge>>,
     ignore_waf: bool,
     user_agent: Option<String>,
+    cancel_token: CancellationToken,
 ) -> Result<FetchRouter, DownloadError> {
     let connect_timeout = timeout_secs.min(10);
     Ok(match strategy {
@@ -82,10 +87,12 @@ pub fn build_fetch_router(
         },
         // Full renders every page directly in Chrome (no wreq → Obscura
         // escalation) and gates concurrency on system RAM via its own
-        // ResourceGovernor to prevent OOM on large crawls.
+        // ResourceGovernor to prevent OOM on large crawls. The governor
+        // shares the engine's cancellation token so permit waits abort on
+        // shutdown (#509).
         JsStrategy::Full => {
             let dl = ChromiumoxideDownloader::new(cookie_bridge);
-            let governor = ResourceGovernor::new();
+            let governor = ResourceGovernor::with_cancel_token(cancel_token);
             FetchRouter::Full(Arc::new(dl), Arc::new(governor))
         },
     })
@@ -141,6 +148,7 @@ mod router_tests {
             test_cookie_bridge(),
             false,
             None,
+            CancellationToken::new(),
         )
         .expect("static router must build");
         assert!(
@@ -158,6 +166,7 @@ mod router_tests {
             test_cookie_bridge(),
             false,
             None,
+            CancellationToken::new(),
         )
         .expect("hybrid router must build");
         assert!(
@@ -175,6 +184,7 @@ mod router_tests {
             test_cookie_bridge(),
             false,
             None,
+            CancellationToken::new(),
         )
         .expect("full router must build");
         assert!(

--- a/crates/webfang_core/src/application/rate_limiter.rs
+++ b/crates/webfang_core/src/application/rate_limiter.rs
@@ -19,6 +19,7 @@ use governor::{
     state::{InMemoryState, NotKeyed},
     Quota, RateLimiter as GovernorLimiter,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::error::ScraperError;
 
@@ -53,6 +54,14 @@ impl RateLimiterConfig {
     }
 }
 
+/// A rate-limit wait was cancelled before a permit was granted (#509).
+///
+/// Control signal, not an operational failure: the engine's cancellation
+/// token fired while the task waited for a token-bucket permit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("rate limit wait cancelled by engine shutdown")]
+pub struct RateLimitCancelled;
+
 /// Shared rate limiter for crawl operations
 #[derive(Clone)]
 pub struct SharedRateLimiter(Arc<CrawlRateLimiter>);
@@ -75,6 +84,26 @@ impl SharedRateLimiter {
     /// Wait until a permit is available
     pub async fn until_ready(&self) {
         self.0.until_ready().await;
+    }
+
+    /// Wait until a permit is available, abandoning the wait if `cancel`
+    /// fires first (#509).
+    ///
+    /// Dropping the pending governor future consumes no token, so a
+    /// cancelled caller leaves the bucket untouched for the next task.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RateLimitCancelled`] when the token fires before a permit
+    /// is granted.
+    pub async fn until_ready_or_cancel(
+        &self,
+        cancel: &CancellationToken,
+    ) -> Result<(), RateLimitCancelled> {
+        tokio::select! {
+            () = self.0.until_ready() => Ok(()),
+            () = cancel.cancelled() => Err(RateLimitCancelled),
+        }
     }
 }
 
@@ -364,5 +393,81 @@ mod tests {
     fn test_rate_limiter_config_extreme_burst() {
         let config = RateLimiterConfig::new(100, 1000);
         assert!(SharedRateLimiter::new(&config).is_ok());
+    }
+
+    // ============================================================================
+    // Cancellation tests (#509)
+    // ============================================================================
+
+    #[tokio::test]
+    async fn until_ready_or_cancel_grants_permit_from_available_burst() {
+        let limiter = SharedRateLimiter::new(&RateLimiterConfig::new(100, 5)).unwrap();
+        let cancel = CancellationToken::new();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            limiter.until_ready_or_cancel(&cancel),
+        )
+        .await;
+
+        assert!(matches!(result, Ok(Ok(()))));
+    }
+
+    #[tokio::test]
+    async fn until_ready_or_cancel_returns_cancelled_while_waiting() {
+        // 60s period with burst 2: exhaust the burst, then the third wait
+        // would block for ~60s without cancellation.
+        let limiter = SharedRateLimiter::new(&RateLimiterConfig::new(60_000, 2)).unwrap();
+        let cancel = CancellationToken::new();
+        limiter.until_ready().await;
+        limiter.until_ready().await;
+
+        let waiter = {
+            let limiter = limiter.clone();
+            let cancel = cancel.clone();
+            tokio::spawn(async move { limiter.until_ready_or_cancel(&cancel).await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), waiter).await;
+        assert!(matches!(result, Ok(Ok(Err(RateLimitCancelled)))));
+    }
+
+    #[tokio::test]
+    async fn until_ready_or_cancel_bucket_survives_cancelled_wait() {
+        // 500ms period, burst 1: consume the token, block a waiter, cancel it
+        // before the first refill (~100ms < 500ms).
+        let limiter = SharedRateLimiter::new(&RateLimiterConfig::new(500, 1)).unwrap();
+        let cancel = CancellationToken::new();
+        limiter.until_ready().await; // consume the single burst token
+
+        let start = tokio::time::Instant::now();
+        let waiter = {
+            let limiter = limiter.clone();
+            let cancel = cancel.clone();
+            tokio::spawn(async move { limiter.until_ready_or_cancel(&cancel).await })
+        };
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        cancel.cancel();
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), waiter).await,
+            Ok(Ok(Err(RateLimitCancelled)))
+        ));
+
+        // The next wait must obtain the first period's refill (~500ms from
+        // start) — if the cancelled wait had consumed a token it would take
+        // ~1000ms. Asserting well below the leak case proves no state leaked.
+        let next = tokio::time::timeout(
+            Duration::from_secs(2),
+            limiter.until_ready_or_cancel(&CancellationToken::new()),
+        )
+        .await;
+        assert!(matches!(next, Ok(Ok(()))));
+        assert!(
+            start.elapsed() < Duration::from_millis(900),
+            "cancelled wait leaked a token: next refill took {:?}",
+            start.elapsed()
+        );
     }
 }

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -148,6 +148,9 @@ pub async fn scrape_urls(
         // of dropping it on the floor. `http_config` stays usable below —
         // only this field moves out.
         http_config.user_agent,
+        // #509: the scrape flow has no shutdown policy yet — pass an inert
+        // token so Full-strategy governor waits keep pre-#509 behavior.
+        tokio_util::sync::CancellationToken::new(),
     )?;
 
     let _total_urls = urls.len();

--- a/crates/webfang_core/src/domain/error/crawl_error.rs
+++ b/crates/webfang_core/src/domain/error/crawl_error.rs
@@ -215,6 +215,14 @@ pub enum CrawlError {
     /// Semaphore exhausted (backpressure)
     #[error("semáforo agotado: no hay permisos disponibles")]
     SemaphoreInanition,
+
+    /// Task cancelled by engine shutdown (#509)
+    ///
+    /// Control signal, not an operational failure: the crawl engine cancelled
+    /// this task while it waited for a rate-limit permit or a resource-governor
+    /// permit. Handlers must NOT count it as a crawl error.
+    #[error("task cancelled by engine shutdown")]
+    Cancelled,
 }
 
 impl From<crate::domain::http_error::HttpError> for CrawlError {
@@ -285,6 +293,12 @@ mod tests {
     fn test_crawl_error_semaphore_inanition() {
         let error = CrawlError::SemaphoreInanition;
         assert!(error.to_string().contains("semáforo agotado"));
+    }
+
+    #[test]
+    fn test_crawl_error_cancelled_display() {
+        let error = CrawlError::Cancelled;
+        assert_eq!(error.to_string(), "task cancelled by engine shutdown");
     }
 
     #[test]

--- a/crates/webfang_core/src/error.rs
+++ b/crates/webfang_core/src/error.rs
@@ -568,6 +568,12 @@ impl From<crate::domain::error::CrawlError> for ScraperError {
                 ScraperError::CrawlLimit("sitemap depth exceeded".to_string())
             },
             CrawlError::SemaphoreInanition => ScraperError::SemaphoreInanition,
+            // Cancellation is an engine control signal (#509), not a failure —
+            // the crawl engine consumes it before any error surfaces here.
+            // Defensive mapping only.
+            CrawlError::Cancelled => {
+                ScraperError::Internal("task cancelled by engine shutdown".to_string())
+            },
         }
     }
 }

--- a/crates/webfang_core/src/infrastructure/downloader/mod.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/mod.rs
@@ -144,6 +144,11 @@ pub enum DownloadError {
     /// Internal error (should not happen in normal operation).
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// Acquisition cancelled by the engine's cancellation token (#509) —
+    /// the caller was waiting for a resource permit when shutdown fired.
+    #[error("operation cancelled while waiting for resources")]
+    Cancelled,
 }
 
 impl From<DownloadError> for crate::domain::CrawlError {

--- a/crates/webfang_core/src/infrastructure/downloader/resource_governor.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/resource_governor.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use sysinfo::System;
 use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use super::DownloadError;
@@ -32,18 +33,35 @@ const WARNING_THRESHOLD: u8 = 80;
 const CRITICAL_THRESHOLD: u8 = 90;
 
 /// Gates concurrent heavyweight downloader instances based on system RAM.
+///
+/// Holds a [`CancellationToken`] (#509) so a caller blocked in
+/// [`acquire`](Self::acquire) can be woken on engine shutdown instead of
+/// hanging on the semaphore forever. [`new`](Self::new) uses a fresh token
+/// that never fires (pre-#509 behavior); the crawl engine injects its own
+/// token via [`with_cancel_token`](Self::with_cancel_token).
 pub struct ResourceGovernor {
     semaphore: Arc<Semaphore>,
+    cancel: CancellationToken,
 }
 
 impl ResourceGovernor {
     /// Create a governor calibrated to current system RAM.
+    ///
+    /// The embedded cancellation token never fires; use
+    /// [`with_cancel_token`](Self::with_cancel_token) to wire shutdown.
     pub fn new() -> Self {
+        Self::with_cancel_token(CancellationToken::new())
+    }
+
+    /// Create a governor calibrated to current system RAM whose
+    /// [`acquire`](Self::acquire) aborts when `cancel` fires (#509).
+    pub fn with_cancel_token(cancel: CancellationToken) -> Self {
         let max_permits = Self::compute_max_instances();
         debug!("ResourceGovernor: max_permits={max_permits}");
 
         Self {
             semaphore: Arc::new(Semaphore::new(max_permits)),
+            cancel,
         }
     }
 
@@ -78,12 +96,26 @@ impl ResourceGovernor {
     ///
     /// Returns a [`tokio::sync::OwnedSemaphorePermit`] (`'static`) so callers can hold
     /// it across async boundaries without tying it to the governor's lifetime.
+    ///
+    /// The wait aborts with [`DownloadError::Cancelled`] if the governor's
+    /// cancellation token fires while blocked (#509). Dropping the pending
+    /// acquire consumes no permit, so a cancelled wait cannot leak one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DownloadError::Cancelled`] on cancellation and
+    /// [`DownloadError::Internal`] if the semaphore was closed.
     pub async fn acquire(&self) -> Result<tokio::sync::OwnedSemaphorePermit, DownloadError> {
         let arc = Arc::clone(&self.semaphore);
 
-        arc.acquire_owned()
-            .await
-            .map_err(|_| DownloadError::Internal("resource governor semaphore closed".to_string()))
+        tokio::select! {
+            result = arc.acquire_owned() => {
+                result.map_err(|_| {
+                    DownloadError::Internal("resource governor semaphore closed".to_string())
+                })
+            },
+            () = self.cancel.cancelled() => Err(DownloadError::Cancelled),
+        }
     }
 
     /// Current number of available permits.
@@ -147,6 +179,8 @@ impl From<ResourceError> for DownloadError {
 mod tests {
     use super::*;
 
+    use std::time::Duration;
+
     #[test]
     fn test_governor_creation() {
         let gov = ResourceGovernor::new();
@@ -185,5 +219,73 @@ mod tests {
         let res_err = ResourceError::Insufficient("test".into());
         let dl_err: DownloadError = res_err.into();
         assert!(matches!(dl_err, DownloadError::Internal(_)));
+    }
+
+    // ========================================================================
+    // RAII permit tests (#509) — prove no semaphore permit leaks
+    // ========================================================================
+
+    #[tokio::test]
+    async fn acquire_releases_permit_on_drop() {
+        let gov = ResourceGovernor::new();
+        let baseline = gov.available_permits();
+        assert!(baseline >= 1);
+
+        let permit = gov.acquire().await.expect("first acquire must succeed");
+        assert_eq!(gov.available_permits(), baseline - 1);
+
+        drop(permit);
+        assert_eq!(
+            gov.available_permits(),
+            baseline,
+            "dropping the permit must return it to the pool"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_grants_permit_when_token_idle() {
+        let gov = ResourceGovernor::with_cancel_token(CancellationToken::new());
+
+        let permit = tokio::time::timeout(Duration::from_secs(1), gov.acquire())
+            .await
+            .expect("acquire must not hang when permits are available");
+        assert!(permit.is_ok());
+    }
+
+    // ========================================================================
+    // Cancellation tests (#509)
+    // ========================================================================
+
+    #[tokio::test]
+    async fn acquire_returns_cancelled_when_blocked_and_token_fires() {
+        let cancel = CancellationToken::new();
+        let gov = std::sync::Arc::new(ResourceGovernor::with_cancel_token(cancel.clone()));
+
+        // Exhaust every permit so the next acquire must block.
+        let baseline = gov.available_permits();
+        let mut held = Vec::with_capacity(baseline);
+        for _ in 0..baseline {
+            held.push(gov.acquire().await.expect("exhaust acquire must succeed"));
+        }
+        assert_eq!(gov.available_permits(), 0);
+
+        let waiter = {
+            let gov = std::sync::Arc::clone(&gov);
+            tokio::spawn(async move { gov.acquire().await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cancel.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("cancelled acquire must return within the bound");
+        assert!(matches!(result, Ok(Err(DownloadError::Cancelled))));
+
+        // The cancelled wait must not have consumed a permit.
+        assert_eq!(gov.available_permits(), 0);
+
+        // RAII: releasing one held permit makes it visible again.
+        held.pop();
+        assert_eq!(gov.available_permits(), 1);
     }
 }

--- a/crates/webfang_core/src/infrastructure/downloader/resource_governor.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/resource_governor.rs
@@ -56,7 +56,17 @@ impl ResourceGovernor {
     /// Create a governor calibrated to current system RAM whose
     /// [`acquire`](Self::acquire) aborts when `cancel` fires (#509).
     pub fn with_cancel_token(cancel: CancellationToken) -> Self {
-        let max_permits = Self::compute_max_instances();
+        Self::with_max_instances(Self::compute_max_instances(), cancel)
+    }
+
+    /// Create a governor with an explicit permit budget.
+    ///
+    /// Calibration seam behind [`new`](Self::new) /
+    /// [`with_cancel_token`](Self::with_cancel_token): lets constrained
+    /// environments (containers) and tests set the budget directly instead
+    /// of deriving it from system RAM.
+    pub fn with_max_instances(max_permits: usize, cancel: CancellationToken) -> Self {
+        let max_permits = max_permits.max(1);
         debug!("ResourceGovernor: max_permits={max_permits}");
 
         Self {
@@ -181,7 +191,11 @@ mod tests {
 
     use std::time::Duration;
 
+    // The sysinfo-backed tests below read /proc via `sysconf`, which Miri
+    // cannot execute — gate them there. The semaphore/cancellation tests use
+    // the explicit-budget seam (`with_max_instances`) and DO run under Miri.
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_governor_creation() {
         let gov = ResourceGovernor::new();
         // On any real machine we should have at least 1 permit
@@ -189,6 +203,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_check_resources_returns_ok() {
         let gov = ResourceGovernor::new();
         // On CI or dev machines RAM usage is typically well below 80%
@@ -197,12 +212,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_total_ram_nonzero() {
         let bytes = ResourceGovernor::total_ram_bytes();
         assert!(bytes > 0, "total RAM should be > 0 on any running system");
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_usage_percent_range() {
         let pct = ResourceGovernor::ram_usage_percent();
         assert!(pct <= 100);
@@ -227,24 +244,23 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_releases_permit_on_drop() {
-        let gov = ResourceGovernor::new();
-        let baseline = gov.available_permits();
-        assert!(baseline >= 1);
+        let gov = ResourceGovernor::with_max_instances(2, CancellationToken::new());
+        assert_eq!(gov.available_permits(), 2);
 
         let permit = gov.acquire().await.expect("first acquire must succeed");
-        assert_eq!(gov.available_permits(), baseline - 1);
+        assert_eq!(gov.available_permits(), 1);
 
         drop(permit);
         assert_eq!(
             gov.available_permits(),
-            baseline,
+            2,
             "dropping the permit must return it to the pool"
         );
     }
 
     #[tokio::test]
     async fn acquire_grants_permit_when_token_idle() {
-        let gov = ResourceGovernor::with_cancel_token(CancellationToken::new());
+        let gov = ResourceGovernor::with_max_instances(1, CancellationToken::new());
 
         let permit = tokio::time::timeout(Duration::from_secs(1), gov.acquire())
             .await
@@ -259,14 +275,10 @@ mod tests {
     #[tokio::test]
     async fn acquire_returns_cancelled_when_blocked_and_token_fires() {
         let cancel = CancellationToken::new();
-        let gov = std::sync::Arc::new(ResourceGovernor::with_cancel_token(cancel.clone()));
+        let gov = std::sync::Arc::new(ResourceGovernor::with_max_instances(1, cancel.clone()));
 
-        // Exhaust every permit so the next acquire must block.
-        let baseline = gov.available_permits();
-        let mut held = Vec::with_capacity(baseline);
-        for _ in 0..baseline {
-            held.push(gov.acquire().await.expect("exhaust acquire must succeed"));
-        }
+        // Take the single permit so the next acquire must block.
+        let held = gov.acquire().await.expect("single permit must be granted");
         assert_eq!(gov.available_permits(), 0);
 
         let waiter = {
@@ -284,8 +296,8 @@ mod tests {
         // The cancelled wait must not have consumed a permit.
         assert_eq!(gov.available_permits(), 0);
 
-        // RAII: releasing one held permit makes it visible again.
-        held.pop();
+        // RAII: releasing the held permit makes it visible again.
+        drop(held);
         assert_eq!(gov.available_permits(), 1);
     }
 }


### PR DESCRIPTION
Closes #509

## Summary
- Introduces `tokio_util::sync::CancellationToken` into `Engine`, `SharedRateLimiter`, and `ResourceGovernor` acquisition paths via `until_ready_or_cancel()` / `acquire()` (tokio::select!)
- Worker drain is now bounded: `tokio::time::timeout` at JoinSet join level; parked workers abort when token fires rather than hanging on 60s refills
- New error: `RateLimitCancelled` + `DownloadError::Cancelled` surfaced with context
- RAII permit test proves semaphore permit is returned on drop (with_max_instances calibration seam, Miri-compatible)

## Test plan
- nextest full suite green (1871/1871)
- Miri: resource_governor cancellation + RAII tests green
- Miri: rate_limiter exclusion documented — QuantaClock::new() uses /sys clocksource (immutable); tracked in #515

## Worktree
Branch: feat/engine-cancellation-token