### PR TITLE
fix(infra): strip rustdoc HTML before blank-line collapse in LLM doc artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -195,13 +195,15 @@ jobs:
                       -e 's/<[^>]*>//g' \
                       -e 's/Show [0-9][0-9]* fields[[:space:]]*//g' \
                       -e 's/Show [0-9][0-9]* variants[[:space:]]*//g' \
-                      -e '/^[[:space:]]*$/N;/^\n[[:space:]]*$/D' \
+                | sed -e '/^[[:space:]]*$/N;/^\n[[:space:]]*$/D' \
                 > "target/doc/$crate.md"
                 # Gate ONLY the cleaned API markdown. The Source Code section below
                 # intentionally contains HTML inside Rust string/test/doc-comment
                 # literals (e.g. extractor/html_cleaner/link_extractor tests), so a
-                # whole-file grep would false-positive there.
-                if grep -q 'Expand description\|href="\|<a \|<span\|<div\|<abbr\|<code\|§' "target/doc/$crate.md"; then
+                # whole-file grep would false-positive there. The gate is also
+                # fence-aware: doctests may legitimately contain HTML inside
+                # ``` code fences (e.g. assert!(html.contains("<span"))).
+                if awk 'BEGIN{f=0} /^```/{f=!f; next} !f && /Expand description|Copy item path|href="|<a |<span|<div|<abbr|<code|§/{bad=1} END{exit !bad}' "target/doc/$crate.md"; then
                   echo "::error::rustdoc noise not fully stripped for $crate"
                   exit 1
                 fi


### PR DESCRIPTION
Closes #561

## Summary
- The blank-line collapse ran in the SAME `sed` as the tag substitutions: when `N` merges a blank line with the next content line, that line is emitted without `s/<[^>]*>//g` — ~66K raw HTML tags survived and the noise gate fired.
- Split the collapse into a second `sed` pass so every line is tag-stripped first.
- Made the gate fence-aware (awk) so doctests with legit HTML inside ``` fences (e.g. `assert!(html.contains("<span"))`) no longer false-positive.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/docs.yml` | split sed (tag strip -> blank collapse) + fence-aware awk gate |

## Test Plan
- [x] Reproduced the original gate failure locally (bash -x: `::error::rustdoc noise not fully stripped for webfang_core`, exit 1)
- [x] Full artifact builds with the fix: 214,622 lines, gate passes, 0 stray HTML outside code fences
- [x] `actionlint` passes on the workflow

## Contributor Checklist
- [x] Linked an approved issue (#561)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers