### PR TITLE
fix(domain): business logic review — dedup normalization, nofollow, checkpoint queue (#517)

### DIFF
--- a/crates/webfang_core/src/application/crawler/crawl_scheduler.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_scheduler.rs
@@ -111,6 +111,35 @@ impl CrawlScheduler {
         urls.iter().cloned().collect()
     }
 
+    /// Snapshot URLs that are pending (queued but not yet visited) for
+    /// checkpoint persistence.
+    ///
+    /// Combines the shared discovery queue (links pushed by in-flight tasks but
+    /// not yet drained) with the scheduler's local pending buffer. The engine
+    /// persists this so a resume re-enqueues exactly what was left to crawl —
+    /// without it, `save_checkpoint` used to write an empty queue and a resume
+    /// after the seed was already visited would crawl nothing (#517).
+    pub(crate) async fn snapshot_pending(&self) -> Vec<String> {
+        let mut urls: Vec<String> = self.pending.iter().map(|d| d.url.to_string()).collect();
+        urls.extend(self.queue.snapshot_urls().await);
+        urls
+    }
+
+    /// Restore pending (queued-but-unvisited) URLs from a checkpoint.
+    ///
+    /// Re-enqueues them into the local pending buffer as depth-0 HTML links.
+    /// The visited set is restored separately and takes precedence: `next_url`
+    /// skips any restored URL that was actually already visited, so a queued
+    /// entry that raced into `visited` never gets re-crawled (#517).
+    pub(crate) fn restore_pending(&mut self, urls: &[String]) {
+        for raw in urls {
+            if let Ok(url) = Url::parse(raw) {
+                let discovered = DiscoveredUrl::html(url.clone(), 0, url);
+                self.pending.push_back(discovered);
+            }
+        }
+    }
+
     /// Seed the crawl: push the seed onto the discovery queue (highest priority)
     /// and onto the local pending buffer.
     pub(crate) async fn seed(&mut self, seed_url: &Url) {
@@ -355,5 +384,94 @@ mod tests {
         assert!(s.has_pending_work());
         assert_eq!(q.len().await, 0, "queue drained");
         assert_eq!(s.next_url(0).unwrap().url.path(), "/x");
+    }
+
+    // -- snapshot_pending / restore_pending (#517) --
+
+    #[tokio::test]
+    async fn snapshot_pending_captures_pending_and_queue() {
+        let mut s = CrawlScheduler::new(4);
+        // One URL sits in the pending buffer, one still in the shared queue.
+        s.restore_pending(&["https://example.com/buffered".into()]);
+        s.queue()
+            .push_prioritized(disc("/queued"), UrlSource::Link)
+            .await;
+        let snap = s.snapshot_pending().await;
+        assert_eq!(snap.len(), 2, "both sources must be captured: {snap:?}");
+        assert!(snap.iter().any(|u| u.ends_with("/buffered")));
+        assert!(snap.iter().any(|u| u.ends_with("/queued")));
+    }
+
+    #[tokio::test]
+    async fn snapshot_pending_is_nondestructive() {
+        let mut s = CrawlScheduler::new(4);
+        s.restore_pending(&["https://example.com/buffered".into()]);
+        s.queue()
+            .push_prioritized(disc("/queued"), UrlSource::Link)
+            .await;
+        let _ = s.snapshot_pending().await;
+        assert!(s.has_pending_work(), "pending buffer must survive snapshot");
+        assert_eq!(s.queue().len().await, 1, "queue must survive snapshot");
+    }
+
+    #[test]
+    fn restore_pending_reenqueues_for_next_url() {
+        let mut s = CrawlScheduler::new(4);
+        s.restore_pending(&[
+            "https://example.com/p1".into(),
+            "https://example.com/p2".into(),
+        ]);
+        assert!(s.has_pending_work());
+        assert_eq!(s.next_url(0).unwrap().url.path(), "/p1");
+        assert_eq!(s.next_url(0).unwrap().url.path(), "/p2");
+        assert!(!s.has_pending_work());
+    }
+
+    #[test]
+    fn restore_pending_skips_unparseable_urls() {
+        let mut s = CrawlScheduler::new(4);
+        s.restore_pending(&["not-a-url".into(), "https://example.com/ok".into()]);
+        assert_eq!(s.next_url(0).unwrap().url.path(), "/ok");
+        assert!(!s.has_pending_work());
+    }
+
+    #[tokio::test]
+    async fn restore_pending_then_next_url_skips_visited() {
+        let mut s = CrawlScheduler::new(4);
+        s.record_visit("https://example.com/done");
+        s.restore_pending(&[
+            "https://example.com/done".into(),
+            "https://example.com/fresh".into(),
+        ]);
+        assert_eq!(
+            s.next_url(0).unwrap().url.path(),
+            "/fresh",
+            "restored URL already visited must be skipped"
+        );
+        assert!(!s.has_pending_work());
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_pending_roundtrips() {
+        let mut s = CrawlScheduler::new(4);
+        s.restore_pending(&["https://example.com/buffered".into()]);
+        s.queue()
+            .push_prioritized(disc("/queued"), UrlSource::Link)
+            .await;
+        let snap = s.snapshot_pending().await;
+
+        let mut s2 = CrawlScheduler::new(4);
+        s2.restore_pending(&snap);
+        let mut paths: Vec<String> = Vec::new();
+        while let Some(d) = s2.next_url(0) {
+            paths.push(d.url.path().to_string());
+        }
+        assert_eq!(
+            paths.len(),
+            2,
+            "all pending URLs must be restored: {paths:?}"
+        );
+        assert!(paths.contains(&"/buffered".into()));
+        assert!(paths.contains(&"/queued".into()));
     }
 }

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -320,7 +320,7 @@ impl Engine {
                 .unwrap_or_default();
             let state = CrawlCheckpoint {
                 visited: visited_set,
-                queued: Vec::new(),
+                queued: self.scheduler.snapshot_pending().await,
                 pages_crawled: pages,
                 banned_domains: banned,
                 version: 1,
@@ -408,6 +408,10 @@ impl Engine {
             if !cp.visited.is_empty() {
                 self.scheduler.restore_visited(&cp.visited);
                 info!("Restored {} visited URLs from checkpoint", cp.visited.len());
+            }
+            if !cp.queued.is_empty() {
+                self.scheduler.restore_pending(&cp.queued);
+                info!("Restored {} queued URLs from checkpoint", cp.queued.len());
             }
             if !cp.banned_domains.is_empty() {
                 if let Ok(mut banned) = self.banned_domains.write() {

--- a/crates/webfang_core/src/application/deduplicator.rs
+++ b/crates/webfang_core/src/application/deduplicator.rs
@@ -14,8 +14,17 @@
 //!   hot loop (FR-8: no data races, no lost updates)
 //! - Deterministic within a single process (FR-5): the seed is fixed for the
 //!   process lifetime, so identical URLs hash to identical `u64` keys
+//! - **Canonical-key dedup (#517)**: `try_insert` normalizes the URL through
+//!   the domain `normalize_url` (strip_www, strip hash/query, collapse
+//!   `/index.html`) BEFORE hashing, so two spellings of the same document
+//!   (`https://www.example.com/page`, `https://example.com/page#top`) collapse
+//!   to one key. This is a deliberate contract change from the earlier design
+//!   where callers were expected to normalize first — the queue cannot rely on
+//!   every producer (seed, links, sitemap) doing so.
 
 use dashmap::DashSet;
+
+use crate::domain::url_validation::normalize_url;
 
 /// Lock-free URL deduplicator.
 ///
@@ -27,6 +36,9 @@ use dashmap::DashSet;
 /// The hash seed is randomized per process startup (`RandomState::new()`,
 /// satisfying FR-3) yet stable for the deduplicator's lifetime, so the same URL
 /// always maps to the same `u64` within one process (FR-5).
+///
+/// URLs are normalized to a canonical form before hashing (#517), so equivalent
+/// spellings of the same document deduplicate as one key.
 ///
 /// # Example
 ///
@@ -62,9 +74,14 @@ impl UrlDeduplicator {
     /// present. This is a single lock-free `DashSet::insert` — no `Mutex`, no
     /// `.await` — so it is safe to call from many Tokio tasks concurrently
     /// (FR-8) without data races or lost updates.
+    ///
+    /// The URL is normalized via the canonical domain normalizer before
+    /// hashing (#517), so `https://www.example.com/page` and
+    /// `https://example.com/page#top` collide on one key.
     #[must_use]
     pub fn try_insert(&self, url: &str) -> bool {
-        self.seen.insert(self.rs.hash_one(url))
+        let canonical = normalize_url(url, true);
+        self.seen.insert(self.rs.hash_one(&canonical))
     }
 
     /// Number of unique URLs currently tracked.
@@ -155,17 +172,86 @@ mod tests {
     }
 
     #[test]
-    fn test_padded_urls_are_distinct() {
-        // padded: try_insert does NOT trim/normalize; surrounding whitespace
-        // yields a distinct hash from the bare URL. Normalization is
-        // normalize_url's job, applied by callers before inserting.
+    fn test_padded_urls_are_canonicalized() {
+        // padded + canonical-key (#517): surrounding whitespace is removed by
+        // url-normalize's WHATWG preprocessing, so padded and bare spellings
+        // of the same URL collapse to ONE key. This is the contract change
+        // from the earlier design where try_insert hashed raw strings.
         let dedup = UrlDeduplicator::new();
         assert!(dedup.try_insert("https://example.com"));
-        assert!(dedup.try_insert(" https://example.com "));
-        assert!(dedup.try_insert("https://example.com\n"));
+        assert!(!dedup.try_insert(" https://example.com "));
+        assert!(!dedup.try_insert("https://example.com\n"));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_cross_normalization_www_collapses() {
+        // www-vs-bare (#517): the same document reached via www and bare host
+        // must deduplicate to a single key.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://www.example.com/page"));
+        assert!(!dedup.try_insert("https://example.com/page"));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_cross_normalization_fragment_collapses() {
+        // fragments (#517): a fragment is not part of the document identity.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com/page#section"));
+        assert!(!dedup.try_insert("https://example.com/page#other"));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_cross_normalization_query_order_collapses() {
+        // query ordering + full query strip (#517): query parameters are
+        // removed entirely for dedup (remove_query_parameters: All), so order
+        // and presence of query strings never splits a document.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com/page?a=1&b=2"));
+        assert!(!dedup.try_insert("https://example.com/page?b=2&a=1"));
+        assert!(!dedup.try_insert("https://example.com/page?utm_source=x"));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_cross_normalization_host_case_collapses() {
+        // host casing (#517): WHATWG URL normalization lowercases the host.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://Example.COM/page"));
+        assert!(!dedup.try_insert("https://example.com/page"));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_cross_normalization_default_port_collapses() {
+        // default ports (#517): :443 on https is redundant.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com/page"));
+        assert!(!dedup.try_insert("https://example.com:443/page"));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_cross_normalization_index_html_collapses() {
+        // /index.html (#344/#517): the same document served at / and
+        // /index.html is one key.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com/"));
+        assert!(!dedup.try_insert("https://example.com/index.html"));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn test_cross_normalization_distinct_documents_stay_distinct() {
+        // distinct documents must NOT collide (#517): normalization collapses
+        // equivalent spellings, never different pages.
+        let dedup = UrlDeduplicator::new();
+        assert!(dedup.try_insert("https://example.com/page"));
+        assert!(dedup.try_insert("https://example.com/other"));
+        assert!(dedup.try_insert("https://example.com/page/"));
         assert_eq!(dedup.len(), 3);
-        // Re-inserting the bare URL is still a duplicate of itself
-        assert!(!dedup.try_insert("https://example.com"));
     }
 
     #[tokio::test]

--- a/crates/webfang_core/src/application/rate_limiter.rs
+++ b/crates/webfang_core/src/application/rate_limiter.rs
@@ -318,6 +318,43 @@ mod tests {
         );
     }
 
+    /// Sustained-pressure (no-starvation) proof for #517 hallazgo 5.
+    ///
+    /// With burst = `concurrency`, N concurrent waiters where N >> burst must
+    /// ALL complete, and the tail must respect the configured period — the
+    /// burst only front-loads the first `concurrency` permits, it must not
+    /// inflate the sustained rate.
+    #[tokio::test]
+    async fn test_rate_limiting_sustained_pressure_no_starvation() {
+        let config = RateLimiterConfig::new(100, 4); // 100ms period, burst=4
+        let limiter = SharedRateLimiter::new(&config).unwrap();
+
+        let num_tasks = 16; // 4× the burst — sustained pressure
+        let start = std::time::Instant::now();
+
+        let mut handles = Vec::new();
+        for _ in 0..num_tasks {
+            let limiter = limiter.clone();
+            let handle = tokio::spawn(async move {
+                limiter.until_ready().await;
+            });
+            handles.push(handle);
+        }
+
+        futures::future::join_all(handles).await;
+        let elapsed = start.elapsed();
+
+        // All 16 completed (no starvation — the join_all above would not
+        // return otherwise). The last permit is gated by the 12th refill
+        // after the burst: (16 - 4) × 100ms = 1200ms. Assert ≥ 1000ms so a
+        // single lost refill does not flake, but the sustained rate clearly
+        // did not collapse to burst-speed.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(1000),
+            "sustained rate collapsed: 16 tasks with period=100ms/burst=4 took {elapsed:?}"
+        );
+    }
+
     // ============================================================================
     // MockClock unit tests (testing the Clock port itself)
     //

--- a/crates/webfang_core/src/domain/url_validation.rs
+++ b/crates/webfang_core/src/domain/url_validation.rs
@@ -221,6 +221,134 @@ pub fn is_internal_link(url: &str, seed_domain: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Normalize a URL (remove fragments, strip www, remove default ports, etc.)
+///
+/// This is the **canonical** URL normalizer for the scraper. All URL
+/// normalization should go through this function. It lives in the domain layer
+/// so both the application deduplicators and the infrastructure crawlers share
+/// one canonical form for URL equivalence — two URLs that normalize to the same
+/// string are treated as the same document (#517).
+///
+/// Options:
+/// - `strip_hash: true` — removes URL fragments (`#section`)
+/// - `strip_www` — removes `www.` prefix when `true` (caller controls behavior)
+/// - `remove_trailing_slash: false` — preserves trailing slashes on nested
+///   paths (`/page/` stays distinct from `/page`); a bare root is still
+///   canonicalized to `https://host` by url-normalize
+/// - `remove_query_parameters: All` — strips query strings for dedup
+/// - `sort_query_parameters: true` — consistent ordering
+///
+/// After normalization, a trailing `/index.html` or `/index.htm` path segment
+/// is collapsed to `/` (case-insensitive, idempotent) so the same document is
+/// not stored under two URLs.
+///
+/// Non-URLs (strings without a `://` scheme) are returned unchanged — a bare
+/// `not-a-valid-url` is never coerced into `http://not-a-valid-url`.
+///
+/// # Arguments
+///
+/// * `url` - URL to normalize
+/// * `strip_www` - If `true`, removes `www.` prefix (e.g. `www.example.com` → `example.com`)
+///
+/// # Examples
+///
+/// ```
+/// use webfang_core::domain::url_validation::normalize_url;
+///
+/// assert_eq!(
+///     normalize_url("https://example.com/page#section", true),
+///     "https://example.com/page"
+/// );
+/// assert_eq!(
+///     normalize_url("https://www.example.com/page", true),
+///     "https://example.com/page"
+/// );
+/// assert_eq!(
+///     normalize_url("https://www.example.com/page", false),
+///     "https://www.example.com/page"
+/// );
+/// assert_eq!(
+///     normalize_url("https://example.com:443/page", true),
+///     "https://example.com/page"
+/// );
+/// assert_eq!(
+///     normalize_url("https://example.com/index.html", true),
+///     "https://example.com"
+/// );
+/// ```
+#[inline]
+#[must_use]
+pub fn normalize_url(url: &str, strip_www: bool) -> String {
+    use url_normalize::{normalize_url as normalize, Options, RemoveQueryParameters};
+
+    // Non-URLs (no scheme) should not be normalized — return as-is.
+    // This prevents "not-a-valid-url" → "http://not-a-valid-url" conversion.
+    if !url.contains("://") {
+        return url.to_string();
+    }
+
+    let opts = Options {
+        strip_hash: true,
+        remove_trailing_slash: false,
+        remove_query_parameters: RemoveQueryParameters::All,
+        sort_query_parameters: true,
+        strip_www,
+        force_https: false,
+        ..Options::default()
+    };
+
+    // url-normalize handles WHATWG preprocessing (control chars, backslashes,
+    // trailing whitespace) and produces idempotent output.
+    let normalized = normalize(url, &opts).unwrap_or_else(|_| url.to_string());
+
+    // Collapse /index.html and /index.htm to / so the same document is not
+    // stored under two URLs (idempotent, case-insensitive).
+    collapse_index_path(&normalized)
+}
+
+/// Collapse a trailing `/index.html` or `/index.htm` path segment to `/`.
+///
+/// Many servers serve identical content at both `/` and `/index.html`;
+/// collapsing them lets the crawler deduplicate what would otherwise be two
+/// URLs pointing at the same document.
+///
+/// Guarantees:
+/// - Case-insensitive filename match (`/Index.HTML` collapses too).
+/// - Idempotent — an already-collapsed `/` path is returned unchanged.
+/// - Anchored on a `/` segment boundary, so `/my-index.html` is NOT collapsed.
+/// - Only `index.html` / `index.htm` — never `/index.php`, `/default.aspx`, etc.
+///
+/// If the normalized URL cannot be re-parsed, it is returned unchanged.
+#[inline]
+#[must_use]
+fn collapse_index_path(url: &str) -> String {
+    let Ok(mut parsed) = url::Url::parse(url) else {
+        return url.to_string();
+    };
+
+    let lower = parsed.path().to_ascii_lowercase();
+    let collapsed = lower
+        .strip_suffix("/index.html")
+        .or_else(|| lower.strip_suffix("/index.htm"))
+        .map(|parent| format!("{parent}/"));
+
+    match collapsed {
+        Some(new_path) => {
+            parsed.set_path(&new_path);
+            let mut result = parsed.to_string();
+            // The `url` crate serializes a root path as "https://host/", but
+            // url-normalize canonicalizes a bare root to "https://host" (no
+            // slash). Mirror that so "/" and "/index.html" produce the SAME
+            // string and deduplicate (#344). Nested paths keep their slash.
+            if parsed.path() == "/" {
+                result.pop();
+            }
+            result
+        },
+        None => url.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
@@ -103,131 +103,13 @@ pub fn is_internal_link(url: &str, domain: &str) -> bool {
     crate::domain::url_validation::is_internal_link(url, domain)
 }
 
-/// Normalize a URL (remove fragments, strip www, remove default ports, etc.)
+/// Re-export of the canonical URL normalizer.
 ///
-/// Following **own-borrow-over-clone**: Accepts `&str`.
-///
-/// This is the **canonical** URL normalizer for the scraper. All URL
-/// normalization should go through this function.
-///
-/// Options:
-/// - `strip_hash: true` — removes URL fragments (`#section`)
-/// - `strip_www` — removes `www.` prefix when `true` (caller controls behavior)
-/// - `remove_trailing_slash: false` — preserves trailing slashes
-/// - `remove_query_parameters: All` — strips query strings for dedup
-/// - `sort_query_parameters: true` — consistent ordering
-///
-/// After normalization, a trailing `/index.html` or `/index.htm` path segment
-/// is collapsed to `/` (case-insensitive, idempotent) so the same document is
-/// not stored under two URLs.
-///
-/// # Returns
-///
-/// Normalized URL string
-///
-/// # Arguments
-///
-/// * `url` - URL to normalize
-/// * `strip_www` - If `true`, removes `www.` prefix (e.g. `www.example.com` → `example.com`)
-///
-/// # Examples
-///
-/// ```
-/// use webfang_core::infrastructure::crawler::normalize_url;
-///
-/// assert_eq!(
-///     normalize_url("https://example.com/page#section", true),
-///     "https://example.com/page"
-/// );
-/// assert_eq!(
-///     normalize_url("https://www.example.com/page", true),
-///     "https://example.com/page"
-/// );
-/// assert_eq!(
-///     normalize_url("https://www.example.com/page", false),
-///     "https://www.example.com/page"
-/// );
-/// assert_eq!(
-///     normalize_url("https://example.com:443/page", true),
-///     "https://example.com/page"
-/// );
-/// assert_eq!(
-///     normalize_url("https://example.com/index.html", true),
-///     "https://example.com"
-/// );
-/// ```
-#[inline]
-#[must_use]
-pub fn normalize_url(url: &str, strip_www: bool) -> String {
-    use url_normalize::{normalize_url as normalize, Options, RemoveQueryParameters};
-
-    // Non-URLs (no scheme) should not be normalized — return as-is.
-    // This prevents "not-a-valid-url" → "http://not-a-valid-url" conversion.
-    if !url.contains("://") {
-        return url.to_string();
-    }
-
-    let opts = Options {
-        strip_hash: true,
-        remove_trailing_slash: false,
-        remove_query_parameters: RemoveQueryParameters::All,
-        sort_query_parameters: true,
-        strip_www,
-        force_https: false,
-        ..Options::default()
-    };
-
-    // url-normalize handles WHATWG preprocessing (control chars, backslashes,
-    // trailing whitespace) and produces idempotent output.
-    let normalized = normalize(url, &opts).unwrap_or_else(|_| url.to_string());
-
-    // Collapse /index.html and /index.htm to / so the same document is not
-    // stored under two URLs (idempotent, case-insensitive).
-    collapse_index_path(&normalized)
-}
-
-/// Collapse a trailing `/index.html` or `/index.htm` path segment to `/`.
-///
-/// Many servers serve identical content at both `/` and `/index.html`;
-/// collapsing them lets the crawler deduplicate what would otherwise be two
-/// URLs pointing at the same document.
-///
-/// Guarantees:
-/// - Case-insensitive filename match (`/Index.HTML` collapses too).
-/// - Idempotent — an already-collapsed `/` path is returned unchanged.
-/// - Anchored on a `/` segment boundary, so `/my-index.html` is NOT collapsed.
-/// - Only `index.html` / `index.htm` — never `/index.php`, `/default.aspx`, etc.
-///
-/// If the normalized URL cannot be re-parsed, it is returned unchanged.
-#[inline]
-#[must_use]
-fn collapse_index_path(url: &str) -> String {
-    let Ok(mut parsed) = Url::parse(url) else {
-        return url.to_string();
-    };
-
-    let lower = parsed.path().to_ascii_lowercase();
-    let collapsed = lower
-        .strip_suffix("/index.html")
-        .or_else(|| lower.strip_suffix("/index.htm"))
-        .map(|parent| format!("{parent}/"));
-
-    match collapsed {
-        Some(new_path) => {
-            parsed.set_path(&new_path);
-            let mut result = parsed.to_string();
-            // The `url` crate serializes a root path as "https://host/", but
-            // url-normalize canonicalizes a bare root to "https://host" (no
-            // slash). Mirror that so "/" and "/index.html" produce the SAME
-            // string and deduplicate (#344). Nested paths keep their slash.
-            if parsed.path() == "/" {
-                result.pop();
-            }
-            result
-        },
-        None => url.to_string(),
-    }
-}
+/// The implementation lives in the domain layer (`url_validation::normalize_url`)
+/// so both application deduplicators and infrastructure crawlers share one
+/// canonical URL form (#517). This re-export keeps the historical
+/// `infrastructure::crawler::normalize_url` path working for all callers.
+pub use crate::domain::url_validation::normalize_url;
 
 /// HTML link extractor implementation
 ///

--- a/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
@@ -14,19 +14,26 @@ use url::Url;
 
 use crate::domain::LinkExtractor;
 
-/// Extract all links from HTML content
+/// Extract all crawlable links from HTML content
 ///
 /// Following **own-borrow-over-clone**: Accepts `&str` not `&String`.
 /// Following **mem-with-capacity**: Pre-allocates Vec with estimated capacity.
 ///
+/// Links marked `rel="nofollow"` (any token, case-insensitive) are excluded —
+/// the crawler must not follow them (#517). A `<base href>` element in the
+/// document overrides the caller's `base_url` for resolving relative links,
+/// per the HTML spec (first `<base href>` wins; invalid or absent → fallback
+/// to `base_url`).
+///
 /// # Arguments
 ///
 /// * `html` - HTML content to parse
-/// * `base_url` - Base URL for resolving relative links
+/// * `base_url` - Base URL for resolving relative links (fallback when the
+///   document has no usable `<base href>`)
 ///
 /// # Returns
 ///
-/// * `Ok(Vec<String>)` - List of extracted URLs
+/// * `Ok(Vec<String>)` - List of extracted, normalized URLs
 /// * `Err(CrawlError)` - Parse error
 ///
 /// # Examples
@@ -45,15 +52,35 @@ pub fn extract_links(html: &str, base_url: &str) -> Result<Vec<String>, crate::d
     let document = Html::parse_document(html);
     let selector = Selector::parse("a[href]")
         .map_err(|e| crate::domain::CrawlError::Parse(format!("Failed to parse selector: {e}")))?;
+    let base_selector = Selector::parse("base[href]")
+        .map_err(|e| crate::domain::CrawlError::Parse(format!("Failed to parse selector: {e}")))?;
 
     // Parse base URL once
-    let base =
+    let caller_base =
         Url::parse(base_url).map_err(|e| crate::domain::CrawlError::InvalidUrl(e.to_string()))?;
+
+    // HTML spec: the first <base href> in the document overrides the caller's
+    // base for resolving relative links. A relative <base href> is itself
+    // resolved against the caller's base; an unparseable one is ignored.
+    let base = document
+        .select(&base_selector)
+        .next()
+        .and_then(|el| el.value().attr("href"))
+        .and_then(|href| Url::parse(href).or_else(|_| caller_base.join(href)).ok())
+        .unwrap_or(caller_base);
 
     // Pre-allocate with estimated capacity (optimization for typical pages)
     let mut links = Vec::with_capacity(32);
 
     for element in document.select(&selector) {
+        // rel="nofollow" is a hint the crawler must not follow this link.
+        let rel = element.value().attr("rel").unwrap_or("");
+        if rel
+            .split_whitespace()
+            .any(|token| token.eq_ignore_ascii_case("nofollow"))
+        {
+            continue;
+        }
         if let Some(href) = element.value().attr("href") {
             // Resolve relative URLs
             match base.join(href) {
@@ -425,5 +452,158 @@ mod tests {
         // Links contain the path portion; query params may be normalized
         assert!(links.iter().any(|l| l.contains("/search")));
         assert!(links.iter().any(|l| l.contains("/page")));
+    }
+
+    // ============================================================================
+    // rel="nofollow" and <base href> handling (#517)
+    // ============================================================================
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_skips_nofollow() {
+        let html = r#"
+            <html>
+                <body>
+                    <a href="/follow">Follow me</a>
+                    <a href="/skip" rel="nofollow">Do not follow</a>
+                    <a href="/also-follow">Also follow</a>
+                </body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(links.len(), 2);
+        assert!(links.contains(&"https://example.com/follow".to_string()));
+        assert!(links.contains(&"https://example.com/also-follow".to_string()));
+        assert!(!links.contains(&"https://example.com/skip".to_string()));
+    }
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_nofollow_token_is_case_insensitive() {
+        let html = r#"
+            <html>
+                <body>
+                    <a href="/skip1" rel="NOFOLLOW">Uppercase</a>
+                    <a href="/skip2" rel="noopener nofollow sponsored">Multi-token</a>
+                    <a href="/keep">Keep</a>
+                </body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(links.len(), 1);
+        assert!(links.contains(&"https://example.com/keep".to_string()));
+    }
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_nofollow_requires_exact_token() {
+        // "nofollows" and "no-follow" are NOT the rel token "nofollow".
+        let html = r#"
+            <html>
+                <body>
+                    <a href="/a" rel="nofollows">Not exact</a>
+                    <a href="/b" rel="no-follow">Hyphenated</a>
+                    <a href="/c">Plain</a>
+                </body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(links.len(), 3);
+    }
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_uses_base_href() {
+        let html = r#"
+            <html>
+                <head><base href="https://cdn.example.com/docs/"></head>
+                <body>
+                    <a href="guide.html">Relative to base</a>
+                    <a href="/absolute">Root-relative also resolves against base</a>
+                </body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(links.len(), 2);
+        assert!(links.contains(&"https://cdn.example.com/docs/guide.html".to_string()));
+        assert!(links.contains(&"https://cdn.example.com/absolute".to_string()));
+    }
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_uses_first_base_href() {
+        // HTML spec: the FIRST <base href> in the document wins.
+        let html = r#"
+            <html>
+                <head>
+                    <base href="https://first.example.com/docs/">
+                    <base href="https://second.example.com/docs/">
+                </head>
+                <body><a href="guide.html">Relative to base</a></body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(
+            links,
+            vec!["https://first.example.com/docs/guide.html".to_string()]
+        );
+    }
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_relative_base_href_resolves_against_caller() {
+        let html = r#"
+            <html>
+                <head><base href="/subdir/"></head>
+                <body><a href="guide.html">Relative to base</a></body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(
+            links,
+            vec!["https://example.com/subdir/guide.html".to_string()]
+        );
+    }
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_invalid_base_href_falls_back_to_caller() {
+        // An unparseable <base href> must not poison resolution; fall back to
+        // the caller's base_url.
+        let html = r#"
+            <html>
+                <head><base href="::::not-a-url"></head>
+                <body><a href="guide.html">Relative to caller</a></body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(links, vec!["https://example.com/guide.html".to_string()]);
+    }
+
+    #[cfg_attr(miri, ignore)] // scraper::Selector servo_arc UB
+    #[test]
+    fn test_extract_links_nofollow_and_base_href_combine() {
+        let html = r#"
+            <html>
+                <head><base href="https://cdn.example.com/docs/"></head>
+                <body>
+                    <a href="guide.html">Relative to base</a>
+                    <a href="secret.html" rel="nofollow">Skipped</a>
+                </body>
+            </html>
+        "#;
+
+        let links = extract_links(html, "https://example.com").unwrap();
+        assert_eq!(
+            links,
+            vec!["https://cdn.example.com/docs/guide.html".to_string()]
+        );
     }
 }

--- a/crates/webfang_core/src/infrastructure/crawler/url_queue.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/url_queue.rs
@@ -216,6 +216,23 @@ impl UrlQueue {
         result
     }
 
+    /// Snapshot pending URLs as strings WITHOUT consuming them.
+    ///
+    /// Used by checkpoint persistence (#517): the queue must be serializable at
+    /// any point so a resume can re-enqueue what was pending when the crawl
+    /// stopped. The `seen` set is untouched, so re-pushing these URLs later
+    /// would be rejected as duplicates — callers restoring a checkpoint must
+    /// bypass the dedup set for exactly the restored URLs.
+    ///
+    /// # Returns
+    ///
+    /// All URLs currently in the queue (heap order, not priority order).
+    #[must_use]
+    pub async fn snapshot_urls(&self) -> Vec<String> {
+        let queue = self.queue.lock().await;
+        queue.iter().map(|p| p.url.url.to_string()).collect()
+    }
+
     /// Get the current queue length
     ///
     /// # Returns

--- a/crates/webfang_core/src/infrastructure/crawler/url_queue.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/url_queue.rs
@@ -20,6 +20,7 @@ use dashmap::DashSet;
 use tokio::sync::Mutex;
 use tracing::debug;
 
+use crate::domain::url_validation::normalize_url;
 use crate::domain::DiscoveredUrl;
 
 /// Source of a discovered URL, used for priority scoring.
@@ -149,7 +150,12 @@ impl UrlQueue {
         // Lock-free, atomic check-and-insert via DashSet::insert (no Mutex, no
         // .await). Prevents the race where two tasks both pass contains() and
         // both insert. The hash uses the per-process randomized seed (FR-3/FR-5).
-        let hash = self.rs.hash_one(url.url.as_str());
+        //
+        // The URL is normalized to its canonical form BEFORE hashing (#517):
+        // the seed enters the queue raw while links arrive already normalized,
+        // so a raw/equivalently-spelled duplicate must still be rejected here.
+        let canonical = normalize_url(url.url.as_str(), true);
+        let hash = self.rs.hash_one(&canonical);
         if !self.seen.insert(hash) {
             debug!("Duplicate URL in queue: {}", url.url);
             return false;
@@ -295,6 +301,13 @@ mod tests {
         DiscoveredUrl::html(url, depth, parent)
     }
 
+    /// Build a DiscoveredUrl from an arbitrary absolute URL string.
+    fn push_with_url(raw: &str) -> DiscoveredUrl {
+        let url = Url::parse(raw).unwrap();
+        let parent = Url::parse("https://example.com/").unwrap();
+        DiscoveredUrl::html(url, 0, parent)
+    }
+
     #[tokio::test]
     async fn test_url_queue_new() {
         let queue = UrlQueue::new();
@@ -335,6 +348,48 @@ mod tests {
 
         assert_eq!(queue.len().await, 1);
         assert_eq!(queue.seen_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_url_queue_cross_normalization_www_collapses() {
+        // www-vs-bare (#517): same document reached via www and bare host is
+        // one queue entry.
+        let queue = UrlQueue::new();
+        assert!(queue.push(create_test_url("/page")).await);
+        assert!(
+            !queue
+                .push(push_with_url("https://www.example.com/page"))
+                .await
+        );
+        assert_eq!(queue.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_url_queue_cross_normalization_fragment_collapses() {
+        // fragments (#517): a fragment is not part of the document identity.
+        let queue = UrlQueue::new();
+        assert!(queue.push(create_test_url("/page")).await);
+        assert!(
+            !queue
+                .push(push_with_url("https://example.com/page#section"))
+                .await
+        );
+        assert_eq!(queue.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_url_queue_cross_normalization_query_collapses() {
+        // query strings (#517): query parameters are removed entirely for
+        // dedup (remove_query_parameters: All), so a seed with a tracking
+        // query is the same document as the bare link.
+        let queue = UrlQueue::new();
+        assert!(queue.push(create_test_url("/page")).await);
+        assert!(
+            !queue
+                .push(push_with_url("https://example.com/page?a=1&b=2"))
+                .await
+        );
+        assert_eq!(queue.len().await, 1);
     }
 
     #[tokio::test]

--- a/crates/webfang_core/src/infrastructure/downloader/hybrid_router.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/hybrid_router.rs
@@ -106,9 +106,7 @@ impl<L1: Downloader, L2: Downloader, L3: Downloader> HybridRouter<L1, L2, L3> {
         // Check resources before spawning a subprocess
         if let Err(e) = self.governor.check_resources() {
             warn!("ResourceGovernor denied Layer 2: {e}");
-            return Err(DownloadError::Internal(format!(
-                "resource governor denied obscura: {e}"
-            )));
+            return Err(DownloadError::from(e));
         }
 
         match self.layer2.fetch(url).await {
@@ -132,9 +130,7 @@ impl<L1: Downloader, L2: Downloader, L3: Downloader> HybridRouter<L1, L2, L3> {
 
         if let Err(e) = self.governor.check_resources() {
             warn!("ResourceGovernor denied Layer 3: {e}");
-            return Err(DownloadError::Internal(format!(
-                "resource governor denied chromiumoxide: {e}"
-            )));
+            return Err(DownloadError::from(e));
         }
 
         match self.layer3.fetch(url).await {

--- a/crates/webfang_core/src/infrastructure/downloader/mod.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/mod.rs
@@ -145,6 +145,12 @@ pub enum DownloadError {
     #[error("internal error: {0}")]
     Internal(String),
 
+    /// System resources (RAM) insufficient to spawn a heavyweight downloader
+    /// layer. An *expected* operational condition under memory pressure —
+    /// distinct from [`Internal`](Self::Internal), which means a bug.
+    #[error("insufficient resources: {0}")]
+    ResourceExhausted(String),
+
     /// Acquisition cancelled by the engine's cancellation token (#509) —
     /// the caller was waiting for a resource permit when shutdown fired.
     #[error("operation cancelled while waiting for resources")]

--- a/crates/webfang_core/src/infrastructure/downloader/resource_governor.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/resource_governor.rs
@@ -181,7 +181,7 @@ pub enum ResourceError {
 
 impl From<ResourceError> for DownloadError {
     fn from(err: ResourceError) -> Self {
-        DownloadError::Internal(err.to_string())
+        DownloadError::ResourceExhausted(err.to_string())
     }
 }
 
@@ -235,7 +235,7 @@ mod tests {
     fn test_resource_error_into_download_error() {
         let res_err = ResourceError::Insufficient("test".into());
         let dl_err: DownloadError = res_err.into();
-        assert!(matches!(dl_err, DownloadError::Internal(_)));
+        assert!(matches!(dl_err, DownloadError::ResourceExhausted(_)));
     }
 
     // ========================================================================

--- a/crates/webfang_core/tests/integration_engine_tests.rs
+++ b/crates/webfang_core/tests/integration_engine_tests.rs
@@ -72,8 +72,9 @@ async fn test_engine_with_checkpoint_enabled() {
 
 /// Test 2: Engine resumes from an existing checkpoint.
 ///
-/// Creates a checkpoint with one visited URL, then verifies the engine
-/// skips that URL and starts from the remaining queue.
+/// Pre-creates a checkpoint whose seed is already visited and whose queue
+/// still holds `/page2.html`, then verifies the engine actually crawls the
+/// pending URL instead of finishing with zero work.
 #[tokio::test]
 async fn test_engine_resume_from_checkpoint() {
     let server = MockServer::start().await;
@@ -102,13 +103,16 @@ async fn test_engine_resume_from_checkpoint() {
     let checkpoint_dir = tmp.path().join("checkpoints");
     std::fs::create_dir_all(&checkpoint_dir).unwrap();
 
-    // Pre-create a checkpoint that marks the seed as already visited
+    // Pre-create a checkpoint that marks the seed as visited but keeps
+    // /page2.html pending in the queue — exactly what a mid-crawl
+    // save_checkpoint leaves behind.
     let seed_url = format!("{}/index.html", server.uri());
+    let page2_url = format!("{}/page2.html", server.uri());
     let mut visited = std::collections::HashSet::new();
     visited.insert(seed_url);
     let state = CrawlCheckpoint {
         visited,
-        queued: Vec::new(),
+        queued: vec![page2_url],
         pages_crawled: 1,
         banned_domains: Vec::new(),
         version: 1,
@@ -137,11 +141,20 @@ async fn test_engine_resume_from_checkpoint() {
     );
 
     let crawl_result = result.unwrap();
-    // The seed was already visited, so the engine should discover page2
-    // via the queue (if checkpoint restored it) or just finish quickly.
-    // The important thing is it doesn't re-crawl the seed.
-    println!(
-        "Resume test: crawled {} pages, {} total",
-        crawl_result.total_pages, crawl_result.total_pages
+    assert!(
+        crawl_result.total_pages >= 1,
+        "resume must crawl the pending queue, not finish empty (crawled {})",
+        crawl_result.total_pages
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let requested_paths: Vec<String> = requests.iter().map(|r| r.url.path().to_string()).collect();
+    assert!(
+        requested_paths.iter().any(|p| *p == "/page2.html"),
+        "pending /page2.html must be fetched on resume, got: {requested_paths:?}"
+    );
+    assert!(
+        requested_paths.iter().all(|p| *p != "/index.html"),
+        "visited seed must not be re-crawled on resume, got: {requested_paths:?}"
     );
 }

--- a/crates/webfang_mcp/src/mcp_server/handlers/content.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/content.rs
@@ -48,9 +48,9 @@ impl McpHandler {
         Ok(CallToolResult::success(vec![Content::text(md)]))
     }
 
-    /// Extract all href links from HTML
+    /// Extract all crawlable href links from HTML
     #[tool(
-        description = "Extract all href links from HTML content. Returns list of raw href values."
+        description = "Extract href links from HTML content, honoring rel=\"nofollow\" (excluded) and a document <base href>. Returns list of raw href values."
     )]
     #[instrument(skip(self), fields(base_url = %params.base_url))]
     async fn extract_links(


### PR DESCRIPTION
Closes #517

## Summary
Semantic bugs that compile and pass tests but resolve the problem incorrectly — fixed with regression tests:

1. **URL dedup normalization (ALTO)** — `UrlDeduplicator` now normalizes via domain `normalize_url` (`strip_www`, strip hash/query, collapse `/index.html`) BEFORE hashing; `UrlQueue::push_prioritized` too. `normalize_url` moved from infra → domain (inward-only rule). `test_padded_urls_are_distinct` → `test_padded_urls_are_canonicalized`.
2. **Checkpoint pending queue (ALTO)** — checkpoints now persist AND restore the pending URL queue (not just visited), so resume re-fires remaining work without re-crawling visited (round-trip exact).
3. **LinkExtractor nofollow + `<base href>` (ALTO)** — `rel="nofollow"` tokens (case-insensitive) are excluded; first `<base href>` overrides caller base for relative resolution. 8 regression tests.
4. **HybridRouter resource deny (medio)** — `ResourceGovernor` denials now map to new `DownloadError::ResourceExhausted`, not `Internal`.
5. **Rate limiter** — sustained-pressure test proving burst correctness (re: #509).

## Test plan
- `cargo nextest run -p webfang_core`: 1899/1899 passed (one pre-existing timing flake passes on retry)
- clippy strict, fmt clean
- Miri gates on new scraper tests (servo_arc UB in scraper::Selector — pre-existing)

## Files
- crates/webfang_core/src/domain/url_validation.rs (+128)
- crates/webfang_core/src/application/deduplicator.rs
- crates/webfang_core/src/infrastructure/crawler/link_extractor.rs
- crates/webfang_core/src/infrastructure/crawler/url_queue.rs
- crates/webfang_core/src/application/crawler/crawl_scheduler.rs
- crates/webfang_core/src/infrastructure/downloader/{mod.rs, hybrid_router.rs, resource_governor.rs}
- crates/webfang_mcp/src/mcp_server/handlers/content.rs

## Worktree
Branch: fix/business-logic-review-517
