### PR TITLE
fix(mcp): params validation foundation — deny_unknown_fields + validate() (#512, slice 1/2)

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/mod.rs
+++ b/crates/webfang_mcp/src/mcp_server/mod.rs
@@ -17,6 +17,7 @@ pub mod params;
 pub mod selector_service;
 pub mod server;
 pub mod state;
+pub mod validation;
 
 /// Vault-search AI port wiring (#433) — only compiled with the `ai` feature.
 #[cfg(feature = "ai")]

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -1,19 +1,58 @@
 //! MCP parameter structs — shared request parameter types
 //!
 //! These structs define the input parameters for MCP tool invocations.
+//!
+//! Every struct in this module carries:
+//!
+//! * `#[serde(deny_unknown_fields)]` — rejects unexpected JSON keys at the
+//!   deserialization boundary (defence against schema-drift typos and typosquat
+//!   parameter names that could otherwise pass through to handlers).
+//! * `pub fn validate(&self) -> Result<(), McpError>` — semantic validation
+//!   (URL scheme, path traversal, oversize blobs, numeric bounds). Handlers
+//!   call this at the top of every tool body (`params.validate()?`); the
+//!   wiring is delivered in slice 2 of issue #512.
+//!
+//! The `validate()` methods are not yet called from any handler — the
+//! `#![allow(dead_code)]` below keeps clippy clean until slice 2 wires them
+//! into the tool bodies. Remove the allow once slice 2 lands.
 
+// `validate()` methods are foundation only — slice 2 wires them into handlers.
+#![allow(dead_code)]
+
+use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use serde_json::Value;
+
+use crate::mcp_server::validation::{
+    require_http_url, require_max_len, require_max_value_u16, require_max_value_u64,
+    require_non_empty, require_one_of, require_safe_domain, require_safe_name, require_safe_path,
+    MAX_BLOB_LEN,
+};
+
+const EXPORT_FORMATS: &[&str] = &["jsonl", "vector", "auto"];
 
 /// Parameters for the `scrape_url` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ScrapeUrlParams {
     /// URL to scrape (must start with http:// or https://)
     pub url: String,
 }
 
+impl ScrapeUrlParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL
+    /// or exceeds the maximum length.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        Ok(())
+    }
+}
+
 /// Parameters for the `scrape_with_options` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ScrapeWithOptionsParams {
     /// URL to scrape
     pub url: String,
@@ -32,8 +71,22 @@ pub struct ScrapeWithOptionsParams {
     pub selector: Option<String>,
 }
 
+impl ScrapeWithOptionsParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL
+    /// or `selector` exceeds 1024 bytes.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        if let Some(sel) = &self.selector {
+            require_max_len("selector", sel, 1024)?;
+        }
+        Ok(())
+    }
+}
+
 /// Parameters for the `scrape_batch` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ScrapeBatchParams {
     /// List of URLs to scrape
     pub urls: Vec<String>,
@@ -41,8 +94,30 @@ pub struct ScrapeBatchParams {
     pub concurrency: Option<usize>,
 }
 
+impl ScrapeBatchParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `urls` is empty, any URL is not
+    /// http(s), or `concurrency` exceeds 64.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if self.urls.is_empty() {
+            return Err(McpError::invalid_params(
+                "urls must not be empty",
+                Some(Value::String("urls".to_string())),
+            ));
+        }
+        for u in &self.urls {
+            require_http_url("urls[]", u)?;
+        }
+        if let Some(c) = self.concurrency {
+            require_max_value_u64("concurrency", c as u64, 64)?;
+        }
+        Ok(())
+    }
+}
+
 /// Parameters for the `crawl_site` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct CrawlSiteParams {
     /// Base URL to crawl
     pub url: String,
@@ -52,8 +127,25 @@ pub struct CrawlSiteParams {
     pub max_pages: Option<u32>,
 }
 
+impl CrawlSiteParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL,
+    /// `max_depth` exceeds 10, or `max_pages` exceeds 100_000.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        if let Some(d) = self.max_depth {
+            require_max_value_u64("max_depth", u64::from(d), 10)?;
+        }
+        if let Some(p) = self.max_pages {
+            require_max_value_u64("max_pages", u64::from(p), 100_000)?;
+        }
+        Ok(())
+    }
+}
+
 /// Parameters for the `crawl_with_sitemap` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct CrawlWithSitemapParams {
     /// Base URL of the website
     pub url: String,
@@ -61,36 +153,94 @@ pub struct CrawlWithSitemapParams {
     pub sitemap_url: Option<String>,
 }
 
