### PR TITLE
fix(ai): resolve ONNX input mapping + elastic semaphore deadlock (#543 #544)

### DIFF
--- a/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
@@ -249,70 +249,7 @@ impl InferencePool {
             let handle = thread::Builder::new()
                 .name(format!("inference-worker-{worker_id}"))
                 .spawn(move || {
-                    // Build ONE session at startup — single-threaded
-                    let session_result = (|| -> Result<Session, SemanticError> {
-                        let mut builder = Session::builder().map_err(|e| {
-                            SemanticError::Inference(format!(
-                                "Failed to create ONNX session builder: {e}"
-                            ))
-                        })?;
-                        builder = builder
-                            .with_optimization_level(GraphOptimizationLevel::Level3)
-                            .map_err(|e| {
-                                SemanticError::Inference(format!(
-                                    "Failed to set optimization level: {e}"
-                                ))
-                            })?;
-                        builder = builder.with_intra_threads(1).map_err(|e| {
-                            SemanticError::Inference(format!("Failed to set intra threads: {e}"))
-                        })?;
-                        builder.commit_from_memory(&bytes).map_err(|e| {
-                            SemanticError::Inference(format!(
-                                "Failed to create ONNX session from memory: {e}"
-                            ))
-                        })
-                    })();
-
-                    let mut session = match session_result {
-                        Ok(s) => s,
-                        Err(e) => {
-                            error!(
-                                worker_id,
-                                error = %e,
-                                "Failed to build ONNX session"
-                            );
-                            // Drain channel so other workers aren't blocked
-                            while receiver.recv().is_ok() {}
-                            return;
-                        },
-                    };
-
-                    // Resolve the real input set ONCE (per worker), after the
-                    // session is built. This decouples feeding from the old
-                    // hardcoded 3-input assumption (#543).
-                    let plan = match InputPlan::from_session(&session) {
-                        Ok(plan) => plan,
-                        Err(e) => {
-                            error!(
-                                worker_id,
-                                error = %e,
-                                "Failed to resolve model input plan"
-                            );
-                            while receiver.recv().is_ok() {}
-                            return;
-                        },
-                    };
-
-                    debug!(worker_id, "Worker ready, waiting for requests");
-
-                    // Request loop
-                    while let Ok(request) = receiver.recv() {
-                        let result =
-                            run_session_inference(&mut session, &request.input, variant, &plan);
-                        let _ = request.reply_tx.send(result);
-                    }
-
-                    debug!(worker_id, "Worker exiting (channel disconnected)");
+                    worker_main(receiver, bytes, variant, worker_id);
                 })
                 .map_err(|e| {
                     SemanticError::Inference(format!("failed to spawn worker {worker_id}: {e}"))
@@ -404,6 +341,82 @@ impl Drop for InferencePool {
 
         info!(worker_count = self.worker_count, "InferencePool shut down");
     }
+}
+
+/// Builds a single-threaded ONNX session from model bytes in memory.
+fn build_session(bytes: &[u8]) -> Result<Session, SemanticError> {
+    let mut builder = Session::builder().map_err(|e| {
+        SemanticError::Inference(format!("Failed to create ONNX session builder: {e}"))
+    })?;
+    builder = builder
+        .with_optimization_level(GraphOptimizationLevel::Level3)
+        .map_err(|e| SemanticError::Inference(format!("Failed to set optimization level: {e}")))?;
+    builder = builder
+        .with_intra_threads(1)
+        .map_err(|e| SemanticError::Inference(format!("Failed to set intra threads: {e}")))?;
+    builder.commit_from_memory(bytes).map_err(|e| {
+        SemanticError::Inference(format!("Failed to create ONNX session from memory: {e}"))
+    })
+}
+
+/// Drains the request channel so a failed worker does not block its peers.
+fn drain_channel(receiver: &crossbeam_channel::Receiver<WorkerRequest>) {
+    while receiver.recv().is_ok() {}
+}
+
+/// Logs a worker startup failure (session build or input-plan resolution) and
+/// drains the channel so peers aren't blocked, then the caller returns.
+fn report_worker_failure(
+    receiver: &Arc<crossbeam_channel::Receiver<WorkerRequest>>,
+    worker_id: usize,
+    stage: &str,
+    e: &SemanticError,
+) {
+    error!(worker_id, error = %e, "{stage}");
+    drain_channel(receiver);
+}
+
+/// Entry point for one inference worker thread.
+///
+/// Builds the ONNX session, resolves the model input plan once, then serves
+/// requests from the channel until it disconnects. On a build/resolve failure
+/// it drains the channel (so peers aren't blocked) and exits.
+fn worker_main(
+    receiver: Arc<crossbeam_channel::Receiver<WorkerRequest>>,
+    bytes: Arc<Vec<u8>>,
+    variant: AiModel,
+    worker_id: usize,
+) {
+    let session_result = build_session(&bytes);
+    let mut session = match session_result {
+        Ok(s) => s,
+        Err(e) => {
+            report_worker_failure(&receiver, worker_id, "Failed to build ONNX session", &e);
+            return;
+        },
+    };
+
+    let plan = match InputPlan::from_session(&session) {
+        Ok(plan) => plan,
+        Err(e) => {
+            report_worker_failure(
+                &receiver,
+                worker_id,
+                "Failed to resolve model input plan",
+                &e,
+            );
+            return;
+        },
+    };
+
+    debug!(worker_id, "Worker ready, waiting for requests");
+
+    while let Ok(request) = receiver.recv() {
+        let result = run_session_inference(&mut session, &request.input, variant, &plan);
+        let _ = request.reply_tx.send(result);
+    }
+
+    debug!(worker_id, "Worker exiting (channel disconnected)");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/inference_engine.rs
@@ -5,7 +5,10 @@
 //! - Async inference via `spawn_blocking` (`async-spawn-blocking`)
 //! - Clone Arc before await (`async-clone-before-await`)
 //! - 384-dimensional embedding output for IBM Granite models
-//! - **3-input ONNX model**: input_ids, attention_mask, token_type_ids
+//! - **2 required ONNX inputs**: `input_ids` and `attention_mask`
+//! - **`token_type_ids` is OPTIONAL**: only sent when the model graph declares it
+//!   (ModernBert/Granite never declare it). The input set is resolved from the
+//!   graph at worker startup, not hardcoded (#543).
 //!
 //! # Design Decisions
 //!
@@ -28,12 +31,13 @@ use webfang_core::error::SemanticError;
 
 /// Input data for ONNX model inference
 ///
-/// The Granite embedding models require 3 input tensors:
+/// The Granite/ModernBert embedding models require 2 input tensors:
 /// 1. `input_ids` - Token IDs (vocab indices)
 /// 2. `attention_mask` - Which tokens are real (1) vs padding (0)
-/// 3. `token_type_ids` - Segment IDs (0 for single sentence)
 ///
-/// All vectors must have the same length (sequence length).
+/// `token_type_ids` is OPTIONAL and is only sent when the model graph declares
+/// it (forward-compat). All vectors must have the same length (sequence length).
+/// See [`InputPlan`] for how the actual input set is resolved from the graph.
 #[derive(Debug, Clone)]
 pub struct ModelInput {
     /// Token IDs (vocab indices)
@@ -95,6 +99,83 @@ impl ModelInput {
             attention_mask: vec![1i64; seq_len],
             token_type_ids: vec![0i64; seq_len],
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// InputPlan: resolve the real input set of the ONNX graph once per worker
+// ---------------------------------------------------------------------------
+
+/// Resolved ONNX input plan: the subset of inputs the model graph actually
+/// declares, in graph declaration order.
+///
+/// The Granite/ModernBert models only require `input_ids` and `attention_mask`.
+/// `token_type_ids` is OPTIONAL and is only fed when the graph declares it.
+/// Resolving the plan once at worker startup (instead of using a hardcoded
+/// 3-input assumption) is what fixes the `Invalid input name: token_type_ids`
+/// failure (#543): we never send an input the graph does not declare.
+#[derive(Debug, Clone)]
+pub struct InputPlan {
+    /// Owned input names in graph declaration order.
+    names: Vec<String>,
+}
+
+impl InputPlan {
+    /// Resolve a plan from the raw input names declared by the model graph.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SemanticError::Inference` if a required input (`input_ids` or
+    /// `attention_mask`) is missing, or if the graph declares an unsupported
+    /// input name (anything other than the three recognized tensors).
+    pub fn resolve(names: &[&str]) -> Result<Self, SemanticError> {
+        const REQUIRED: [&str; 2] = ["input_ids", "attention_mask"];
+        const KNOWN: [&str; 3] = ["input_ids", "attention_mask", "token_type_ids"];
+
+        let present: std::collections::HashSet<&str> = names.iter().copied().collect();
+        let missing: Vec<&str> = REQUIRED
+            .iter()
+            .copied()
+            .filter(|r| !present.contains(r))
+            .collect();
+        if !missing.is_empty() {
+            return Err(SemanticError::Inference(format!(
+                "missing required model inputs: {}",
+                missing.join(", ")
+            )));
+        }
+
+        for n in names {
+            if !KNOWN.contains(n) {
+                return Err(SemanticError::Inference(format!("unsupported input: {n}")));
+            }
+        }
+
+        Ok(Self {
+            names: names.iter().map(|n| n.to_string()).collect(),
+        })
+    }
+
+    /// Build a plan by introspecting a built `ort::Session`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`InputPlan::resolve`] errors when the graph's inputs do not
+    /// satisfy the required/known contract.
+    pub fn from_session(session: &Session) -> Result<Self, SemanticError> {
+        let owned: Vec<String> = session
+            .inputs()
+            .iter()
+            .map(|o| o.name().to_string())
+            .collect();
+        let borrowed: Vec<&str> = owned.iter().map(String::as_str).collect();
+        Self::resolve(&borrowed)
+    }
+
+    /// Input names in graph declaration order.
+    #[must_use]
+    pub fn names(&self) -> &[String] {
+        &self.names
     }
 }
 
@@ -206,11 +287,28 @@ impl InferencePool {
                         },
                     };
 
+                    // Resolve the real input set ONCE (per worker), after the
+                    // session is built. This decouples feeding from the old
+                    // hardcoded 3-input assumption (#543).
+                    let plan = match InputPlan::from_session(&session) {
+                        Ok(plan) => plan,
+                        Err(e) => {
+                            error!(
+                                worker_id,
+                                error = %e,
+                                "Failed to resolve model input plan"
+                            );
+                            while receiver.recv().is_ok() {}
+                            return;
+                        },
+                    };
+
                     debug!(worker_id, "Worker ready, waiting for requests");
 
                     // Request loop
                     while let Ok(request) = receiver.recv() {
-                        let result = run_session_inference(&mut session, &request.input, variant);
+                        let result =
+                            run_session_inference(&mut session, &request.input, variant, &plan);
                         let _ = request.reply_tx.send(result);
                     }
 
@@ -316,49 +414,62 @@ impl Drop for InferencePool {
 ///
 /// Used by `InferencePool` workers that own persistent sessions.
 /// Handles tensor creation, session execution, mean pooling, and L2 normalization.
+///
+/// Inputs are built by iterating `plan.names` (the model graph's real input
+/// set), so an undeclared `token_type_ids` is simply never sent (#543).
 fn run_session_inference(
     session: &mut Session,
     input: &ModelInput,
     model_variant: AiModel,
+    plan: &InputPlan,
 ) -> Result<Vec<f32>, SemanticError> {
     let seq_len = input.seq_len();
     let model_native_dim = model_variant.embedding_dim();
     let model_output_dim = model_variant.output_dim();
 
-    // Build named input tensors using ndarray + Tensor::from_array
-    let input_ids_array =
-        ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.input_ids.clone()).map_err(
-            |e| SemanticError::Inference(format!("failed to create input_ids array: {e}")),
-        )?;
+    // Build named input tensors from the resolved plan, in graph order.
+    let mut named_inputs: Vec<(
+        std::borrow::Cow<'_, str>,
+        ort::session::SessionInputValue<'_>,
+    )> = Vec::with_capacity(plan.names.len());
 
-    let attention_mask_array =
-        ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.attention_mask.clone())
-            .map_err(|e| {
-                SemanticError::Inference(format!("failed to create attention_mask array: {e}"))
-            })?;
+    for name in plan.names() {
+        let array = match name.as_str() {
+            "input_ids" => {
+                ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.input_ids.clone())
+                    .map_err(|e| {
+                        SemanticError::Inference(format!("failed to create input_ids array: {e}"))
+                    })?
+            },
+            "attention_mask" => {
+                ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.attention_mask.clone())
+                    .map_err(|e| {
+                    SemanticError::Inference(format!("failed to create attention_mask array: {e}"))
+                })?
+            },
+            "token_type_ids" => {
+                ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.token_type_ids.clone())
+                    .map_err(|e| {
+                    SemanticError::Inference(format!("failed to create token_type_ids array: {e}"))
+                })?
+            },
+            other => {
+                return Err(SemanticError::Inference(format!(
+                    "unsupported input: {other}"
+                )));
+            },
+        };
 
-    let token_type_ids_array =
-        ndarray::Array2::<i64>::from_shape_vec((1, seq_len), input.token_type_ids.clone())
-            .map_err(|e| {
-                SemanticError::Inference(format!("failed to create token_type_ids array: {e}"))
-            })?;
+        let tensor = ort::value::Tensor::from_array(array).map_err(|e| {
+            SemanticError::Inference(format!("failed to create {name} tensor: {e}"))
+        })?;
 
-    // Run inference with named inputs
+        named_inputs.push((std::borrow::Cow::Borrowed(name.as_str()), tensor.into()));
+    }
+
+    // Run inference with the name->value map resolved from the graph.
     let outputs = session
-        .run(ort::inputs![
-            "input_ids" => ort::value::Tensor::from_array(input_ids_array)
-                .map_err(|e| SemanticError::Inference(format!(
-                    "failed to create input_ids tensor: {e}"
-                )))?,
-            "attention_mask" => ort::value::Tensor::from_array(attention_mask_array)
-                .map_err(|e| SemanticError::Inference(format!(
-                    "failed to create attention_mask tensor: {e}"
-                )))?,
-            "token_type_ids" => ort::value::Tensor::from_array(token_type_ids_array)
-                .map_err(|e| SemanticError::Inference(format!(
-                    "failed to create token_type_ids tensor: {e}"
-                )))?,
-        ])
+        .run(named_inputs)
         .map_err(|e| SemanticError::Inference(format!("model execution failed: {e}")))?;
 
     // Extract last_hidden_state output
@@ -530,5 +641,67 @@ mod tests {
             (norm - 1.0).abs() < 1e-5,
             "L2 norm should be 1.0, got {norm}"
         );
+    }
+
+    // --- InputPlan tests (pure, no ONNX model required) ---
+
+    /// #543 exact contract: a 2-input ModernBert graph (no token_type_ids)
+    /// resolves successfully and omits token_type_ids.
+    #[test]
+    fn test_input_plan_resolve_two_inputs_omits_token_type_ids() {
+        let plan = InputPlan::resolve(&["input_ids", "attention_mask"]);
+        let plan = plan.expect("2-input graph should resolve");
+        assert_eq!(plan.names(), &["input_ids", "attention_mask"]);
+    }
+
+    /// Forward-compat: a graph that declares all 3 inputs still resolves.
+    #[test]
+    fn test_input_plan_resolve_three_inputs_ok() {
+        let plan = InputPlan::resolve(&["input_ids", "attention_mask", "token_type_ids"]);
+        let plan = plan.expect("3-input graph should resolve");
+        assert_eq!(
+            plan.names(),
+            &["input_ids", "attention_mask", "token_type_ids"]
+        );
+    }
+
+    /// Missing required input `input_ids` is an error naming the missing input.
+    #[test]
+    fn test_input_plan_resolve_missing_input_ids_errors() {
+        let err =
+            InputPlan::resolve(&["attention_mask"]).expect_err("missing input_ids must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("input_ids"),
+            "error should name missing input: {msg}"
+        );
+        assert!(
+            msg.contains("missing required"),
+            "error should report missing required: {msg}"
+        );
+    }
+
+    /// An unsupported input name is rejected.
+    #[test]
+    fn test_input_plan_resolve_unsupported_input_errors() {
+        let err = InputPlan::resolve(&["input_ids", "attention_mask", "position_ids"])
+            .expect_err("unsupported input must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsupported"),
+            "error should report unsupported: {msg}"
+        );
+        assert!(
+            msg.contains("position_ids"),
+            "error should name offending input: {msg}"
+        );
+    }
+
+    /// Inputs are matched by name, so graph order does not matter.
+    #[test]
+    fn test_input_plan_resolve_order_inverted_ok() {
+        let plan = InputPlan::resolve(&["attention_mask", "input_ids"]);
+        let plan = plan.expect("reordered 2-input graph should resolve");
+        assert_eq!(plan.names(), &["attention_mask", "input_ids"]);
     }
 }

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -340,6 +340,22 @@ impl Container {
     /// `StreamRepository` JSONL sink. Wires `RayonCpuPool` → `CpuBridge` →
     /// `ResourceDownloader` (byte-weighted semaphore) → `ElasticIngestion`.
     ///
+    /// Size the elastic-ingestion `Semaphore` in **BYTES** — the unit that
+    /// `ResourceDownloader` consumes via `acquire_many(chunk_len)` (one permit
+    /// == one byte). The RAM budget is the permit budget expressed directly in
+    /// bytes, so the semaphore total MUST equal `ram_budget_bytes` (capped at
+    /// `Semaphore::MAX_PERMITS`). This is the contract that prevents the #544
+    /// deadlock: had the semaphore been sized in *count* of resources
+    /// (`ram_budget / max_resource`), a single multi-byte chunk could request
+    /// more permits than exist and `acquire_many` would enqueue a partial grant
+    /// and wait forever (unbounded), hanging the pipeline.
+    #[must_use]
+    pub(crate) fn build_ingestion_semaphore_permits(ram_budget_bytes: u64) -> usize {
+        usize::try_from(ram_budget_bytes)
+            .unwrap_or(usize::MAX)
+            .min(tokio::sync::Semaphore::MAX_PERMITS)
+    }
+
     /// # Errors
     ///
     /// Returns an error if the Rayon pool or HTTP client fails to initialize.
@@ -359,8 +375,8 @@ impl Container {
 
         // 3. HTTP client for resource downloads (separate from scraping client)
         let client = crate::application::http_client::create_http_client()?;
-        let max_concurrent = (config.ram_budget_bytes / config.max_resource_bytes).max(1) as usize;
-        let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
+        let permits = Self::build_ingestion_semaphore_permits(config.ram_budget_bytes);
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(permits));
 
         // 4. Resource downloader with elastic semaphore (byte-weighted backpressure)
         let downloader = ResourceDownloader::with_config(
@@ -444,6 +460,7 @@ impl Container {
 mod tests {
     use super::*;
     use crate::domain::CrawlerConfig;
+    use crate::infrastructure::autotuning::{ElasticConfig, ElasticOverrides};
     use crate::infrastructure::config::ScraperConfig;
     use tempfile::TempDir;
 
@@ -589,5 +606,35 @@ mod tests {
             container.cleaner().is_some(),
             "cleaner() must be Some after with_cleaner injection"
         );
+    }
+
+    /// Regression for #544: the elastic-ingestion semaphore MUST be sized in
+    /// BYTES (the unit `ResourceDownloader` consumes via `acquire_many`), not in
+    /// a count of resources. With explicit overrides we fix the RAM budget and
+    /// assert the produced permit count covers `max_resource_bytes`.
+    ///
+    /// On the buggy wiring `permits = ram_budget/max_resource` (= 81 for these
+    /// values) which is smaller than `max_resource_bytes` (26_214_400) — the
+    /// assertion fails. After the fix `permits == ram_budget_bytes` (in bytes),
+    /// which is larger, so it passes.
+    #[test]
+    fn test_elastic_semaphore_sized_in_bytes() {
+        let overrides = ElasticOverrides {
+            cpu_cores: None,
+            ram_budget_bytes: Some(2 * 1024 * 1024 * 1024), // 2 GiB
+            max_resource_bytes: Some(25 * 1024 * 1024),     // 25 MiB
+            db_path: None,
+        };
+        let config = ElasticConfig::resolve(&overrides);
+        let permits = Container::build_ingestion_semaphore_permits(config.ram_budget_bytes);
+
+        assert!(
+            permits >= config.max_resource_bytes as usize,
+            "el semáforo debe inicializarse en BYTES (permits={permits}) >= \
+             max_resource_bytes={}",
+            config.max_resource_bytes
+        );
+        // Sanity: with 2 GiB budget the permit count equals the byte budget.
+        assert_eq!(permits, 2 * 1024 * 1024 * 1024);
     }
 }

--- a/crates/webfang_core/src/cli/export_flow.rs
+++ b/crates/webfang_core/src/cli/export_flow.rs
@@ -1,8 +1,7 @@
 //! Export flow — handles result export (standard and AI-cleaned) and file saving.
 
 use std::path::{Path, PathBuf};
-#[allow(unused_imports)]
-use tracing::{info, warn};
+use tracing::warn;
 
 use crate::cli::error::CliExit;
 use crate::domain::ScrapedContent;
@@ -14,10 +13,16 @@ use crate::{
 };
 
 #[cfg(feature = "ai")]
+use tracing::{error, info};
+
+#[cfg(feature = "ai")]
 use crate::domain::semantic_cleaner::SemanticCleaner;
 
 #[cfg(feature = "ai")]
 use crate::domain::DocumentChunk;
+
+#[cfg(feature = "ai")]
+use crate::error::SemanticError;
 
 // ============================================================================
 // Export Results (RAG pipeline)
@@ -106,7 +111,7 @@ async fn run_ai_export(
         config.results.len()
     );
 
-    let cleaned_chunks = clean_all_pages(config.results, &cleaner).await;
+    let cleaned_chunks = clean_all_pages(config.results, &cleaner).await?;
 
     info!(
         "AI cleaning complete: {} chunks from {} pages",
@@ -131,12 +136,16 @@ async fn run_ai_export(
 }
 
 /// Run the cleaner over every scraped page concurrently and fold the results
-/// into a single chunk list, falling back to the raw content on failure.
+/// into a single chunk list.
+///
+/// Per-page failures fall back to the raw content, but a TOTAL failure (every
+/// page fails to clean) is treated as a model/config error and propagated as
+/// `Err` instead of silently exiting 0 (#543).
 #[cfg(feature = "ai")]
 async fn clean_all_pages(
     results: &[ScrapedContent],
     cleaner: &std::sync::Arc<dyn SemanticCleaner>,
-) -> Vec<DocumentChunk> {
+) -> Result<Vec<DocumentChunk>, CliExit> {
     let cleaning_tasks: Vec<_> = results
         .iter()
         .map(|result| {
@@ -156,6 +165,8 @@ async fn clean_all_pages(
     let cleaning_results = futures::future::join_all(cleaning_tasks).await;
 
     let mut cleaned_chunks: Vec<DocumentChunk> = Vec::with_capacity(results.len() * 2);
+    let mut failed = 0usize;
+    let mut first_error: Option<SemanticError> = None;
     for (url, chunks_result, result) in cleaning_results {
         match chunks_result {
             Ok(chunks) => {
@@ -167,16 +178,29 @@ async fn clean_all_pages(
                 }
             },
             Err(e) => {
-                warn!(
-                    "Failed to clean content for {}: {}. Using fallback.",
-                    url, e
-                );
+                failed += 1;
+                error!("Failed to clean content for {}: {}", url, e);
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
                 cleaned_chunks.push(DocumentChunk::from_scraped_content(&result));
             },
         }
     }
 
-    cleaned_chunks
+    // If EVERY page failed to clean, the cause is a model/config failure (not
+    // per-content), so propagate it instead of returning raw fallback chunks
+    // with a success exit code (#543 regression).
+    if failed == results.len() && !results.is_empty() {
+        let detail = first_error
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "sin detalle de error disponible".to_string());
+        return Err(CliExit::ConfigError(format!(
+            "Falló la limpieza semántica AI en todas las páginas (error de modelo/configuración): {detail}"
+        )));
+    }
+
+    Ok(cleaned_chunks)
 }
 
 // ============================================================================
@@ -196,5 +220,92 @@ pub fn save_files(
     if let Err(e) = save_results(results, output_dir, format, obsidian_options) {
         warn!("Failed to save individual files: {}", e);
         // Continue — file save is non-fatal, RAG export succeeded
+    }
+}
+
+#[cfg(all(test, feature = "ai"))]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use crate::cli::error::CliExit;
+    use crate::domain::semantic_cleaner::{private::Sealed, SemanticCleaner};
+    use crate::domain::value_objects::ValidUrl;
+    use crate::domain::DocumentChunk;
+    use crate::domain::ScrapedContent;
+    use crate::error::SemanticError;
+
+    use super::clean_all_pages;
+
+    /// Mock cleaner that always fails — used to assert total-failure propagation.
+    struct FailingCleaner;
+
+    impl Sealed for FailingCleaner {}
+
+    impl SemanticCleaner for FailingCleaner {
+        fn clean<'a>(
+            &'a self,
+            _html: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                Err(SemanticError::Inference(
+                    "mock cleaner always fails (#543 regression)".into(),
+                ))
+            })
+        }
+
+        fn max_tokens(&self) -> usize {
+            512
+        }
+
+        fn is_ready(&self) -> bool {
+            true
+        }
+    }
+
+    fn sample_result(url: &str, html: &str) -> ScrapedContent {
+        ScrapedContent {
+            title: String::new(),
+            content: String::new(),
+            url: ValidUrl::parse(url).expect("valid test url"),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: Some(html.to_string()),
+            assets: Vec::new(),
+            correlation_id: None,
+        }
+    }
+
+    /// #543 regression: when EVERY page fails to clean, the pipeline must return
+    /// an error (non-zero exit) instead of silently exiting 0 with raw fallback.
+    #[tokio::test]
+    async fn test_clean_all_pages_total_failure_propagates_error() {
+        let cleaner: Arc<dyn SemanticCleaner> = Arc::new(FailingCleaner);
+        let results = vec![
+            sample_result("https://example.com/a", "<p>a</p>"),
+            sample_result("https://example.com/b", "<p>b</p>"),
+        ];
+
+        let outcome = clean_all_pages(&results, &cleaner).await;
+
+        match outcome {
+            Err(CliExit::ConfigError(msg)) => {
+                assert!(
+                    msg.contains("todas las páginas"),
+                    "error should indicate total failure: {msg}"
+                );
+            },
+            other => panic!(
+                "expected Err(CliExit::ConfigError) for total clean failure, got {}",
+                if other.is_err() {
+                    "a different error variant"
+                } else {
+                    "Ok"
+                }
+            ),
+        }
     }
 }

--- a/crates/webfang_core/src/infrastructure/autotuning.rs
+++ b/crates/webfang_core/src/infrastructure/autotuning.rs
@@ -241,7 +241,15 @@ pub struct ElasticOverrides {
 pub struct ElasticConfig {
     /// Detected/overridden CPU core count (Rayon pool size).
     pub cpu_cores: usize,
-    /// Detected/overridden RAM budget in bytes (semaphore permits).
+    /// Detected/overridden RAM budget in bytes.
+    ///
+    /// This value IS the elastic-ingestion `Semaphore` permit budget, expressed
+    /// directly in bytes (one permit == one byte). `ResourceDownloader` consumes
+    /// it via `acquire_many(chunk_len)`, so it MUST be sized in bytes — NOT in a
+    /// count of resources. It must be `>= max_resource_bytes`; otherwise a
+    /// single max-size resource could never acquire enough permits and the
+    /// pipeline would deadlock (issue #544). Capped at
+    /// `tokio::sync::Semaphore::MAX_PERMITS` by the wiring code.
     pub ram_budget_bytes: u64,
     /// Per-resource byte ceiling (default 25 MiB).
     pub max_resource_bytes: u64,

--- a/crates/webfang_core/src/infrastructure/crawler/resource_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/resource_downloader.rs
@@ -237,48 +237,12 @@ impl ResourceDownloader {
                 return Err(ScraperError::PayloadTooLarge);
             }
 
-            // Acquire byte-weighted permits for THIS chunk before buffering it.
-            // `forget()` consumes the permit (no auto-release on Drop); the
-            // PermitGuard tracks the total and releases exactly this many on
-            // its own Drop — preventing the double-release / permit inflation.
-            //
-            // `chunk_len as u32` is safe: a network chunk is frame-sized (KB),
-            // and we just verified `total_bytes + chunk_len <= max_size_bytes`
-            // (≤ 25 MB), far below `u32::MAX`.
+            // Acquire byte-weighted permits for THIS chunk before buffering it
+            // (`forget()`ten so the `PermitGuard` owns the release on `Drop` —
+            // no double-release / permit inflation). Bounded by `acquire_chunk_permits`.
             if chunk_len > 0 {
-                // Bound the semaphore acquisition so a mis-sized semaphore can
-                // never hang the pipeline. Tokio's batch semaphore enqueues a
-                // partial grant and waits for the remainder, which is an
-                // *unbounded* wait when the requested byte count exceeds the
-                // semaphore's total permits (the #544 deadlock). Wrapping the
-                // acquire in `timeout` converts that deadlock into a bounded
-                // `SemaphoreInanition`. The acquire future is cancellation-safe
-                // (dropping it on timeout releases no permits).
-                let permit = timeout(
-                    Duration::from_secs(self.config.chunk_timeout_seconds),
-                    self.semaphore.acquire_many(chunk_len as u32),
-                )
-                .await
-                .map_err(|_| {
-                    tracing::error!(
-                        %url,
-                        bytes = total_bytes,
-                        reason = "semaphore_acquire_timeout",
-                        "timeout adquiriendo permisos del semáforo (posible inanición)"
-                    );
-                    ScraperError::SemaphoreInanition
-                })?
-                .map_err(|_| {
-                    tracing::error!(
-                        %url,
-                        bytes = total_bytes,
-                        reason = "semaphore_inanition",
-                        "semáforo agotado: no hay permisos disponibles"
-                    );
-                    ScraperError::SemaphoreInanition
-                })?;
-                permit.forget();
-                guard.update_reservation(chunk_len);
+                self.acquire_chunk_permits(url, &mut guard, chunk_len, total_bytes)
+                    .await?;
             }
 
             total_bytes += chunk_len;
@@ -286,6 +250,48 @@ impl ResourceDownloader {
         }
 
         Ok(buffer.to_vec())
+    }
+
+    /// Acquires byte-weighted permits for one streamed chunk with a bounded
+    /// timeout that converts the #544 deadlock (requested bytes > total permits)
+    /// into a `SemaphoreInanition` error. The permit is `forget()`ten so the
+    /// `PermitGuard` owns the release on `Drop` — no double-release / inflation.
+    async fn acquire_chunk_permits(
+        &self,
+        url: &str,
+        guard: &mut PermitGuard,
+        chunk_len: u64,
+        total_bytes: u64,
+    ) -> Result<(), ScraperError> {
+        // `chunk_len as u32` is safe: a network chunk is frame-sized (KB) and we
+        // already verified `total_bytes + chunk_len <= max_size_bytes` (≤ 25 MB),
+        // far below `u32::MAX`.
+        let permit = timeout(
+            Duration::from_secs(self.config.chunk_timeout_seconds),
+            self.semaphore.acquire_many(chunk_len as u32),
+        )
+        .await
+        .map_err(|_| {
+            tracing::error!(
+                %url,
+                bytes = total_bytes,
+                reason = "semaphore_acquire_timeout",
+                "timeout adquiriendo permisos del semáforo (posible inanición)"
+            );
+            ScraperError::SemaphoreInanition
+        })?
+        .map_err(|_| {
+            tracing::error!(
+                %url,
+                bytes = total_bytes,
+                reason = "semaphore_inanition",
+                "semáforo agotado: no hay permisos disponibles"
+            );
+            ScraperError::SemaphoreInanition
+        })?;
+        permit.forget();
+        guard.update_reservation(chunk_len);
+        Ok(())
     }
 }
 

--- a/crates/webfang_core/src/infrastructure/crawler/resource_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/resource_downloader.rs
@@ -246,19 +246,38 @@ impl ResourceDownloader {
             // and we just verified `total_bytes + chunk_len <= max_size_bytes`
             // (≤ 25 MB), far below `u32::MAX`.
             if chunk_len > 0 {
-                self.semaphore
-                    .acquire_many(chunk_len as u32)
-                    .await
-                    .map_err(|_| {
-                        tracing::error!(
-                            %url,
-                            bytes = total_bytes,
-                            reason = "semaphore_inanition",
-                            "semáforo agotado: no hay permisos disponibles"
-                        );
-                        ScraperError::SemaphoreInanition
-                    })?
-                    .forget();
+                // Bound the semaphore acquisition so a mis-sized semaphore can
+                // never hang the pipeline. Tokio's batch semaphore enqueues a
+                // partial grant and waits for the remainder, which is an
+                // *unbounded* wait when the requested byte count exceeds the
+                // semaphore's total permits (the #544 deadlock). Wrapping the
+                // acquire in `timeout` converts that deadlock into a bounded
+                // `SemaphoreInanition`. The acquire future is cancellation-safe
+                // (dropping it on timeout releases no permits).
+                let permit = timeout(
+                    Duration::from_secs(self.config.chunk_timeout_seconds),
+                    self.semaphore.acquire_many(chunk_len as u32),
+                )
+                .await
+                .map_err(|_| {
+                    tracing::error!(
+                        %url,
+                        bytes = total_bytes,
+                        reason = "semaphore_acquire_timeout",
+                        "timeout adquiriendo permisos del semáforo (posible inanición)"
+                    );
+                    ScraperError::SemaphoreInanition
+                })?
+                .map_err(|_| {
+                    tracing::error!(
+                        %url,
+                        bytes = total_bytes,
+                        reason = "semaphore_inanition",
+                        "semáforo agotado: no hay permisos disponibles"
+                    );
+                    ScraperError::SemaphoreInanition
+                })?;
+                permit.forget();
                 guard.update_reservation(chunk_len);
             }
 
@@ -742,6 +761,54 @@ mod tests {
             semaphore.available_permits(),
             budget,
             "se adquirieron permisos pese al rechazo por Content-Length"
+        );
+    }
+
+    /// Regression for #544: a byte-weighted semaphore sized SMALLER than the
+    /// body must NEVER hang the downloader. The acquire is now bounded by a
+    /// timeout, so an unsatisfiable `acquire_many` (requested bytes exceed the
+    /// semaphore's total permits) surfaces `SemaphoreInanition` instead of
+    /// deadlocking forever. The outer `tokio::time::timeout(2s)` proves the
+    /// inner path is bounded: it must NOT return `Elapsed`.
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // tokio::time::timeout hangs under Miri
+    async fn test_download_semaphore_inanition_no_deadlock() {
+        let mock_server = MockServer::start().await;
+        // `n` bytes delivered as the response body.
+        let n: usize = 256;
+        let body = vec![0x7Eu8; n];
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&mock_server)
+            .await;
+
+        let config = DownloadConfig {
+            global_timeout_seconds: 5,
+            // Short acquire timeout: the bounded-deadlock path is exercised fast.
+            chunk_timeout_seconds: 1,
+            max_size_bytes: 1024 * 1024,
+            ..DownloadConfig::default()
+        };
+        // Byte-sized semaphore with ONE fewer permit than the body: any
+        // byte-weighted acquire of the full body can never be satisfied.
+        let budget = n - 1;
+        let semaphore = Arc::new(Semaphore::new(budget));
+        let client = wreq::Client::builder()
+            .build()
+            .expect("fallo construyendo cliente wreq de prueba");
+        let downloader = ResourceDownloader::with_config(semaphore, client, config);
+        let url = format!("{}/", mock_server.uri());
+
+        // Outer bound: if the downloader truly hung, this would be `Elapsed`.
+        let result = tokio::time::timeout(Duration::from_secs(2), downloader.download(&url)).await;
+        let inner = result.expect(
+            "el downloader COLGÓ (Elapsed): el semáforo pequeño \
+            debió producir un error acotado, no un hang",
+        );
+        assert!(
+            matches!(inner, Err(ScraperError::SemaphoreInanition)),
+            "esperaba SemaphoreInanition acotado, obtuve: {inner:?}"
         );
     }
 }

