### PR TITLE
ci(docs): mdbook-linkcheck from prebuilt release binary

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,16 +37,24 @@ jobs:
       - uses: actions/checkout@v4
 
       # rust-toolchain.toml pins 1.88.0; install it FIRST so cargo-based steps
-      # (mdbook-linkcheck, rustdoc) never race toolchain bootstrap with the
-      # runner's sccache rustc-wrapper.
+      # (rustdoc) never race toolchain bootstrap with the runner's sccache
+      # rustc-wrapper. mdbook-linkcheck comes from a prebuilt release binary.
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-docs
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install mdbook-linkcheck
-        run: cargo install mdbook-linkcheck --locked
+      # Prebuilt binary from the project release (v0.7.7) — seconds instead of
+      # ~1.6 min per run spent compiling from crates.io via `cargo install`.
+      - name: Install mdbook-linkcheck (prebuilt binary)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/mdbook-linkcheck.zip \
+            https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.7/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip
+          unzip -o /tmp/mdbook-linkcheck.zip -d "$HOME/.cargo/bin"
+          chmod +x "$HOME/.cargo/bin/mdbook-linkcheck"
+          mdbook-linkcheck --version
 
       - name: Install mise toolchain (mdbook + pandoc)
         uses: jdx/mise-action@v2
@@ -82,16 +90,24 @@ jobs:
       - uses: actions/checkout@v4
 
       # rust-toolchain.toml pins 1.88.0; install it FIRST so cargo-based steps
-      # (mdbook-linkcheck, rustdoc) never race toolchain bootstrap with the
-      # runner's sccache rustc-wrapper.
+      # (rustdoc) never race toolchain bootstrap with the runner's sccache
+      # rustc-wrapper. mdbook-linkcheck comes from a prebuilt release binary.
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-docs
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install mdbook-linkcheck
-        run: cargo install mdbook-linkcheck --locked
+      # Prebuilt binary from the project release (v0.7.7) — seconds instead of
+      # ~1.6 min per run spent compiling from crates.io via `cargo install`.
+      - name: Install mdbook-linkcheck (prebuilt binary)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/mdbook-linkcheck.zip \
+            https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.7/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip
+          unzip -o /tmp/mdbook-linkcheck.zip -d "$HOME/.cargo/bin"
+          chmod +x "$HOME/.cargo/bin/mdbook-linkcheck"
+          mdbook-linkcheck --version
 
       - name: Install mise toolchain (mdbook + pandoc)
         uses: jdx/mise-action@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -124,18 +124,19 @@ jobs:
         run: cargo doc --workspace --all-features --no-deps
 
       # Combine: rustdoc API lives under /api/<crate>/ on the published site.
+      # mdBook outputs straight into docs/book/ (no html/ subdir).
       - name: Combine rustdoc into mdBook site
         run: |
           set -euo pipefail
-          cp -r target/doc docs/book/html/api
-          touch docs/book/html/.nojekyll
+          cp -r target/doc docs/book/api
+          touch docs/book/.nojekyll
 
       # Build the NotebookLM / LLM markdown: narrative (SUMMARY order) +
       # rustdoc API (all 6 crates) converted via pandoc.
       - name: Build LLM markdown artifact
         run: |
           set -euo pipefail
-          OUT=docs/book/html/webfang-docs-llm.md
+          OUT=docs/book/webfang-docs-llm.md
           echo "# WebFang Documentation" > "$OUT"
           echo "" >> "$OUT"
           echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$OUT"
@@ -194,7 +195,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: webfang-docs-llm
-          path: docs/book/html/webfang-docs-llm.md
+          path: docs/book/webfang-docs-llm.md
           if-no-files-found: error
           retention-days: 30
 
@@ -202,7 +203,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book/html
+          publish_dir: ./docs/book
           publish_branch: gh-pages
           force_orphan: true
           user_name: 'github-actions[bot]'

--- a/mise.toml
+++ b/mise.toml
@@ -22,7 +22,6 @@ typos = "1.42.3"                       # spell checker (aqua shorthand, pinned f
 "cargo:cargo-udeps" = "latest"
 "aqua:rust-lang/mdBook" = "0.4.51"
 "aqua:jgm/pandoc" = "3.10.1"
-"cargo:mdbook-linkcheck" = "latest"
 
 # === Optional (uncomment when needed) ===
 # rust-analyzer = "latest"             # LSP — global install preferred


### PR DESCRIPTION
## Linked Issue

Closes #549

## PR Type

- [ ] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [x] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- `cargo install mdbook-linkcheck` recompiled the crate from crates.io on every docs CI run (~1.6 min).
- Now fetches the prebuilt v0.7.7 x86_64-linux binary from the project release in ~5s, in both `validate` and `deploy` jobs.
- Removes `cargo:mdbook-linkcheck` from `mise.toml` — nothing compiles it anymore.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/docs.yml` | `Install mdbook-linkcheck` step: curl the prebuilt release binary instead of `cargo install --locked` (both jobs) |
| `.github/workflows/docs.yml` | Fix deploy output path: mdBook renders into `docs/book/` (no `html/` subdir) — combine, artifact upload and gh-pages `publish_dir` now point at `docs/book/` (fixes first deploy failure) |
| `mise.toml` | Drop `cargo:mdbook-linkcheck` |

## Test Plan

- [x] YAML valid, both jobs structured correctly
- [ ] CI `Validate Docs` green with prebuilt-binary install path
- [ ] `mdbook-linkcheck --standalone docs` still runs

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed
- [x] Defensive error paths annotated with `// LCOV_EXCL_*` markers per docs/testing.md (issue #527)