+impl CrawlWithSitemapParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` (or `sitemap_url` when
+    /// present) is not a valid http(s) URL.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        if let Some(s) = &self.sitemap_url {
+            require_http_url("sitemap_url", s)?;
+        }
+        Ok(())
+    }
+}
+
 /// Parameters for the `discover_urls` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DiscoverUrlsParams {
     /// URL to extract links from
     pub url: String,
 }
 
+impl DiscoverUrlsParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        Ok(())
+    }
+}
+
 /// Parameters for the `detect_spa` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DetectSpaParams {
     /// URL to check for SPA content
     pub url: String,
 }
 
+impl DetectSpaParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        Ok(())
+    }
+}
+
 /// Parameters for the `clean_html` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct CleanHtmlParams {
     /// Raw HTML to clean
     pub html: String,
 }
 
+impl CleanHtmlParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `html` is empty or exceeds the
+    /// maximum blob size.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_non_empty("html", &self.html)?;
+        require_max_len("html", &self.html, MAX_BLOB_LEN)?;
+        Ok(())
+    }
+}
+
 /// Parameters for the `convert_html_to_markdown` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct HtmlToMarkdownParams {
     /// HTML to convert
     pub html: String,
 }
 
+impl HtmlToMarkdownParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `html` is empty or exceeds the
+    /// maximum blob size.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_non_empty("html", &self.html)?;
+        require_max_len("html", &self.html, MAX_BLOB_LEN)?;
+        Ok(())
+    }
+}
+
 /// Parameters for the `extract_links` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ExtractLinksParams {
     /// HTML to extract links from
     pub html: String,
@@ -98,13 +248,37 @@ pub struct ExtractLinksParams {
     pub base_url: String,
 }
 
+impl ExtractLinksParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `html` exceeds the maximum blob
+    /// size or `base_url` is not a valid http(s) URL.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_max_len("html", &self.html, MAX_BLOB_LEN)?;
+        require_http_url("base_url", &self.base_url)?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct HighlightCodeParams {
     /// Markdown with code blocks
     pub markdown: String,
 }
 
+impl HighlightCodeParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `markdown` is empty or exceeds the
+    /// maximum blob size.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_non_empty("markdown", &self.markdown)?;
+        require_max_len("markdown", &self.markdown, MAX_BLOB_LEN)?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ConvertWikiLinksParams {
     /// Markdown content
     pub markdown: String,
@@ -112,25 +286,67 @@ pub(crate) struct ConvertWikiLinksParams {
     pub base_domain: String,
 }
 
+impl ConvertWikiLinksParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `markdown` exceeds the maximum
+    /// blob size or `base_domain` is not a bare domain string.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_max_len("markdown", &self.markdown, MAX_BLOB_LEN)?;
+        require_http_url("base_domain", &self.base_domain)?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ValidateUrlParams {
     /// URL to validate
     pub url: String,
 }
 
+impl ValidateUrlParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ExtractDomainParams {
     /// URL to extract domain from
     pub url: String,
 }
 
+impl ExtractDomainParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct NormalizeUrlParams {
     /// URL to normalize
     pub url: String,
 }
 
+impl NormalizeUrlParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct MatchUrlPatternParams {
     /// URL to check
     pub url: String,
@@ -138,22 +354,59 @@ pub(crate) struct MatchUrlPatternParams {
     pub pattern: String,
 }
 
-#[derive(Deserialize, JsonSchema, Debug)]
-pub(crate) struct IsInternalLinkParams {
-    /// URL to check
-    pub url: String,
-    /// Seed domain to compare against
-    pub seed_domain: String,
+impl MatchUrlPatternParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL,
+    /// `pattern` is empty, or `pattern` exceeds 1024 bytes.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        require_non_empty("pattern", &self.pattern)?;
+        require_max_len("pattern", &self.pattern, 1024)?;
+        Ok(())
+    }
 }
 
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct IsInternalLinkParams {
+    /// URL to check
+    pub url: String,
+    /// Seed domain to compare against (bare domain, e.g. "example.com")
+    pub seed_domain: String,
+}
+
+impl IsInternalLinkParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` is not a valid http(s) URL
+    /// or `seed_domain` is not a well-formed bare domain string.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_http_url("url", &self.url)?;
+        require_safe_domain("seed_domain", &self.seed_domain)?;
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct DetectWafParams {
     /// HTML body to scan for WAF signatures
     pub html: String,
 }
 
+impl DetectWafParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `html` is empty or exceeds the
+    /// maximum blob size.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_non_empty("html", &self.html)?;
+        require_max_len("html", &self.html, MAX_BLOB_LEN)?;
+        Ok(())
+    }
+}
+
 /// Parameters for the `export_file` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ExportFileParams {
     /// Output directory path
     pub output_dir: String,
@@ -165,14 +418,42 @@ pub struct ExportFileParams {
     pub content: String,
 }
 
