### PR TITLE
refactor(test): Test Suite Audit #239 remediation — deterministic, observable tests

### DIFF
--- a/crates/webfang_ai/tests/ai_integration.rs
+++ b/crates/webfang_ai/tests/ai_integration.rs
@@ -317,42 +317,50 @@ fn test_matryoshka_identity_for_384d() {
 // Full RAG Pipeline Integration Tests (require cached model)
 // ============================================================================
 
+/// Builds an offline-mode semantic cleaner from the default config.
+///
+/// The default config resolves the model from the local cache at
+/// `~/.cache/webfang/ai_models`. The cleaner is `.expect()`ed to initialize so
+/// that an absent model makes the test FAIL LOUDLY rather than silently
+/// passing. These pipeline tests are `#[ignore]`'d (see below), so they are
+/// excluded from default runs and never count as green; run them explicitly
+/// with `--ignored` only when the model cache is populated.
+async fn build_offline_cleaner() -> SemanticCleanerImpl {
+    let config = ModelConfig::default().with_offline_mode(true);
+    SemanticCleanerImpl::new(config)
+        .await
+        .expect("cached ONNX model required: run with --ignored only when ~/.cache/webfang/ai_models is populated")
+}
+
 /// Test full pipeline: HTML -> Chunk -> Tokenize -> Embed -> Score -> Filter
 ///
 /// This test verifies the complete RAG pipeline integration.
-/// Skips if model is not cached to avoid network dependency.
+/// Ignored by default because it requires the cached ONNX model.
 #[tokio::test]
 #[ignore = "requires cached ONNX model"]
 async fn test_semantic_cleaner_full_pipeline() {
-    let config = ModelConfig::default().with_offline_mode(true);
-    let cleaner = SemanticCleanerImpl::new(config).await;
+    let cleaner = build_offline_cleaner().await;
 
-    if let Ok(cleaner) = cleaner {
-        let html = "<article><p>Hello world. Test content for semantic cleaning.</p></article>";
-        let chunks = cleaner.clean(html).await;
+    let html = "<article><p>Hello world. Test content for semantic cleaning.</p></article>";
+    let chunks = cleaner.clean(html).await;
 
-        assert!(
-            chunks.is_ok(),
-            "Pipeline should succeed: {:?}",
-            chunks.err()
-        );
+    assert!(
+        chunks.is_ok(),
+        "Pipeline should succeed: {:?}",
+        chunks.err()
+    );
 
-        let chunks = chunks.unwrap();
-        eprintln!("Generated {} chunks", chunks.len());
-    } else {
-        eprintln!("SKIP: cleaner creation failed");
-    }
+    let chunks = chunks.unwrap();
+    eprintln!("Generated {} chunks", chunks.len());
 }
 
 /// Test semantic cleaner with longer content
 #[tokio::test]
 #[ignore = "requires cached ONNX model"]
 async fn test_semantic_cleaner_long_content() {
-    let config = ModelConfig::default().with_offline_mode(true);
-    let cleaner = SemanticCleanerImpl::new(config).await;
+    let cleaner = build_offline_cleaner().await;
 
-    if let Ok(cleaner) = cleaner {
-        let html = r#"
+    let html = r#"
             <article>
                 <h1>Test Article</h1>
                 <p>This is a comprehensive test article with multiple paragraphs.
@@ -371,19 +379,16 @@ async fn test_semantic_cleaner_long_content() {
             </article>
         "#;
 
-        let chunks = cleaner.clean(html).await;
+    let chunks = cleaner.clean(html).await;
 
-        assert!(
-            chunks.is_ok(),
-            "Pipeline should succeed: {:?}",
-            chunks.err()
-        );
+    assert!(
+        chunks.is_ok(),
+        "Pipeline should succeed: {:?}",
+        chunks.err()
+    );
 
-        let chunks = chunks.unwrap();
-        eprintln!("Generated {} chunks from long content", chunks.len());
-    } else {
-        eprintln!("SKIP: cleaner creation failed");
-    }
+    let chunks = chunks.unwrap();
+    eprintln!("Generated {} chunks from long content", chunks.len());
 }
 
 /// Test concurrent embedding generation

--- a/crates/webfang_core/src/application/rate_limiter.rs
+++ b/crates/webfang_core/src/application/rate_limiter.rs
@@ -137,7 +137,6 @@ mod tests {
     // ============================================================================
 
     #[tokio::test]
-    #[ignore = "timing-sensitive: run with cargo test -- --ignored"]
     async fn test_rate_limiter_until_ready_spreads_over_time() {
         // Test que N tasks concurrentes llamando until_ready() son espaciadas
         // Config: delay_ms=50ms, concurrency=1
@@ -174,7 +173,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "timing-sensitive: run with cargo test -- --ignored"]
+    #[ignore = "governor uses QuantaClock (real time), not injectable with domain::clock::MockClock; \
+                this test asserts elapsed < 50ms (upper-bound real-time) which flakes under CI load. \
+                Deterministic parallelism is covered by test_rate_limiting_burst_protection."]
     async fn test_rate_limiter_burst_allows_parallel_requests() {
         // Test que burst de N requests ocurren en paralelo
         // Config: delay_ms=100ms, concurrency=5
@@ -208,7 +209,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "timing-sensitive: run with cargo test -- --ignored"]
     async fn test_rate_limiter_concurrent_backpressure() {
         // Test que 20 tasks concurrentes no colapsan — se encolan correctamente
         let config = RateLimiterConfig::new(10, 1); // 10ms, burst=1

--- a/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
@@ -363,11 +363,38 @@ impl Downloader for WreqDownloader {
 }
 
 #[cfg(test)]
-#[cfg(not(miri))] // wreq uses boring-sys2 FFI (unsupported by Miri)
-mod tests {
+mod test_support {
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Mount a `GET /` mock returning `body` (200), then fetch it via a fresh
+    /// `WreqDownloader` and assert the basics (ok, status 200, body matches).
+    /// Returns the fetched `FetchedPage` so callers can add extra assertions.
+    pub(super) async fn fetch_mock_get(body: &str) -> FetchedPage {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&mock_server)
+            .await;
+
+        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
+        let url: Url = mock_server.uri().parse().unwrap();
+
+        let result = downloader.fetch(&url).await;
+        assert!(result.is_ok());
+        let page = result.unwrap();
+        assert_eq!(page.status, 200);
+        assert_eq!(page.html, body);
+        page
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(miri))] // wreq uses boring-sys2 FFI (unsupported by Miri)
+mod tests {
+    use super::*;
 
     #[test]
     fn test_wreq_downloader_creation() {
@@ -448,24 +475,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_uses_mock_server() {
-        let mock_server = MockServer::start().await;
         let expected_body = "<html><body><h1>mock</h1></body></html>";
-
-        Mock::given(method("GET"))
-            .and(path("/"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(expected_body))
-            .mount(&mock_server)
-            .await;
-
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
-        let url: Url = mock_server.uri().parse().unwrap();
-
-        let result = downloader.fetch(&url).await;
-        assert!(result.is_ok());
-
-        let page = result.unwrap();
-        assert_eq!(page.status, 200);
-        assert_eq!(page.html, expected_body);
+        super::test_support::fetch_mock_get(expected_body).await;
     }
 }
 
@@ -478,23 +489,8 @@ mod wiremock_tests {
 
     #[tokio::test]
     async fn test_fetch_200_returns_body() {
-        let mock_server = MockServer::start().await;
         let expected_body = "<html><body>Hello World</body></html>";
-
-        Mock::given(method("GET"))
-            .and(path("/"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(expected_body))
-            .mount(&mock_server)
-            .await;
-
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
-        let url: Url = mock_server.uri().parse().unwrap();
-
-        let result = downloader.fetch(&url).await;
-        assert!(result.is_ok());
-
-        let page = result.unwrap();
-        assert_eq!(page.status, 200);
+        let page = super::test_support::fetch_mock_get(expected_body).await;
         assert_eq!(page.html, expected_body);
     }
 

--- a/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
@@ -366,6 +366,8 @@ impl Downloader for WreqDownloader {
 #[cfg(not(miri))] // wreq uses boring-sys2 FFI (unsupported by Miri)
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_wreq_downloader_creation() {
@@ -445,18 +447,25 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires network — wiremock tests below cover same scenario"]
-    async fn test_fetch_example_com() {
+    async fn test_fetch_uses_mock_server() {
+        let mock_server = MockServer::start().await;
+        let expected_body = "<html><body><h1>mock</h1></body></html>";
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(expected_body))
+            .mount(&mock_server)
+            .await;
+
         let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
-        let url: Url = "https://example.com".parse().unwrap();
+        let url: Url = mock_server.uri().parse().unwrap();
 
         let result = downloader.fetch(&url).await;
         assert!(result.is_ok());
 
         let page = result.unwrap();
         assert_eq!(page.status, 200);
-        assert!(!page.html.is_empty());
-        assert!(page.html.contains("Example Domain"));
+        assert_eq!(page.html, expected_body);
     }
 }
 

--- a/crates/webfang_core/src/infrastructure/scraper/readability.rs
+++ b/crates/webfang_core/src/infrastructure/scraper/readability.rs
@@ -99,24 +99,21 @@ mod tests {
             </html>
         "#;
 
-        let result = parse(html, Some("https://example.com"));
-        // Legible parsing is heuristic - accept either Ok or Err,
-        // but if Ok, verify the article has meaningful content
-        match result {
-            Ok(article) => {
-                assert!(
-                    !article.title.is_empty() || !article.text_content.is_empty(),
-                    "article should have title or text content"
-                );
-            },
-            Err(e) => {
-                // Heuristic parser may fail on this structure - that's acceptable
-                assert!(
-                    e.to_string().contains("Readability failed"),
-                    "unexpected error: {e}"
-                );
-            },
-        }
+        // The fixture is a well-formed article with a clear <h1> title and a
+        // substantial body, so legible is expected to extract content rather
+        // than fail. Assert the concrete Ok outcome and validate the extracted
+        // fields instead of accepting either variant.
+        let article = parse(html, Some("https://example.com"))
+            .expect("legible should extract content from a well-formed article fixture");
+        assert_eq!(article.title, "Article Title");
+        assert!(
+            article.text_content.contains("main content of the article"),
+            "extracted text should contain the article body"
+        );
+        assert!(
+            article.text_content.contains("By John Doe"),
+            "byline text in <address> should be present in the extracted content"
+        );
     }
 
     #[test]

--- a/crates/webfang_core/tests/downloader_headers_test.rs
+++ b/crates/webfang_core/tests/downloader_headers_test.rs
@@ -29,8 +29,10 @@ async fn wreq_downloader_populates_response_headers() {
         .mount(&server)
         .await;
 
-    let downloader = WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
-        .expect("downloader builds");
+    let downloader: Box<dyn Downloader> = Box::new(
+        WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
+            .expect("downloader builds"),
+    );
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 
     let page = downloader
@@ -71,8 +73,10 @@ async fn wreq_downloader_headers_keys_are_lowercased() {
         .mount(&server)
         .await;
 
-    let downloader = WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
-        .expect("downloader builds");
+    let downloader: Box<dyn Downloader> = Box::new(
+        WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
+            .expect("downloader builds"),
+    );
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 
     let page = downloader.fetch(&url).await.expect("fetch should succeed");

--- a/crates/webfang_core/tests/headless_tui_fallback.rs
+++ b/crates/webfang_core/tests/headless_tui_fallback.rs
@@ -7,16 +7,19 @@
 
 #![cfg(not(feature = "ui"))]
 
+#[path = "common/cli_harness.rs"]
+mod common;
+
 use assert_cmd::Command;
+use common::webfang_path;
 
 /// Expected Spanish message (spec S2.2 exact wording).
 const EXPECTED_MSG: &str = "TUI no disponible: compilar con --features ui";
 
 fn webfang_core() -> Command {
-    Command::cargo_bin("webfang_core").expect("webfang_core binary must be built for this test")
+    Command::new(webfang_path())
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn tui_flag_prints_spanish_message_when_ui_off() {
     let output = webfang_core()
@@ -40,7 +43,6 @@ fn tui_flag_prints_spanish_message_when_ui_off() {
     );
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn config_tui_flag_prints_spanish_message_when_ui_off() {
     let output = webfang_core()
@@ -64,7 +66,6 @@ fn config_tui_flag_prints_spanish_message_when_ui_off() {
     );
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn interactive_flag_prints_spanish_message_when_ui_off() {
     let output = webfang_core()

--- a/crates/webfang_core/tests/obsidian_mock_test.rs
+++ b/crates/webfang_core/tests/obsidian_mock_test.rs
@@ -5,7 +5,6 @@ mod common;
 
 use common::MockVault;
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn mock_vault_path_exists() {
     let vault = MockVault::new();
@@ -13,7 +12,6 @@ fn mock_vault_path_exists() {
     assert!(vault.path().is_dir(), "vault path should be a directory");
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn mock_vault_has_obsidian_directory() {
     let vault = MockVault::new();
@@ -22,7 +20,6 @@ fn mock_vault_has_obsidian_directory() {
     assert!(obsidian_dir.is_dir(), ".obsidian/ should be a directory");
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn mock_vault_has_obsidian_json() {
     let vault = MockVault::new();
@@ -40,7 +37,6 @@ fn mock_vault_has_obsidian_json() {
     assert!(vault_obj["fsPath"].is_string(), "fsPath should be a string");
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn mock_vault_has_workspace_json() {
     let vault = MockVault::new();
@@ -48,7 +44,6 @@ fn mock_vault_has_workspace_json() {
     assert!(ws_path.exists(), "workspace.json should exist");
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn mock_vault_has_test_note() {
     let vault = MockVault::new();
@@ -63,7 +58,6 @@ fn mock_vault_has_test_note() {
     assert!(content.contains("# Test Note"), "note should have heading");
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn mock_vault_is_recognized_as_vault() {
     let vault = MockVault::new();
@@ -73,7 +67,6 @@ fn mock_vault_is_recognized_as_vault() {
     );
 }
 
-#[ignore = "resurrected: pending triage"]
 #[test]
 fn mock_vault_metadata_json_content() {
     let vault = MockVault::new();

--- a/crates/webfang_core/tests/orchestrator_unit_tests.rs
+++ b/crates/webfang_core/tests/orchestrator_unit_tests.rs
@@ -14,7 +14,6 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 // ===========================================================================
 
 /// Sitemap served by wiremock is parsed and URLs are extracted.
-#[ignore = "resurrected: pending triage"]
 #[tokio::test]
 async fn sitemap_valid_xml_discovers_urls() {
     let mock = MockServer::start().await;
@@ -46,7 +45,6 @@ async fn sitemap_valid_xml_discovers_urls() {
 }
 
 /// Malformed sitemap XML returns an error gracefully.
-#[ignore = "resurrected: pending triage"]
 #[tokio::test]
 async fn sitemap_malformed_xml_returns_error() {
     let mock = MockServer::start().await;
@@ -70,7 +68,6 @@ async fn sitemap_malformed_xml_returns_error() {
 }
 
 /// Large sitemap (200 URLs) is parsed without error.
-#[ignore = "resurrected: pending triage"]
 #[tokio::test]
 async fn sitemap_large_sitemap_parses_all_urls() {
     let mock = MockServer::start().await;
@@ -104,7 +101,6 @@ async fn sitemap_large_sitemap_parses_all_urls() {
 }
 
 /// Empty sitemap returns NoUrlsFound error.
-#[ignore = "resurrected: pending triage"]
 #[tokio::test]
 async fn sitemap_empty_returns_no_urls_found() {
     let mock = MockServer::start().await;
@@ -137,7 +133,6 @@ async fn sitemap_empty_returns_no_urls_found() {
 }
 
 /// Sitemap with duplicate URLs is deduplicated.
-#[ignore = "resurrected: pending triage"]
 #[tokio::test]
 async fn sitemap_deduplicates_urls() {
     let mock = MockServer::start().await;

--- a/crates/webfang_core/tests/session_pool_integration.rs
+++ b/crates/webfang_core/tests/session_pool_integration.rs
@@ -5,9 +5,9 @@
 
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use webfang_core::domain::clock::SystemClock;
+use webfang_core::domain::clock::{MockClock, SystemClock};
 use webfang_core::{DomainSessionPool, SessionId, SessionManager, SessionPoolConfig};
 
 // ===== ACQUIRE / RELEASE CYCLE =====
@@ -129,7 +129,10 @@ fn test_banned_session_recovers_after_cooldown() {
         max_exp: 1,
         ..Default::default()
     };
-    let pool = DomainSessionPool::new(config, Arc::new(SystemClock));
+    // Inject a controllable clock so the cooldown is simulated deterministically
+    // instead of relying on real wall-clock time (no flaky thread::sleep).
+    let clock = MockClock::new(Instant::now());
+    let pool = DomainSessionPool::new(config, clock.handle());
 
     let id = pool.acquire("example.com").expect("should acquire");
     pool.report_failure("example.com", id, 429);
@@ -137,12 +140,8 @@ fn test_banned_session_recovers_after_cooldown() {
     // Immediately: banned
     assert!(pool.acquire("example.com").is_none());
 
-    // NOTE: This sleep is intentionally kept — the pool uses SystemClock and
-    // there's no FakeClock injection point in SessionPoolConfig. Eliminating
-    // this requires injecting a clock abstraction (trait object or feature-gated
-    // clock), which is a design change beyond this refactor scope.
-    // Wait past cooldown (2^1 * 1ms = 2ms)
-    thread::sleep(Duration::from_millis(50));
+    // Advance the clock past the cooldown (2^1 * 1ms = 2ms)
+    clock.advance(Duration::from_millis(100));
 
     assert!(
         pool.acquire("example.com").is_some(),

--- a/crates/webfang_mcp/tests/obsidian_tools_test.rs
+++ b/crates/webfang_mcp/tests/obsidian_tools_test.rs
@@ -158,6 +158,18 @@ fn is_tool_error(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
+/// Control-character rejection is signaled by `isError:true` on the tool
+/// result, NOT by the user-facing error message (may change). The handler
+/// returns `Ok(CallToolResult::error(...))` — a tool-level error with no
+/// `code` (see crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs).
+fn assert_control_chars_rejected(result: &Value) {
+    assert!(
+        is_tool_error(result),
+        "control chars must yield isError:true, got: {}",
+        tool_text(result)
+    );
+}
+
 /// A relative temporary directory that deletes itself on drop.
 ///
 /// `tempfile::TempDir` always returns an absolute path (it joins with
@@ -302,16 +314,7 @@ async fn test_build_obsidian_uri_rejects_control_chars() {
         .unwrap_or_else(|| panic!("expected result, got: {resp}"))
         .clone();
 
-    assert!(
-        is_tool_error(&result),
-        "control chars must yield isError:true, got: {}",
-        tool_text(&result)
-    );
-    // Rejection is signaled by `isError:true` on the tool result, NOT by the
-    // Spanish error message (user-facing text, may change). No JSON-RPC
-    // `error.code` is produced here: the handler returns
-    // `Ok(CallToolResult::error(...))` (crates/webfang_mcp/src/mcp_server/
-    // handlers/obsidian.rs), a tool-level error that carries no `code` field.
+    assert_control_chars_rejected(&result);
 }
 
 // ============================================================================
@@ -381,11 +384,7 @@ async fn test_open_in_obsidian_control_chars_validation_error() {
         .unwrap_or_else(|| panic!("expected result, got: {resp}"))
         .clone();
 
-    assert!(
-        is_tool_error(&result),
-        "control chars must yield isError:true, got: {}",
-        tool_text(&result)
-    );
+    assert_control_chars_rejected(&result);
     // Rejection is signaled by `isError:true`, NOT the Spanish error message
     // (user-facing text, may change). The handler returns
     // `Ok(CallToolResult::error(...))` — a tool-level error with no `code`.

--- a/crates/webfang_mcp/tests/obsidian_tools_test.rs
+++ b/crates/webfang_mcp/tests/obsidian_tools_test.rs
@@ -307,11 +307,11 @@ async fn test_build_obsidian_uri_rejects_control_chars() {
         "control chars must yield isError:true, got: {}",
         tool_text(&result)
     );
-    let text = tool_text(&result);
-    assert!(
-        text.contains("caracteres de control no permitidos"),
-        "Spanish control-char error expected, got: {text}"
-    );
+    // Rejection is signaled by `isError:true` on the tool result, NOT by the
+    // Spanish error message (user-facing text, may change). No JSON-RPC
+    // `error.code` is produced here: the handler returns
+    // `Ok(CallToolResult::error(...))` (crates/webfang_mcp/src/mcp_server/
+    // handlers/obsidian.rs), a tool-level error that carries no `code` field.
 }
 
 // ============================================================================
@@ -386,11 +386,10 @@ async fn test_open_in_obsidian_control_chars_validation_error() {
         "control chars must yield isError:true, got: {}",
         tool_text(&result)
     );
+    // Rejection is signaled by `isError:true`, NOT the Spanish error message
+    // (user-facing text, may change). The handler returns
+    // `Ok(CallToolResult::error(...))` — a tool-level error with no `code`.
     let text = tool_text(&result);
-    assert!(
-        text.contains("caracteres de control no permitidos"),
-        "Spanish control-char error expected, got: {text}"
-    );
     assert!(
         !text.contains("Opened in Obsidian"),
         "no real app launch may be reported, got: {text}"

--- a/crates/webfang_mcp/tests/security_tools_test.rs
+++ b/crates/webfang_mcp/tests/security_tools_test.rs
@@ -307,6 +307,12 @@ async fn test_verify_waf_integrity_t1_challenge_blocks_degraded() {
         "verify_waf_integrity should succeed: {}",
         tool_text(&result)
     );
+    // The block verdict is reported as a SUCCESS result (isError:false) whose
+    // content begins with the stable ENGLISH prefix "WAF blocked:" (see
+    // crates/webfang_mcp/src/mcp_server/handlers/security.rs). No JSON-RPC
+    // `error.code` is produced on this path — the handler returns
+    // `Ok(CallToolResult::success(...))` — so we assert on the stable prefix
+    // rather than any localized message text.
     assert!(
         tool_text(&result).starts_with("WAF blocked:"),
         "T1 challenge must block, got: {}",
@@ -344,6 +350,12 @@ async fn test_verify_waf_integrity_t2_with_waf_status_blocks() {
         "verify_waf_integrity should succeed: {}",
         tool_text(&result)
     );
+    // The block verdict is reported as a SUCCESS result (isError:false) whose
+    // content begins with the stable ENGLISH prefix "WAF blocked:" (see
+    // crates/webfang_mcp/src/mcp_server/handlers/security.rs). No JSON-RPC
+    // `error.code` is produced on this path — the handler returns
+    // `Ok(CallToolResult::success(...))` — so we assert on the stable prefix
+    // rather than any localized message text.
     assert!(
         tool_text(&result).starts_with("WAF blocked:"),
         "T2 fingerprint + WAF status 403 must block, got: {}",

--- a/crates/webfang_mcp/tests/security_tools_test.rs
+++ b/crates/webfang_mcp/tests/security_tools_test.rs
@@ -152,6 +152,25 @@ fn is_tool_error(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
+/// Assert a WAF block verdict: the tool succeeds (`isError:false`) and its
+/// content begins with the stable ENGLISH prefix "WAF blocked:" (see
+/// crates/webfang_mcp/src/mcp_server/handlers/security.rs). No JSON-RPC
+/// `error.code` is produced on this path — the handler returns
+/// `Ok(CallToolResult::success(...))` — so we assert on the stable prefix
+/// rather than any localized message text. `label` disambiguates the call site.
+fn assert_waf_blocked(result: &Value, label: &str) {
+    assert!(
+        !is_tool_error(result),
+        "verify_waf_integrity should succeed: {}",
+        tool_text(result)
+    );
+    assert!(
+        tool_text(result).starts_with("WAF blocked:"),
+        "{label}, got: {}",
+        tool_text(result)
+    );
+}
+
 // ============================================================================
 // detect_waf — degraded mode (no HTTP context)
 // ============================================================================
@@ -302,22 +321,7 @@ async fn test_verify_waf_integrity_t1_challenge_blocks_degraded() {
         .unwrap_or_else(|| panic!("expected result, got: {resp}"))
         .clone();
 
-    assert!(
-        !is_tool_error(&result),
-        "verify_waf_integrity should succeed: {}",
-        tool_text(&result)
-    );
-    // The block verdict is reported as a SUCCESS result (isError:false) whose
-    // content begins with the stable ENGLISH prefix "WAF blocked:" (see
-    // crates/webfang_mcp/src/mcp_server/handlers/security.rs). No JSON-RPC
-    // `error.code` is produced on this path — the handler returns
-    // `Ok(CallToolResult::success(...))` — so we assert on the stable prefix
-    // rather than any localized message text.
-    assert!(
-        tool_text(&result).starts_with("WAF blocked:"),
-        "T1 challenge must block, got: {}",
-        tool_text(&result)
-    );
+    assert_waf_blocked(&result, "T1 challenge must block");
 }
 
 /// Additive context: a bare vendor fingerprint (T2) blocks when a correlated
@@ -345,22 +349,7 @@ async fn test_verify_waf_integrity_t2_with_waf_status_blocks() {
         .unwrap_or_else(|| panic!("expected result, got: {resp}"))
         .clone();
 
-    assert!(
-        !is_tool_error(&result),
-        "verify_waf_integrity should succeed: {}",
-        tool_text(&result)
-    );
-    // The block verdict is reported as a SUCCESS result (isError:false) whose
-    // content begins with the stable ENGLISH prefix "WAF blocked:" (see
-    // crates/webfang_mcp/src/mcp_server/handlers/security.rs). No JSON-RPC
-    // `error.code` is produced on this path — the handler returns
-    // `Ok(CallToolResult::success(...))` — so we assert on the stable prefix
-    // rather than any localized message text.
-    assert!(
-        tool_text(&result).starts_with("WAF blocked:"),
-        "T2 fingerprint + WAF status 403 must block, got: {}",
-        tool_text(&result)
-    );
+    assert_waf_blocked(&result, "T2 fingerprint + WAF status 403 must block");
 }
 
 /// Additive context: the SAME T2 body at an OK status (200) passes.


### PR DESCRIPTION
## Linked Issue

Closes #239

## PR Type

- [x] Code refactoring (`type:refactor`)

## Summary

- Remedia la Test Suite Audit (#239): elimina tests frágiles/no deterministas y aserciones sin sentido en la suite de `webfang_core` / `webfang_ai` / `webfang_mcp`.
- Inyecta `MockClock` para des-flakear tests de TTL/cooldown, reemplaza red real por wiremock, y hace observable la cobertura antes ignorada.
- Worktree `fix/test-audit`, 8 commits; todos los gates (`cargo clippy -- -D warnings`, `fmt`, `check`) limpios por crate.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/tests/session_pool_integration.rs` | Inyecta `MockClock`, elimina `thread::sleep` flaky (corría en CI). |
| `crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs` | `test_fetch_example_com` → wiremock, corre en CI default (sin red). |
| `crates/webfang_core/src/infrastructure/scraper/readability.rs` | Aserta `Ok(Article)` con título/contenido (fin de la tautología). |
| `crates/webfang_mcp/tests/security_tools_test.rs`, `obsidian_tools_test.rs` | Aserciones sobre señal estructural `is_tool_error` (sin texto de mensaje frágil). |
| `crates/webfang_core/src/application/rate_limiter.rs` | Des-ignora 2 tests TTL deterministas. |
| `crates/webfang_ai/tests/ai_integration.rs` | Builder compartido + `.expect()` (sin verde silencioso). |
| `crates/webfang_core/tests/downloader_headers_test.rs` | Test vía `Box<dyn Downloader>` (puerto público). |
| `crates/webfang_core/tests/headless_tui_fallback.rs`, `obsidian_mock_test.rs`, `orchestrator_unit_tests.rs` | Re-habilita 15 tests "resurrected"; corrige `webfang_path()`. |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` / `cargo nextest run` passes (verificado por crate en cada fix)
- [x] Manually verified: tests deterministas, sin red en CI default

## Contributor Checklist

- [x] Linked an issue with `Closes #239`
- [x] Added exactly one `type:*` label (`type:refactor`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (N/A — solo tests)

> Follow-ups fuera de scope trackeados en #545 (3 silent-skip en `ai_integration.rs`, ~5 MCP string-match restantes, `rate_limiter` burst determinista).
