### PR TITLE
chore(fuzz): align HTML targets with tier policy + cargo fuzz build in CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,78 @@
+# Fuzz Build — compile-time verification of all fuzz targets (#514)
+#
+# cargo fuzz build was NOT in any CI workflow: a broken fuzz target shipped
+# silently. This workflow compiles all fuzz targets on PRs + main (build only,
+# no fuzzing runs). It is report-only — NOT a required check — so the ~10 min
+# BoringSSL + libfuzzer build never blocks the fast tiered CI pipeline.
+#
+# Fuzz tier policy (max_len/timeout per tier) lives in fuzz/fuzz.toml (#507).
+
+name: Fuzz Build
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Bulkhead: PR runs and push runs never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  # CI optimizations: disable debuginfo + incremental for faster builds
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_DEV_INCREMENTAL: "false"
+
+jobs:
+  fuzz-build:
+    name: cargo fuzz build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # cargo-fuzz requires nightly (libfuzzer-sys). The repo pins stable via
+      # rust-toolchain.toml; `cargo +nightly` forces the override per command.
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      # wreq → boring2 → boring-sys2 needs cmake to build BoringSSL.
+      - name: Install cmake
+        run: sudo apt-get install -y cmake
+
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz@0.13.0
+
+      # fuzz/ is NOT a workspace member: cargo-fuzz builds into fuzz/target,
+      # so the cache must cover that directory (not the root workspace target).
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+
+      - name: Build all fuzz targets
+        run: cargo +nightly fuzz build
+
+      - name: Verify all declared targets built
+        run: |
+          EXPECTED=$(grep -c 'name = "fuzz_' fuzz/Cargo.toml)
+          BUILT=$(ls fuzz/target/*/release/fuzz_* 2>/dev/null | grep -v '\.d$' | wc -l)
+          echo "Targets declared: $EXPECTED — built: $BUILT"
+          if [ "$BUILT" -lt "$EXPECTED" ]; then
+            echo "::error::Only $BUILT of $EXPECTED fuzz targets were built"
+            exit 1
+          fi
+
+      - name: Publish summary
+        if: always()
+        run: |
+          echo "## Fuzz Build" >> $GITHUB_STEP_SUMMARY
+          echo "All declared fuzz targets compiled with \`cargo +nightly fuzz build\`." >> $GITHUB_STEP_SUMMARY

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -111,12 +111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,7 +3172,6 @@ version = "2.0.0"
 dependencies = [
  "ahash",
  "aho-corasick",
- "anyhow",
  "async-compression",
  "built",
  "bytes",
@@ -3220,6 +3213,7 @@ dependencies = [
  "sysinfo",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-appender",

--- a/fuzz/fuzz.toml
+++ b/fuzz/fuzz.toml
@@ -6,6 +6,26 @@ opt-level = 3
 lto = true
 codegen-units = 1
 
+# ============================================================================
+# Tier policy (#507 Fase 7 — Fuzz Compliance)
+# Any target added to fuzz/Cargo.toml MUST declare the tier it belongs to and
+# get a matching override here. Touching a fuzzed function without updating the
+# target/override is a CI regression (issue #514).
+#
+# | Tier | Scope                                | max_len | timeout |
+# |------|--------------------------------------|---------|---------|
+# | 1    | Core HTML pipeline (parse/clean/convert/readability/extract) | 16384 | 10 |
+# | 2    | Sitemap XML                          | 32768   | 15      |
+# | 3    | Link/URL processing                  | 8192    | 10      |
+# | 4    | Security-sensitive (WAF, compression, cookies) | 4096–32768 | 10–15 |
+# | 5    | Content processing (post-extraction) | 8192   | 10      |
+# | 6    | Asset extraction                    | 8192    | 10      |
+#
+# HTML targets run at max_len=16384 (HTML can be large).
+# Decompression/sitemap run at max_len=32768 + timeout=15 (slower work).
+# HTTP-header-like inputs stay small (max_len=4096).
+# ============================================================================
+
 # Default libfuzzer settings applied to all targets
 [libfuzzer]
 max_len = 8192
@@ -14,7 +34,8 @@ runs = 0  # unlimited (run until Ctrl-C)
 max_total_time = 600  # 10 minutes per target
 jobs = 1
 
-# Per-target overrides
+# --- TIER 1: Core HTML pipeline (max_len=16384) ---
+
 [[target]]
 name = "fuzz_parse_html"
 max_len = 16384  # HTML can be large
@@ -24,6 +45,41 @@ name = "fuzz_html_cleaner"
 max_len = 16384  # HTML can be large
 
 [[target]]
+name = "fuzz_convert_to_markdown"
+max_len = 16384  # HTML can be large
+
+[[target]]
+name = "fuzz_readability_parse"
+max_len = 16384  # HTML can be large
+
+[[target]]
+name = "fuzz_extract_text"
+max_len = 16384  # HTML can be large
+
+# --- TIER 2: Sitemap XML ---
+
+[[target]]
+name = "fuzz_parse_sitemap"
+max_len = 32768  # sitemaps can be large XML
+timeout = 15
+
+# --- TIER 3: Link/URL processing ---
+
+[[target]]
+name = "fuzz_extract_links"
+max_len = 16384  # extracts links from HTML
+
+# --- TIER 4: Security-sensitive (WAF, compression, cookies) ---
+
+[[target]]
+name = "fuzz_waf_detection"
+max_len = 8192
+
+[[target]]
+name = "fuzz_compression_detect"
+max_len = 16384
+
+[[target]]
 name = "fuzz_parse_content_disposition"
 max_len = 4096  # HTTP headers are typically small
 
@@ -31,16 +87,3 @@ max_len = 4096  # HTTP headers are typically small
 name = "fuzz_decompression"
 max_len = 32768  # compressed payloads can be larger
 timeout = 15  # decompression can be slower
-
-[[target]]
-name = "fuzz_compression_detect"
-max_len = 16384
-
-[[target]]
-name = "fuzz_waf_detection"
-max_len = 8192
-
-[[target]]
-name = "fuzz_parse_sitemap"
-max_len = 32768  # sitemaps can be large XML
-timeout = 15


### PR DESCRIPTION
Closes #514

## PR Type

- [x] Maintenance / tooling (`type:chore`)

## Summary

- Added `max_len=16384` overrides for the four HTML fuzz targets still on the 8192 default (`fuzz_convert_to_markdown`, `fuzz_extract_text`, `fuzz_extract_links`, `fuzz_readability_parse`)
- Verified all 17 targets compile with `cargo +nightly fuzz build` (8m27s local)
- Added a report-only `fuzz.yml` workflow so `cargo fuzz build` runs on PRs + main — it was missing from every CI workflow

## Changes

| File | Change |
|------|--------|
| `fuzz/fuzz.toml` | 4 HTML targets to max_len=16384; documented tier policy (max_len/timeout per tier) |
| `fuzz/Cargo.lock` | Refreshed stale lock (still referenced the removed `anyhow` dep) |
| `.github/workflows/fuzz.yml` | New workflow: nightly + cargo-fuzz 0.13.0 + cmake, builds all targets, not a required check |

## Test Plan

- [x] `cargo +nightly fuzz build` passes locally (17/17 targets built)
- [x] `actionlint` clean on the new workflow
- [x] YAML validated (triggers: push main/develop, pull_request, workflow_dispatch)
- [ ] `cargo fmt --check` clean (no Rust code changed — config/CI only)

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers