### PR TITLE
fix(ai): robust centroid reference + cosine similarity correctness + filter warn

### DIFF
--- a/crates/webfang_ai/src/infrastructure_ai/embedding_ops.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/embedding_ops.rs
@@ -14,34 +14,33 @@ use wide::f32x8;
 
 /// SIMD-accelerated cosine similarity
 ///
-/// Computes cosine similarity between two vectors using AVX2 SIMD instructions.
+/// Computes true cosine similarity between two vectors using AVX2 SIMD for the
+/// dot product and scalar magnitude normalization.
 ///
 /// # Mathematical Background
 ///
-/// For normalized vectors (unit length), cosine similarity equals dot product:
 /// ```text
 /// cos(θ) = (A · B) / (||A|| × ||B||)
 /// ```
 ///
-/// When `||A|| = ||B|| = 1` (normalized):
-/// ```text
-/// cos(θ) = A · B = Σ(aᵢ × bᵢ)
-/// ```
-///
-/// The `all-MiniLM-L6-v2` model outputs normalized embeddings, so we can use
-/// dot product directly.
+/// Unlike a raw dot product, this function divides by both magnitudes so it
+/// produces correct cosine similarity for **any** input vectors — not just
+/// pre-normalized unit vectors. This is critical for [`RelevanceScorer::score`],
+/// which does not normalize embeddings before scoring.
 ///
 /// # Arguments
 ///
-/// * `a` - First vector (should be normalized)
-/// * `b` - Second vector (should be normalized)
+/// * `a` - First vector
+/// * `b` - Second vector
 ///
 /// # Returns
 ///
 /// Cosine similarity in range [-1.0, 1.0]:
-/// - `1.0`: Identical vectors
-/// - `0.0`: Orthogonal (unrelated)
-/// - `-1.0`: Opposite vectors
+/// - `1.0`: Identical direction
+/// - `0.0`: Orthogonal (unrelated) or zero-magnitude vector
+/// - `-1.0`: Opposite direction
+///
+/// Returns `0.0` for empty inputs or when either vector has zero magnitude.
 ///
 /// # Examples
 ///
@@ -50,9 +49,9 @@ use wide::f32x8;
 /// # fn example() {
 /// use webfang_ai::infrastructure_ai::embedding_ops::cosine_similarity;
 ///
-/// // Identical vectors
-/// let vec = vec![0.5f32, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5];
-/// let sim = cosine_similarity(&vec, &vec);
+/// // Identical non-unit vectors — true cosine similarity normalizes magnitudes
+/// let v = vec![2.0f32, 0.0, 0.0, 0.0];
+/// let sim = cosine_similarity(&v, &v);
 /// assert!((sim - 1.0).abs() < 0.001);
 ///
 /// // Orthogonal vectors
@@ -65,8 +64,8 @@ use wide::f32x8;
 ///
 /// # Performance Notes
 ///
-/// - Uses `wide::f32x8` for 8-wide SIMD parallelism
-/// - Processes 8 floats per instruction on Haswell (AVX2)
+/// - Uses `wide::f32x8` for 8-wide SIMD parallelism on the dot product
+/// - Magnitudes are computed scalar (cheap relative to inference)
 /// - Falls back to scalar for remainder elements
 #[must_use]
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
@@ -104,7 +103,15 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         dot_product += a[i] * b[i];
     }
 
-    dot_product
+    // Compute magnitudes for true cosine similarity normalization
+    let mag_a: f32 = a[..len].iter().map(|x| x * x).sum::<f32>().sqrt();
+    let mag_b: f32 = b[..len].iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    if mag_a == 0.0 || mag_b == 0.0 {
+        return 0.0;
+    }
+
+    dot_product / (mag_a * mag_b)
 }
 
 /// Compute dot product of two vectors (scalar fallback)

--- a/crates/webfang_ai/src/infrastructure_ai/embedding_ops.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/embedding_ops.rs
@@ -25,7 +25,8 @@ use wide::f32x8;
 ///
 /// Unlike a raw dot product, this function divides by both magnitudes so it
 /// produces correct cosine similarity for **any** input vectors — not just
-/// pre-normalized unit vectors. This is critical for [`RelevanceScorer::score`],
+/// pre-normalized unit vectors. This is critical for
+/// [`RelevanceScorer::score`](crate::infrastructure_ai::RelevanceScorer::score),
 /// which does not normalize embeddings before scoring.
 ///
 /// # Arguments

