### PR TITLE
fix(ai): inject SemanticCleaner into ElasticIngestion for --output-vectors and --elastic

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -464,7 +464,8 @@ async fn build_ai_cleaner(
                 // Extracted before type-erasing the cleaner behind the trait.
                 let (pool, tokenizer) = cleaner.shared_inference();
                 let cleaner: Option<Arc<dyn SemanticCleaner>> = Some(Arc::new(cleaner));
-                let ports = build_vault_ports(pool, tokenizer).await;
+                let mut ports = build_vault_ports(pool, tokenizer).await;
+                ports.cleaner = cleaner.clone();
                 Ok((cleaner, ports))
             },
             Err(e) => {

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -402,6 +402,23 @@ impl Container {
         ))
     }
 
+    /// Build an [`ElasticIngestion`] and attach the AI semantic cleaner when
+    /// present under the `ai` feature. Shared by [`with_elastic`] and
+    /// [`with_stream`] so the injection logic lives in exactly one place.
+    fn build_ingestion(
+        repository: DynVectorRepository,
+        config: &ElasticConfig,
+        cleaner: Option<Arc<dyn SemanticCleaner>>,
+    ) -> Result<ElasticIngestion<DynVectorRepository>, Box<dyn std::error::Error + Send + Sync>>
+    {
+        let mut ingestion = Self::build_elastic(repository, config)?;
+        #[cfg(feature = "ai")]
+        if let Some(cleaner) = cleaner {
+            ingestion = ingestion.with_cleaner(cleaner);
+        }
+        Ok(ingestion)
+    }
+
     /// Activate the elastic ingestion pipeline with SQLite persistence.
     ///
     /// Resolves `ElasticConfig` from the provided options, then wires
@@ -430,11 +447,7 @@ impl Container {
         sqlite_persistence::setup_schema(&pool).await?;
         let repository: DynVectorRepository = Arc::new(SqliteVectorRepository::new(pool));
 
-        let mut ingestion = Self::build_elastic(repository, &config)?;
-        #[cfg(feature = "ai")]
-        if let Some(cleaner) = self.cleaner.clone() {
-            ingestion = ingestion.with_cleaner(cleaner);
-        }
+        let ingestion = Self::build_ingestion(repository, &config, self.cleaner.clone())?;
         self.elastic_ingestion = Some(Arc::new(ingestion));
         Ok(self)
     }
@@ -461,11 +474,7 @@ impl Container {
         let repository: DynVectorRepository =
             Arc::new(crate::infrastructure::stream::StreamRepository::new(path)?);
 
-        let mut ingestion = Self::build_elastic(repository, &config)?;
-        #[cfg(feature = "ai")]
-        if let Some(cleaner) = self.cleaner.clone() {
-            ingestion = ingestion.with_cleaner(cleaner);
-        }
+        let ingestion = Self::build_ingestion(repository, &config, self.cleaner.clone())?;
         self.elastic_ingestion = Some(Arc::new(ingestion));
         Ok(self)
     }

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -118,6 +118,10 @@ pub struct VaultAiPorts {
     pub note_repository: Option<Arc<dyn NoteRepository>>,
     /// Text chunker for Markdown segmentation.
     pub text_chunker: Option<Arc<dyn TextChunker>>,
+
+    /// Semantic cleaner for AI-driven content extraction. `None` when the `ai`
+    /// feature is off or no cleaner was injected.
+    pub cleaner: Option<Arc<dyn SemanticCleaner>>,
 }
 
 impl Container {
@@ -331,6 +335,9 @@ impl Container {
         if let Some(chunker) = ports.text_chunker {
             self.text_chunker = Some(chunker);
         }
+        if let Some(cleaner) = ports.cleaner {
+            self.cleaner = Some(cleaner);
+        }
         self
     }
 
@@ -423,7 +430,10 @@ impl Container {
         sqlite_persistence::setup_schema(&pool).await?;
         let repository: DynVectorRepository = Arc::new(SqliteVectorRepository::new(pool));
 
-        let ingestion = Self::build_elastic(repository, &config)?;
+        let mut ingestion = Self::build_elastic(repository, &config)?;
+        if let Some(cleaner) = self.cleaner.clone() {
+            ingestion = ingestion.with_cleaner(cleaner);
+        }
         self.elastic_ingestion = Some(Arc::new(ingestion));
         Ok(self)
     }
@@ -450,7 +460,10 @@ impl Container {
         let repository: DynVectorRepository =
             Arc::new(crate::infrastructure::stream::StreamRepository::new(path)?);
 
-        let ingestion = Self::build_elastic(repository, &config)?;
+        let mut ingestion = Self::build_elastic(repository, &config)?;
+        if let Some(cleaner) = self.cleaner.clone() {
+            ingestion = ingestion.with_cleaner(cleaner);
+        }
         self.elastic_ingestion = Some(Arc::new(ingestion));
         Ok(self)
     }

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -431,6 +431,7 @@ impl Container {
         let repository: DynVectorRepository = Arc::new(SqliteVectorRepository::new(pool));
 
         let mut ingestion = Self::build_elastic(repository, &config)?;
+        #[cfg(feature = "ai")]
         if let Some(cleaner) = self.cleaner.clone() {
             ingestion = ingestion.with_cleaner(cleaner);
         }
@@ -461,6 +462,7 @@ impl Container {
             Arc::new(crate::infrastructure::stream::StreamRepository::new(path)?);
 
         let mut ingestion = Self::build_elastic(repository, &config)?;
+        #[cfg(feature = "ai")]
         if let Some(cleaner) = self.cleaner.clone() {
             ingestion = ingestion.with_cleaner(cleaner);
         }


### PR DESCRIPTION
Closes #575

## Summary
- `--output-vectors` and `--elastic` produced empty vector files because `SemanticCleaner` was never injected into `ElasticIngestion`
- Added `cleaner` field to `VaultAiPorts` bundle
- `with_vault_ports` now propagates cleaner into `Container`
- `with_stream`/`with_elastic` now inject cleaner into the ingestion pipeline via `.with_cleaner(c)`

## Verification
- `cargo check --features ai` ✅
- `cargo clippy --all-targets --all-features` ✅
- `cargo fmt` ✅
- `cargo nextest run -p webfang_core --features ai` — 1972 passed / 0 failed ✅