### PR TITLE
chore(ci): skip ONNX-model-dependent ignored tests in bug-discovery

### DIFF
--- a/.github/workflows/bug-discovery.yml
+++ b/.github/workflows/bug-discovery.yml
@@ -41,7 +41,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Run ignored tests (bug discovery)
-        run: cargo nextest run --workspace --all-features --run-ignored only --no-fail-fast
+        # Skips `webfang_ai::ai_integration::` tests: they require the ONNX model
+        # (~390 MB, not cached in CI) and only pass locally with a cached model.
+        # Excludes them so this (non-required) bug-discovery job stays green
+        # instead of emitting false-failure noise.
+        run: cargo nextest run --workspace --all-features --run-ignored only --skip 'webfang_ai::ai_integration::' --no-fail-fast
       - name: Summary
         if: always()
         run: |


### PR DESCRIPTION
## Linked Issue

Closes #567

## PR Type

- [x] Maintenance / tooling (`type:chore`)

## Summary

- Excludes `webfang_ai::ai_integration::` ignored tests from the `bug-discovery.yml`
  `ignored-tests` job via `nextest --skip 'webfang_ai::ai_integration::'`.
- These tests require the ~390 MB ONNX model (not cached in CI) and always fail
  there; they are `#[ignore]` tests meant for local runs only.
- The change is non-blocking to merges already (the job has
  `continue-on-error: true` and is not a required check), but it removes the
  false-failure noise on every AI-touching PR (#560 et al.).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/bug-discovery.yml` | add `--skip 'webfang_ai::ai_integration::'` to ignored-tests nextest run |

## Test Plan

- [x] `cargo fmt --check` clean (YAML-only change; no Rust)
- [x] `Validate PR metadata` (issue link + label + branch) passes
- [ ] CI green on PR