--- a/crates/webfang_ai/src/infrastructure_ai/mod.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/mod.rs
@@ -62,7 +62,7 @@
 //! let cleaner = SemanticCleanerImpl::new(config).await?;
 //!
 //! let html = "<article><p>Hello World</p></article>";
-//! let chunks = cleaner.clean(html).await?;
+//! let chunks = cleaner.clean("https://example.com", html).await?;
 //!
 //! println!("Generated {} chunks", chunks.len());
 //! # Ok(())

--- a/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
+++ b/crates/webfang_ai/src/infrastructure_ai/semantic_cleaner_impl.rs
@@ -44,7 +44,7 @@
 //! let cleaner = SemanticCleanerImpl::new(config).await?;
 //!
 //! let html = "<article><p>Hello world. Test content.</p></article>";
-//! let chunks = cleaner.clean(html).await?;
+//! let chunks = cleaner.clean("https://example.com", html).await?;
 //!
 //! println!("Generated {} chunks", chunks.len());
 //! # Ok(())
@@ -59,7 +59,7 @@ use futures::future::{try_join, try_join_all};
 use hf_hub::api::tokio::ApiBuilder;
 use hf_hub::{Cache as HfCache, Repo, RepoType};
 use sha2::{Digest, Sha256};
-use tracing::{debug, info, Instrument};
+use tracing::{debug, info, warn, Instrument};
 
 use crate::infrastructure_ai::cache_config::AiModel;
 use crate::infrastructure_ai::{
@@ -354,10 +354,12 @@ impl private::Sealed for SemanticCleanerImpl {}
 impl SemanticCleaner for SemanticCleanerImpl {
     fn clean<'a>(
         &'a self,
+        url: &'a str,
         html: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>> {
         Box::pin(async move {
             debug!(
+                url = %url,
                 html_length = html.len(),
                 "Starting full RAG pipeline: prune → chunk → tokenize → embed → score"
             );
@@ -432,7 +434,7 @@ impl SemanticCleaner for SemanticCleanerImpl {
             // Step 4: Score and filter (own-borrow-over-clone: borrow embeddings)
             // Following `own-borrow-over-clone`: borrow &chunks and &embeddings, don't clone
             // Following `opt-simd-portable`: RelevanceScorer uses SIMD cosine similarity
-            let filtered = self.filter_by_relevance(&chunks, &embeddings)?;
+            let filtered = self.filter_by_relevance(url, &chunks, &embeddings)?;
 
             debug!(
                 chunks_before = chunks.len(),
@@ -459,20 +461,22 @@ impl SemanticCleaner for SemanticCleanerImpl {
 impl SemanticCleanerImpl {
     /// Filter chunks by relevance score and **preserve embeddings**
     ///
-    /// Pairs each chunk with its embedding, scores against a reference,
-    /// filters by threshold, and **preserves** the embedding vectors in the output.
+    /// Pairs each chunk with its embedding, scores against the **centroid**
+    /// of all embeddings, filters by threshold, and **preserves** the embedding
+    /// vectors in the output.
     ///
-    /// **Critical bug fix**: Previously called `scorer.filter()` which discarded
-    /// embeddings via `.map(|(chunk, _)| chunk.clone())`, resulting in:
-    /// - "Generated 0 chunks with embeddings" log messages
-    /// - Empty embeddings fields in JSONL output
-    /// - Loss of 49536 dimensions of embedding data
+    /// **Centroid reference**: Using the mean-pooled centroid of all chunk
+    /// embeddings as the reference vector is more robust than using the first
+    /// chunk — which may be a navigation element, header, or other non-representative
+    /// content. The centroid captures the overall semantic center of the page.
     ///
-    /// **Solution**: Uses `scorer.filter_with_embeddings()` to preserve embeddings,
-    /// then restores them to each chunk before returning `Vec<DocumentChunk>`.
+    /// **Aggressive filtering detection**: Emits a `warn!` when >50% of chunks
+    /// are discarded, indicating a potential threshold misconfiguration or
+    /// off-topic page.
     ///
     /// # Arguments
     ///
+    /// * `url` - Source URL for diagnostics and warning logs
     /// * `chunks` - Slice of DocumentChunks (borrowed, following `own-borrow-over-clone`)
     /// * `embeddings` - Slice of embedding vectors (borrowed)
     ///
@@ -489,45 +493,14 @@ impl SemanticCleanerImpl {
     /// # Performance
     ///
     /// Uses SIMD-accelerated cosine similarity via `RelevanceScorer`.
-    /// Concurrent operations use arena allocator to reduce allocation overhead.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # #[cfg(feature = "ai")]
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// use webfang_ai::{SemanticCleaner, SemanticCleanerImpl, ModelConfig, SemanticError};
-    ///
-    /// // Create semantic cleaner (requires --features ai)
-    /// let config = ModelConfig::default();
-    /// let cleaner = SemanticCleanerImpl::new(config).await?;
-    ///
-    /// // Clean HTML content - will generate chunks with embeddings
-    /// let html = "<article><h1>Title</h1><p>Content here.</p></article>";
-    /// let chunks = cleaner.clean(html).await?;
-    ///
-    /// // Verify embeddings are present (bug fix validation)
-    /// let has_embeddings = chunks.first()
-    ///     .map(|c| c.embeddings.is_some())
-    ///     .ok_or_else(|| SemanticError::Inference(
-    ///         "No chunks returned from semantic cleaner. Check HTML content and AI model availability.".to_string()
-    ///     ))?;
-    /// assert!(has_embeddings, "embeddings should not be None after fix");
-    ///
-    /// // Embedding dimension: 384 for all-MiniLM-L6-v2 model
-    /// let dim = chunks.first()
-    ///     .map(|c| c.embeddings.as_ref().map(|e| e.len()))
-    ///     .ok_or(SemanticError::Inference("No chunks or Embeddings returned".to_string()))?;
-    /// assert_eq!(dim, Some(384));
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// The centroid is mean-pooled in O(n×d) where n = chunks, d = embedding dim.
     ///
     /// See also:
     /// - [`SemanticCleaner::clean()`](SemanticCleaner::clean) - Full pipeline entry point
     /// - [`RelevanceScorer::filter_with_embeddings()`](RelevanceScorer::filter_with_embeddings)
     fn filter_by_relevance(
         &self,
+        url: &str,
         chunks: &[DocumentChunk],
         embeddings: &[Vec<f32>],
     ) -> Result<Vec<DocumentChunk>, SemanticError> {
@@ -541,6 +514,8 @@ impl SemanticCleanerImpl {
             )));
         }
 
+        let chunks_before = chunks.len();
+
         // Create (chunk, embedding) pairs
         // Following `mem-with-capacity`: pre-allocate
         let mut chunk_embedding_pairs = Vec::with_capacity(chunks.len());
@@ -549,16 +524,51 @@ impl SemanticCleanerImpl {
             chunk_embedding_pairs.push((chunk.clone(), embedding.clone()));
         }
 
-        // Use first embedding as reference (simple strategy)
-        // In production, this could be a query vector or domain-specific reference
-        let reference = embeddings.first().ok_or_else(|| {
-            SemanticError::Inference("No embeddings available for relevance scoring".to_string())
-        })?;
+        // Compute centroid (mean-pooled reference) of all embeddings.
+        // More robust than using embeddings.first() — the first chunk may be a
+        // nav element, header, or other non-representative content.
+        let embedding_dim = embeddings.first().map(|e| e.len()).unwrap_or(0);
+        if embedding_dim == 0 {
+            return Err(SemanticError::Inference(
+                "No embeddings available for relevance scoring".to_string(),
+            ));
+        }
+
+        let mut centroid = vec![0.0f32; embedding_dim];
+        for embedding in embeddings {
+            for (i, &val) in embedding.iter().enumerate() {
+                if i < centroid.len() {
+                    centroid[i] += val;
+                }
+            }
+        }
+        let n = embeddings.len() as f32;
+        for val in &mut centroid {
+            *val /= n;
+        }
 
         // Filter using scorer WITH embeddings preserved
         let filtered_with_embeddings: Vec<(DocumentChunk, Vec<f32>)> = self
             .scorer
-            .filter_with_embeddings(&chunk_embedding_pairs, Some(reference));
+            .filter_with_embeddings(&chunk_embedding_pairs, Some(&centroid));
+
+        let filtered_out = chunks_before - filtered_with_embeddings.len();
+
+        // Warn when filtering is aggressive (>50% discarded) — possible over-aggressive
+        // threshold or off-topic page. Structured fields for trace querying.
+        if chunks_before > 0 && filtered_out as f64 / chunks_before as f64 > 0.5 {
+            warn!(
+                url = %url,
+                chunks_before = chunks_before,
+                chunks_after = filtered_with_embeddings.len(),
+                filtered_out = filtered_out,
+                loss_ratio = format!(
+                    "{:.0}%",
+                    filtered_out as f64 / chunks_before as f64 * 100.0
+                ),
+                "AI relevance filter discarded >50% of chunks for this page — possible over-aggressive filtering"
+            );
+        }
 
         // Restore embeddings to chunks following `mem-preserving-embeddings`
         let mut result = Vec::with_capacity(filtered_with_embeddings.len());

--- a/crates/webfang_ai/tests/ai_integration.rs
+++ b/crates/webfang_ai/tests/ai_integration.rs
@@ -21,6 +21,9 @@ use webfang_ai::SemanticCleaner;
 use webfang_ai::SemanticError;
 use webfang_core::domain::DocumentChunk;
 
+/// Test URL for semantic cleaner calls
+const TEST_URL: &str = "https://example.com/test";
+
 // ============================================================================
 // Integration-only tests (not covered by unit tests)
 // ============================================================================
@@ -345,7 +348,7 @@ async fn test_semantic_cleaner_full_pipeline() {
     let cleaner = build_offline_cleaner().await;
 
     let html = "<article><p>Hello world. Test content for semantic cleaning.</p></article>";
-    let chunks = cleaner.clean(html).await;
+    let chunks = cleaner.clean(TEST_URL, html).await;
 
     assert!(
         chunks.is_ok(),
@@ -382,7 +385,7 @@ async fn test_semantic_cleaner_long_content() {
             </article>
         "#;
 
-    let chunks = cleaner.clean(html).await;
+    let chunks = cleaner.clean(TEST_URL, html).await;
 
     assert!(
         chunks.is_ok(),
@@ -449,7 +452,7 @@ async fn test_error_chunk_too_large() {
     let long_content = "Test. ".repeat(2000);
     let html = format!("<p>{long_content}</p>");
 
-    let result = cleaner.clean(&html).await;
+    let result = cleaner.clean(TEST_URL, &html).await;
 
     match result {
         Ok(chunks) => {
@@ -497,7 +500,7 @@ async fn test_pipeline_empty_input() {
         .expect("cached ONNX model required");
 
     let html = "";
-    let chunks = cleaner.clean(html).await;
+    let chunks = cleaner.clean(TEST_URL, html).await;
 
     assert!(chunks.is_ok(), "Empty input should not fail");
     let chunks = chunks.unwrap();
@@ -514,7 +517,7 @@ async fn test_pipeline_html_only() {
         .expect("cached ONNX model required");
 
     let html = "<div></div><span></span>";
-    let chunks = cleaner.clean(html).await;
+    let chunks = cleaner.clean(TEST_URL, html).await;
 
     assert!(chunks.is_ok(), "HTML-only input should not fail");
     let chunks = chunks.unwrap();

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -585,6 +585,7 @@ mod tests {
     impl crate::domain::semantic_cleaner::SemanticCleaner for FakeCleaner {
         fn clean<'a>(
             &'a self,
+            _url: &'a str,
             _html: &'a str,
         ) -> std::pin::Pin<
             Box<

--- a/crates/webfang_core/src/application/elastic_ingestion.rs
+++ b/crates/webfang_core/src/application/elastic_ingestion.rs
@@ -196,7 +196,7 @@ impl<R: VectorRepository + Send + Sync> ElasticIngestion<R> {
         #[cfg(feature = "ai")]
         {
             if let Some(cleaner) = &self.cleaner {
-                self.cleaner_chunks(cleaner, &bytes).await
+                self.cleaner_chunks(cleaner, url, &bytes).await
             } else {
                 self.bridge_chunks(url, bytes, size).await
             }
@@ -342,11 +342,12 @@ impl<R: VectorRepository + Send + Sync> ElasticIngestion<R> {
     async fn cleaner_chunks(
         &self,
         cleaner: &std::sync::Arc<dyn crate::domain::semantic_cleaner::SemanticCleaner>,
+        url: &str,
         bytes: &[u8],
     ) -> Result<Vec<crate::infrastructure::bridge::ProcessedChunk>, ScraperError> {
         let html = String::from_utf8_lossy(bytes);
         let doc_chunks = cleaner
-            .clean(&html)
+            .clean(url, &html)
             .await
             .map_err(|e| ScraperError::ingestion(format!("limpieza semántica falló: {e}")))?;
         Ok(doc_chunks

--- a/crates/webfang_core/src/cli/export_flow.rs
+++ b/crates/webfang_core/src/cli/export_flow.rs
@@ -156,7 +156,7 @@ async fn clean_all_pages(
             let url = result.url.clone();
             let cleaner = std::sync::Arc::clone(cleaner);
             async move {
-                let chunks_result = cleaner.clean(&html_content).await;
+                let chunks_result = cleaner.clean(url.as_str(), &html_content).await;
                 (url, chunks_result, result.clone())
             }
         })
@@ -253,6 +253,7 @@ mod tests {
     impl SemanticCleaner for FailingCleaner {
         fn clean<'a>(
             &'a self,
+            _url: &'a str,
             _html: &'a str,
         ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>>
         {

--- a/crates/webfang_core/src/domain/semantic_cleaner.rs
+++ b/crates/webfang_core/src/domain/semantic_cleaner.rs
@@ -47,7 +47,7 @@ pub mod private {
 /// # use webfang_core::domain::semantic_cleaner::SemanticCleaner;
 /// # async fn example(cleaner: &dyn SemanticCleaner) -> Result<(), Box<dyn std::error::Error>> {
 /// let html = "<html><body><p>Hello World</p></body></html>";
-/// let chunks = cleaner.clean(html).await?;
+/// let chunks = cleaner.clean("https://example.com", html).await?;
 /// println!("Generated {} chunks", chunks.len());
 /// # Ok(())
 /// # }
@@ -74,10 +74,12 @@ pub trait SemanticCleaner: private::Sealed + Send + Sync {
     /// 1. Strips HTML tags and extracts text
     /// 2. Splits text into semantic chunks (paragraphs, sections)
     /// 3. Validates chunk sizes against model token limits
-    /// 4. Returns chunks ready for embedding generation
+    /// 4. Scores relevance against the centroid of all chunk embeddings
+    /// 5. Returns chunks ready for embedding generation
     ///
     /// # Arguments
     ///
+    /// * `url` - Source URL of the HTML content (used for logging and diagnostics)
     /// * `html` - Raw HTML content to clean (borrowed, `&str` not `&String`)
     ///
     /// # Returns
@@ -99,7 +101,7 @@ pub trait SemanticCleaner: private::Sealed + Send + Sync {
     /// # use webfang_core::domain::semantic_cleaner::SemanticCleaner;
     /// # async fn example(cleaner: &dyn SemanticCleaner) -> Result<(), Box<dyn std::error::Error>> {
     /// let html = "<article><h1>Title</h1><p>Content here...</p></article>";
-    /// let chunks = cleaner.clean(html).await?;
+    /// let chunks = cleaner.clean("https://example.com/page", html).await?;
     ///
     /// for chunk in &chunks {
     ///     println!("Chunk {}: {} chars", chunk.id, chunk.content.len());
@@ -118,10 +120,11 @@ pub trait SemanticCleaner: private::Sealed + Send + Sync {
     ///
     /// Desugared to a boxed future (`Pin<Box<dyn Future + Send>>`) instead of
     /// `async fn` so the trait stays dyn-compatible (`Box<dyn SemanticCleaner>`).
-    /// The single lifetime `'a` ties `&self` and `html` to the returned future,
-    /// matching the `async-trait` macro's default desugaring.
+    /// The single lifetime `'a` ties `&self`, `url`, and `html` to the returned
+    /// future, matching the `async-trait` macro's default desugaring.
     fn clean<'a>(
         &'a self,
+        url: &'a str,
         html: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>>;
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -110,7 +110,7 @@ impl McpHandler {
             Ok(resp) => resp,
             Err(e) => return Ok(honest_error(format!("no se pudo obtener la página: {e}"))),
         };
-        let documents = match cleaner.clean(&response.body).await {
+        let documents = match cleaner.clean(&params.url, &response.body).await {
             Ok(docs) => docs,
             Err(e) => return Ok(honest_error(format!("error al limpiar el contenido: {e}"))),
         };


### PR DESCRIPTION
Closes #576

## Summary

- **cosine_similarity** ahora es verdadero coseno (divide por magnitudes), no producto punto disfrazado. Mantiene SIMD para el dot product.
- **SemanticCleaner::clean** recibe URL para diagnósticos.
- **filter_by_relevance** usa centroide mean-pooled de todos los embeddings como referencia, no el primer chunk del DOM.
- **warn!** cuando >50% de chunks se descartan (posible filtrado agresivo).

## Cambios

| Archivo | Cambio |
|:---|:---|
| `embedding_ops.rs` | True cosine similarity (dot / mag_a × mag_b) |
| `semantic_cleaner.rs` | Trait `clean()` toma `url: &'a str` |
| `semantic_cleaner_impl.rs` | Centroid reference + warn! + URL param |
| 6 archivos adicionales | Callers actualizados |

## Verificación

- ✅ cargo check + clippy + fmt
- ✅ cargo nextest run --features ai (2486 passed, 0 failed)