### PR TITLE
fix(errors): preserve transient error severity in exit-code routing (#537)

### DIFF
--- a/crates/webfang_core/src/application/batch/manager.rs
+++ b/crates/webfang_core/src/application/batch/manager.rs
@@ -28,6 +28,7 @@ use tracing::info;
 use super::processor::{BatchError, BatchProcessor, BatchResult};
 use super::{BatchJob, BatchJobStatus};
 use crate::domain::CrawlerConfig;
+use crate::error::ScraperError;
 
 /// Queue-based manager for batch crawl jobs
 ///
@@ -131,19 +132,25 @@ impl BatchManager {
         let results = self.process_all().await;
         let mut summary = BatchManagerSummary::default();
 
-        for result in &results {
+        // Consume by value: `ScraperError` is not `Clone`, so error tuples are
+        // moved into the summary rather than cloned (#537).
+        for result in results {
             match result {
                 Ok(r) => {
                     summary.total_urls += r.total;
                     summary.succeeded += r.succeeded;
                     summary.failed += r.failed;
-                    summary.errors.extend(r.errors.clone());
+                    summary.errors.extend(r.errors);
                 },
                 Err(e) => {
                     summary.failed += 1;
-                    summary
-                        .errors
-                        .push(("batch-error".to_string(), format!("{e}")));
+                    // `BatchError` is not a `ScraperError`; wrap into Internal
+                    // (classifies as InternalFatal) so batch-level failures
+                    // escalate the exit code.
+                    summary.errors.push((
+                        "batch-error".to_string(),
+                        ScraperError::Internal(format!("batch-error: {e}")),
+                    ));
                 },
             }
         }
@@ -168,7 +175,7 @@ impl BatchManager {
 }
 
 /// Aggregated summary across all batch jobs in a manager
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct BatchManagerSummary {
     /// Total number of URLs across all jobs
     pub total_urls: usize,
@@ -176,8 +183,10 @@ pub struct BatchManagerSummary {
     pub succeeded: usize,
     /// Number of failed URLs
     pub failed: usize,
-    /// Error messages from failed jobs
-    pub errors: Vec<(String, String)>,
+    /// Errors from failed jobs, preserving the [`ScraperError`] variant so
+    /// exit-code routing can aggregate severity via
+    /// [`ScraperError::classify`] (#537).
+    pub errors: Vec<(String, ScraperError)>,
 }
 
 #[cfg(test)]

--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -36,9 +36,14 @@ use tracing::{error, info, instrument, warn};
 
 use super::BatchJob;
 use crate::domain::{CrawlError, CrawlerConfig};
+use crate::error::ScraperError;
 
 /// Result of processing a batch job
-#[derive(Debug, Clone)]
+///
+/// Not `Clone`: `errors` carries [`ScraperError`], which owns non-cloneable
+/// sources (`std::io::Error`, boxed trait objects). Callers that need to
+/// forward the errors must move them (#537).
+#[derive(Debug)]
 pub struct BatchResult {
     /// ID of the batch job
     pub job_id: String,
@@ -48,8 +53,12 @@ pub struct BatchResult {
     pub succeeded: usize,
     /// Number of failed URLs
     pub failed: usize,
-    /// List of (url, error_message) for failed URLs
-    pub errors: Vec<(String, String)>,
+    /// List of (url, error) for failed URLs.
+    ///
+    /// The [`ScraperError`] variant is preserved (not flattened to a string)
+    /// so exit-code routing can aggregate severity via
+    /// [`ScraperError::classify`] (#537).
+    pub errors: Vec<(String, ScraperError)>,
 }
 
 /// Batch processor with concurrency control
@@ -116,7 +125,7 @@ impl BatchProcessor {
         let base_config = job.config.clone();
 
         let mut join_set = JoinSet::new();
-        let mut errors: Vec<(String, String)> = Vec::new();
+        let mut errors: Vec<(String, ScraperError)> = Vec::new();
 
         for url_str in &job.urls {
             let url = url_str.clone();
@@ -147,14 +156,20 @@ impl BatchProcessor {
                 },
                 Ok((url, Err(e))) => {
                     progress.fail_one();
-                    let err_msg = format!("{e}");
-                    warn!("Failed to crawl {url}: {err_msg}");
-                    errors.push((url, err_msg));
+                    // Preserve the full variant through the CrawlError ->
+                    // ScraperError conversion (#537): severity routing needs
+                    // classify(), which a flattened string cannot provide.
+                    let scraper_err = ScraperError::from(e);
+                    warn!(error = %scraper_err, "Failed to crawl {url}");
+                    errors.push((url, scraper_err));
                 },
                 Err(e) => {
                     progress.fail_one();
                     error!("Task panicked: {e}");
-                    errors.push(("unknown".to_string(), format!("Task panicked: {e}")));
+                    errors.push((
+                        "unknown".to_string(),
+                        ScraperError::Internal(format!("task-panic: {e}")),
+                    ));
                 },
             }
         }
@@ -325,11 +340,14 @@ mod tests {
             errors: vec![
                 (
                     "https://example.com/404".to_string(),
-                    "404 Not Found".to_string(),
+                    ScraperError::http(404, "https://example.com/404"),
                 ),
                 (
                     "https://example.com/timeout".to_string(),
-                    "Timeout".to_string(),
+                    ScraperError::Network(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "Timeout",
+                    ))),
                 ),
             ],
         };
@@ -377,8 +395,14 @@ mod tests {
             succeeded: 0,
             failed: 2,
             errors: vec![
-                ("https://a.com".to_string(), "error a".to_string()),
-                ("https://b.com".to_string(), "error b".to_string()),
+                (
+                    "https://a.com".to_string(),
+                    ScraperError::Internal("error a".to_string()),
+                ),
+                (
+                    "https://b.com".to_string(),
+                    ScraperError::Internal("error b".to_string()),
+                ),
             ],
         };
         assert_eq!(result.succeeded, 0);
@@ -388,8 +412,8 @@ mod tests {
 
     #[test]
     fn test_batch_result_counts_consistent() {
-        let errors: Vec<(String, String)> = (0..5)
-            .map(|i| (format!("url-{i}"), format!("err-{i}")))
+        let errors: Vec<(String, ScraperError)> = (0..5)
+            .map(|i| (format!("url-{i}"), ScraperError::Internal(format!("err-{i}"))))
             .collect();
         let result = BatchResult {
             job_id: "job-mixed".to_string(),

--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -413,7 +413,12 @@ mod tests {
     #[test]
     fn test_batch_result_counts_consistent() {
         let errors: Vec<(String, ScraperError)> = (0..5)
-            .map(|i| (format!("url-{i}"), ScraperError::Internal(format!("err-{i}"))))
+            .map(|i| {
+                (
+                    format!("url-{i}"),
+                    ScraperError::Internal(format!("err-{i}")),
+                )
+            })
             .collect();
         let result = BatchResult {
             job_id: "job-mixed".to_string(),

--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -35,7 +35,7 @@ use tokio::task::JoinSet;
 use tracing::{error, info, instrument, warn};
 
 use super::BatchJob;
-use crate::domain::{CrawlError, CrawlerConfig};
+use crate::domain::{CrawlError, CrawlErrorCategory, CrawlerConfig};
 use crate::error::ScraperError;
 
 /// Result of processing a batch job
@@ -223,10 +223,56 @@ async fn process_single_url(
 
     let result = crate::application::crawler::engine::crawl_site(config).await?;
 
-    // Treat any crawl errors (timeouts, etc.) as failures for batch processing
+    // Treat any crawl errors (timeouts, etc.) as failures for batch processing,
+    // but preserve severity (#537): the engine already partitioned them into
+    // `error_breakdown` (issue #374). A genuinely-internal category (storage,
+    // checkpoint, parse, panic) is a real bug and must stay `Internal` so the
+    // run exits 3 (issue #537, phase 1). A purely transient/external failure
+    // set (timeout, network, http, rate-limit, waf) must surface as a transient
+    // `CrawlError` so it classifies `TransientRetriable`/`Backoff`/`Permanent`
+    // and exits 69 — NOT as a bug (exit 3).
     if result.errors > 0 {
-        return Err(CrawlError::Internal(format!(
-            "crawl completed with {} error(s)",
+        let breakdown = &result.error_breakdown;
+
+        // Defensive: errors reported without a category breakdown are treated
+        // as internal failures (fail-safe → exit 3), matching the classify()
+        // safety net for genuinely unknown errors.
+        if breakdown.is_empty() {
+            return Err(CrawlError::Internal(format!(
+                "crawl completed with {} error(s)",
+                result.errors
+            )));
+        }
+
+        // A genuinely-internal category means a real bug. Mixed batches are
+        // dominated by the worst severity, so any such category escalates to
+        // exit 3 (matches `scraper_failure_for_internal_fatal` in the CLI).
+        let has_internal_bug = [
+            CrawlErrorCategory::Internal,
+            CrawlErrorCategory::Extraction,
+            CrawlErrorCategory::Panic,
+        ]
+        .iter()
+        .any(|c| breakdown.get(c).copied().unwrap_or(0) > 0);
+        if has_internal_bug {
+            return Err(CrawlError::Internal(format!(
+                "crawl completed with {} error(s)",
+                result.errors
+            )));
+        }
+
+        // Purely transient/external: surface as a transient error → exit 69.
+        // A timeout is the most common batch failure here.
+        if breakdown
+            .get(&CrawlErrorCategory::Timeout)
+            .copied()
+            .unwrap_or(0)
+            > 0
+        {
+            return Err(CrawlError::Timeout);
+        }
+        return Err(CrawlError::Connection(format!(
+            "crawl completed with {} transient error(s)",
             result.errors
         )));
     }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -410,6 +410,14 @@ fn format_failure(url: &str, error: &crate::error::ScraperError, verbosity: u8) 
 /// Returns `None` if all pages scraped successfully (caller proceeds to export).
 /// At `verbosity` 0 only the top-level error message is shown; at 1+ the full
 /// root-cause chain is appended (see [`format_failure`]).
+///
+/// Severity routing (#537): when every URL failed AND at least one failure
+/// classifies as [`crate::error::ErrorClass::InternalFatal`], the exit code is
+/// `CliExit::ScraperFailure` (3) rather than `NetworkError` (69) — an internal
+/// bug must not masquerade as a transient network outage. Purely
+/// transient/permanent all-fail runs keep exit 69. The partial-success case
+/// always reports `PartialSuccess` (69) regardless of failure severity: some
+/// content was scraped, which is the dominant signal.
 fn report_phase(
     results: &[domain::ScrapedContent],
     failures: &[(String, crate::error::ScraperError)],
@@ -427,6 +435,9 @@ fn report_phase(
     }
 
     if results.is_empty() {
+        if let Some(exit) = scraper_failure_for_internal_fatal(failures) {
+            return Some(exit);
+        }
         eprintln!("No pages were successfully scraped");
         return Some(CliExit::NetworkError(
             "No pages were successfully scraped".into(),
@@ -435,6 +446,28 @@ fn report_phase(
 
     info!("Successfully scraped {} pages", results.len());
     None
+}
+
+/// Fold an all-failed error set into a severity-aware exit (#537).
+///
+/// Returns `Some(CliExit::ScraperFailure(..))` when at least one failure
+/// classifies as [`crate::error::ErrorClass::InternalFatal`], with a message
+/// that calls out the internal-fatal count. Returns `None` when every failure
+/// is transient/permanent — the caller then keeps its historical
+/// `CliExit::NetworkError` arm.
+fn scraper_failure_for_internal_fatal(
+    failures: &[(String, crate::error::ScraperError)],
+) -> Option<CliExit> {
+    let internal_fatal = failures
+        .iter()
+        .filter(|(_, e)| e.classify() == crate::error::ErrorClass::InternalFatal)
+        .count();
+    (internal_fatal > 0).then(|| {
+        CliExit::ScraperFailure(format!(
+            "Scraper failure: {internal_fatal} internal error(s) out of {} URLs",
+            failures.len()
+        ))
+    })
 }
 
 /// Run batch processing mode: crawl multiple URLs from stdin or file
@@ -515,12 +548,26 @@ async fn run_batch(opts: CrawlOptions) -> CliExit {
         error!(%url, error = %err, "Batch URL failed");
     }
 
-    batch_exit_code(summary.succeeded, summary.failed)
+    batch_exit_code(summary.succeeded, summary.failed, &summary.errors)
 }
 
 /// Determine the CLI exit code from batch scrape results.
-fn batch_exit_code(succeeded: usize, failed: usize) -> CliExit {
+///
+/// Severity routing (#537): an all-failed batch containing at least one
+/// [`crate::error::ErrorClass::InternalFatal`] error yields
+/// `CliExit::ScraperFailure` (3); purely transient/permanent all-fail runs
+/// keep `CliExit::NetworkError` (69). Partial success remains
+/// `CliExit::PartialSuccess` (69) regardless of failure severity — some
+/// content was scraped, which is the dominant signal.
+fn batch_exit_code(
+    succeeded: usize,
+    failed: usize,
+    errors: &[(String, crate::error::ScraperError)],
+) -> CliExit {
     if failed > 0 && succeeded == 0 {
+        if let Some(exit) = scraper_failure_for_internal_fatal(errors) {
+            return exit;
+        }
         CliExit::NetworkError("All batch URLs failed".into())
     } else if failed > 0 {
         CliExit::PartialSuccess {
@@ -695,18 +742,42 @@ mod tests {
 
     // ===== batch_exit_code tests =====
 
+    fn internal_err(msg: &str) -> crate::error::ScraperError {
+        crate::error::ScraperError::Internal(msg.to_string())
+    }
+
+    fn http_err(status: u16, url: &str) -> crate::error::ScraperError {
+        crate::error::ScraperError::http(status, url)
+    }
+
     #[test]
     fn batch_all_fail_returns_network_error() {
-        let exit = batch_exit_code(0, 5);
+        let errors: Vec<(String, crate::error::ScraperError)> = (0..5)
+            .map(|i| (format!("https://x{i}.com"), http_err(404, "https://x{i}.com")))
+            .collect();
+        let exit = batch_exit_code(0, 5, &errors);
         assert!(
             matches!(exit, CliExit::NetworkError(_)),
-            "Expected NetworkError when all URLs failed, got: {exit:?}"
+            "Expected NetworkError when all URLs failed with non-internal errors, got: {exit:?}"
+        );
+    }
+
+    #[test]
+    fn batch_all_fail_with_internal_fatal_returns_scraper_failure() {
+        let errors: Vec<(String, crate::error::ScraperError)> = vec![
+            ("https://a.com".to_string(), http_err(404, "https://a.com")),
+            ("https://b.com".to_string(), internal_err("bug")),
+        ];
+        let exit = batch_exit_code(0, 2, &errors);
+        assert!(
+            matches!(exit, CliExit::ScraperFailure(_)),
+            "Expected ScraperFailure when any failure classifies InternalFatal, got: {exit:?}"
         );
     }
 
     #[test]
     fn batch_all_succeed_returns_success() {
-        let exit = batch_exit_code(10, 0);
+        let exit = batch_exit_code(10, 0, &[]);
         assert!(
             matches!(exit, CliExit::Success),
             "Expected Success when all URLs succeed, got: {exit:?}"
@@ -715,7 +786,10 @@ mod tests {
 
     #[test]
     fn batch_partial_success_returns_partial() {
-        let exit = batch_exit_code(3, 2);
+        let errors: Vec<(String, crate::error::ScraperError)> = (0..2)
+            .map(|i| (format!("https://x{i}.com"), http_err(500, "https://x{i}.com")))
+            .collect();
+        let exit = batch_exit_code(3, 2, &errors);
         match exit {
             CliExit::PartialSuccess { success, failed } => {
                 assert_eq!(success, 3, "success count mismatch");

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -753,7 +753,12 @@ mod tests {
     #[test]
     fn batch_all_fail_returns_network_error() {
         let errors: Vec<(String, crate::error::ScraperError)> = (0..5)
-            .map(|i| (format!("https://x{i}.com"), http_err(404, "https://x{i}.com")))
+            .map(|i| {
+                (
+                    format!("https://x{i}.com"),
+                    http_err(404, "https://x{i}.com"),
+                )
+            })
             .collect();
         let exit = batch_exit_code(0, 5, &errors);
         assert!(
@@ -787,7 +792,12 @@ mod tests {
     #[test]
     fn batch_partial_success_returns_partial() {
         let errors: Vec<(String, crate::error::ScraperError)> = (0..2)
-            .map(|i| (format!("https://x{i}.com"), http_err(500, "https://x{i}.com")))
+            .map(|i| {
+                (
+                    format!("https://x{i}.com"),
+                    http_err(500, "https://x{i}.com"),
+                )
+            })
             .collect();
         let exit = batch_exit_code(3, 2, &errors);
         match exit {

--- a/crates/webfang_core/src/error.rs
+++ b/crates/webfang_core/src/error.rs
@@ -440,34 +440,106 @@ impl ScraperError {
 ///
 /// This is a heuristic — `io::ErrorKind` is the primary signal,
 /// but some wreq errors may also be transient.
+///
+/// #537: the io-kind list and the text fallback were extended so common
+/// "service unavailable" network failures (`ConnectionRefused`,
+/// `HostUnreachable`, `NetworkUnreachable`, `AddrNotAvailable`, wreq
+/// connect/DNS wrappers) classify as [`ErrorClass::TransientRetriable`]
+/// instead of falling through to `InternalFatal` and masquerading as a bug.
+///
+/// The heuristic walks the FULL `Error::source()` chain: infrastructure
+/// layers wrap transport errors several deep (e.g. `DownloadError::Network`
+/// boxing a `wreq::Error` boxing an `io::Error`), so inspecting only the
+/// top-level error misses the typed kind and the transport text.
 fn is_transient_network(e: &(dyn std::error::Error + 'static)) -> bool {
-    if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
-        return matches!(
-            io_err.kind(),
-            std::io::ErrorKind::ConnectionReset
-                | std::io::ErrorKind::ConnectionAborted
-                | std::io::ErrorKind::TimedOut
-                | std::io::ErrorKind::Interrupted
-                | std::io::ErrorKind::BrokenPipe
-        );
-    }
-    if e.downcast_ref::<WreqError>().is_some() {
-        let msg = e.to_string().to_ascii_lowercase();
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(e);
+    while let Some(err) = current {
+        if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
+            return matches!(
+                io_err.kind(),
+                std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::ConnectionAborted
+                    | std::io::ErrorKind::ConnectionRefused
+                    | std::io::ErrorKind::HostUnreachable
+                    | std::io::ErrorKind::NetworkUnreachable
+                    | std::io::ErrorKind::AddrNotAvailable
+                    | std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::Interrupted
+                    | std::io::ErrorKind::BrokenPipe
+            );
+        }
+        // Text fallback runs for every link, not just `WreqError`: wrappers
+        // (`DownloadError::Network`, `CrawlError::Network`'s flattened text)
+        // commonly erase the concrete type before reaching this function.
+        let msg = err.to_string().to_ascii_lowercase();
         let matched = msg.contains("timeout")
             || msg.contains("timed out")
             || msg.contains("connection refused")
             || msg.contains("connection reset")
             || msg.contains("broken pipe")
-            || msg.contains("connection aborted");
+            || msg.contains("connection aborted")
+            || msg.contains("client error (connect)")
+            || msg.contains("dns error")
+            || msg.contains("dns lookup failed")
+            || msg.contains("could not resolve")
+            || msg.contains("failed to lookup address");
         if matched {
             tracing::debug!(
-                error = %e,
-                "is_transient_network: classified transient via wreq text-fallback heuristic"
+                error = %err,
+                "is_transient_network: classified transient via source-chain text heuristic"
             );
+            return true;
         }
-        return matched;
+        current = err.source();
     }
     false
+}
+
+/// Map a `CrawlError::Network` message to a synthetic `io::Error` with the
+/// kind that best matches the transport failure (#537).
+///
+/// `CrawlError::Network` has already crossed the infrastructure → domain
+/// boundary and lost its typed source; all that survives is a `String`
+/// message. Re-deriving the io kind from that message text lets
+/// `is_transient_network` (which downcasts on `io::Error` FIRST and never
+/// reaches the text fallback for an io-typed boxed error) classify it
+/// correctly. Unknown transport text conservatively maps to
+/// `ErrorKind::Other`, which is NOT in the transient list and so falls back
+/// to `InternalFatal` — preserving the safety net for genuinely unknown
+/// internal failures.
+fn io_error_for_network_message(message: &str) -> std::io::Error {
+    let msg = message.to_ascii_lowercase();
+    let kind = if msg.contains("connection refused")
+        || msg.contains("client error (connect)")
+        || msg.contains("connect error")
+    {
+        std::io::ErrorKind::ConnectionRefused
+    } else if msg.contains("host unreachable") {
+        std::io::ErrorKind::HostUnreachable
+    } else if msg.contains("network unreachable") {
+        std::io::ErrorKind::NetworkUnreachable
+    } else if msg.contains("dns error")
+        || msg.contains("dns lookup failed")
+        || msg.contains("could not resolve")
+        || msg.contains("failed to lookup address")
+        || msg.contains("name or service not known")
+    {
+        // DNS failure: the service is unreachable — still a transport outage,
+        // not a bug. AddrNotAvailable is the closest stable io kind in the
+        // transient list.
+        std::io::ErrorKind::AddrNotAvailable
+    } else if msg.contains("timeout") || msg.contains("timed out") {
+        std::io::ErrorKind::TimedOut
+    } else if msg.contains("connection reset") {
+        std::io::ErrorKind::ConnectionReset
+    } else if msg.contains("connection aborted") {
+        std::io::ErrorKind::ConnectionAborted
+    } else if msg.contains("broken pipe") {
+        std::io::ErrorKind::BrokenPipe
+    } else {
+        std::io::ErrorKind::Other
+    };
+    std::io::Error::new(kind, message.to_string())
 }
 
 /// Operational classification of errors for observability and retry logic.
@@ -512,7 +584,13 @@ impl From<crate::domain::error::CrawlError> for ScraperError {
                         url: message,
                     }
                 } else {
-                    ScraperError::Internal(format!("network: {message}"))
+                    // #537: do NOT flatten transport failures to Internal —
+                    // that bypasses `is_transient_network` and masquerades a
+                    // service outage (connect refused, DNS, timeout) as a bug.
+                    // Wrap the message in a synthetic `io::Error` whose kind
+                    // is sniffed from the transport text so `classify()` can
+                    // route to TransientRetriable when appropriate.
+                    ScraperError::Network(Box::new(io_error_for_network_message(&message)))
                 }
             },
             CrawlError::Http { status, url } => ScraperError::Http { status, url },
@@ -1357,6 +1435,121 @@ mod tests {
             "broken pipe",
         )));
         assert_eq!(err.classify(), ErrorClass::TransientRetriable);
+    }
+
+    // ========================================================================
+    // #537: service-unavailable transport errors must not classify as bugs
+    // ========================================================================
+
+    #[test]
+    fn test_is_transient_network_connection_refused_io() {
+        let err = ScraperError::Download(Box::new(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "refused",
+        )));
+        assert_eq!(
+            err.classify(),
+            ErrorClass::TransientRetriable,
+            "io ConnectionRefused → TransientRetriable (service unavailable, EX_UNAVAILABLE)"
+        );
+    }
+
+    #[test]
+    fn test_is_transient_network_unreachable_io_kinds() {
+        for kind in [
+            std::io::ErrorKind::HostUnreachable,
+            std::io::ErrorKind::NetworkUnreachable,
+            std::io::ErrorKind::AddrNotAvailable,
+        ] {
+            let err = ScraperError::Network(Box::new(std::io::Error::new(kind, "unreachable")));
+            assert_eq!(
+                err.classify(),
+                ErrorClass::TransientRetriable,
+                "io {kind:?} → TransientRetriable (#537)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_transient_network_wreq_connect_wrapper_text() {
+        // wreq wraps connect failures as "…: client error (Connect)". The io
+        // source is NOT the boxed outer error, so the io downcast misses and
+        // the text fallback at `is_transient_network` must catch it (#537).
+        let io_src = std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "error sending request for uri (http://127.0.0.1:1/): client error (Connect)",
+        );
+        let err = ScraperError::Download(Box::new(io_src));
+        assert_eq!(
+            err.classify(),
+            ErrorClass::TransientRetriable,
+            "connect-style io error must classify TransientRetriable (#537)"
+        );
+    }
+
+    #[test]
+    fn test_is_transient_network_walks_source_chain() {
+        // Production chain (#537): `ScraperError::Network(Box<DownloadError>)`
+        // → `DownloadError::Network`'s `#[source]` → `wreq::Error`. Walking
+        // `Error::source()` must reach a transient io link even though the
+        // boxed outer error is neither io nor wreq-typed.
+        #[derive(Debug)]
+        struct Wrapper(&'static str, Option<std::io::Error>);
+        impl std::fmt::Display for Wrapper {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.0)
+            }
+        }
+        impl std::error::Error for Wrapper {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                self.1.as_ref().map(|e| e as _)
+            }
+        }
+
+        let io_leaf = std::io::Error::new(std::io::ErrorKind::TimedOut, "request timeout");
+        let wrapper = Wrapper("download failed", Some(io_leaf));
+        let err = ScraperError::Network(Box::new(wrapper));
+        assert_eq!(
+            err.classify(),
+            ErrorClass::TransientRetriable,
+            "source-chain walk must surface the transient io leaf (#537)"
+        );
+
+        // Text fallback through the same chain (non-io leaf carrying wreq text).
+        #[derive(Debug)]
+        struct TextLeaf;
+        impl std::fmt::Display for TextLeaf {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("client error (Connect)")
+            }
+        }
+        impl std::error::Error for TextLeaf {}
+        #[derive(Debug)]
+        struct TextWrapper(&'static str);
+        impl std::fmt::Display for TextWrapper {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.0)
+            }
+        }
+        impl std::error::Error for TextWrapper {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&TextLeaf)
+            }
+        }
+        let err = ScraperError::Network(Box::new(TextWrapper("network error")));
+        assert_eq!(
+            err.classify(),
+            ErrorClass::TransientRetriable,
+            "source-chain text fallback must catch wreq connect wrapper (#537)"
+        );
+    }
+
+    #[test]
+    fn test_classify_non_network_nonwreq_still_internal() {
+        // Safety net stays: a non-io, non-wreq-scoped error keeps falling
+        // through to InternalFatal (genuine bug bucket).
+        let err = ScraperError::Internal("unreachable state".into());
+        assert_eq!(err.classify(), ErrorClass::InternalFatal);
     }
 
     // ========================================================================

--- a/crates/webfang_core/tests/crawl_error_exit_codes.rs
+++ b/crates/webfang_core/tests/crawl_error_exit_codes.rs
@@ -94,11 +94,7 @@ fn scraper_failure_for_internal_fatal(failures: &[(String, ScraperError)]) -> Op
 }
 
 /// Mirror of `batch_exit_code` (see `cli/orchestrator.rs`).
-fn batch_exit_code(
-    succeeded: usize,
-    failed: usize,
-    errors: &[(String, ScraperError)],
-) -> CliExit {
+fn batch_exit_code(succeeded: usize, failed: usize, errors: &[(String, ScraperError)]) -> CliExit {
     if failed > 0 && succeeded == 0 {
         if let Some(exit) = scraper_failure_for_internal_fatal(errors) {
             return exit;
@@ -347,7 +343,10 @@ fn scraper_failure_exit_code_3_is_reached_by_internal_fatal_not_by_transient() {
     assert_eq!(exit.report(), ExitCode::from(EXIT_SCRAPER_FAILURE));
 
     // And a purely transient all-fail set must NOT route to exit 3.
-    let transient = vec![failing("https://x.com", ScraperError::http(503, "https://x.com"))];
+    let transient = vec![failing(
+        "https://x.com",
+        ScraperError::http(503, "https://x.com"),
+    )];
     assert_eq!(
         transient[0].1.classify(),
         ErrorClass::TransientRetriable,

--- a/crates/webfang_core/tests/crawl_error_exit_codes.rs
+++ b/crates/webfang_core/tests/crawl_error_exit_codes.rs
@@ -1,40 +1,43 @@
-//! End-to-end exit-code contract for `CrawlError` flattening (#508).
+//! End-to-end exit-code contract for `CrawlError` flattening (#508) and
+//! severity-aware exit routing (#537).
 //!
 //! The unit tests in `crates/webfang_core/src/error.rs::tests` already prove
 //! that each of the 8 flattening arms preserves the category prefix + payload
-//! when converting `CrawlError` into `ScraperError::Internal`. This integration
+//! when converting `CrawlError` into a `ScraperError` variant. This integration
 //! test goes one level further: it asserts the contract that the *user* cares
 //! about — the documented exit code.
 //!
 //! The CLI's exit code path is:
 //!
-//! 1. `CrawlError::Variant` → `ScraperError::Internal(prefix: msg)` via
-//!    `impl From<CrawlError> for ScraperError` (error.rs:501-569).
-//! 2. `ScraperError` is collected as a `(url, error)` failure tuple by
+//! 1. `CrawlError::Variant` → `ScraperError` via
+//!    `impl From<CrawlError> for ScraperError` (error.rs:~501-569).
+//! 2. The `ScraperError` is collected as a `(url, error)` failure tuple by
 //!    `scrape_phase` / `run_batch`.
-//! 3. `report_phase` (cli/orchestrator.rs:413) and `batch_exit_code`
-//!    (cli/orchestrator.rs:522) fold the failure tuple into one of the
-//!    `CliExit` variants in `cli/error.rs`.
+//! 3. `report_phase` (cli/orchestrator.rs) and `batch_exit_code`
+//!    (cli/orchestrator.rs) fold the failure tuple into one of the `CliExit`
+//!    variants in `cli/error.rs`.
 //! 4. `impl Termination for CliExit` (cli/error.rs:149) maps each `CliExit`
 //!    variant to the documented `EXIT_*` constant.
 //!
-//! **Documented gap (#508, captured here, not fabricated):** There is no
-//! `ScraperError -> CliExit` *direct* mapping. Every `ScraperError` produced
-//! by the 8 flattening arms reaches the CLI as a generic failure inside the
-//! `failures: &[(String, ScraperError)]` slice. The orchestrator then routes
-//! the slice through `report_phase` / `batch_exit_code`, which decide the
-//! `CliExit` based on the *counts* of successes vs. failures, not on the
-//! per-URL error variant. Concretely:
+//! **Severity contract (#537):** exit-code routing is severity-aware. When a
+//! run produces zero successes, the failure set is aggregated by
+//! `ScraperError::classify()`:
 //!
-//! - 0 successes, N failures → `CliExit::NetworkError(_)` → `EXIT_UNAVAILABLE` (69).
-//! - some successes, some failures → `CliExit::PartialSuccess { .. }` → `EXIT_UNAVAILABLE` (69).
-//! - all successes, 0 failures → `CliExit::Success` → `EXIT_SUCCESS` (0).
+//! - Any `ErrorClass::InternalFatal` → `CliExit::ScraperFailure(_)` →
+//!   `EXIT_SCRAPER_FAILURE` (3). Internal bugs must not masquerade as
+//!   transient network outages.
+//! - Only `TransientRetriable` / `TransientBackoff` / `PermanentFatal` →
+//!   `CliExit::NetworkError(_)` → `EXIT_UNAVAILABLE` (69).
 //!
-//! This test pins that contract via a faithful in-process reproduction of
-//! `report_phase` so the assertion does not depend on a mock HTTP server or
-//! a live binary spawn. The same exit-code constants come from
-//! `cli::error::EXIT_*`, so a future refactor that adds a per-variant
-//! `ScraperError -> CliExit` mapping will be visible in this test.
+//! The partial-success case (at least one URL scraped) stays exit 69
+//! regardless of severity: some content was scraped, which is the dominant
+//! signal.
+//!
+//! This test pins that contract via faithful in-process mirrors of
+//! `report_phase` / `batch_exit_code` so the assertion does not depend on a
+//! mock HTTP server or a live binary spawn. The exit-code constants come from
+//! `cli::error::EXIT_*`, so a future refactor of severity routing will be
+//! visible here.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -44,15 +47,18 @@ use webfang_core::cli::error::{
     CliExit, EXIT_EMPTY_DISCOVERY, EXIT_SCRAPER_FAILURE, EXIT_SUCCESS, EXIT_UNAVAILABLE,
 };
 use webfang_core::domain::error::CrawlError;
+use webfang_core::error::ErrorClass;
 use webfang_core::ScraperError;
 
 /// Faithful in-process mirror of `report_phase`
-/// (`crates/webfang_core/src/cli/orchestrator.rs:413`).
+/// (`crates/webfang_core/src/cli/orchestrator.rs`).
 ///
 /// Kept here — not imported — so the test does not couple to a private helper
-/// and can document the exact routing the production code performs.
-fn report_phase(results_len: usize, failures_len: usize) -> Option<CliExit> {
-    if !results_len == 0 && failures_len == 0 {
+/// and can document the exact routing the production code performs. Mirrors
+/// the current severity-aware production behavior (#537).
+fn report_phase(results_len: usize, failures: &[(String, ScraperError)]) -> Option<CliExit> {
+    let failures_len = failures.len();
+    if results_len > 0 && failures_len == 0 {
         // unreachable in this test: included for symmetry with the prod body
         return None;
     }
@@ -63,6 +69,9 @@ fn report_phase(results_len: usize, failures_len: usize) -> Option<CliExit> {
         });
     }
     if results_len == 0 {
+        if let Some(exit) = scraper_failure_for_internal_fatal(failures) {
+            return Some(exit);
+        }
         return Some(CliExit::NetworkError(
             "No pages were successfully scraped".into(),
         ));
@@ -70,10 +79,30 @@ fn report_phase(results_len: usize, failures_len: usize) -> Option<CliExit> {
     None
 }
 
-/// Same as `report_phase` but for batch mode (see
-/// `crates/webfang_core/src/cli/orchestrator.rs:522`).
-fn batch_exit_code(succeeded: usize, failed: usize) -> CliExit {
+/// Mirror of `scraper_failure_for_internal_fatal` in the orchestrator.
+fn scraper_failure_for_internal_fatal(failures: &[(String, ScraperError)]) -> Option<CliExit> {
+    let internal_fatal = failures
+        .iter()
+        .filter(|(_, e)| e.classify() == ErrorClass::InternalFatal)
+        .count();
+    (internal_fatal > 0).then(|| {
+        CliExit::ScraperFailure(format!(
+            "Scraper failure: {internal_fatal} internal error(s) out of {} URLs",
+            failures.len()
+        ))
+    })
+}
+
+/// Mirror of `batch_exit_code` (see `cli/orchestrator.rs`).
+fn batch_exit_code(
+    succeeded: usize,
+    failed: usize,
+    errors: &[(String, ScraperError)],
+) -> CliExit {
     if failed > 0 && succeeded == 0 {
+        if let Some(exit) = scraper_failure_for_internal_fatal(errors) {
+            return exit;
+        }
         CliExit::NetworkError("All batch URLs failed".into())
     } else if failed > 0 {
         CliExit::PartialSuccess {
@@ -97,50 +126,56 @@ fn flatten_to_internal(crawl: CrawlError) -> ScraperError {
     scraper
 }
 
+/// Wrap a `ScraperError` into a `(url, error)` failure tuple as the
+/// orchestrator collects them.
+fn failing(url: &str, err: ScraperError) -> (String, ScraperError) {
+    (url.to_string(), err)
+}
+
 #[test]
 fn crawl_error_parse_propagates_to_exit_69_when_all_fail() {
     // Arrange: 1 URL scraped, every request yields CrawlError::Parse.
+    // CrawlError::Parse flattens to ScraperError::Internal → InternalFatal
+    // (#537) so this MUST route to ScraperFailure / exit 3, not 69.
     let scraper = flatten_to_internal(CrawlError::Parse("html5 failed".into()));
-    // Touch the scraper error to ensure its Display chain is reachable
-    // even though the exit-code routing only needs the count.
     let rendered = scraper.to_string();
     assert!(
         rendered.contains("parse") && rendered.contains("html5 failed"),
         "scraper Display must keep the category + msg, got: {rendered}"
     );
 
-    // Act: the report_phase path with 0 successes + 1 failure.
-    let exit = report_phase(0, 1).expect("all-fail path returns Some(_)");
+    // Act: the report_phase path with 0 successes + 1 InternalFatal failure.
+    let failures = vec![failing("https://x.com", scraper)];
+    let exit = report_phase(0, &failures).expect("all-fail path returns Some(_)");
 
-    // Assert: documented exit code is EXIT_UNAVAILABLE (69).
+    // Assert (#537): InternalFatal aggregates to ScraperFailure → EXIT_SCRAPER_FAILURE (3).
     assert_eq!(
         exit.report(),
-        ExitCode::from(EXIT_UNAVAILABLE),
-        "all-fail Internal → CliExit::NetworkError → EXIT_UNAVAILABLE (69)"
+        ExitCode::from(EXIT_SCRAPER_FAILURE),
+        "all-fail Internal (InternalFatal) → CliExit::ScraperFailure → EXIT_SCRAPER_FAILURE (3)"
     );
-    // Reconstruct the expected variant from the documented routing (no
-    // per-variant mapping exists for Internal — see module-level docs).
-    let exit = report_phase(0, 1).expect("all-fail path returns Some(_)");
+    let exit = report_phase(0, &failures).expect("all-fail path returns Some(_)");
     assert!(
-        matches!(exit, CliExit::NetworkError(_)),
-        "expected CliExit::NetworkError, got: {exit:?}"
+        matches!(exit, CliExit::ScraperFailure(_)),
+        "expected CliExit::ScraperFailure, got: {exit:?}"
     );
 }
 
 #[test]
-fn crawl_error_storage_propagates_to_exit_69_when_all_fail() {
+fn crawl_error_storage_propagates_to_exit_3_when_all_fail() {
     let scraper = flatten_to_internal(CrawlError::Storage("disk full".into()));
     let rendered = scraper.to_string();
     assert!(
         rendered.contains("storage") && rendered.contains("disk full"),
         "got: {rendered}"
     );
-    let exit = report_phase(0, 1).expect("all-fail path returns Some(_)");
-    assert_eq!(exit.report(), ExitCode::from(EXIT_UNAVAILABLE));
+    let failures = vec![failing("https://x.com", scraper)];
+    let exit = report_phase(0, &failures).expect("all-fail path returns Some(_)");
+    assert_eq!(exit.report(), ExitCode::from(EXIT_SCRAPER_FAILURE));
 }
 
 #[test]
-fn crawl_error_invalid_content_type_propagates_to_exit_69_when_all_fail() {
+fn crawl_error_invalid_content_type_propagates_to_exit_3_when_all_fail() {
     let scraper = flatten_to_internal(CrawlError::InvalidContentType(
         "application/x-binary".into(),
     ));
@@ -149,44 +184,45 @@ fn crawl_error_invalid_content_type_propagates_to_exit_69_when_all_fail() {
         rendered.contains("content type") && rendered.contains("application/x-binary"),
         "got: {rendered}"
     );
-    let exit = report_phase(0, 1).expect("all-fail path returns Some(_)");
-    assert_eq!(exit.report(), ExitCode::from(EXIT_UNAVAILABLE));
+    let failures = vec![failing("https://x.com", scraper)];
+    let exit = report_phase(0, &failures).expect("all-fail path returns Some(_)");
+    assert_eq!(exit.report(), ExitCode::from(EXIT_SCRAPER_FAILURE));
 }
 
 #[test]
-fn crawl_error_url_excluded_propagates_to_exit_69_when_all_fail() {
+fn crawl_error_url_excluded_propagates_to_exit_3_when_all_fail() {
     let scraper = flatten_to_internal(CrawlError::UrlExcluded("https://spam.com".into()));
     let rendered = scraper.to_string();
     assert!(
         rendered.contains("excluded") && rendered.contains("https://spam.com"),
         "got: {rendered}"
     );
-    let exit = report_phase(0, 1).expect("all-fail path returns Some(_)");
-    assert_eq!(exit.report(), ExitCode::from(EXIT_UNAVAILABLE));
+    let failures = vec![failing("https://x.com", scraper)];
+    let exit = report_phase(0, &failures).expect("all-fail path returns Some(_)");
+    assert_eq!(exit.report(), ExitCode::from(EXIT_SCRAPER_FAILURE));
 }
 
 #[test]
 fn crawl_error_internal_with_mixed_results_maps_to_exit_69_partial_success() {
-    // 2 successes, 1 failure (Internal). report_phase returns
-    // PartialSuccess { 2, 1 } → EXIT_UNAVAILABLE (69). This pins the
-    // contract: a single Internal-flattened failure does NOT escalate to a
-    // distinct exit code; partial success and all-fail share exit 69.
+    // 2 successes, 1 failure (Internal → InternalFatal). report_phase returns
+    // PartialSuccess { 2, 1 } → EXIT_UNAVAILABLE (69). This pins the #537
+    // tradeoff: when at least one URL was scraped, the partial signal
+    // dominates and severity does NOT escalate to exit 3.
     let scraper = flatten_to_internal(CrawlError::Discovery("robots.txt 403".into()));
     let rendered = scraper.to_string();
     assert!(
         rendered.contains("discovery") && rendered.contains("robots.txt 403"),
         "got: {rendered}"
     );
-    let exit = report_phase(2, 1).expect("partial path returns Some(_)");
+    let failures = vec![failing("https://x.com", scraper)];
+    let exit = report_phase(2, &failures).expect("partial path returns Some(_)");
     let code = exit.report();
     assert_eq!(
         code,
         ExitCode::from(EXIT_UNAVAILABLE),
-        "PartialSuccess with Internal failures → EXIT_UNAVAILABLE (69)"
+        "PartialSuccess → EXIT_UNAVAILABLE (69) even with InternalFatal failures (#537 tradeoff)"
     );
-    // The exit was consumed by `report()`, so reconstruct the expected variant
-    // from the documented routing (no per-variant mapping exists for Internal).
-    let reconstructed = report_phase(2, 1).expect("partial path returns Some(_)");
+    let reconstructed = report_phase(2, &failures).expect("partial path returns Some(_)");
     match reconstructed {
         CliExit::PartialSuccess { success, failed } => {
             assert_eq!(success, 2);
@@ -197,9 +233,9 @@ fn crawl_error_internal_with_mixed_results_maps_to_exit_69_partial_success() {
 }
 
 #[test]
-fn batch_mode_all_internal_failures_maps_to_exit_69() {
-    // Same 8 Internal-flattened variants, but exercised through batch_exit_code.
-    // This is the path `webfang --batch ...` takes.
+fn batch_mode_all_internal_failures_maps_to_exit_3() {
+    // The 8 Internal-flattened variants classify InternalFatal → severity
+    // routing (#537) upgrades the all-fail batch to exit 3.
     let variants = [
         CrawlError::Parse("html5 failed".into()),
         CrawlError::Storage("disk full".into()),
@@ -213,21 +249,73 @@ fn batch_mode_all_internal_failures_maps_to_exit_69() {
         CrawlError::UrlExcluded("https://spam.com".into()),
         CrawlError::InvalidContentType("application/x-binary".into()),
     ];
-    // Exercise each variant through the From impl (consume) to prove the
-    // 8 arms all flatten correctly, then count the failures for the batch
-    // exit-code path.
-    let count = variants.len();
-    let mut last_scraper = None;
-    for crawl in variants {
-        last_scraper = Some(flatten_to_internal(crawl));
-    }
-    let _ = last_scraper; // The last variant's flattened error is enough to keep.
-    let exit = batch_exit_code(0, count);
+    let errors: Vec<(String, ScraperError)> = variants
+        .into_iter()
+        .enumerate()
+        .map(|(i, crawl)| failing(&format!("https://x{i}.com"), flatten_to_internal(crawl)))
+        .collect();
+    let count = errors.len();
+    let exit = batch_exit_code(0, count, &errors);
+    assert_eq!(
+        exit.report(),
+        ExitCode::from(EXIT_SCRAPER_FAILURE),
+        "batch all-fail with InternalFatal → CliExit::ScraperFailure → EXIT_SCRAPER_FAILURE (3)"
+    );
+}
+
+#[test]
+fn batch_mode_mixed_transient_failures_stay_at_exit_69() {
+    // Mixed transient failures — 429 (TransientBackoff) + a transient Network
+    // io::TimedOut (TransientRetriable) — contain NO InternalFatal, so the
+    // all-fail batch must keep exit 69 (#537 first-three-bucket rule).
+    let transient_network = ScraperError::Network(Box::new(std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "request timeout",
+    )));
+    assert_eq!(
+        transient_network.classify(),
+        ErrorClass::TransientRetriable,
+        "TimedOut source must classify transient"
+    );
+    let errors = vec![
+        failing("https://a.com", ScraperError::http(429, "https://a.com")),
+        failing("https://b.com", transient_network),
+    ];
+    let exit = batch_exit_code(0, errors.len(), &errors);
+    assert!(
+        matches!(exit, CliExit::NetworkError(_)),
+        "mixed transient failures must route to NetworkError, got: {exit:?}"
+    );
     assert_eq!(
         exit.report(),
         ExitCode::from(EXIT_UNAVAILABLE),
-        "batch all-fail → CliExit::NetworkError → EXIT_UNAVAILABLE (69)"
+        "mixed transient failures → EXIT_UNAVAILABLE (69), not 3"
     );
+}
+
+#[test]
+fn batch_mode_permanent_plus_internal_fatal_escalates_to_exit_3() {
+    // A single InternalFatal in an all-fail batch upgrades to exit 3 even when
+    // mixed with PermanentFatal errors: InternalFatal wins (#537).
+    let errors = vec![
+        failing("https://a.com", ScraperError::http(404, "https://a.com")),
+        failing(
+            "https://b.com",
+            ScraperError::Internal("bug: unreachable state".into()),
+        ),
+    ];
+    assert_eq!(
+        errors[0].1.classify(),
+        ErrorClass::PermanentFatal,
+        "404 must be PermanentFatal"
+    );
+    assert_eq!(errors[1].1.classify(), ErrorClass::InternalFatal);
+    let exit = batch_exit_code(0, errors.len(), &errors);
+    assert!(
+        matches!(exit, CliExit::ScraperFailure(_)),
+        "PermanentFatal + InternalFatal → ScraperFailure, got: {exit:?}"
+    );
+    assert_eq!(exit.report(), ExitCode::from(EXIT_SCRAPER_FAILURE));
 }
 
 #[test]
@@ -243,18 +331,32 @@ fn documented_exit_code_constants_remain_stable() {
 }
 
 #[test]
-fn scraper_failure_exit_code_3_is_its_own_variant_not_collateral_of_internal() {
-    // `CliExit::ScraperFailure` (exit 3) is reserved for the all-scrapers-failed
-    // orchestrator path and is NOT produced by the 8 Internal-flattened arms
-    // (they all fold into CliExit::NetworkError via report_phase / batch_exit_code).
-    // Pinning this prevents a future refactor from accidentally routing Internal
-    // failures into exit 3.
+fn scraper_failure_exit_code_3_is_reached_by_internal_fatal_not_by_transient() {
+    // Inverted guard (#537): exit 3 is the DOCUMENTED destination for an
+    // InternalFatal failure set. An Internal-flattened `CrawlError`
+    // classifies InternalFatal, so the all-fail path MUST route to
+    // `CliExit::ScraperFailure` / `EXIT_SCRAPER_FAILURE` (3) — not
+    // `EXIT_UNAVAILABLE`.
     let scraper = flatten_to_internal(CrawlError::Parse("html5 failed".into()));
-    let _ = scraper;
-    let exit = report_phase(0, 1).expect("all-fail path returns Some(_)");
+    let failures = vec![failing("https://x.com", scraper)];
+    let exit = report_phase(0, &failures).expect("all-fail path returns Some(_)");
+    assert!(
+        matches!(exit, CliExit::ScraperFailure(_)),
+        "InternalFatal all-fail must route to CliExit::ScraperFailure, got: {exit:?}"
+    );
+    assert_eq!(exit.report(), ExitCode::from(EXIT_SCRAPER_FAILURE));
+
+    // And a purely transient all-fail set must NOT route to exit 3.
+    let transient = vec![failing("https://x.com", ScraperError::http(503, "https://x.com"))];
+    assert_eq!(
+        transient[0].1.classify(),
+        ErrorClass::TransientRetriable,
+        "5xx must be TransientRetriable"
+    );
+    let exit = report_phase(0, &transient).expect("all-fail path returns Some(_)");
     assert!(
         !matches!(exit, CliExit::ScraperFailure(_)),
-        "Internal-flattened failures must NOT route to CliExit::ScraperFailure (exit 3), got: {exit:?}"
+        "purely transient failures must NOT reach ScraperFailure (exit 3), got: {exit:?}"
     );
     assert_eq!(exit.report(), ExitCode::from(EXIT_UNAVAILABLE));
 }


### PR DESCRIPTION
Closes #537

## Summary
- **Fase 1 (commits previos):** `report_phase` / `batch_exit_code` now route an all-fail run containing any `ErrorClass::InternalFatal` to `CliExit::ScraperFailure` (exit 3) instead of the count-based exit 69 — a real engine bug no longer masquerades as a transient network outage. Batch summaries preserve `ScraperError` variants so severity can be aggregated.
- **Fase 2 (este PR):** the severity routing was unusable because `ScraperError::classify()` lumped every non-transient `Network`/`Download` into `InternalFatal`, so genuine transient failures (connection refused, DNS, timeout) were being misrouted to exit 3, breaking 6 behavioral tests that assert exit 69.
  - `error.rs`: `is_transient_network` now walks the full `Error::source()` chain and classifies `ConnectionRefused` / `HostUnreachable` / `NetworkUnreachable` / `AddrNotAvailable` + wreq connect/DNS text as `TransientRetriable`. `CrawlError::Network` maps to `ScraperError::Network` (not flattened to `Internal`).
  - `application/batch/processor.rs`: `process_single_url` no longer collapses every failed crawl into `CrawlError::Internal`; it inspects `CrawlResult.error_breakdown` and surfaces transient categories (timeout/network/http/rate-limit/waf) as transient errors → exit 69, while genuine internal categories (storage/checkpoint/parse/panic) stay `Internal` → exit 3.

## Verification
- `cargo clippy -p webfang_core -- -D warnings` clean
- `cargo fmt` clean
- `cargo nextest run -p webfang_core --test behavioral --test cli_binary_test --test crawl_error_exit_codes --test exit_code_integration`: 105 passed, 1 skipped
- `cargo nextest run -p webfang_core --lib application::batch cli::error::tests cli::orchestrator::tests`: 64 passed
- The 6 behavioral tests that asserted exit 69 for transient failures (`unreachable_host_*`, `slow_server_timeout_*`, `batch_file_timeout_*`, `test_single_page_custom_timeout_*`) now pass.