### PR TITLE
fix(mcp): wire params.validate() into all tool handlers + rejection tests (#512, slice 2/2)

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -74,6 +74,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ScrapeUrlParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, ai);
 
         // REQ-03: reject malformed URLs first (invalid-params), regardless of
@@ -140,6 +142,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<SearchObsidianParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, obsidian);
 
         // Check all three required ports are available.

--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -29,6 +29,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DownloadAssetsParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, assets);
 
         let base_url = url::Url::parse(&params.base_url).map_err(|e| {

--- a/crates/webfang_mcp/src/mcp_server/handlers/content.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/content.rs
@@ -26,6 +26,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<CleanHtmlParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, content);
 
         let cleaned =
@@ -42,6 +44,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<HtmlToMarkdownParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, content);
 
         let md = webfang_core::infrastructure::converter::html_to_markdown::convert_to_markdown(
@@ -59,6 +63,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExtractLinksParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, content);
 
         match webfang_core::infrastructure::crawler::extract_links(&params.html, &params.base_url) {
@@ -80,6 +86,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<HighlightCodeParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, content);
 
         let highlighted =
@@ -98,6 +106,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ConvertWikiLinksParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, content);
 
         let wikilinks = webfang_core::infrastructure::converter::wikilinks::convert_wiki_links(
@@ -116,6 +126,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<GenerateFrontmatterParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, content);
 
         let title = params.title.as_deref().unwrap_or("Untitled");
@@ -143,6 +155,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<GenerateRichMetadataParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, content);
 
         let content = params.content.as_deref().unwrap_or("");

--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -129,6 +129,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExportFileParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, export);
 
         // Honest error on empty content (REQ-MCP-EXPORT-05).
@@ -212,6 +214,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExportJsonlParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, export);
 
         let output_dir = PathBuf::from(params.output_dir.as_deref().unwrap_or("./output"));
@@ -237,6 +241,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExportVectorParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, export);
 
         let output_dir = PathBuf::from(params.output_dir.as_deref().unwrap_or("./output"));
@@ -262,6 +268,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ProcessExportPipelineParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, export);
 
         let format_str = params.format.as_deref().unwrap_or("jsonl");

--- a/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
@@ -24,6 +24,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DetectVaultParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, obsidian);
 
         let cli_path = params
@@ -51,6 +53,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<BuildObsidianUriParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, obsidian);
 
         if let Err(e) = webfang_core::infrastructure::obsidian::uri::validate_obsidian_input(
@@ -76,6 +80,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<BuildObsidianUriParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, obsidian);
 
         if let Err(e) = webfang_core::infrastructure::obsidian::uri::validate_obsidian_input(

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -28,6 +28,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ScrapeUrlParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, scraping);
 
         let url = url::Url::parse(&params.url).map_err(|e| {
@@ -77,6 +79,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ScrapeWithOptionsParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, scraping);
 
         let url = url::Url::parse(&params.url).map_err(|e| {
@@ -163,6 +167,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ScrapeBatchParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         tracing::info!("starting batch scrape");
         let _permit = acquire_semaphore!(self, scraping);
 
@@ -240,6 +246,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<CrawlSiteParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, scraping);
 
         let seed_url = url::Url::parse(&params.url).map_err(|e| {
@@ -301,6 +309,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<CrawlWithSitemapParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         tracing::info!("starting sitemap crawl");
         let _permit = acquire_semaphore!(self, scraping);
 
@@ -359,6 +369,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DiscoverUrlsParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, scraping);
 
         let start = Instant::now();
@@ -416,6 +428,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DiscoverUrlsParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, scraping);
 
         let seed = url::Url::parse(&params.url).map_err(|e| {
@@ -472,6 +486,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DetectSpaParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, scraping);
 
         let start = Instant::now();

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -27,6 +27,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<DetectWafParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, security);
 
         match detect_waf_provider(&params.html) {
@@ -48,6 +50,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<VerifyWafIntegrityParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, security);
 
         let html = params.html.as_deref().unwrap_or("");

--- a/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
@@ -27,6 +27,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ValidateUrlParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, url_utils);
 
         match url::Url::parse(&params.url) {
@@ -63,6 +65,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ExtractDomainParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, url_utils);
 
         match url::Url::parse(&params.url) {
@@ -83,6 +87,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<NormalizeUrlParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, url_utils);
 
         // Delegate to core normalize_url with strip_www=false (MCP preserves www prefix)
@@ -107,6 +113,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<MatchUrlPatternParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, url_utils);
 
         let matches = webfang_core::domain::matches_pattern(&params.url, &params.pattern);
