### PR TITLE
fix(observability): remove async-unsafe span.enter() guards across .await (#519)

### DIFF
--- a/crates/webfang_core/src/application/crawler/crawl_task.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task.rs
@@ -9,7 +9,7 @@
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
-use tracing::{debug, span, warn, Level};
+use tracing::{debug, instrument, warn};
 use url::Url;
 
 use super::checkpoint::BannedDomain;
@@ -17,7 +17,7 @@ use super::crawl_task_ctx::CrawlTaskCtx;
 use super::ports::waf_challenge_message;
 use crate::application::pipeline::{ScrapedItem, StageOutcome};
 use crate::application::url_filter::is_allowed;
-use crate::domain::{CrawlError, CrawlErrorCategory, DiscoveredUrl};
+use crate::domain::{CorrelationId, CrawlError, CrawlErrorCategory, DiscoveredUrl};
 use crate::infrastructure::crawler::{is_internal_link, UrlSource};
 use crate::infrastructure::observability::log_scrape_error;
 
@@ -77,20 +77,36 @@ pub(crate) async fn run_crawl_task(
         },
     }
 
+    let page_correlation = ctx.correlation_id.child();
+    run_crawl_task_inner(ctx, discovered_url, page_correlation).await
+}
+
+/// Inner implementation of [`run_crawl_task`] — carries the per-page
+/// `crawl_page` span (#519).
+///
+/// The `#[instrument]` span declares the per-page identity (`correlation_id`,
+/// `trace_id`) AT CREATION time (#501): FileTraceLayer snapshots span fields
+/// in `on_new_span`, so fields recorded later never reach the `--trace-file`
+/// JSONL. The instrumented span lifecycle is also async-safe — no `enter()`
+/// guard crosses an `.await` (#519).
+#[instrument(
+    name = "crawl_page",
+    skip(ctx, page_correlation, discovered_url),
+    fields(
+        correlation_id = %page_correlation,
+        trace_id = %page_correlation.trace_id(),
+        url = %discovered_url.url,
+        depth = discovered_url.depth
+    )
+)]
+async fn run_crawl_task_inner(
+    ctx: Arc<CrawlTaskCtx>,
+    discovered_url: DiscoveredUrl,
+    page_correlation: CorrelationId,
+) -> Result<(), CrawlError> {
     let url_str = discovered_url.url.as_str().to_string();
     let url_depth = discovered_url.depth;
     let parent_url = discovered_url.url.clone();
-
-    let page_correlation = ctx.correlation_id.child();
-    let page_span = span!(
-        Level::DEBUG,
-        "crawl_page",
-        correlation_id = %page_correlation,
-        trace_id = %page_correlation.trace_id(),
-        url = %url_str,
-        depth = url_depth
-    );
-    let _page_guard = page_span.enter();
 
     let mut session_id = None;
     if let Some(ref pool) = ctx.session_pool {

--- a/crates/webfang_core/src/application/crawler/discovery.rs
+++ b/crates/webfang_core/src/application/crawler/discovery.rs
@@ -6,7 +6,7 @@
 //! and sitemap XML parsing in the infrastructure layer (issue #442); both are
 //! re-exported here so existing import paths keep resolving.
 
-use tracing::{debug, info, instrument, span, warn, Level};
+use tracing::{debug, info, instrument, warn};
 use url::Url;
 
 use crate::application::url_filter::is_allowed;
@@ -86,9 +86,6 @@ pub async fn discover_urls_for_tui(
     base_url: &str,
     config: &CrawlerConfig,
 ) -> ScraperResult<Vec<Url>> {
-    let span = span!(Level::INFO, "discover_urls", base_url = base_url);
-    let _guard = span.enter();
-
     info!("Discovering URLs from {}", base_url);
 
     // If sitemap enabled, use sitemap (preferred)

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, instrument, span, warn, Instrument, Level};
+use tracing::{debug, info, instrument, warn, Instrument};
 use wreq_util::Profile;
 
 use super::checkpoint::{
@@ -778,10 +778,23 @@ impl Default for EngineOptions {
 /// # Ok(())
 /// # }
 /// ```
+pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError> {
+    crawl_site_inner(config, CorrelationId::new()).await
+}
+
+/// Inner implementation of [`crawl_site`].
+///
+/// The `#[instrument]` span declares the run-root identity (`correlation_id`,
+/// `trace_id`) AT CREATION time (#501): FileTraceLayer snapshots span fields
+/// in `on_new_span`, so fields recorded later never reach the `--trace-file`
+/// JSONL. The instrumented span lifecycle is also async-safe — no `enter()`
+/// guard crosses an `.await` (#519).
 #[instrument(
     name = "crawl_site",
-    skip(config),
+    skip(config, correlation_id),
     fields(
+        correlation_id = %correlation_id,
+        trace_id = %correlation_id.trace_id(),
         seed_url = %config.seed_url,
         max_depth = config.max_depth,
         max_pages = config.max_pages,
@@ -789,19 +802,10 @@ impl Default for EngineOptions {
         concurrency = config.concurrency
     )
 )]
-pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError> {
-    let correlation_id = CorrelationId::new();
-    let span = span!(
-        Level::INFO,
-        "crawl_site",
-        correlation_id = %correlation_id,
-        trace_id = %correlation_id.trace_id(),
-        seed_url = %config.seed_url,
-        max_depth = config.max_depth,
-        max_pages = config.max_pages
-    );
-    let _guard = span.enter();
-
+async fn crawl_site_inner(
+    config: CrawlerConfig,
+    correlation_id: CorrelationId,
+) -> Result<CrawlResult, CrawlError> {
     info!(
         "Starting crawl from {} with max_depth={} max_pages={}",
         config.seed_url, config.max_depth, config.max_pages
@@ -860,10 +864,25 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
 /// # Ok(())
 /// # }
 /// ```
+pub async fn crawl_site_with_options(
+    config: CrawlerConfig,
+    options: EngineOptions,
+) -> Result<CrawlResult, CrawlError> {
+    crawl_site_with_options_inner(config, options, CorrelationId::new()).await
+}
+
+/// Inner implementation of [`crawl_site_with_options`].
+///
+/// The `#[instrument]` span declares the run-root identity (`correlation_id`,
+/// `trace_id`) AT CREATION time (#501): FileTraceLayer snapshots span fields
+/// in `on_new_span`. The instrumented span lifecycle is also async-safe — no
+/// `enter()` guard crosses an `.await` (#519).
 #[instrument(
     name = "crawl_site_with_options",
-    skip(config, options),
+    skip(config, options, correlation_id),
     fields(
+        correlation_id = %correlation_id,
+        trace_id = %correlation_id.trace_id(),
         seed_url = %config.seed_url,
         max_depth = config.max_depth,
         max_pages = config.max_pages,
@@ -872,22 +891,11 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
         ignore_robots = options.ignore_robots
     )
 )]
-pub async fn crawl_site_with_options(
+async fn crawl_site_with_options_inner(
     config: CrawlerConfig,
     options: EngineOptions,
+    correlation_id: CorrelationId,
 ) -> Result<CrawlResult, CrawlError> {
-    let correlation_id = CorrelationId::new();
-    let span = span!(
-        Level::INFO,
-        "crawl_site_with_options",
-        correlation_id = %correlation_id,
-        trace_id = %correlation_id.trace_id(),
-        seed_url = %config.seed_url,
-        max_depth = config.max_depth,
-        max_pages = config.max_pages
-    );
-    let _guard = span.enter();
-
     info!(
         "Starting crawl from {} with max_depth={} max_pages={} (checkpoint={}, session_pool={}, ignore_robots={})",
         config.seed_url,

--- a/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
+++ b/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
@@ -5,7 +5,7 @@
 //! were extracted from `discovery.rs` (issue #442) to separate the sitemap
 //! infrastructure concern from DOM-link discovery.
 
-use tracing::{info, span, Level};
+use tracing::{info, instrument};
 use url::Url;
 
 use crate::application::url_filter::is_allowed;
@@ -46,14 +46,19 @@ use crate::infrastructure::crawler::{SitemapConfig, SitemapParser};
 /// # Ok(())
 /// # }
 /// ```
+#[instrument(
+    name = "crawl_with_sitemap",
+    skip(config),
+    fields(
+        base_url,
+        sitemap_url = ?sitemap_url
+    )
+)]
 pub async fn crawl_with_sitemap(
     base_url: &str,
     sitemap_url: Option<&str>,
     config: &CrawlerConfig,
 ) -> Result<Vec<DiscoveredUrl>, CrawlError> {
-    let span = span!(Level::INFO, "crawl_with_sitemap", base_url = base_url);
-    let _guard = span.enter();
-
     crawl_with_sitemap_internal(base_url, sitemap_url, config).await
 }
 

--- a/crates/webfang_core/tests/span_attribution_across_await.rs
+++ b/crates/webfang_core/tests/span_attribution_across_await.rs
@@ -1,0 +1,135 @@
+//! Regression test for issue #519: span attribution must survive `.await`
+//! under the multi-threaded runtime.
+//!
+//! Production spans in the crawl path use `#[instrument]` / `.instrument(span)`
+//! (the pattern fixed in #519). That re-enters the span on EVERY poll — on
+//! whichever worker thread polls the future — so `FileTraceLayer`'s
+//! thread-local `SPAN_STACK` is always correct while the body runs. The
+//! previous pattern held a `span.enter()` guard across `.await`: the guard
+//! registered the span only on the creating thread, so after a worker-thread
+//! hop the polling thread had an empty stack and every event lost its
+//! `span_fields` attribution.
+//!
+//! Each round runs in its own `tokio::spawn`'d task (the `#[tokio::test]` body
+//! itself is driven by `block_on` on the main thread and never migrates). The
+//! task fills its worker's local queue and parks on a timer; the timer wakeup
+//! is then stolen by a different worker — a real thread hop. The test asserts
+//! EVERY event emitted inside the instrumented span still carries
+//! `span_fields.correlation_id` and `span_fields.trace_id`.
+
+use std::io::{BufRead, BufReader};
+use std::sync::Once;
+use std::time::Duration;
+
+use serde_json::Value;
+use tracing::Instrument;
+use tracing_subscriber::layer::SubscriberExt;
+
+use webfang_core::domain::value_objects::CorrelationId;
+use webfang_core::infrastructure::observability::FileTraceLayer;
+
+/// This test binary runs in its own process, so a process-wide global
+/// subscriber is safe — and required: Tokio worker threads resolve the
+/// *global* default dispatcher, not a thread-local `with_default`, so events
+/// are only captured on every polling thread if the layer is global.
+static INSTALL_GLOBAL_SUBSCRIBER: Once = Once::new();
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn span_attribution_survives_await_under_multi_thread_runtime() {
+    let trace_path = std::env::temp_dir().join(format!(
+        "webfang_span_attribution_{}.jsonl",
+        std::process::id()
+    ));
+
+    INSTALL_GLOBAL_SUBSCRIBER.call_once(|| {
+        let layer = FileTraceLayer::new(trace_path.clone()).unwrap();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("global subscriber must not be installed twice in this test binary");
+    });
+
+    // Fixed IDs keep the assertions exact-equality and deterministic.
+    let trace_id = uuid::Uuid::parse_str("01949e0e-8b8e-7000-8000-000000000001").unwrap();
+    let correlation = CorrelationId::new_with_ids(trace_id, 0x0000_0000_0000_0042);
+    let expected_traceparent = correlation.to_string();
+
+    // Multiple rounds: each round mints a fresh span and forces at least one
+    // thread hop, so a reintroduced enter-guard pattern loses attribution on
+    // at least one post-hop event.
+    for _ in 0..12 {
+        let span = tracing::info_span!(
+            "crawl_page",
+            url = "https://example.com/page",
+            correlation_id = %correlation,
+            trace_id = %correlation.trace_id(),
+        );
+
+        let work = async move {
+            tracing::info!("before first await");
+
+            // Saturate every worker with longer-lived tasks so THIS task's
+            // timer wakeup cannot be serviced by its owning worker and must be
+            // stolen by a different one — a real thread hop.
+            let mut flood = Vec::new();
+            for _ in 0..128 {
+                flood.push(tokio::spawn(async {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }));
+            }
+
+            tokio::time::sleep(Duration::from_millis(2)).await;
+            tracing::info!("after timer hop");
+
+            for handle in flood {
+                handle.await.expect("flood task must complete");
+            }
+            tracing::info!("after flood drain");
+        };
+        tokio::spawn(work.instrument(span))
+            .await
+            .expect("spawned instrumented task must complete");
+    }
+
+    // Every event record (events have a `message`; span_close records do not)
+    // must still be attributed to the span after all the awaits.
+    let records = read_jsonl_records(&trace_path);
+    let events: Vec<&Value> = records
+        .iter()
+        .filter(|r| r["message"].is_string())
+        .collect();
+    assert!(
+        !events.is_empty(),
+        "the trace file must contain event records"
+    );
+
+    for event in events {
+        let span_fields = event["span_fields"]
+            .as_object()
+            .unwrap_or_else(|| panic!("event lost span attribution after an await: {event}"));
+        assert_eq!(
+            span_fields["correlation_id"].as_str(),
+            Some(expected_traceparent.as_str()),
+            "correlation_id must be re-declared on the polling thread after each await: {event}"
+        );
+        assert_eq!(
+            span_fields["trace_id"].as_str(),
+            Some(trace_id.to_string().as_str()),
+            "trace_id must be re-declared on the polling thread after each await: {event}"
+        );
+    }
+
+    let _ = std::fs::remove_file(&trace_path);
+}
+
+/// Read the JSONL trace back as parsed records.
+fn read_jsonl_records(path: &std::path::Path) -> Vec<Value> {
+    let file = std::fs::File::open(path).expect("trace file must exist");
+    let reader = BufReader::new(file);
+    reader
+        .lines()
+        .map(|line| {
+            let line = line.expect("line must be readable");
+            serde_json::from_str(&line).expect("each trace line must be a JSON object")
+        })
+        .collect()
+}

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -156,13 +156,11 @@ impl McpHandler {
     #[tool(
         description = "Scrape multiple URLs with concurrency control. Failed URLs are logged but don't stop the batch."
     )]
+    #[instrument(skip(self), name = "mcp.scrape_batch", fields(url_count = params.urls.len()))]
     async fn scrape_batch(
         &self,
         Parameters(params): Parameters<ScrapeBatchParams>,
     ) -> Result<CallToolResult, McpError> {
-        let span = tracing::info_span!("mcp.scrape_batch", url_count = params.urls.len());
-        let _enter = span.enter();
-
         tracing::info!("starting batch scrape");
         let _permit = acquire_semaphore!(self, scraping);
 
@@ -296,13 +294,11 @@ impl McpHandler {
     )]
     // serde_json::to_string cannot fail for a serde_json::Value.
     #[allow(clippy::expect_used)]
+    #[instrument(skip(self), name = "mcp.crawl_with_sitemap", fields(url = %params.url))]
     async fn crawl_with_sitemap(
         &self,
         Parameters(params): Parameters<CrawlWithSitemapParams>,
     ) -> Result<CallToolResult, McpError> {
-        let span = tracing::info_span!("mcp.crawl_with_sitemap", url = %params.url);
-        let _enter = span.enter();
-
         tracing::info!("starting sitemap crawl");
         let _permit = acquire_semaphore!(self, scraping);
 


### PR DESCRIPTION
Closes #519

## Summary
Removes the async-unsafe `span.enter()` guard pattern from the 7 remaining production sites (the #506 cleanup completed for `scrape_single_url_for_tui` / `scrape_with_config`).

Per-thread spans leak in `FileTraceLayer`'s thread-local `SPAN_STACK` when a future hops workers at `.await`: `on_enter` pushes on thread A, the guard's drop fires `on_exit` on thread B where the pop-guard check no-ops — stale entries corrupt attribution for later events.

**Pattern applied per site** (mirrors #506):
- `engine.rs` — `crawl_site` / `crawl_site_with_options`: wrapper mints `CorrelationId` → instrumented `_inner` declares `correlation_id`/`trace_id` at span creation (async-safe lifecycle).
- `crawl_task.rs` — `run_crawl_task` wrapper + `run_crawl_task_inner`; per-page `crawl_page` span carries url/depth/correlation.
- `discovery.rs` — removed redundant manual span (wrapper already declares base_url).
- `sitemap_discovery.rs` — `#[instrument]` wrapper replaces manual INFO span.
- `mcp scraping.rs` — `scrape_batch` + `crawl_with_sitemap` → `#[instrument(name = "mcp.*")]`.

`file_trace_layer.rs` `enter()` calls are synchronous test closures — left untouched per the issue.

**Regression test** (`crates/webfang_core/tests/span_attribution_across_await.rs`):
Forces a real worker-thread hop (128 sleeping flood tasks + 2ms timer steal) and asserts every event in the instrumented span still carries `span_fields.correlation_id`/`trace_id`. Validated in both directions: old guard pattern fails 3/3, fixed `.instrument()` passes 5/5.

## Test plan
- `rg "span.enter()"` → only synchronous-context hits in `file_trace_layer.rs` tests ✓
- `cargo nextest run -p webfang_core`: 1900/1900 passed ✓
- clippy strict + fmt clean ✓
- New FileTraceLayer contract tests green ✓

## Files
- crates/webfang_core/src/application/crawler/engine.rs
- crates/webfang_core/src/application/crawler/crawl_task.rs
- crates/webfang_core/src/application/crawler/discovery.rs
- crates/webfang_core/src/application/crawler/sitemap_discovery.rs
- crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
- crates/webfang_core/tests/span_attribution_across_await.rs (new)

## Secondary finding (upstream tooling)
GitNexus `detect_changes` fails **open** in worktrees — returns "No changes detected" on dirty files (verified #506 work). Worked around with manual `git status`/`git diff` in this worktree.
