### PR TITLE
docs(pipeline): clean RAG markdown artifact incl. full source code

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -138,65 +138,101 @@ jobs:
           cp -r target/doc docs/book/api
           touch docs/book/.nojekyll
 
-      # Build the NotebookLM / LLM markdown: narrative (SUMMARY order) +
-      # rustdoc API (all 6 crates) converted via pandoc.
+      # Build the LLM / RAG markdown: clean text for a language model that needs
+      # the whole system. Single H1 (# WebFang Documentation) at the top; chapters,
+      # crate API sections, and source files are H3 under H2 parents so chunkers
+      # split cleanly. Three parts:
+      #   1. Narrative (mdBook chapters) — chapter H1 downgraded to H3, no dupes.
+      #   2. API reference (rustdoc via pandoc) — ALL noise stripped: <a>, "Expand
+      #      description", "§", "Copy item path", stray HTML tags, blank-line runs.
+      #   3. Full source code — crates/**/*.rs (production + per-crate tests) so
+      #      the model sees the implementation, not just signatures. (No root
+      #      `tests/` dir exists; integration tests live per-crate.)
+      # Output: docs/book/webfang-docs-llm.md → uploaded as `webfang-docs-llm`,
+      # consumed locally by `just docs`.
       - name: Build LLM markdown artifact
         run: |
           set -euo pipefail
           OUT=docs/book/webfang-docs-llm.md
-          echo "# WebFang Documentation" > "$OUT"
-          echo "" >> "$OUT"
-          echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$OUT"
-          echo "" >> "$OUT"
-          echo "---" >> "$OUT"
-          echo "" >> "$OUT"
+          {
+            echo "# WebFang Documentation"
+            echo
+            echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo
+            echo "---"
+            echo
+            echo "## Narrative Documentation"
+            echo
+            for f in overview debugging testing troubleshooting tui-unified-design; do
+              # Downgrade the chapter's leading "# Title" to "### Title" so the
+              # artifact has a single H1 (the doc title) and no duplicate headers.
+              sed '1s/^# /### /' "docs/src/$f.md"
+              echo
+              echo "---"
+              echo
+            done
 
-          echo "## Narrative Documentation" >> "$OUT"
-          echo "" >> "$OUT"
-          for entry in \
-            "overview:Overview" \
-            "debugging:Debugging & Observability" \
-            "testing:Testing" \
-            "troubleshooting:Troubleshooting" \
-            "tui-unified-design:TUI Unified Design"; do
-            f="${entry%%:*}"
-            title="${entry#*:}"
-            echo "# $title" >> "$OUT"
-            echo "" >> "$OUT"
-            cat "docs/src/$f.md" >> "$OUT"
-            echo "" >> "$OUT"
-            echo "---" >> "$OUT"
-            echo "" >> "$OUT"
-          done
-
-          echo "## API Reference (rustdoc)" >> "$OUT"
-          echo "" >> "$OUT"
-          for crate in webfang_core webfang_ai webfang_tui webfang_mcp webfang_cli webfang_test_utils; do
-            if [ -d "target/doc/$crate" ]; then
-              echo "# API: $crate" >> "$OUT"
-              echo "" >> "$OUT"
-              {
-                pandoc -f html -t gfm --wrap=none "target/doc/$crate/index.html" 2>/dev/null
-                find "target/doc/$crate" -name '*.html' ! -name 'index.html' ! -path '*/src/*' -print0 \
-                  | sort -z \
-                  | while IFS= read -r -d '' fl; do
-                    pandoc -f html -t gfm --wrap=none "$fl" 2>/dev/null
-                  done
-              } \
-              | sed -e 's/Copy item path//' \
-                    -e 's/<span[^>]*>//g' \
-                    -e 's/<\/span>//g' \
-                    -e 's/<div[^>]*>//g' \
-                    -e 's/<\/div>//g' \
-                    -e 's/Show [0-9][0-9]* fields[[:space:]]*//g' \
-                    -e 's/Show [0-9][0-9]* variants[[:space:]]*//g' \
+            echo "## API Reference (rustdoc)"
+            echo
+            for crate in webfang_core webfang_ai webfang_tui webfang_mcp webfang_cli webfang_test_utils; do
+              if [ -d "target/doc/$crate" ]; then
+                echo "### API: $crate"
+                echo
+                {
+                  pandoc -f html -t gfm --wrap=none "target/doc/$crate/index.html" 2>/dev/null
+                  find "target/doc/$crate" -name '*.html' ! -name 'index.html' ! -path '*/src/*' -print0 \
+                    | sort -z \
+                    | while IFS= read -r -d '' fl; do
+                        pandoc -f html -t gfm --wrap=none "$fl" 2>/dev/null
+                      done
+                } \
+                | sed -e 's/Copy item path//g' \
+                      -e 's/Expand description//g' \
+                      -e 's/§//g' \
+                      -e 's/<span[^>]*>//g' -e 's/<\/span>//g' \
+                      -e 's/<div[^>]*>//g' -e 's/<\/div>//g' \
+                      -e 's/<a [^>]*>//g' -e 's/<\/a>//g' \
+                      -e 's/<[^>]*>//g' \
+                      -e 's/Show [0-9][0-9]* fields[[:space:]]*//g' \
+                      -e 's/Show [0-9][0-9]* variants[[:space:]]*//g' \
+                      -e '/^[[:space:]]*$/N;/^\n[[:space:]]*$/D' \
                 > "target/doc/$crate.md"
-              cat "target/doc/$crate.md" >> "$OUT"
-              echo "" >> "$OUT"
-              echo "---" >> "$OUT"
-              echo "" >> "$OUT"
-            fi
-          done
+                # Gate ONLY the cleaned API markdown. The Source Code section below
+                # intentionally contains HTML inside Rust string/test/doc-comment
+                # literals (e.g. extractor/html_cleaner/link_extractor tests), so a
+                # whole-file grep would false-positive there.
+                if grep -q 'Expand description\|href="\|<a \|<span\|<div\|<abbr\|<code\|§' "target/doc/$crate.md"; then
+                  echo "::error::rustdoc noise not fully stripped for $crate"
+                  exit 1
+                fi
+                cat "target/doc/$crate.md"
+                echo
+                echo "---"
+                echo
+              fi
+            done
+
+            echo "## Source Code"
+            echo
+            # Every Rust source file in the workspace (production + per-crate tests),
+            # in a deterministic order so the artifact is reproducible. No root `tests/`
+            # dir exists; integration tests live under each crate. Files are emitted
+            # verbatim — they may contain HTML inside string/test/doc literals.
+            find crates -name '*.rs' -print0 \
+              | sort -z \
+              | while IFS= read -r -d '' fl; do
+                  echo "### \`$fl\`"
+                  echo
+                  echo '```rust'
+                  cat "$fl"
+                  echo '```'
+                  echo
+                  echo "---"
+                  echo
+                done
+          } > "$OUT"
+
+          echo "wrote $OUT ($(wc -l < "$OUT") lines)"
 
       # --- Native GitHub Pages deployment (2025+ "deploy from a workflow") ---
       # configure-pages@v5 enables/gathers the Pages site; upload-pages-artifact


### PR DESCRIPTION
Closes #558

Refactors the Build LLM markdown artifact step (option C, for RAG use):
- Narrative: chapter leading H1 downgraded to H3 → exactly one H1 (doc title); no duplicate headers.
- API (rustdoc): pandoc + sed now strips <a>, Expand description, §, Copy item path, stray HTML; a per-crate gate fails CI on residual rustdoc noise.
- Source Code: appends every crates/**/*.rs (production + per-crate tests) under per-file H3 headers so the artifact documents the whole system.
- Uses find crates only: no root tests/ dir exists (integration tests live per-crate).