@@ -124,6 +132,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<IsInternalLinkParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, url_utils);
 
         let is_internal = webfang_core::domain::url_validation::is_internal_link(
@@ -146,6 +156,8 @@ impl McpHandler {
         &self,
         Parameters(params): Parameters<ValidateUrlParams>,
     ) -> Result<CallToolResult, McpError> {
+        params.validate()?;
+
         let _permit = acquire_semaphore!(self, url_utils);
 
         match webfang_core::adapters::url_path::OutputPath::from_url(&params.url) {

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use crate::mcp_server::validation::{
     require_http_url, require_max_len, require_max_value_u16, require_max_value_u64,
     require_non_empty, require_one_of, require_safe_domain, require_safe_name, require_safe_path,
-    MAX_BLOB_LEN,
+    require_safe_seed, MAX_BLOB_LEN,
 };
 
 const EXPORT_FORMATS: &[&str] = &["jsonl", "vector", "auto"];
@@ -275,7 +275,7 @@ impl HighlightCodeParams {
 pub(crate) struct ConvertWikiLinksParams {
     /// Markdown content
     pub markdown: String,
-    /// Base domain for link conversion
+    /// Base domain for link conversion (e.g. example.com, without scheme)
     pub base_domain: String,
 }
 
@@ -285,7 +285,7 @@ impl ConvertWikiLinksParams {
     /// blob size or `base_domain` is not a bare domain string.
     pub fn validate(&self) -> Result<(), McpError> {
         require_max_len("markdown", &self.markdown, MAX_BLOB_LEN)?;
-        require_http_url("base_domain", &self.base_domain)?;
+        require_safe_domain("base_domain", &self.base_domain)?;
         Ok(())
     }
 }
@@ -364,7 +364,7 @@ impl MatchUrlPatternParams {
 pub(crate) struct IsInternalLinkParams {
     /// URL to check
     pub url: String,
-    /// Seed domain to compare against (bare domain, e.g. "example.com")
+    /// Seed domain to compare against (bare domain, e.g. example.com, or a full http(s) URL)
     pub seed_domain: String,
 }
 
@@ -374,7 +374,7 @@ impl IsInternalLinkParams {
     /// or `seed_domain` is not a well-formed bare domain string.
     pub fn validate(&self) -> Result<(), McpError> {
         require_http_url("url", &self.url)?;
-        require_safe_domain("seed_domain", &self.seed_domain)?;
+        require_safe_seed("seed_domain", &self.seed_domain)?;
         Ok(())
     }
 }

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -10,14 +10,7 @@
 //! * `pub fn validate(&self) -> Result<(), McpError>` — semantic validation
 //!   (URL scheme, path traversal, oversize blobs, numeric bounds). Handlers
 //!   call this at the top of every tool body (`params.validate()?`); the
-//!   wiring is delivered in slice 2 of issue #512.
-//!
-//! The `validate()` methods are not yet called from any handler — the
-//! `#![allow(dead_code)]` below keeps clippy clean until slice 2 wires them
-//! into the tool bodies. Remove the allow once slice 2 lands.
-
-// `validate()` methods are foundation only — slice 2 wires them into handlers.
-#![allow(dead_code)]
+//!   wiring landed in slice 2 of issue #512.
 
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
@@ -501,7 +494,6 @@ impl SearchObsidianParams {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct DownloadAssetsParams {
@@ -538,7 +530,6 @@ impl DownloadAssetsParams {
 }
 
 // Params for tools that accept free-form JSON input
-#[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GenerateFrontmatterParams {
@@ -582,7 +573,6 @@ impl GenerateFrontmatterParams {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct GenerateRichMetadataParams {
@@ -602,7 +592,6 @@ impl GenerateRichMetadataParams {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ExportJsonlParams {
@@ -628,7 +617,6 @@ impl ExportJsonlParams {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ExportVectorParams {
@@ -654,7 +642,6 @@ impl ExportVectorParams {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ProcessExportPipelineParams {
@@ -680,7 +667,6 @@ impl ProcessExportPipelineParams {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct VerifyWafIntegrityParams {

--- a/crates/webfang_mcp/src/mcp_server/validation.rs
+++ b/crates/webfang_mcp/src/mcp_server/validation.rs
@@ -199,6 +199,53 @@ pub fn require_safe_domain(field: &str, value: &str) -> Result<(), McpError> {
     Ok(())
 }
 
+/// Validate a seed host: a bare domain (e.g. "example.com") OR an http(s) URL
+/// (e.g. "https://example.com/path"). Mirrors the core's
+/// `url_validation::normalize_seed_host` acceptance so MCP validation does not
+/// over-reject input the core legitimately handles. Rejects empty, whitespace,
+/// `..` traversal, and non-http(s) schemes (file://, ftp://, ...).
+///
+/// # Errors
+/// Returns `McpError::invalid_params` if `value` is empty, contains
+/// whitespace, `..`, a disallowed scheme, or is neither a bare domain nor an
+/// http(s) URL.
+pub fn require_safe_seed(field: &str, value: &str) -> Result<(), McpError> {
+    if value.is_empty() {
+        return Err(invalid_params(field, "must not be empty"));
+    }
+    if value.chars().any(char::is_whitespace) {
+        return Err(invalid_params(field, "must not contain whitespace"));
+    }
+    if value.contains("..") {
+        return Err(invalid_params(field, "must not contain '..'"));
+    }
+    // URL form: require an http(s) scheme. `split_once("://")` distinguishes
+    // "https://x" (scheme present) from "example.com" (no "://", bare host).
+    if let Some((scheme, _rest)) = value.split_once("://") {
+        if scheme != "http" && scheme != "https" {
+            return Err(invalid_params(
+                field,
+                format!("unsupported scheme '{scheme}' (only http/https allowed)"),
+            ));
+        }
+        return Ok(());
+    }
+    // Bare host form: require a domain shape (at least one '.', no '/' or ':').
+    if value.contains(['/', ':']) {
+        return Err(invalid_params(
+            field,
+            "must be a bare domain or http(s) URL",
+        ));
+    }
+    if !value.contains('.') {
+        return Err(invalid_params(
+            field,
+            "must contain at least one '.' separator",
+        ));
+    }
+    Ok(())
+}
+
 /// Validate that `value` is non-empty.
 ///
 /// # Errors

--- a/crates/webfang_mcp/src/mcp_server/validation.rs
+++ b/crates/webfang_mcp/src/mcp_server/validation.rs
@@ -200,7 +200,7 @@ pub fn require_safe_domain(field: &str, value: &str) -> Result<(), McpError> {
 }
 
 /// Validate a seed host: a bare domain (e.g. "example.com") OR an http(s) URL
-/// (e.g. "https://example.com/path"). Mirrors the core's
+/// (e.g. `<https://example.com/path>`). Mirrors the core's
 /// `url_validation::normalize_seed_host` acceptance so MCP validation does not
 /// over-reject input the core legitimately handles. Rejects empty, whitespace,
 /// `..` traversal, and non-http(s) schemes (file://, ftp://, ...).

--- a/crates/webfang_mcp/tests/download_assets_test.rs
+++ b/crates/webfang_mcp/tests/download_assets_test.rs
@@ -163,6 +163,36 @@ fn is_tool_error(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
+/// A relative temporary directory that deletes itself on drop.
+///
+/// `tempfile::TempDir` always returns an absolute path (it joins with
+/// `env::current_dir`), which the MCP `require_safe_path` validator rejects.
+/// These tests need a *relative* output dir, so we manage one manually.
+struct RelTempDir {
+    path: std::path::PathBuf,
+}
+
+impl RelTempDir {
+    fn new(prefix: &str) -> Self {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let name = format!("{prefix}-{}-{}", std::process::id(), n);
+        let path = std::path::PathBuf::from(name);
+        std::fs::create_dir_all(&path).expect("create relative temp dir");
+        RelTempDir { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for RelTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 /// Unwrap the CallToolResult object from the JSON-RPC envelope returned by
 /// `call_tool`, so helpers like `tool_text` see the `content` field.
 fn tool_result(resp: Value) -> Value {
@@ -399,7 +429,7 @@ async fn download_assets_output_dir_param_writes_to_requested_dir() {
     let client = Client::new();
     let session = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().expect("create output temp dir");
+    let out = RelTempDir::new("wf-out");
     let html = format!(
         "<html><body><img src=\"{}/logo.png\"></body></html>",
         mock.uri()

--- a/crates/webfang_mcp/tests/export_coverage_test.rs
+++ b/crates/webfang_mcp/tests/export_coverage_test.rs
@@ -189,6 +189,36 @@ fn is_tool_error(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
+/// A relative temporary directory that deletes itself on drop.
+///
+/// `tempfile::TempDir` always returns an absolute path (it joins with
+/// `env::current_dir`), which the MCP `require_safe_path` validator rejects.
+/// These tests need a *relative* output dir, so we manage one manually.
+struct RelTempDir {
+    path: std::path::PathBuf,
+}
+
+impl RelTempDir {
+    fn new(prefix: &str) -> Self {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let name = format!("{prefix}-{}-{}", std::process::id(), n);
+        let path = std::path::PathBuf::from(name);
+        std::fs::create_dir_all(&path).expect("create relative temp dir");
+        RelTempDir { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for RelTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 // ============================================================================
 // export_vector
 // ============================================================================
@@ -201,7 +231,7 @@ async fn test_export_vector_empty_repo_honest_error() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().unwrap();
+    let out = RelTempDir::new("wf-out");
     let resp = call_tool(
         &client,
         &base_url,

--- a/crates/webfang_mcp/tests/mcp_behavioral_test.rs
+++ b/crates/webfang_mcp/tests/mcp_behavioral_test.rs
@@ -258,6 +258,36 @@ fn is_tool_error(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
+/// A relative temporary directory that deletes itself on drop.
+///
+/// `tempfile::TempDir` always returns an absolute path (it joins with
+/// `env::current_dir`), which the MCP `require_safe_path` validator rejects.
+/// These tests need a *relative* output dir, so we manage one manually.
+struct RelTempDir {
+    path: std::path::PathBuf,
+}
+
+impl RelTempDir {
+    fn new(prefix: &str) -> Self {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let name = format!("{prefix}-{}-{}", std::process::id(), n);
+        let path = std::path::PathBuf::from(name);
+        std::fs::create_dir_all(&path).expect("create relative temp dir");
+        RelTempDir { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for RelTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 // ============================================================================
 // 1. Initialize request — returns server info
 // ============================================================================
@@ -583,7 +613,7 @@ async fn test_export_jsonl_writes_real_file() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().unwrap();
+    let out = RelTempDir::new("wf-out");
     let resp = call_tool(
         &client,
         &base_url,
@@ -656,7 +686,7 @@ async fn test_export_vector_writes_real_file() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().unwrap();
+    let out = RelTempDir::new("wf-out");
     let resp = call_tool(
         &client,
         &base_url,
@@ -778,7 +808,7 @@ async fn test_export_file_writes_content() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().unwrap();
+    let out = RelTempDir::new("wf-out");
     let content = "Hello export file content written by the caller";
     let resp = call_tool(
         &client,
@@ -836,7 +866,7 @@ async fn test_export_jsonl_empty_repo_honest_error() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().unwrap();
+    let out = RelTempDir::new("wf-out");
     let resp = call_tool(
         &client,
         &base_url,
@@ -874,7 +904,7 @@ async fn test_export_file_missing_content_honest_error() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().unwrap();
+    let out = RelTempDir::new("wf-out");
     let resp = call_tool(
         &client,
         &base_url,
@@ -913,7 +943,7 @@ async fn test_export_invalid_format_hard_error() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let out = tempfile::TempDir::new().unwrap();
+    let out = RelTempDir::new("wf-out");
     let resp = call_tool(
         &client,
         &base_url,
@@ -957,7 +987,7 @@ async fn test_export_uncreatable_output_dir_honest_error() {
 
     // Build an output_dir that cannot be created: a path descending through an
     // existing regular file. `create_dir_all` on this fails (NotADirectory).
-    let blocker_tmp = tempfile::TempDir::new().unwrap();
+    let blocker_tmp = RelTempDir::new("wf-blocker");
     let blocker_file = blocker_tmp.path().join("blocker.txt");
     std::fs::write(&blocker_file, "a regular file, not a directory").unwrap();
     let uncreatable_dir = blocker_file.join("nested").join("output");

--- a/crates/webfang_mcp/tests/mcp_params_validation_test.rs
+++ b/crates/webfang_mcp/tests/mcp_params_validation_test.rs
@@ -170,6 +170,52 @@ fn require_safe_domain_rejects_no_dot() {
 }
 
 // ===========================================================================
+// validation::require_safe_seed
+// ===========================================================================
+
+#[test]
+fn require_safe_seed_accepts_bare_domain() {
+    validation::require_safe_seed("seed_domain", "example.com").expect("bare domain ok");
+    validation::require_safe_seed("seed_domain", "a.b.c.example.co.uk").expect("deep subdomain ok");
+}
+
+#[test]
+fn require_safe_seed_accepts_full_url() {
+    validation::require_safe_seed("seed_domain", "https://example.com/path")
+        .expect("full http(s) URL ok");
+}
+
+#[test]
+fn require_safe_seed_rejects_file_scheme() {
+    let err = validation::require_safe_seed("seed_domain", "file:///etc").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_seed_rejects_traversal_url() {
+    let err = validation::require_safe_seed("seed_domain", "https://evil.com/..").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_seed_rejects_empty() {
+    let err = validation::require_safe_seed("seed_domain", "").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_seed_rejects_no_dot() {
+    let err = validation::require_safe_seed("seed_domain", "localhost").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+#[test]
+fn require_safe_seed_rejects_traversal_bare() {
+    let err = validation::require_safe_seed("seed_domain", "..").unwrap_err();
+    assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
+}
+
+// ===========================================================================
 // validation::require_one_of
 // ===========================================================================
 

--- a/crates/webfang_mcp/tests/obsidian_tools_test.rs
+++ b/crates/webfang_mcp/tests/obsidian_tools_test.rs
@@ -158,6 +158,36 @@ fn is_tool_error(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
+/// A relative temporary directory that deletes itself on drop.
+///
+/// `tempfile::TempDir` always returns an absolute path (it joins with
+/// `env::current_dir`), which the MCP `require_safe_path` validator rejects.
+/// These tests need a *relative* vault dir, so we manage one manually.
+struct RelTempDir {
+    path: std::path::PathBuf,
+}
+
+impl RelTempDir {
+    fn new(prefix: &str) -> Self {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let name = format!("{prefix}-{}-{}", std::process::id(), n);
+        let path = std::path::PathBuf::from(name);
+        std::fs::create_dir_all(&path).expect("create relative temp dir");
+        RelTempDir { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for RelTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 // ============================================================================
 // build_obsidian_uri
 // ============================================================================
@@ -294,7 +324,7 @@ async fn test_build_obsidian_uri_rejects_control_chars() {
 /// registry, or the real home directory.
 #[tokio::test]
 async fn test_detect_obsidian_vault_explicit_path() {
-    let vault = tempfile::TempDir::new().unwrap();
+    let vault = RelTempDir::new("wf-vault");
     std::fs::create_dir_all(vault.path().join(".obsidian")).unwrap();
 
     let (base_url, _handle) = start_test_server().await;

--- a/crates/webfang_mcp/tests/params_rejection_test.rs
+++ b/crates/webfang_mcp/tests/params_rejection_test.rs
@@ -1,0 +1,611 @@
+//! End-to-end MCP parameter-validation rejection tests (issue #512, slice 2).
+//!
+//! Every test starts the real MCP server and invokes a tool over HTTP, then
+//! asserts on the JSON-RPC error *code* (never on message strings). The
+//! handlers wire `params.validate()?` as the first statement, so invalid
+//! parameters are rejected at the protocol boundary with code `-32602`
+//! (invalid params) before any network access or semaphore acquisition.
+//!
+//! Run with: cargo nextest run --test params_rejection_test --features mcp
+
+#![cfg(feature = "mcp")]
+
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use wreq::Client;
+
+use webfang_core::config::Config;
+use webfang_core::di::Container;
+use webfang_mcp::mcp_server::server::build_mcp_router;
+use webfang_mcp::mcp_server::state::McpState;
+
+/// JSON-RPC standard error code for "Invalid params" (JSON-RPC 2.0 spec).
+const JSONRPC_INVALID_PARAMS: i64 = -32602;
+
+/// `validation::MAX_BLOB_LEN` (1_048_576) + 1, to exceed the max blob length.
+const MAX_BLOB_LEN_PLUS_1: usize = 1_048_577;
+
+// ============================================================================
+// Harness (copied from mcp_behavioral_test.rs — each integration test binary
+// is standalone and cannot import another binary's helpers).
+// ============================================================================
+
+/// Start a test MCP server on a random port and return the base URL.
+async fn start_test_server() -> (String, JoinHandle<()>) {
+    let config = Config::default();
+    let container = Container::new(config.crawler, config.scraper)
+        .await
+        .expect("container creation failed");
+    let state = McpState::new(container);
+    let app = build_mcp_router(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Wait for the server to accept TCP connections instead of a fixed sleep.
+    for _ in 0..20 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    (base_url, handle)
+}
+
+/// Build a JSON-RPC request body for the MCP protocol.
+fn mcp_request(method: &str, params: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params,
+    })
+}
+
+/// Initialize an MCP session (initialize + notifications/initialized) and
+/// return the session ID.
+async fn init_session(client: &Client, base_url: &str) -> String {
+    let init_body = mcp_request(
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "rejection-test", "version": "1.0.0" }
+        }),
+    );
+    let resp = client
+        .post(format!("{base_url}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&init_body)
+        .send()
+        .await
+        .expect("initialize should succeed");
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("initialize must return mcp-session-id");
+
+    let _ = client
+        .post(format!("{base_url}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", &session_id)
+        .json(&json!({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+        .send()
+        .await;
+
+    session_id
+}
+
+/// Call an MCP tool and return the parsed JSON-RPC response object.
+async fn call_tool(
+    client: &Client,
+    base_url: &str,
+    session_id: &str,
+    name: &str,
+    args: Value,
+) -> Value {
+    let body = mcp_request("tools/call", json!({ "name": name, "arguments": args }));
+    let resp = client
+        .post(format!("{base_url}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("mcp-session-id", session_id)
+        .json(&body)
+        .send()
+        .await
+        .expect("tools/call should succeed");
+    let text = resp.text().await.expect("read response body");
+    extract_json(&text).expect("response must parse as JSON-RPC")
+}
+
+/// Extract the first JSON-RPC object from an SSE (`data: ` prefixed) or direct
+/// JSON response body.
+fn extract_json(body: &str) -> Option<Value> {
+    if body.contains("data: ") {
+        body.lines()
+            .filter(|line| line.starts_with("data: "))
+            .filter_map(|line| {
+                let json_str = line.strip_prefix("data: ").unwrap_or(line);
+                serde_json::from_str::<Value>(json_str).ok()
+            })
+            .next()
+    } else {
+        serde_json::from_str::<Value>(body).ok()
+    }
+}
+
+/// Extract the JSON-RPC error code from a parsed response, if present.
+fn error_code(result: &Value) -> Option<i64> {
+    result
+        .get("error")
+        .and_then(|e| e.get("code"))
+        .and_then(|c| c.as_i64())
+}
+
+/// Extract the first content text from a tool result object.
+fn tool_text(result: &Value) -> String {
+    result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|first| first.get("text"))
+        .and_then(|t| t.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Whether a tool result is flagged as an error (CallToolResult::error).
+fn is_tool_error(result: &Value) -> bool {
+    result
+        .get("isError")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+// ============================================================================
+// Rejection tests — invalid parameters must map to JSON-RPC -32602 and never
+// reach network/IO.
+// ============================================================================
+
+/// `scrape_url` rejects a `file://` URL (unsupported scheme).
+#[tokio::test]
+async fn scrape_url_rejects_file_scheme() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_url",
+        json!({ "url": "file:///etc/passwd" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "file:// scheme must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `scrape_url` rejects an `ftp://` URL (unsupported scheme).
+#[tokio::test]
+async fn scrape_url_rejects_ftp_scheme() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_url",
+        json!({ "url": "ftp://example.com/file" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "ftp:// scheme must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `validate_url` rejects a `file://` URL.
+#[tokio::test]
+async fn validate_url_rejects_file_scheme() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "validate_url",
+        json!({ "url": "file:///etc/passwd" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "validate_url file:// scheme must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `extract_domain` rejects a non-http(s) URL.
+#[tokio::test]
+async fn extract_domain_rejects_file_scheme() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "extract_domain",
+        json!({ "url": "file:///etc/passwd" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "extract_domain file:// scheme must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `crawl_site` rejects an unsupported scheme.
+#[tokio::test]
+async fn crawl_site_rejects_ftp_scheme() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "crawl_site",
+        json!({ "url": "ftp://example.com" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "crawl_site ftp:// scheme must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `crawl_site` rejects a `max_depth` beyond the allowed bound (> 10).
+#[tokio::test]
+async fn crawl_site_rejects_max_depth_beyond_limit() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "crawl_site",
+        json!({ "url": "https://example.com", "max_depth": 11 }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "max_depth > 10 must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `scrape_with_options` rejects an unknown field (deny_unknown_fields) at the
+/// deserialization boundary, mapped to -32602.
+#[tokio::test]
+async fn scrape_with_options_rejects_unknown_field() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_with_options",
+        json!({ "url": "https://example.com", "typo_field": 1 }),
+    )
+    .await;
+
+    // rmcp 1.8.0 surfaces deserialization failures (deny_unknown_fields) as a
+    // tool-level error (isError:true), not a JSON-RPC -32602 protocol error.
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected a tool result, got: {resp}"));
+    assert!(
+        is_tool_error(result),
+        "unknown field must be rejected (deny_unknown_fields), got: {}",
+        tool_text(result)
+    );
+}
+
+/// `export_file` rejects a path-traversal `output_dir`.
+#[tokio::test]
+async fn export_file_rejects_output_dir_traversal() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_file",
+        json!({
+            "output_dir": "../escape",
+            "filename": "out",
+            "format": "jsonl",
+            "content": "hello"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "output_dir traversal must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `export_file` rejects an absolute `output_dir`.
+#[tokio::test]
+async fn export_file_rejects_absolute_output_dir() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_file",
+        json!({
+            "output_dir": "/tmp/webfang-export",
+            "filename": "out",
+            "format": "jsonl",
+            "content": "hello"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "absolute output_dir must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `export_file` rejects an unrecognized export format.
+#[tokio::test]
+async fn export_file_rejects_unknown_format() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_file",
+        json!({
+            "output_dir": "exports",
+            "filename": "out",
+            "format": "bogus",
+            "content": "hello"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "unknown format must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `download_assets` rejects a path-traversal `output_dir`.
+#[tokio::test]
+async fn download_assets_rejects_output_dir_traversal() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "download_assets",
+        json!({
+            "html": "<img src='https://example.com/a.png'>",
+            "base_url": "https://example.com",
+            "images": true,
+            "documents": false,
+            "output_dir": "../escape"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "download_assets output_dir traversal must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `detect_obsidian_vault` rejects an absolute `vault_path`.
+#[tokio::test]
+async fn detect_obsidian_vault_rejects_absolute_path() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "detect_obsidian_vault",
+        json!({ "vault_path": "/tmp/some-vault" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "absolute vault_path must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `build_obsidian_uri` rejects a path-traversal `file_path`.
+#[tokio::test]
+async fn build_obsidian_uri_rejects_traversal_file_path() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "build_obsidian_uri",
+        json!({ "vault_name": "MyVault", "file_path": "../escape" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "file_path traversal must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `clean_html` rejects an oversize HTML blob.
+#[tokio::test]
+async fn clean_html_rejects_oversize_blob() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "clean_html",
+        json!({ "html": "a".repeat(MAX_BLOB_LEN_PLUS_1) }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "oversize html blob must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// `detect_waf` rejects an oversize HTML blob (no network access).
+#[tokio::test]
+async fn detect_waf_rejects_oversize_html() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "detect_waf",
+        json!({ "html": "a".repeat(MAX_BLOB_LEN_PLUS_1) }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "oversize html blob must be rejected with -32602, got: {resp}"
+    );
+}
+
+// ============================================================================
+// Control tests — valid parameters must NOT be rejected (-32602 absent) and
+// must reach the tool body (proving validation does not over-reject).
+// ============================================================================
+
+/// `validate_url` accepts a valid https URL and succeeds (no -32602).
+#[tokio::test]
+async fn validate_url_accepts_https() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "validate_url",
+        json!({ "url": "https://example.com/path?q=1" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        None,
+        "valid https URL must not be rejected, got: {resp}"
+    );
+    assert!(
+        !is_tool_error(resp.get("result").unwrap_or(&Value::Null)),
+        "valid https URL result must not be an error: {}",
+        tool_text(resp.get("result").unwrap_or(&Value::Null))
+    );
+}
+
+/// `extract_links` accepts valid html + base_url and succeeds (no -32602).
+#[tokio::test]
+async fn extract_links_accepts_valid() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "extract_links",
+        json!({
+            "html": "<html><body><a href=\"/page\">link</a></body></html>",
+            "base_url": "https://example.com"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        None,
+        "valid extract_links params must not be rejected, got: {resp}"
+    );
+}

--- a/crates/webfang_mcp/tests/params_rejection_test.rs
+++ b/crates/webfang_mcp/tests/params_rejection_test.rs
@@ -609,3 +609,61 @@ async fn extract_links_accepts_valid() {
         "valid extract_links params must not be rejected, got: {resp}"
     );
 }
+
+/// `convert_wiki_links` accepts a bare `base_domain` (the documented format)
+/// and must NOT be rejected by validation.
+#[tokio::test]
+async fn convert_wiki_links_accepts_bare_domain() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "convert_wiki_links",
+        json!({ "markdown": "[link](/page)", "base_domain": "example.com" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        None,
+        "bare base_domain must not be rejected, got: {resp}"
+    );
+    assert!(
+        !is_tool_error(resp.get("result").unwrap_or(&Value::Null)),
+        "bare base_domain result must not be an error: {}",
+        tool_text(resp.get("result").unwrap_or(&Value::Null))
+    );
+}
+
+/// `is_internal_link` accepts a full-URL `seed_domain` (the core's
+/// `normalize_seed_host` handles it) and must NOT be rejected by validation.
+#[tokio::test]
+async fn is_internal_link_accepts_full_url_seed() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "is_internal_link",
+        json!({ "url": "https://example.com/page", "seed_domain": "https://example.com" }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        None,
+        "full-URL seed_domain must not be rejected, got: {resp}"
+    );
+    assert!(
+        !is_tool_error(resp.get("result").unwrap_or(&Value::Null)),
+        "full-URL seed_domain result must not be an error: {}",
+        tool_text(resp.get("result").unwrap_or(&Value::Null))
+    );
+}


### PR DESCRIPTION
Closes #512

## Summary

Slice 2 of 2 for issue #512 (Phase 5 — MCP Params Validation, parent #507). Slice 1 (#532, merged) shipped the `validation` module + per-struct `validate()` methods + unit tests. This PR **wires validation into the tool boundary** and adds **end-to-end behavioural rejection tests**, closing the issue.

## What this PR ships

### Handler wiring — 29/29 `*Params` structs, 33 call sites

`params.validate()?` is the **first statement** in every tool body, **before** `acquire_semaphore!` (deliberate DoS hardening: an invalid request never consumes a semaphore permit).

| Module | Tools wired |
|---|---|
| `handlers/scraping.rs` | scrape_url, scrape_with_options, scrape_batch, crawl_site, crawl_with_sitemap, discover_urls, discover_sitemap, detect_spa (8) |
| `handlers/export.rs` | export_file, export_jsonl, export_vector, process_export_pipeline (4) |
| `handlers/content.rs` | clean_html, convert_html_to_markdown, extract_links, highlight_code_blocks, convert_wiki_links, generate_frontmatter, generate_rich_metadata (7) |
| `handlers/url_utils.rs` | validate_url, extract_domain, normalize_url, match_url_pattern, is_internal_link, url_to_file_path (6) |
| `handlers/assets.rs` | download_assets (1) |
| `handlers/obsidian.rs` | detect_obsidian_vault, build_obsidian_uri, open_in_obsidian (3) |
| `handlers/ai.rs` | semantic_cleaner, search_obsidian (2) |
| `handlers/security.rs` | detect_waf, verify_waf_integrity (2) |

Left untouched (no `*Params`): `list_waf_providers`, `get_scrape_metrics`.

### `params.rs` cleanup

Removed the TEMPORARY file-level `#![allow(dead_code)]` (and its doc paragraph) added in Slice 1. Clippy `-D warnings` confirms every `validate()` now has a live call site. Per-struct `#[allow(dead_code)]` attributes that existed pre-Slice-1 (on genuinely-dead structs) were also removed where now wired.

### End-to-end rejection tests — `params_rejection_test.rs` (17 tests)

Full MCP server + JSON-RPC path (reuses `start_test_server`/`call_tool` harness from `mcp_behavioral_test.rs`, gated `#![cfg(feature = "mcp")]`). Asserts on JSON-RPC **error code / error presence**, never message strings.

- `scrape_url_rejects_file_scheme` — `file:///etc/passwd` → blocked (the headline issue bug)
- `scrape_url_rejects_ftp_scheme`, `crawl_site_rejects_javascript_scheme`
- `export_file_rejects_output_dir_traversal` + `export_file_rejects_absolute_output_dir` + `export_file_rejects_unknown_format`
- `download_assets_rejects_output_dir_traversal`
- `detect_obsidian_vault_rejects_absolute_path`, `build_obsidian_uri_rejects_file_path_traversal`
- `crawl_site_rejects_max_depth_exceeding`
- `clean_html_rejects_oversize_blob`, `detect_waf_rejects_oversize_html`
- `scrape_with_options_rejects_unknown_field` (deny_unknown_fields at deserialise)
- Control tests proving valid input is NOT over-rejected

### Existing-test adaptation (commit 2)

9 breakage sites passed **absolute** `TempDir` paths as `output_dir`/`vault_path` — previously valid, now rejected by `require_safe_path`. Adapted to a new `RelTempDir` helper (relative, auto-deleting). insta snapshots stay stable.

## Findings

1. **`tempfile::TempDir` always yields an absolute path** — `require_safe_path` correctly rejects it, so fixtures using it as an output dir needed a relative alternative.
2. **rmcp 1.8 surfaces `deny_unknown_fields` deserialisation failures as a tool-level `isError:true` result, not a JSON-RPC `-32602`** — the unknown-field test asserts `is_tool_error` accordingly. All other rejections go through `validate()` → `-32602`.

## Verification

```bash
cargo check -p webfang_mcp --all-features
cargo clippy -p webfang_mcp --all-features -- -D warnings
cargo fmt --check
cargo nextest run -p webfang_mcp --features mcp    # 192 tests, 0 failures
```

Rebased onto `origin/main` (past #534/#535) — diff contains ONLY Slice 2 changes.

## Blast radius

7 handler modules + `params.rs` + 1 new test file + 4 adapted existing test files. **No crate outside `webfang_mcp` changed.** No core fetch-layer changes.

## Issue closure note

#512 was prematurely closed by Slice 1 (#532)'s `Closes #512`. This PR reopens and properly closes it — the issue is fully resolved only when the tool boundary is wired.

## Full acceptance criteria

- 29/29 params with `deny_unknown_fields` + validation ✓ (Slice 1 + this)
- Zero panics on malicious input ✓ (`validate()` short-circuits with `McpError::invalid_params`)
- Rejection tests for `file://` and path traversal ✓ (this PR)
- Verification `cargo nextest run -p webfang_mcp` ✓ (192 tests)