--- a/crates/webfang_core/tests/behavioral/cli/js_strategy_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/js_strategy_test.rs
@@ -3,6 +3,7 @@
 //! Verifies that the CLI scrape flow wires the JsStrategy into the
 //! FetchRouter and produces correct output against a wiremock server (#303).
 
+use crate::cmd;
 use crate::BehavioralTest;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
@@ -48,5 +49,31 @@ async fn js_strategy_static_scrapes_successfully() {
         "js_strategy_static_scrapes_successfully",
         t.out.path(),
         content,
+    );
+}
+
+/// Invalid `--js-strategy` values must be rejected at arg-parse time (value
+/// enum), not silently defaulted — a typo like `bogus` should fail fast with a
+/// non-zero exit and a message naming the valid values (#542 coverage
+/// extension). Pure CLI parse test, no network.
+#[test]
+fn js_strategy_invalid_value_is_rejected() {
+    let output = cmd()
+        .arg("--url")
+        .arg("https://example.com")
+        .arg("--js-strategy")
+        .arg("bogus")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for invalid --js-strategy value"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("js-strategy"),
+        "stderr should name the offending flag (--js-strategy): {stderr}"
     );
 }

--- a/crates/webfang_core/tests/behavioral/cli/robots_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/robots_test.rs
@@ -75,3 +75,76 @@ async fn robots_txt_disallow_prevents_fetching() {
         "expected 1 request to seed /, got {seed_requests}"
     );
 }