+impl ExportFileParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `output_dir` is not a safe
+    /// relative path, `filename` is empty or too long, `format` is not one of
+    /// the allowed formats, or `content` exceeds the maximum blob size.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_safe_path("output_dir", &self.output_dir)?;
+        require_safe_name("filename", &self.filename)?;
+        require_one_of("format", &self.format, EXPORT_FORMATS)?;
+        require_max_len("content", &self.content, MAX_BLOB_LEN)?;
+        Ok(())
+    }
+}
+
 /// Parameters for the `detect_obsidian_vault` tool.
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DetectVaultParams {
     /// Explicit vault path (optional)
     pub vault_path: Option<String>,
 }
 
+impl DetectVaultParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `vault_path` is present but not a
+    /// safe relative path.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if let Some(p) = &self.vault_path {
+            require_safe_path("vault_path", p)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct BuildObsidianUriParams {
     /// Vault name
     pub vault_name: String,
@@ -180,7 +461,19 @@ pub(crate) struct BuildObsidianUriParams {
     pub file_path: String,
 }
 
+impl BuildObsidianUriParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `vault_name` is empty or too long,
+    /// or `file_path` is not a safe relative path.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_safe_name("vault_name", &self.vault_name)?;
+        require_safe_path("file_path", &self.file_path)?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct SearchObsidianParams {
     /// Search query
     pub query: String,
@@ -190,8 +483,27 @@ pub(crate) struct SearchObsidianParams {
     pub limit: Option<usize>,
 }
 
+impl SearchObsidianParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `query` is empty or exceeds 1024
+    /// bytes, `vault_path` (when present) is not a safe relative path, or
+    /// `limit` exceeds 1000.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_non_empty("query", &self.query)?;
+        require_max_len("query", &self.query, 1024)?;
+        if let Some(p) = &self.vault_path {
+            require_safe_path("vault_path", p)?;
+        }
+        if let Some(l) = self.limit {
+            require_max_value_u64("limit", l as u64, 1000)?;
+        }
+        Ok(())
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct DownloadAssetsParams {
     /// HTML containing asset references
     pub html: String,
@@ -210,9 +522,25 @@ pub(crate) struct DownloadAssetsParams {
     pub output_dir: Option<String>,
 }
 
+impl DownloadAssetsParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `html` exceeds the maximum blob
+    /// size, `base_url` is not a valid http(s) URL, or `output_dir` (when
+    /// present) is not a safe relative path.
+    pub fn validate(&self) -> Result<(), McpError> {
+        require_max_len("html", &self.html, MAX_BLOB_LEN)?;
+        require_http_url("base_url", &self.base_url)?;
+        if let Some(d) = &self.output_dir {
+            require_safe_path("output_dir", d)?;
+        }
+        Ok(())
+    }
+}
+
 // Params for tools that accept free-form JSON input
 #[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct GenerateFrontmatterParams {
     /// Document title
     pub title: Option<String>,
@@ -226,15 +554,57 @@ pub(crate) struct GenerateFrontmatterParams {
     pub tags: Option<Vec<String>>,
 }
 
+impl GenerateFrontmatterParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if any optional string exceeds its
+    /// per-field length cap, `url` (when present) is not a valid http(s) URL,
+    /// `tags` has more than 64 entries, or any tag exceeds 64 bytes.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if let Some(u) = &self.url {
+            require_http_url("url", u)?;
+        }
+        if let Some(t) = &self.title {
+            require_max_len("title", t, 512)?;
+        }
+        if let Some(a) = &self.author {
+            require_max_len("author", a, 256)?;
+        }
+        if let Some(e) = &self.excerpt {
+            require_max_len("excerpt", e, 4096)?;
+        }
+        if let Some(tags) = &self.tags {
+            require_max_value_u64("tags", tags.len() as u64, 64)?;
+            for tag in tags {
+                require_max_len("tags[]", tag, 64)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct GenerateRichMetadataParams {
     /// Document content for analysis
     pub content: Option<String>,
 }
 
+impl GenerateRichMetadataParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `content` exceeds the maximum blob
+    /// size.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if let Some(c) = &self.content {
+            require_max_len("content", c, MAX_BLOB_LEN)?;
+        }
+        Ok(())
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ExportJsonlParams {
     /// Output directory path
     pub output_dir: Option<String>,
@@ -242,8 +612,25 @@ pub(crate) struct ExportJsonlParams {
     pub filename: Option<String>,
 }
 
+impl ExportJsonlParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `output_dir` (when present) is
+    /// not a safe relative path or `filename` (when present) is empty or too
+    /// long.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if let Some(d) = &self.output_dir {
+            require_safe_path("output_dir", d)?;
+        }
+        if let Some(f) = &self.filename {
+            require_safe_name("filename", f)?;
+        }
+        Ok(())
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ExportVectorParams {
     /// Output directory path
     pub output_dir: Option<String>,
@@ -251,8 +638,25 @@ pub(crate) struct ExportVectorParams {
     pub filename: Option<String>,
 }
 
+impl ExportVectorParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `output_dir` (when present) is
+    /// not a safe relative path or `filename` (when present) is empty or too
+    /// long.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if let Some(d) = &self.output_dir {
+            require_safe_path("output_dir", d)?;
+        }
+        if let Some(f) = &self.filename {
+            require_safe_name("filename", f)?;
+        }
+        Ok(())
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ProcessExportPipelineParams {
     /// URL to scrape and export
     pub url: Option<String>,
@@ -260,8 +664,25 @@ pub(crate) struct ProcessExportPipelineParams {
     pub format: Option<String>,
 }
 
+impl ProcessExportPipelineParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `url` (when present) is not a
+    /// valid http(s) URL or `format` (when present) is not one of the allowed
+    /// formats.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if let Some(u) = &self.url {
+            require_http_url("url", u)?;
+        }
+        if let Some(f) = &self.format {
+            require_one_of("format", f, EXPORT_FORMATS)?;
+        }
+        Ok(())
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct VerifyWafIntegrityParams {
     /// HTML body to inspect
     pub html: Option<String>,
@@ -276,4 +697,19 @@ pub(crate) struct VerifyWafIntegrityParams {
     /// When omitted, the body is scanned (degraded mode).
     #[serde(default)]
     pub content_type: Option<String>,
+}
+
+impl VerifyWafIntegrityParams {
+    /// # Errors
+    /// Returns `McpError::invalid_params` if `html` (when present) exceeds the
+    /// maximum blob size or `status` (when present) exceeds 599.
+    pub fn validate(&self) -> Result<(), McpError> {
+        if let Some(h) = &self.html {
+            require_max_len("html", h, MAX_BLOB_LEN)?;
+        }
+        if let Some(s) = self.status {
+            require_max_value_u16("status", s, 599)?;
+        }
+        Ok(())
+    }
 }

--- a/crates/webfang_mcp/src/mcp_server/validation.rs
+++ b/crates/webfang_mcp/src/mcp_server/validation.rs
@@ -1,0 +1,250 @@
+//! MCP parameter validation helpers (issue #512, Slice 1)
+//!
+//! Centralised validation for tool parameter structs. Each helper returns
+//! `Result<_, McpError>` using `McpError::invalid_params` so handlers can
+//! short-circuit with `?`. The module is framework-agnostic: it knows nothing
+//! about the tool router or the request context.
+//!
+//! Every helper produces an error envelope identical to the one already used
+//! by handlers (`McpError::invalid_params(format!(...), Some(field))`), so the
+//! slice-2 wiring (`params.validate()?`) is a drop-in replacement.
+
+use rmcp::ErrorData as McpError;
+use serde_json::Value;
+use std::path::{Component, Path, PathBuf};
+
+/// Max URL length. 8 KiB matches the upper bound recommended by RFC 9110 §5.4
+/// for URI references and protects the server from memory DoS via oversize
+/// inputs.
+pub const MAX_URL_LEN: usize = 8192;
+
+/// Max filesystem path length. 1 KiB is generous for relative paths and
+/// protects against accidentally-joined traversal strings.
+pub const MAX_PATH_LEN: usize = 1024;
+
+/// Max HTML / markdown / content blob length. 1 MiB protects the server from
+/// memory exhaustion via oversize inputs (legitimate pages fit comfortably).
+pub const MAX_BLOB_LEN: usize = 1_048_576;
+
+/// Max length of a domain string (RFC 1035 §2.3.4 caps FQDNs at 253 octets).
+pub const MAX_DOMAIN_LEN: usize = 253;
+
+/// Build the standard `McpError::invalid_params` envelope used by every
+/// handler in this crate. Keeps the field tag and message format identical to
+/// the inline construction at `handlers/scraping.rs:34-37`.
+fn invalid_params(field: &str, msg: impl Into<String>) -> McpError {
+    McpError::invalid_params(msg.into(), Some(Value::String(field.to_string())))
+}
+
+/// Validate that `value` parses as an http or https URL.
+///
+/// Rejects: empty, longer than [`MAX_URL_LEN`], non-http(s) schemes (file://,
+/// ftp://, gopher://, data:, javascript:, etc.), and unparseable strings.
+/// Returns the parsed URL on success so callers can reuse it without a
+/// second parse.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` for any of the rejection reasons above.
+pub fn require_http_url(field: &str, value: &str) -> Result<url::Url, McpError> {
+    if value.is_empty() {
+        return Err(invalid_params(field, "must not be empty"));
+    }
+    if value.len() > MAX_URL_LEN {
+        return Err(invalid_params(
+            field,
+            format!("exceeds maximum length of {MAX_URL_LEN} bytes"),
+        ));
+    }
+    let parsed =
+        url::Url::parse(value).map_err(|e| invalid_params(field, format!("invalid URL: {e}")))?;
+    match parsed.scheme() {
+        "http" | "https" => Ok(parsed),
+        other => Err(invalid_params(
+            field,
+            format!("unsupported scheme '{other}' (only http and https are allowed)"),
+        )),
+    }
+}
+
+/// Validate that `value` is a safe filesystem path: non-empty, ≤
+/// [`MAX_PATH_LEN`], relative (no leading `/`, no Windows drive letter), and
+/// free of `..` traversal components.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` for empty, oversize, absolute, or
+/// `..`-traversal paths.
+pub fn require_safe_path(field: &str, value: &str) -> Result<PathBuf, McpError> {
+    if value.is_empty() {
+        return Err(invalid_params(field, "must not be empty"));
+    }
+    if value.len() > MAX_PATH_LEN {
+        return Err(invalid_params(
+            field,
+            format!("exceeds maximum length of {MAX_PATH_LEN} bytes"),
+        ));
+    }
+    let path = Path::new(value);
+    // Reject absolute paths. `Path::is_absolute()` is platform-aware (returns
+    // false for `C:\Windows` on Unix), so also probe the string for leading
+    // slashes, UNC prefixes, and Windows drive letters explicitly.
+    if value.starts_with('/') || value.starts_with('\\') {
+        return Err(invalid_params(
+            field,
+            "must be a relative path (no leading '/' or UNC prefix)",
+        ));
+    }
+    if has_windows_drive_prefix(value) {
+        return Err(invalid_params(
+            field,
+            "must be a relative path (no Windows drive letter)",
+        ));
+    }
+    if path.is_absolute() {
+        return Err(invalid_params(
+            field,
+            "must be a relative path (no leading '/' or Windows drive letter)",
+        ));
+    }
+    if path.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(invalid_params(
+            field,
+            "must not contain '..' traversal components",
+        ));
+    }
+    Ok(path.to_path_buf())
+}
+
+/// Detect a Windows-style drive-letter prefix (e.g. `C:\foo` or `C:/foo`)
+/// regardless of host platform. Case-insensitive letter; separator can be
+/// either `\` or `/`.
+fn has_windows_drive_prefix(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
+/// Validate that `value` is at most `max_len` characters long.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value.len() > max_len`.
+pub fn require_max_len(field: &str, value: &str, max_len: usize) -> Result<(), McpError> {
+    if value.len() > max_len {
+        return Err(invalid_params(
+            field,
+            format!("exceeds maximum length of {max_len} bytes"),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate that `value` is non-empty and ≤ [`MAX_PATH_LEN`] characters.
+///
+/// Use for fields like `filename` and `vault_name` that are joined into paths
+/// but are not paths themselves (no traversal check needed).
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value` is empty or exceeds
+/// [`MAX_PATH_LEN`].
+pub fn require_safe_name(field: &str, value: &str) -> Result<(), McpError> {
+    if value.is_empty() {
+        return Err(invalid_params(field, "must not be empty"));
+    }
+    if value.len() > MAX_PATH_LEN {
+        return Err(invalid_params(
+            field,
+            format!("exceeds maximum length of {MAX_PATH_LEN} bytes"),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate that `value` is a well-formed bare domain string (e.g. "example.com"
+/// or "a.b.c.d.e.example.com"): non-empty, ≤ [`MAX_DOMAIN_LEN`], no path or
+/// scheme separators (`/`, `\`, `:`), no whitespace, no `..` segments, and at
+/// least one `.`.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value` fails any of the bare-domain
+/// rules.
+pub fn require_safe_domain(field: &str, value: &str) -> Result<(), McpError> {
+    if value.is_empty() {
+        return Err(invalid_params(field, "must not be empty"));
+    }
+    if value.len() > MAX_DOMAIN_LEN {
+        return Err(invalid_params(
+            field,
+            format!("exceeds maximum length of {MAX_DOMAIN_LEN} bytes"),
+        ));
+    }
+    if value.chars().any(char::is_whitespace) {
+        return Err(invalid_params(field, "must not contain whitespace"));
+    }
+    if value.contains(['/', '\\', ':']) {
+        return Err(invalid_params(
+            field,
+            "must be a bare domain (no path, scheme, or port separator)",
+        ));
+    }
+    if value.contains("..") {
+        return Err(invalid_params(field, "must not contain '..'"));
+    }
+    if !value.contains('.') {
+        return Err(invalid_params(
+            field,
+            "must contain at least one '.' separator",
+        ));
+    }
+    Ok(())
+}
+
+/// Validate that `value` is non-empty.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value` is empty.
+pub fn require_non_empty(field: &str, value: &str) -> Result<(), McpError> {
+    if value.is_empty() {
+        return Err(invalid_params(field, "must not be empty"));
+    }
+    Ok(())
+}
+
+/// Validate that `value` does not exceed `max`.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value > max`.
+pub fn require_max_value_u64(field: &str, value: u64, max: u64) -> Result<(), McpError> {
+    if value > max {
+        return Err(invalid_params(field, format!("must be at most {max}")));
+    }
+    Ok(())
+}
+
+/// Validate that `value` does not exceed `max`.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value > max`.
+pub fn require_max_value_u16(field: &str, value: u16, max: u16) -> Result<(), McpError> {
+    if value > max {
+        return Err(invalid_params(field, format!("must be at most {max}")));
+    }
+    Ok(())
+}
+
+/// Validate that `value` (case-insensitive) is one of `options`.
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value` does not match any option
+/// (case-insensitive).
+pub fn require_one_of(field: &str, value: &str, options: &[&str]) -> Result<(), McpError> {
+    let lower = value.to_ascii_lowercase();
+    if options.iter().any(|o| o.eq_ignore_ascii_case(&lower)) {
+        Ok(())
+    } else {
+        Err(invalid_params(
+            field,
+            format!("must be one of: {} (got '{value}')", options.join(", ")),
+        ))
+    }
+}

--- a/crates/webfang_mcp/tests/mcp_params_validation_test.rs
+++ b/crates/webfang_mcp/tests/mcp_params_validation_test.rs
@@ -1,0 +1,387 @@
+//! Unit tests for MCP parameter validation (issue #512, Slice 1)
+//!
+//! These tests cover two contracts:
+//!
+//! 1. The `validation::*` helper functions — they must reject malformed
+//!    inputs (file:// scheme, path traversal, oversize strings) and accept
+//!    well-formed ones, with `McpError::INVALID_PARAMS` as the error code.
+//! 2. The `deny_unknown_fields` serde attribute on every `*Params` struct —
+//!    an extra JSON key must be rejected at deserialization time.
+//!
+//! Per the contract-based-test-audit 6-node diagnostic:
+//! - Observable behavior only: assertions match on `ErrorCode::INVALID_PARAMS`,
+//!   never on error message strings (those are not part of the contract).
+//! - No infrastructure: pure unit tests, no I/O, no time, no randomness.
+//! - Arrange ≤ 5 lines per test.
+
+use webfang_mcp::mcp_server::params::*;
+use webfang_mcp::mcp_server::validation;
+
+// ===========================================================================
+// validation::require_http_url
+// ===========================================================================
+
+#[test]
+fn require_http_url_accepts_https() {
+    let parsed =
+        validation::require_http_url("url", "https://example.com/path?q=1").expect("https ok");
+    assert_eq!(parsed.scheme(), "https");
+}
+
+#[test]
+fn require_http_url_accepts_http() {
+    let parsed = validation::require_http_url("url", "http://example.com").expect("http ok");
+    assert_eq!(parsed.scheme(), "http");
+}
+
+#[test]
+fn require_http_url_rejects_file_scheme() {
+    let err = validation::require_http_url("url", "file:///etc/passwd").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_http_url_rejects_ftp_scheme() {
+    let err = validation::require_http_url("url", "ftp://example.com").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_http_url_rejects_javascript_scheme() {
+    let err = validation::require_http_url("url", "javascript:alert(1)").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_http_url_rejects_data_scheme() {
+    let err = validation::require_http_url("url", "data:text/plain,hello").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_http_url_rejects_empty() {
+    let err = validation::require_http_url("url", "").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_http_url_rejects_oversize() {
+    let oversize = "https://example.com/".to_string() + &"a".repeat(validation::MAX_URL_LEN);
+    let err = validation::require_http_url("url", &oversize).unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_http_url_rejects_unparseable() {
+    let err = validation::require_http_url("url", "not a url at all").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// validation::require_safe_path
+// ===========================================================================
+
+#[test]
+fn require_safe_path_accepts_relative() {
+    let path = validation::require_safe_path("output_dir", "exports/2026").expect("relative ok");
+    assert_eq!(path.to_str(), Some("exports/2026"));
+}
+
+#[test]
+fn require_safe_path_rejects_parent_traversal() {
+    let err = validation::require_safe_path("output_dir", "../etc/passwd").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_path_rejects_parent_traversal_in_middle() {
+    let err = validation::require_safe_path("output_dir", "exports/../secrets").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_path_rejects_absolute_unix() {
+    let err = validation::require_safe_path("output_dir", "/etc/passwd").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_path_rejects_absolute_windows() {
+    let err = validation::require_safe_path("output_dir", "C:\\Windows\\System32").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_path_rejects_empty() {
+    let err = validation::require_safe_path("output_dir", "").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_path_rejects_oversize() {
+    let oversize = "a".repeat(validation::MAX_PATH_LEN + 1);
+    let err = validation::require_safe_path("output_dir", &oversize).unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// validation::require_max_len
+// ===========================================================================
+
+#[test]
+fn require_max_len_accepts_within() {
+    validation::require_max_len("html", "<html/>", 1024).expect("within limit");
+}
+
+#[test]
+fn require_max_len_rejects_over() {
+    let oversize = "x".repeat(11);
+    let err = validation::require_max_len("html", &oversize, 10).unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// validation::require_safe_domain
+// ===========================================================================
+
+#[test]
+fn require_safe_domain_accepts_bare_domain() {
+    validation::require_safe_domain("seed_domain", "example.com").expect("bare domain ok");
+    validation::require_safe_domain("seed_domain", "a.b.c.example.co.uk")
+        .expect("deep subdomain ok");
+}
+
+#[test]
+fn require_safe_domain_rejects_url() {
+    let err = validation::require_safe_domain("seed_domain", "https://example.com").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_domain_rejects_traversal() {
+    let err = validation::require_safe_domain("seed_domain", "example..com").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_domain_rejects_no_dot() {
+    let err = validation::require_safe_domain("seed_domain", "localhost").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// validation::require_one_of
+// ===========================================================================
+
+#[test]
+fn require_one_of_accepts_match() {
+    validation::require_one_of("format", "jsonl", &["jsonl", "vector", "auto"])
+        .expect("exact match");
+    validation::require_one_of("format", "JSONL", &["jsonl", "vector", "auto"])
+        .expect("case-insensitive match");
+}
+
+#[test]
+fn require_one_of_rejects_unknown() {
+    let err =
+        validation::require_one_of("format", "xml", &["jsonl", "vector", "auto"]).unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// Per-struct validate() — ScrapeUrlParams (the headline case)
+// ===========================================================================
+
+#[test]
+fn scrape_url_params_accepts_https() {
+    let p = ScrapeUrlParams {
+        url: "https://example.com".into(),
+    };
+    p.validate().expect("https url should be valid");
+}
+
+#[test]
+fn scrape_url_params_rejects_file_scheme() {
+    let p = ScrapeUrlParams {
+        url: "file:///etc/passwd".into(),
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn scrape_url_params_rejects_empty() {
+    let p = ScrapeUrlParams { url: String::new() };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// Per-struct validate() — ScrapeBatchParams (array element validation)
+// ===========================================================================
+
+#[test]
+fn scrape_batch_params_rejects_empty_list() {
+    let p = ScrapeBatchParams {
+        urls: vec![],
+        concurrency: None,
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn scrape_batch_params_rejects_one_bad_url() {
+    let p = ScrapeBatchParams {
+        urls: vec!["https://ok.example".into(), "file:///etc/passwd".into()],
+        concurrency: None,
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn scrape_batch_params_rejects_oversize_concurrency() {
+    let p = ScrapeBatchParams {
+        urls: vec!["https://example.com".into()],
+        concurrency: Some(65),
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn scrape_batch_params_accepts_valid() {
+    let p = ScrapeBatchParams {
+        urls: vec![
+            "https://example.com".into(),
+            "https://other.example/path".into(),
+        ],
+        concurrency: Some(8),
+    };
+    p.validate().expect("valid batch");
+}
+
+// ===========================================================================
+// Per-struct validate() — ExportFileParams (path + format + content)
+// ===========================================================================
+
+#[test]
+fn export_file_params_accepts_valid() {
+    let p = ExportFileParams {
+        output_dir: "exports/2026".into(),
+        filename: "out".into(),
+        format: "jsonl".into(),
+        content: "row".into(),
+    };
+    p.validate().expect("valid export");
+}
+
+#[test]
+fn export_file_params_rejects_output_dir_traversal() {
+    let p = ExportFileParams {
+        output_dir: "../etc".into(),
+        filename: "out".into(),
+        format: "jsonl".into(),
+        content: "row".into(),
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn export_file_params_rejects_unknown_format() {
+    let p = ExportFileParams {
+        output_dir: "exports".into(),
+        filename: "out".into(),
+        format: "xml".into(),
+        content: "row".into(),
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn export_file_params_rejects_empty_filename() {
+    let p = ExportFileParams {
+        output_dir: "exports".into(),
+        filename: String::new(),
+        format: "jsonl".into(),
+        content: "row".into(),
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// Per-struct validate() — CleanHtmlParams / CrawlSiteParams
+// ===========================================================================
+
+#[test]
+fn clean_html_params_rejects_empty() {
+    let p = CleanHtmlParams {
+        html: String::new(),
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn crawl_site_params_rejects_oversize_max_depth() {
+    let p = CrawlSiteParams {
+        url: "https://example.com".into(),
+        max_depth: Some(11),
+        max_pages: None,
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn crawl_site_params_rejects_oversize_max_pages() {
+    let p = CrawlSiteParams {
+        url: "https://example.com".into(),
+        max_depth: None,
+        max_pages: Some(100_001),
+    };
+    let err = p.validate().unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
+// deny_unknown_fields — serde-level contract
+// ===========================================================================
+
+#[test]
+fn deny_unknown_fields_rejects_extra_field() {
+    let json = r#"{"url": "https://example.com", "extra": "boom"}"#;
+    let result: Result<ScrapeUrlParams, _> = serde_json::from_str(json);
+    assert!(result.is_err(), "deny_unknown_fields must reject extras");
+}
+
+#[test]
+fn deny_unknown_fields_accepts_known_field() {
+    let json = r#"{"url": "https://example.com"}"#;
+    let result: Result<ScrapeUrlParams, _> = serde_json::from_str(json);
+    assert!(result.is_ok(), "known-only payload must deserialize");
+}
+
+#[test]
+fn deny_unknown_fields_rejects_extra_on_export_file() {
+    let json = r#"{
+        "output_dir": "exports",
+        "filename": "out",
+        "format": "jsonl",
+        "content": "row",
+        "unexpected": "boom"
+    }"#;
+    let result: Result<ExportFileParams, _> = serde_json::from_str(json);
+    assert!(result.is_err());
+}
+
+#[test]
+fn deny_unknown_fields_rejects_extra_on_clean_html() {
+    let json = r#"{"html": "<p>hi</p>", "magic": true}"#;
+    let result: Result<CleanHtmlParams, _> = serde_json::from_str(json);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Closes #512

## Summary

Slice 1 of 2 for issue #512 (Phase 5 — MCP Params Validation, parent #507).

This PR adds the **foundation** — a centralised `validation` module and per-struct `validate()` methods for all 29 `*Params` structs, plus unit tests proving the contract.

**Slice 2 (separate PR)** will wire `params.validate()?` into each of the 10 tool handlers and add behavioural integration tests proving `file://`, path traversal, and oversize inputs are rejected end-to-end at the MCP tool boundary.

## What this PR ships

### New module: `crates/webfang_mcp/src/mcp_server/validation.rs` (250 lines)

| Helper | Purpose |
|---|---|
| `require_http_url(field, value)` | Parse + reject non-http(s) schemes (`file://`, `ftp://`, `javascript:`, …) |
| `require_safe_path(field, value)` | Reject `..` traversal, absolute paths (Unix + Windows drive letters) |
| `require_safe_name(field, value)` | Non-empty, ≤ 1 KiB, safe identifier for vault names / filenames |
| `require_safe_domain(field, value)` | Bare-domain check for `seed_domain`-style fields |
| `require_max_len(field, value, max)` | Char-count cap (URLs 8 KiB, blobs 1 MiB) |
| `require_one_of(field, value, options)` | Enum-like membership check (case-insensitive) |

All helpers return `Result<_, McpError>` using the **exact** `McpError::invalid_params` shape already in use across the handlers — drop-in compatible.

### `params.rs`: 29/29 structs updated

- `#[serde(deny_unknown_fields)]` on every `*Params` struct → unknown fields rejected at deserialise time.
- `pub fn validate(&self) -> Result<(), McpError>` on every struct → 3–5 lines of helper calls per impl.

### Tests: 42 new tests, all green

`crates/webfang_mcp/tests/mcp_params_validation_test.rs`:

- 8 `require_http_url` tests (incl. the headline `file://` rejection)
- 7 `require_safe_path` tests (incl. cross-platform Windows drive-letter check — `is_absolute()` is **not** a security check on its own, see code comment)
- 4 `require_safe_domain` tests
- 2 `require_one_of` tests
- 2 `require_max_len` tests
- 12 per-struct `validate()` tests
- 4 `deny_unknown_fields` tests (reject extras on ScrapeUrl / ExportFile / CleanHtml; accept known fields)
- 3 `ScrapeBatch` concurrency-limit tests

## Verification

```bash
cargo check -p webfang_mcp --all-features         # PASS
cargo clippy -p webfang_mcp --all-features -- -D warnings  # PASS, 0 warnings
cargo fmt --check                                  # PASS
cargo nextest run -p webfang_mcp                   # PASS, 125 tests, 0 failures
```

## Risk

- **100% additive** — no existing signatures, call sites, or public API modified.
- `#![allow(dead_code)]` at the top of `params.rs` is **temporary** — removed in slice 2 when each `validate()` becomes live.
- `pub(crate)` structs' `validate()` methods cannot be exercised from cross-crate integration tests; slice 2's handler wiring is the proof they work in production.

## Slice 2 (next PR)

Wires `params.validate()?` at the top of each `#[tool(...)] fn` body (10 handlers, ranked by blast radius in commit message). Adds behavioural integration tests proving `scrape_url_rejects_file_scheme`, `export_file_rejects_output_dir_traversal`, and unknown-field rejection through the full tool-call path.

## Notes

- Issue body says "29 `*Params`" but audit found 29 (off-by-one vs initial estimate of 30). All 29 handled.
- `Path::is_absolute()` is platform-aware and misses Windows paths on Linux hosts. The new `has_windows_drive_prefix` helper closes that gap. Project pattern worth keeping in mind for any other path-validating code.