### PR TITLE
chore(infra): add inter-crate dependency-direction CI gate (#513)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
             exit 1
           fi
           echo "OK: no anyhow imports in webfang_core/src"
+      # Regression guard for #513: inter-crate dependency direction (see
+      # AGENTS.md "Inter-crate dependency direction (ENFORCED POLICY)").
+      # Fails if any crate depends on a prohibited sibling crate (e.g.
+      # webfang_core depending on cli/tui/mcp/ai, or tui on cli).
+      - name: Dependency direction gate
+        run: bash scripts/check_dependency_direction.sh
 
   # ============================================================================
   # TIER 1: FORMAT GATE (30-60 seconds)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,9 +122,23 @@ webfang/                          # virtual workspace root (no [package])
 cli ──→ tui ──→ core ←── ai
 cli ──→ mcp ──→ core
 cli ──────────→ core
+cli ──→ ai   (feature-gated, #433)
+mcp ──→ ai   (feature-gated, #433)
 ```
 
+Full allow-matrix (effective build graph):
+
+| Crate | May depend on |
+|:---|:---|
+| `webfang_core` | — |
+| `webfang_ai` | `webfang_core` |
+| `webfang_tui` | `webfang_core` |
+| `webfang_mcp` | `webfang_core`, `webfang_ai` |
+| `webfang_cli` | `webfang_core`, `webfang_tui`, `webfang_ai`, `webfang_mcp` |
+
 This is an architectural POLICY, not just what the code happens to do. New code must respect this direction. Verify cross-crate usage with `codedb_deps` or GitNexus `impact` before adding any inter-crate import.
+
+**CI gate (#513):** `scripts/check_dependency_direction.sh` runs in the `toolchain` job of `ci.yml` and fails on any prohibited inter-crate dependency (including feature-gated optional deps). It parses each crate's `Cargo.toml` `[dependencies]`/`[dev-dependencies]` against the matrix above and prints the effective graph on success. Keep the matrix in the script and this section in sync.
 
 ### Intra-crate layers (Clean Architecture)
 

--- a/scripts/check_dependency_direction.sh
+++ b/scripts/check_dependency_direction.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# check_dependency_direction.sh
+#
+# CI gate for the inter-crate dependency policy (issue #513).
+# Enforces the direction documented in AGENTS.md ("Inter-crate dependency
+# direction (ENFORCED POLICY)") against the REAL build graph: the internal
+# webfang_* references in each crate's Cargo.toml [dependencies] and
+# [dev-dependencies] tables. Cargo.toml is the source of truth for crate-level
+# dependencies, so this catches violations at build level (including
+# feature-gated optional deps) without needing cargo-modules in CI.
+#
+# Policy matrix (source of truth — keep in sync with AGENTS.md):
+#   webfang_core: (none)
+#   webfang_ai:   webfang_core
+#   webfang_tui:  webfang_core
+#   webfang_mcp:  webfang_core, webfang_ai      (ai feature-gated, #433)
+#   webfang_cli:  webfang_core, webfang_tui, webfang_ai, webfang_mcp
+#
+# Crates outside the policy (webfang_test_utils, fuzz/) are not checked.
+
+set -euo pipefail
+
+declare -A ALLOWED=(
+  [webfang_core]=""
+  [webfang_ai]="webfang_core"
+  [webfang_tui]="webfang_core"
+  [webfang_mcp]="webfang_core webfang_ai"
+  [webfang_cli]="webfang_core webfang_tui webfang_ai webfang_mcp"
+)
+
+CRATES=(webfang_core webfang_ai webfang_tui webfang_mcp webfang_cli)
+status=0
+
+# Extract internal webfang_* dependency names from a crate manifest.
+# Only [dependencies]-style tables are considered ([dependencies],
+# [dev-dependencies], [target.'cfg(...)'.dependencies]); [features] entries
+# like `ai = ["dep:webfang_ai", ...]` and [workspace.dependencies] are skipped.
+extract_internal_deps() {
+  awk -F= '
+    /^\[/ {
+      in_deps = (($0 ~ /^\[(dev-)?dependencies\]/) || ($0 ~ /^\[target\..*dependencies\]/)) \
+                && ($0 !~ /workspace/)
+      next
+    }
+    in_deps && $1 ~ /^[[:space:]]*webfang_(core|ai|tui|mcp|cli)[[:space:]]*$/ {
+      gsub(/[[:space:]]/, "", $1)
+      print $1
+    }
+  ' "$1"
+}
+
+for crate in "${CRATES[@]}"; do
+  manifest="crates/$crate/Cargo.toml"
+  if [[ ! -f "$manifest" ]]; then
+    echo "::error::missing manifest $manifest"
+    status=1
+    continue
+  fi
+  allowed=${ALLOWED[$crate]}
+  while read -r dep; do
+    [[ -n "$dep" ]] || continue
+    if [[ " $allowed " != *" $dep "* ]]; then
+      echo "::error::$crate must NOT depend on $dep (policy: ${allowed:-none})"
+      status=1
+    fi
+  done < <(extract_internal_deps "$manifest")
+done
+
+if [[ $status -eq 0 ]]; then
+  echo "OK: inter-crate dependency direction matches policy (issue #513)"
+  for crate in "${CRATES[@]}"; do
+    deps=$(extract_internal_deps "crates/$crate/Cargo.toml" | sort -u | paste -sd' ' -)
+    printf '  %-14s -> %s\n' "$crate" "${deps:-none}"
+  done
+fi
+
+exit "$status"


### PR DESCRIPTION
## Linked Issue

<!-- REQUIRED — use one of: Closes #N / Fixes #N / Resolves #N -->
Closes #513

## PR Type

<!-- Check exactly ONE, then add the matching label -->
- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [x] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Adds `scripts/check_dependency_direction.sh`: CI gate for the inter-crate dependency policy — parses each crate's `Cargo.toml` dependency tables against the allow-matrix and fails on any prohibited sibling dependency (e.g. `webfang_core` → `cli/tui/mcp/ai`, `webfang_tui` → `cli`), including feature-gated optional deps. Prints the effective build graph on success.
- Wires the gate into the `toolchain` job of `ci.yml` (tier-0 fast gate, same pattern as `check_dead_tests.sh` and the anyhow guard).
- Documents the gate in AGENTS.md and corrects the policy diagram: the feature-gated `cli → ai` / `mcp → ai` edges (#433) were missing — a gate encoding the literal old diagram would have broken the existing build (backward-compat criterion).

## Changes

| File | Change |
|------|--------|
| `scripts/check_dependency_direction.sh` | New gate script: awk-based Cargo.toml parser + allow-matrix, GitHub `::error::` annotations, exit 1 on violation |
| `.github/workflows/ci.yml` | New "Dependency direction gate" step in the `toolchain` job |
| `AGENTS.md` | Fixed policy diagram (+ feature-gated ai edges), full allow-matrix table, gate documentation |

## Test Plan

<!-- Adapt to the change. For Rust work: -->
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo nextest run` passes (workspace: 2146 tests, all pass)
- [x] Manually verified the affected functionality
  - Gate passes on current tree (exit 0, prints effective graph)
  - Negative test: injected `webfang_cli` into `webfang_tui` and `webfang_core` manifests → `::error::` + exit 1 for both headline violations

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed
