### PR TITLE
fix(infra): restore docs deploy broken by comments inside sed pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -178,6 +178,9 @@ jobs:
               if [ -d "target/doc/$crate" ]; then
                 echo "### API: $crate"
                 echo
+                # Single H1 in the artifact: downgrade rustdoc page titles
+                # (Struct/Function/Enum/.../List) to H3 under "## API Reference".
+                # Safe: doctest hidden lines (# use ...) never match these words.
                 {
                   pandoc -f html -t gfm --wrap=none "target/doc/$crate/index.html" 2>/dev/null
                   find "target/doc/$crate" -name '*.html' ! -name 'index.html' ! -path '*/src/*' -print0 \
@@ -195,9 +198,6 @@ jobs:
                       -e 's/<[^>]*>//g' \
                       -e 's/Show [0-9][0-9]* fields[[:space:]]*//g' \
                       -e 's/Show [0-9][0-9]* variants[[:space:]]*//g' \
-                      # Single H1 in the artifact: downgrade rustdoc page titles
-                      # (Struct/Function/Enum/.../List) to H3 under "## API Reference".
-                      # Safe: doctest hidden lines (# use ...) never match these words.
                       -e 's/^# \(Struct\|Function\|Enum\|Trait\|Constant\|Type\|Crate\|Macro\|List\) /### \1 /' \
                 | sed -e '/^[[:space:]]*$/N;/^\n[[:space:]]*$/D' \
                 > "target/doc/$crate.md"


### PR DESCRIPTION
## Linked Issue

Closes #565

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- El merge de #564 rompió el deploy de docs: los comentarios `#` quedaron entre argumentos de `sed` unidos por `\`. El backslash fusionaba el primer comentario a la línea anterior, el `-e 's/^# ...'` siguiente se ejecutaba como comando suelto (`-e: command not found`), el archivo `target/doc/<crate>.md` quedaba vacío/parcial y el gate de noise disparaba `::error::rustdoc noise not fully stripped`.
- Fix: los comentarios viven ahora ANTES del grupo `{ }` (líneas sueltas, sin backslash previo); el `-e` de downgrade de H1 queda dentro del primer `sed` (junto al resto de `-e`), sin interrumpir la cadena de continuación.
- Se conserva la mejora de #564: un solo H1 real en el artefacto.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/docs.yml` | Mueve los 3 comentarios fuera de la cadena `\` del `sed` (antes del `{`); el `-e 's/^# \(Struct\|...\) /### \1 /'` queda en el primer `sed` |

## Test Plan

- [x] Reproducido el fallo localmente con el step extraído: `-e: orden no encontrada` + gate disparando
- [x] Verificado el fix localmente (step completo contra `target/doc`): exit 0, 0 errores, 0 gate errors, `# Struct` → `### Struct` degradados (174 core / 21 tui / 20 mcp / 1 ai), artefacto con 1 solo H1
- [x] `actionlint` limpio sobre `docs.yml`
- [ ] `cargo fmt --check` clean (sin cambios de Rust)
- [ ] `cargo clippy -- -D warnings` clean (sin cambios de Rust)
- [ ] `cargo nextest run` passes (sin cambios de Rust)
- [x] Manually verified the affected functionality

## Contributor Checklist

- [x] Linked an issue with `Closes/Fixes/Resolves #N`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed
- [ ] Defensive error paths annotated with `// LCOV_EXCL_*` markers per docs/testing.md (issue #527)