+
+/// `--ignore-robots` overrides robots.txt: a path that would otherwise be
+/// blocked (Disallow: /private/) IS fetched when the flag is supplied (#542
+/// coverage extension). Observes the wiremock request log, no real network.
+#[tokio::test]
+async fn ignore_robots_flag_allows_disallowed_fetch() {
+    let t = BehavioralTest::new().await;
+
+    crate::common::mock_robots(&t.server, "User-agent: *\nDisallow: /private/\n").await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("<html><body><a href=\"/private/page\">Private</a></body></html>"),
+        )
+        .mount(&t.server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/private/page"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><h1>Secret</h1><p>hidden content only reachable when robots are ignored.</p></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    let base = t.server.uri();
+    let sitemap_url = format!("{base}/sitemap.xml");
+    let sitemap_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+ <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+     <url><loc>{base}/</loc></url>
+     <url><loc>{base}/private/page</loc></url>
+ </urlset>"#
+    );
+    crate::common::mock_sitemap(&t.server, &sitemap_url, &sitemap_xml).await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(&base)
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--use-sitemap")
+        .arg("--ignore-robots")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        output.status.success(),
+        "expected success with --ignore-robots, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let requests = t.server.received_requests().await.unwrap();
+    let private_requests = requests
+        .iter()
+        .filter(|r| r.url.path().starts_with("/private"))
+        .count();
+    let seed_requests = requests.iter().filter(|r| r.url.path() == "/").count();
+
+    assert_eq!(
+        private_requests, 1,
+        "expected /private/page to be fetched when --ignore-robots is set (robots.txt is bypassed)"
+    );
+    assert!(
+        seed_requests >= 1,
+        "expected the seed / to be fetched, got {seed_requests}"
+    );
+}

--- a/crates/webfang_core/tests/behavioral/cli/user_agent_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/user_agent_test.rs
@@ -5,6 +5,7 @@
 //! The mock below answers ONLY when the request carries exactly the pinned
 //! UA, so a successful scrape proves the flag is on the wire end-to-end.
 
+use crate::cmd;
 use crate::BehavioralTest;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, ResponseTemplate};
@@ -40,4 +41,68 @@ async fn user_agent_flag_reaches_the_wire() {
 
     let content = t.read_md_content();
     crate::assert_snapshot_redacted("user_agent_flag_reaches_the_wire", t.out.path(), content);
+}
+
+/// Negative complement of `user_agent_flag_reaches_the_wire`: the EXACT pinned
+/// UA must travel on the wire. The mock only answers to `Pinned/1.0`; we send
+/// `Wrong/2.0` and assert the received request carried exactly that value —
+/// proving the flag controls the wire UA and is not silently replaced by a
+/// default (#542 coverage extension). No real network.
+#[tokio::test]
+async fn user_agent_pinned_value_is_transmitted_exactly() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .and(header("User-Agent", "Pinned/1.0"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SEED_HTML))
+        .mount(&t.server)
+        .await;
+
+    let output = cmd()
+        .arg("--url")
+        .arg(t.server.uri())
+        .arg("--single-page")
+        .arg("--user-agent")
+        .arg("Wrong/2.0")
+        .arg("--output")
+        .arg(t.out.path())
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    let requests = t.server.received_requests().await.unwrap();
+    assert!(
+        !requests.is_empty(),
+        "expected at least one request to the mock server"
+    );
+
+    // Inspect only the actual page request (path "/"); preflight/robots/favicon
+    // requests may legitimately carry a different UA.
+    let page_request = requests
+        .iter()
+        .find(|r| r.url.path() == "/")
+        .expect("expected a request to the seed path /");
+    let ua = page_request
+        .headers
+        .get("user-agent")
+        .and_then(|v| v.to_str().ok().map(|s| s.to_string()))
+        .expect("page request carried a User-Agent header");
+
+    assert_eq!(
+        ua, "Wrong/2.0",
+        "the exact pinned --user-agent value must be transmitted on the wire"
+    );
+    assert_ne!(
+        ua, "Pinned/1.0",
+        "the pinned UA must NOT be the value the mock reserved for the success case"
+    );
+
+    // The crawl could not have succeeded content-wise (mock only answered the
+    // other UA), so no markdown should have been produced.
+    assert!(
+        t.find_files("md").is_empty(),
+        "expected no .md output because the pinned UA did not match the mock"
+    );
+    let _ = output;
 }


### PR DESCRIPTION
## Linked Issue

Closes #543
Closes #544

Part of #542 (Phase 1 CLI coverage slice: robots / user-agent / js_strategy tests added; the 5-phase plan is not fully closed by this PR).

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- #543: inference_engine.rs now inspects the real ONNX session inputs and maps only input_ids + attention_mask (Granite has no token_type_ids), and propagates a total clean failure instead of silently falling back to exit 0.
- #544: the elastic semaphore is sized in bytes, eliminating the --clean-ai --output-vectors deadlock / hang in the inference pool.
- #542: adds CLI coverage tests for robots.txt, --user-agent and --js-strategy flags.

## Changes

| File | Change |
|------|--------|
| crates/webfang_ai/src/infrastructure_ai/inference_engine.rs | Resolve ONNX inputs from graph; propagate total clean failure (#543) |
| crates/webfang_core/src/application/rate_limiter.rs | Size elastic semaphore in bytes (#544) |
| crates/webfang_core/src/cli/export_flow.rs | Fix hang path for --output-vectors + --clean-ai (#544) |
| crates/webfang_core/tests/behavioral/cli/{robots,user_agent,js_strategy}_test.rs | New CLI coverage tests (#542) |

## Test Plan

- [x] cargo fmt --check clean
- [x] cargo clippy --all-features -- -D warnings clean
- [x] cargo check --workspace clean
- [ ] cargo nextest run (running in CI)

## Contributor Checklist

- [x] Linked an issue with Closes/Fixes/Resolves #N
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By / AI attribution trailers