### PR TITLE
fix(ai): --clean-ai exporta 0 chunks — enriquecer chunks AI con url/title (#569)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
           echo "Verifying tokenizer SHA256..."
           echo "$TOKENIZER_BLOB_SHA  $TOKENIZER_BLOB_FILE" | sha256sum --check --status
           # Create hf_hub cache structure: refs/main + snapshot symlinks
+          mkdir -p "$MODEL_DIR/refs"
           echo "835ad14087e140460703cf0fae09f97d469d65c2" > "$MODEL_DIR/refs/main"
           ln -s "../../../blobs/$BLOB_SHA" "$SNAPSHOT_FILE"
           ln -s "../../blobs/$TOKENIZER_BLOB_SHA" "$SNAPSHOT_TOKENIZER"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,9 +238,12 @@ jobs:
       - name: Pre-build test binary
         run: cargo build -p webfang_cli --bin webfang --all-features
       - run: cargo nextest run --all-features --test-threads 4 --retries 2
-      - name: AI integration tests (CLI+AI, MCP+AI)
+      - name: AI integration tests (CLI+AI, MCP+AI, AI crate)
         run: |
           set -e
+          # webfang_ai tests (#[ignore]'d, require model, run serially to avoid OOM)
+          cargo test -p webfang_ai --features ai --test ai_integration -- \
+            --ignored --test-threads=1 2>&1 | tail -5
           # CLI+AI tests (#[ignore]'d, require model)
           cargo test -p webfang_core --features ai --test behavioral -- \
             --ignored --test-threads=1 2>&1 | tail -5

--- a/crates/webfang_ai/tests/ai_integration.rs
+++ b/crates/webfang_ai/tests/ai_integration.rs
@@ -325,8 +325,8 @@ fn test_matryoshka_identity_for_384d() {
 /// The default config resolves the model from the local cache at
 /// `~/.cache/webfang/ai_models`. The cleaner is `.expect()`ed to initialize so
 /// that an absent model makes the test FAIL LOUDLY rather than silently
-/// passing. These pipeline tests now run as part of the standard suite
-/// (model cache verified).
+/// passing. These pipeline tests are `#[ignore]`'d (require the cached ONNX
+/// model and must run serially to avoid OOM in CI).
 async fn build_offline_cleaner() -> SemanticCleanerImpl {
     let config = ModelConfig::default().with_offline_mode(true);
     SemanticCleanerImpl::new(config)
@@ -337,7 +337,10 @@ async fn build_offline_cleaner() -> SemanticCleanerImpl {
 /// Test full pipeline: HTML -> Chunk -> Tokenize -> Embed -> Score -> Filter
 ///
 /// This test verifies the complete RAG pipeline integration.
+/// Ignored by default: requires the cached ONNX model and must run serially
+/// (parallel ONNX model loading exhausts CI memory).
 #[tokio::test]
+#[ignore = "requires cached ONNX model"]
 async fn test_semantic_cleaner_full_pipeline() {
     let cleaner = build_offline_cleaner().await;
 
@@ -356,6 +359,7 @@ async fn test_semantic_cleaner_full_pipeline() {
 
 /// Test semantic cleaner with longer content
 #[tokio::test]
+#[ignore = "requires cached ONNX model"]
 async fn test_semantic_cleaner_long_content() {
     let cleaner = build_offline_cleaner().await;
 
@@ -432,6 +436,7 @@ fn test_relevance_filtering() {
 
 /// Test error handling: chunk too large
 #[tokio::test]
+#[ignore = "requires cached ONNX model"]
 async fn test_error_chunk_too_large() {
     let config = ModelConfig::default()
         .with_offline_mode(true)
@@ -484,6 +489,7 @@ async fn test_offline_mode_error() {
 
 /// Test pipeline with empty input
 #[tokio::test]
+#[ignore = "requires cached ONNX model"]
 async fn test_pipeline_empty_input() {
     let config = ModelConfig::default().with_offline_mode(true);
     let cleaner = SemanticCleanerImpl::new(config)
@@ -500,6 +506,7 @@ async fn test_pipeline_empty_input() {
 
 /// Test pipeline with HTML-only input (no text content)
 #[tokio::test]
+#[ignore = "requires cached ONNX model"]
 async fn test_pipeline_html_only() {
     let config = ModelConfig::default().with_offline_mode(true);
     let cleaner = SemanticCleanerImpl::new(config)

--- a/crates/webfang_core/src/cli/export_flow.rs
+++ b/crates/webfang_core/src/cli/export_flow.rs
@@ -174,7 +174,14 @@ async fn clean_all_pages(
                     warn!("AI cleaner produced 0 chunks for: {}", url);
                     cleaned_chunks.push(DocumentChunk::from_scraped_content(&result));
                 } else {
-                    cleaned_chunks.extend(chunks);
+                    // The cleaner produces chunks with empty url/title (it only
+                    // sees raw HTML). Enrich each chunk with identity from its
+                    // source page so validate() passes and export succeeds (#569).
+                    cleaned_chunks.extend(
+                        chunks
+                            .into_iter()
+                            .map(|chunk| chunk.enrich_from_scraped_content(&result)),
+                    );
                 }
             },
             Err(e) => {

--- a/crates/webfang_core/src/domain/entities/content.rs
+++ b/crates/webfang_core/src/domain/entities/content.rs
@@ -355,6 +355,48 @@ impl DocumentChunk<Draft> {
         self
     }
 
+    /// Enrich this AI-generated chunk with url/title/metadata from its source page.
+    ///
+    /// The semantic cleaner operates on raw HTML and produces `DocumentChunk`s
+    /// with empty `url`/`title`. Before these chunks can pass `validate()` and
+    /// be exported, they must inherit identity from the `ScrapedContent` they
+    /// originated from. This method performs that enrichment in place.
+    ///
+    /// Metadata (`excerpt`, `author`, `date`, `domain`) is merged: existing
+    /// entries from the AI chunk are preserved, and any missing keys are filled
+    /// from the scraped page.
+    #[must_use]
+    pub fn enrich_from_scraped_content(mut self, scraped: &ScrapedContent) -> Self {
+        self.url = scraped.url.to_string();
+        self.title = scraped.title.clone();
+
+        // Merge metadata from scraped page, preserving any AI-side entries.
+        if let Some(ref excerpt) = scraped.excerpt {
+            self.metadata
+                .entry("excerpt".to_string())
+                .or_insert_with(|| excerpt.clone());
+        }
+        if let Some(ref author) = scraped.author {
+            self.metadata
+                .entry("author".to_string())
+                .or_insert_with(|| author.clone());
+        }
+        if let Some(ref date) = scraped.date {
+            self.metadata
+                .entry("date".to_string())
+                .or_insert_with(|| date.clone());
+        }
+        if let Ok(url) = url::Url::parse(&scraped.url.to_string()) {
+            if let Some(host) = url.host_str() {
+                self.metadata
+                    .entry("domain".to_string())
+                    .or_insert_with(|| host.to_string());
+            }
+        }
+
+        self
+    }
+
     /// Validate this Draft DocumentChunk
     ///
     /// Returns Validated state if content is valid:
@@ -951,5 +993,107 @@ mod tests {
         assert!(ValidationError::InvalidMetadata("reason".to_string())
             .to_string()
             .contains("reason"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Regression tests for #569: AI chunks must inherit url/title from scraped page
+    // ---------------------------------------------------------------------------
+
+    /// `enrich_from_scraped_content` must fill empty url/title so validate() passes.
+    #[test]
+    fn test_enrich_from_scraped_content_fills_empty_fields() {
+        // Simulate an AI-generated chunk: has content + embeddings but no url/title.
+        let ai_chunk = DocumentChunk::new(
+            Uuid::new_v4(),
+            "", // empty url (from HtmlChunker)
+            "", // empty title (from HtmlChunker)
+            "AI-cleaned semantic content",
+        )
+        .with_embeddings(vec![0.1, 0.2, 0.3]);
+
+        let scraped = ScrapedContent {
+            title: "Source Page Title".to_string(),
+            content: "raw page content".to_string(),
+            url: ValidUrl::parse("https://example.com/article").unwrap(),
+            excerpt: Some("An excerpt".to_string()),
+            author: Some("Author Name".to_string()),
+            date: Some("2024-01-15".to_string()),
+            html: None,
+            assets: Vec::new(),
+            correlation_id: None,
+        };
+
+        let enriched = ai_chunk.enrich_from_scraped_content(&scraped);
+
+        assert_eq!(enriched.url, "https://example.com/article");
+        assert_eq!(enriched.title, "Source Page Title");
+        assert_eq!(enriched.content, "AI-cleaned semantic content");
+        assert_eq!(enriched.embeddings, Some(vec![0.1, 0.2, 0.3]));
+        assert_eq!(enriched.metadata["excerpt"], "An excerpt");
+        assert_eq!(enriched.metadata["author"], "Author Name");
+        assert_eq!(enriched.metadata["date"], "2024-01-15");
+        assert_eq!(enriched.metadata["domain"], "example.com");
+
+        // The enriched chunk must now pass validation (the core of #569).
+        assert!(
+            enriched.validate().is_ok(),
+            "enriched AI chunk must pass validation"
+        );
+    }
+
+    /// Enrichment must NOT overwrite existing metadata from the AI side.
+    #[test]
+    fn test_enrich_from_scraped_content_preserves_existing_metadata() {
+        let mut meta = HashMap::new();
+        meta.insert("author".to_string(), "AI-Inferred-Author".to_string());
+        meta.insert("custom_key".to_string(), "custom_value".to_string());
+
+        let ai_chunk = DocumentChunk::with_metadata(Uuid::new_v4(), "", "", "content", meta);
+
+        let scraped = ScrapedContent {
+            title: "Title".to_string(),
+            content: "content".to_string(),
+            url: ValidUrl::parse("https://example.com").unwrap(),
+            excerpt: None,
+            author: Some("Scraped-Author".to_string()),
+            date: None,
+            html: None,
+            assets: Vec::new(),
+            correlation_id: None,
+        };
+
+        let enriched = ai_chunk.enrich_from_scraped_content(&scraped);
+
+        // AI-side author is preserved, scraped author is NOT inserted.
+        assert_eq!(enriched.metadata["author"], "AI-Inferred-Author");
+        // Custom AI-side key is preserved.
+        assert_eq!(enriched.metadata["custom_key"], "custom_value");
+        // Domain is inserted (was missing).
+        assert_eq!(enriched.metadata["domain"], "example.com");
+    }
+
+    /// Enrichment with minimal scraped content (no optional fields) still works.
+    #[test]
+    fn test_enrich_from_scraped_content_minimal_scraped() {
+        let ai_chunk = DocumentChunk::new(Uuid::new_v4(), "", "", "AI content");
+
+        let scraped = ScrapedContent {
+            title: "Minimal".to_string(),
+            content: "raw".to_string(),
+            url: ValidUrl::parse("https://example.com").unwrap(),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: Vec::new(),
+            correlation_id: None,
+        };
+
+        let enriched = ai_chunk.enrich_from_scraped_content(&scraped);
+
+        assert_eq!(enriched.url, "https://example.com/");
+        assert_eq!(enriched.title, "Minimal");
+        assert_eq!(enriched.metadata.len(), 1); // only domain
+        assert!(enriched.validate().is_ok());
     }
 }

--- a/crates/webfang_core/tests/behavioral/cli/ai_integration_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/ai_integration_test.rs
@@ -397,3 +397,62 @@ fn webfang_path_no_ai() -> std::path::PathBuf {
 
     no_ai_target.join("debug").join("webfang")
 }
+
+/// Regression test for #569: `--clean-ai` must export the AI-cleaned chunks.
+///
+/// Before the fix, the semantic cleaner produced `DocumentChunk`s with empty
+/// `url`/`title`, and `validate()` silently discarded every one — the export
+/// file was never created while the log claimed success.
+#[tokio::test]
+#[ignore = "requires cached ONNX model"]
+async fn clean_ai_exports_chunks_regression_569() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(PAGE_HTML))
+        .expect(1)
+        .mount(&t.server)
+        .await;
+
+    t.scraper_cmd()
+        .arg("--single-page")
+        .arg("--clean-ai")
+        .arg("--quiet")
+        .assert()
+        .success();
+
+    // The export file MUST exist and contain at least one document.
+    let export_path = t.out.path().join("export.jsonl");
+    assert!(
+        export_path.exists(),
+        "export.jsonl must exist after --clean-ai: {:?}",
+        t.out.path()
+    );
+
+    let content = std::fs::read_to_string(&export_path).expect("read export.jsonl");
+    let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+    assert!(
+        !lines.is_empty(),
+        "export.jsonl must contain at least one document"
+    );
+
+    // Each line must be a valid DocumentChunk with non-empty url/title.
+    for line in &lines {
+        let json: serde_json::Value =
+            serde_json::from_str(line).expect("each line must be valid JSON");
+        let url = json["url"].as_str().expect("url field must be a string");
+        let title = json["title"]
+            .as_str()
+            .expect("title field must be a string");
+        let chunk_content = json["content"]
+            .as_str()
+            .expect("content field must be a string");
+        assert!(!url.is_empty(), "url must not be empty (#569 regression)");
+        assert!(
+            !title.is_empty(),
+            "title must not be empty (#569 regression)"
+        );
+        assert!(!chunk_content.is_empty(), "content must not be empty");
+    }
+}


### PR DESCRIPTION
Closes #569

## Resumen

Regresión expuesta por #560. Antes la inferencia fallaba y se hacía fallback a chunks con url/title válidos. Ahora la inferencia funciona pero los chunks AI tienen url/title vacíos → validate() los descarta todos.

## Fix

- `DocumentChunk::enrich_from_scraped_content()`: rellena url/title/metadata desde el ScrapedContent de la página origen
- `clean_all_pages()`: usa enrich después del clean exitoso

## Tests

- 3 unit tests para enrich_from_scraped_content
- 1 integration test de regresión: verifica que export.jsonl existe y tiene documentos con url/title/content no vacíos