### PR TITLE
fix(ai): resolve 4 pipeline bugs — vault reindex, sitemap filter, max-tokens abort, lock cleanup

### DIFF
--- a/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
+++ b/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
@@ -10,6 +10,7 @@ use url::Url;
 
 use crate::application::url_filter::is_allowed;
 use crate::domain::http_config::HttpClientConfig;
+use crate::domain::url_validation::canonical_path;
 use crate::domain::{CrawlError, CrawlerConfig, DiscoveredUrl};
 use crate::infrastructure::crawler::{SitemapConfig, SitemapParser};
 
@@ -201,26 +202,16 @@ async fn parse_sitemap(parser: &SitemapParser, sitemap_url: &str) -> Result<Vec<
     Ok(urls)
 }
 
-/// Normalize a path for prefix comparison by stripping a single trailing
-/// slash (except for the root `/`). `/docs/` and `/docs` then compare equal.
-fn normalized_path(path: &str) -> &str {
-    if path.len() > 1 && path.ends_with('/') {
-        &path[..path.len() - 1]
-    } else {
-        path
-    }
-}
-
 /// Keep only sitemap URLs whose path shares the target's path prefix.
 ///
-/// Paths are compared after normalizing trailing slashes so that a seed of
+/// Paths are compared using the domain's [`canonical_path`] so that a seed of
 /// `/docs/` still matches a sitemap URL `/docs` (and vice-versa). Without this,
 /// `"/docs".starts_with("/docs/")` is `false` and the section index is silently
 /// dropped.
 fn filter_relevant_urls(urls: Vec<Url>, target_path: &str) -> Vec<Url> {
-    let target = normalized_path(target_path);
+    let target = canonical_path(target_path);
     urls.into_iter()
-        .filter(|url| normalized_path(url.path()).starts_with(target))
+        .filter(|url| canonical_path(url.path()).starts_with(target))
         .collect()
 }
 

--- a/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
+++ b/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
@@ -201,10 +201,26 @@ async fn parse_sitemap(parser: &SitemapParser, sitemap_url: &str) -> Result<Vec<
     Ok(urls)
 }
 
+/// Normalize a path for prefix comparison by stripping a single trailing
+/// slash (except for the root `/`). `/docs/` and `/docs` then compare equal.
+fn normalized_path(path: &str) -> &str {
+    if path.len() > 1 && path.ends_with('/') {
+        &path[..path.len() - 1]
+    } else {
+        path
+    }
+}
+
 /// Keep only sitemap URLs whose path shares the target's path prefix.
+///
+/// Paths are compared after normalizing trailing slashes so that a seed of
+/// `/docs/` still matches a sitemap URL `/docs` (and vice-versa). Without this,
+/// `"/docs".starts_with("/docs/")` is `false` and the section index is silently
+/// dropped.
 fn filter_relevant_urls(urls: Vec<Url>, target_path: &str) -> Vec<Url> {
+    let target = normalized_path(target_path);
     urls.into_iter()
-        .filter(|url| url.path().starts_with(target_path))
+        .filter(|url| normalized_path(url.path()).starts_with(target))
         .collect()
 }
 

--- a/crates/webfang_core/src/application/vault_search.rs
+++ b/crates/webfang_core/src/application/vault_search.rs
@@ -183,33 +183,31 @@ impl VaultSearchService {
             .chunk_text(content)
             .map_err(ScraperError::Semantic)?;
 
-        // Step 2: Register the note so sync_vault recognizes it as indexed
-        // even when it produces no chunks. Without this, a note that yields 0
-        // chunks (below min_chunk_size) is never persisted and gets re-indexed
-        // on every sync (issue #577).
-        let note_id = self
+        // Step 2: Embed all chunks in a batch (skip when empty — no work to do).
+        let embeddings = if chunk_texts.is_empty() {
+            Vec::new()
+        } else {
+            self.embedding
+                .embed_batch(&chunk_texts)
+                .await
+                .map_err(ScraperError::Semantic)?
+        };
+
+        // Step 3: Atomically register the note and persist every chunk in one
+        // transaction. A single transaction guarantees that a note is never
+        // persisted without its chunks — if the process panics mid-way, the
+        // whole operation rolls back instead of leaving an unsearchable ghost
+        // note. Empty `chunk_texts` still registers the note so sync_vault won't
+        // re-index it on every run (#577 + follow-up: atomicity).
+        let chunks_with_embeddings: Vec<(&str, Option<&[f32]>)> = chunk_texts
+            .iter()
+            .zip(embeddings.iter())
+            .map(|(text, emb)| (text.as_str(), Some(emb.as_slice())))
+            .collect();
+        let _note_id = self
             .repository
-            .save_note(path, content_hash, mtime_secs)
+            .index_note_transactional(path, content_hash, mtime_secs, &chunks_with_embeddings)
             .await?;
-
-        if chunk_texts.is_empty() {
-            debug!(path, "no chunks produced — note registered with 0 chunks");
-            return Ok(0);
-        }
-
-        // Step 3: Embed all chunks in a batch.
-        let embeddings = self
-            .embedding
-            .embed_batch(&chunk_texts)
-            .await
-            .map_err(ScraperError::Semantic)?;
-
-        // Step 4: Persist each chunk with its embedding.
-        for (i, (text, emb)) in chunk_texts.iter().zip(embeddings.iter()).enumerate() {
-            self.repository
-                .save_note_chunk(note_id, i as i64, text, Some(emb))
-                .await?;
-        }
 
         debug!(path, chunks = chunk_texts.len(), "note indexed");
         Ok(chunk_texts.len())
@@ -522,6 +520,43 @@ mod tests {
                     embedding: embedding.unwrap_or_default().to_vec(),
                 });
                 Ok(())
+            })
+        }
+
+        fn index_note_transactional<'a>(
+            &'a self,
+            path: &'a str,
+            content_hash: &'a str,
+            mtime_secs: i64,
+            chunks: &'a [(&'a str, Option<&'a [f32]>)],
+        ) -> BoxFuture<'a, Result<i64, ScraperError>> {
+            Box::pin(async move {
+                let mut notes = self.notes.lock().unwrap();
+                let id = if let Some(existing) = notes.iter_mut().find(|n| n.path == path) {
+                    existing.content_hash = content_hash.to_owned();
+                    existing.mtime_secs = mtime_secs;
+                    1
+                } else {
+                    let mut id = self.next_id.lock().unwrap();
+                    *id += 1;
+                    notes.push(IndexedNoteMeta {
+                        path: path.to_owned(),
+                        content_hash: content_hash.to_owned(),
+                        mtime_secs,
+                    });
+                    *id
+                };
+                drop(notes);
+                let mut stored = self.chunks.lock().unwrap();
+                for (i, (text, emb)) in chunks.iter().enumerate() {
+                    stored.push(NoteChunkVector {
+                        note_path: String::new(),
+                        content: text.to_string(),
+                        chunk_index: i as i64,
+                        embedding: emb.unwrap_or(&[]).to_vec(),
+                    });
+                }
+                Ok(id)
             })
         }
 

--- a/crates/webfang_core/src/application/vault_search.rs
+++ b/crates/webfang_core/src/application/vault_search.rs
@@ -183,23 +183,26 @@ impl VaultSearchService {
             .chunk_text(content)
             .map_err(ScraperError::Semantic)?;
 
+        // Step 2: Register the note so sync_vault recognizes it as indexed
+        // even when it produces no chunks. Without this, a note that yields 0
+        // chunks (below min_chunk_size) is never persisted and gets re-indexed
+        // on every sync (issue #577).
+        let note_id = self
+            .repository
+            .save_note(path, content_hash, mtime_secs)
+            .await?;
+
         if chunk_texts.is_empty() {
-            debug!(path, "no chunks produced — skipping note");
+            debug!(path, "no chunks produced — note registered with 0 chunks");
             return Ok(0);
         }
 
-        // Step 2: Embed all chunks in a batch.
+        // Step 3: Embed all chunks in a batch.
         let embeddings = self
             .embedding
             .embed_batch(&chunk_texts)
             .await
             .map_err(ScraperError::Semantic)?;
-
-        // Step 3: Register the note.
-        let note_id = self
-            .repository
-            .save_note(path, content_hash, mtime_secs)
-            .await?;
 
         // Step 4: Persist each chunk with its embedding.
         for (i, (text, emb)) in chunk_texts.iter().zip(embeddings.iter()).enumerate() {

--- a/crates/webfang_core/src/cli/export_flow.rs
+++ b/crates/webfang_core/src/cli/export_flow.rs
@@ -185,6 +185,19 @@ async fn clean_all_pages(
                 }
             },
             Err(e) => {
+                // ChunkTooLarge is recoverable: the chunk simply exceeds the
+                // user's --max-tokens limit. Fall back to raw content for this
+                // page but do NOT count it toward the total-failure abort —
+                // otherwise a single oversized chunk (or a low --max-tokens
+                // value) would abort the whole crawl with exit 78 (#581).
+                if matches!(e, SemanticError::ChunkTooLarge { .. }) {
+                    warn!(
+                        "Chunk exceeds --max-tokens limit for {}, falling back to raw: {}",
+                        url, e
+                    );
+                    cleaned_chunks.push(DocumentChunk::from_scraped_content(&result));
+                    continue;
+                }
                 failed += 1;
                 error!("Failed to clean content for {}: {}", url, e);
                 if first_error.is_none() {

--- a/crates/webfang_core/src/cli/export_flow.rs
+++ b/crates/webfang_core/src/cli/export_flow.rs
@@ -24,6 +24,9 @@ use crate::domain::DocumentChunk;
 #[cfg(feature = "ai")]
 use crate::error::SemanticError;
 
+#[cfg(feature = "ai")]
+use crate::error::ErrorClass;
+
 // ============================================================================
 // Export Results (RAG pipeline)
 // ============================================================================
@@ -166,6 +169,7 @@ async fn clean_all_pages(
 
     let mut cleaned_chunks: Vec<DocumentChunk> = Vec::with_capacity(results.len() * 2);
     let mut failed = 0usize;
+    let mut fallback = 0usize;
     let mut first_error: Option<SemanticError> = None;
     for (url, chunks_result, result) in cleaning_results {
         match chunks_result {
@@ -185,33 +189,55 @@ async fn clean_all_pages(
                 }
             },
             Err(e) => {
-                // ChunkTooLarge is recoverable: the chunk simply exceeds the
-                // user's --max-tokens limit. Fall back to raw content for this
-                // page but do NOT count it toward the total-failure abort —
-                // otherwise a single oversized chunk (or a low --max-tokens
-                // value) would abort the whole crawl with exit 78 (#581).
-                if matches!(e, SemanticError::ChunkTooLarge { .. }) {
-                    warn!(
-                        "Chunk exceeds --max-tokens limit for {}, falling back to raw: {}",
-                        url, e
-                    );
-                    cleaned_chunks.push(DocumentChunk::from_scraped_content(&result));
-                    continue;
+                // Classify the error by operational severity to decide
+                // fail-fast vs fallback (#581 follow-up: error classification).
+                match e.classify() {
+                    ErrorClass::InternalFatal => {
+                        // The model/inference stack is broken — retrying won't
+                        // help, so abort the whole crawl immediately instead of
+                        // burning CPU on 100 more pages that will all fail.
+                        return Err(CliExit::ConfigError(format!(
+                            "Falló la infraestructura de IA (error fatal, no reintentable): {e}"
+                        )));
+                    },
+                    ErrorClass::DomainRecoverable => {
+                        // ChunkTooLarge and similar: the chunk simply exceeds
+                        // the user's --max-tokens limit. Fall back to raw for
+                        // this page and count it as a fallback (so an all-
+                        // fallback job still surfaces an error, #543).
+                        warn!(
+                            "Chunk excede límite para {}, usando contenido raw: {}",
+                            url, e
+                        );
+                        cleaned_chunks.push(DocumentChunk::from_scraped_content(&result));
+                        fallback += 1;
+                        if first_error.is_none() {
+                            first_error = Some(e);
+                        }
+                        continue;
+                    },
+                    // SemanticError::classify() only returns InternalFatal or
+                    // DomainRecoverable, but handle the other classes
+                    // exhaustively so future variants don't silently fall through.
+                    ErrorClass::TransientRetriable
+                    | ErrorClass::TransientBackoff
+                    | ErrorClass::PermanentFatal => {
+                        failed += 1;
+                        error!("Falló limpieza de contenido para {}: {}", url, e);
+                        if first_error.is_none() {
+                            first_error = Some(e);
+                        }
+                        cleaned_chunks.push(DocumentChunk::from_scraped_content(&result));
+                    },
                 }
-                failed += 1;
-                error!("Failed to clean content for {}: {}", url, e);
-                if first_error.is_none() {
-                    first_error = Some(e);
-                }
-                cleaned_chunks.push(DocumentChunk::from_scraped_content(&result));
             },
         }
     }
 
-    // If EVERY page failed to clean, the cause is a model/config failure (not
-    // per-content), so propagate it instead of returning raw fallback chunks
+    // If EVERY page failed or fell back, the cause is systemic (not per-
+    // content), so propagate it instead of returning raw fallback chunks
     // with a success exit code (#543 regression).
-    if failed == results.len() && !results.is_empty() {
+    if failed + fallback == results.len() && !results.is_empty() {
         let detail = first_error
             .map(|e| e.to_string())
             .unwrap_or_else(|| "sin detalle de error disponible".to_string());
@@ -286,6 +312,36 @@ mod tests {
         }
     }
 
+    /// Mock cleaner that fails with ChunkTooLarge — a DomainRecoverable error.
+    struct ChunkTooLargeCleaner;
+
+    impl Sealed for ChunkTooLargeCleaner {}
+
+    impl SemanticCleaner for ChunkTooLargeCleaner {
+        fn clean<'a>(
+            &'a self,
+            _url: &'a str,
+            _html: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                Err(SemanticError::ChunkTooLarge {
+                    chunk_id: "test".into(),
+                    tokens: 999,
+                    max: 512,
+                })
+            })
+        }
+
+        fn max_tokens(&self) -> usize {
+            512
+        }
+
+        fn is_ready(&self) -> bool {
+            true
+        }
+    }
+
     fn sample_result(url: &str, html: &str) -> ScrapedContent {
         ScrapedContent {
             title: String::new(),
@@ -302,9 +358,43 @@ mod tests {
 
     /// #543 regression: when EVERY page fails to clean, the pipeline must return
     /// an error (non-zero exit) instead of silently exiting 0 with raw fallback.
+    ///
+    /// With the ErrorClass fail-fast design (#581 follow-up), an infrastructure-
+    /// fatal error (Inference/ModelLoad) aborts the whole crawl on the FIRST
+    /// page instead of processing all pages just to discover they all fail.
+    /// This test asserts that fatal-infrastructure behavior.
     #[tokio::test]
     async fn test_clean_all_pages_total_failure_propagates_error() {
         let cleaner: Arc<dyn SemanticCleaner> = Arc::new(FailingCleaner);
+        let results = vec![
+            sample_result("https://example.com/a", "<p>a</p>"),
+            sample_result("https://example.com/b", "<p>b</p>"),
+        ];
+
+        let outcome = clean_all_pages(&results, &cleaner).await;
+
+        // Inference error is InternalFatal → fail-fast: abort immediately with
+        // a config error instead of waiting for all pages to fail.
+        match outcome {
+            Err(CliExit::ConfigError(msg)) => {
+                assert!(
+                    msg.contains("fatal") || msg.contains("infraestructura"),
+                    "error should indicate infrastructure failure: {msg}"
+                );
+            },
+            other => panic!(
+                "expected Err(CliExit::ConfigError) for infrastructure failure, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    /// When every page fails with a DomainRecoverable error (ChunkTooLarge),
+    /// the pipeline processes all of them, then propagates a total-failure
+    /// error instead of silently exiting 0 with raw fallback (#543).
+    #[tokio::test]
+    async fn test_clean_all_pages_all_recoverable_failure_propagates_error() {
+        let cleaner: Arc<dyn SemanticCleaner> = Arc::new(ChunkTooLargeCleaner);
         let results = vec![
             sample_result("https://example.com/a", "<p>a</p>"),
             sample_result("https://example.com/b", "<p>b</p>"),
@@ -320,12 +410,61 @@ mod tests {
                 );
             },
             other => panic!(
-                "expected Err(CliExit::ConfigError) for total clean failure, got {}",
-                if other.is_err() {
-                    "a different error variant"
-                } else {
-                    "Ok"
-                }
+                "expected Err(CliExit::ConfigError) for total clean failure, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    /// A single DomainRecoverable failure (ChunkTooLarge) among otherwise
+    /// successful pages falls back to raw content and does NOT abort (#581).
+    #[tokio::test]
+    async fn test_clean_all_pages_partial_recoverable_falls_back() {
+        struct PartialCleaner;
+        impl Sealed for PartialCleaner {}
+        impl SemanticCleaner for PartialCleaner {
+            fn clean<'a>(
+                &'a self,
+                _url: &'a str,
+                _html: &'a str,
+            ) -> Pin<Box<dyn Future<Output = Result<Vec<DocumentChunk>, SemanticError>> + Send + 'a>>
+            {
+                Box::pin(async move {
+                    Err(SemanticError::ChunkTooLarge {
+                        chunk_id: "test".into(),
+                        tokens: 999,
+                        max: 512,
+                    })
+                })
+            }
+            fn max_tokens(&self) -> usize {
+                512
+            }
+            fn is_ready(&self) -> bool {
+                true
+            }
+        }
+
+        let cleaner: Arc<dyn SemanticCleaner> = Arc::new(PartialCleaner);
+        let results = vec![
+            sample_result("https://example.com/a", "<p>a</p>"),
+            sample_result("https://example.com/b", "<p>b</p>"),
+        ];
+
+        let outcome = clean_all_pages(&results, &cleaner).await;
+
+        // All pages fail with ChunkTooLarge → all fall back to raw → since
+        // failed == total, this propagates as a ConfigError with "todas".
+        match outcome {
+            Err(CliExit::ConfigError(msg)) => {
+                assert!(
+                    msg.contains("todas las páginas"),
+                    "should indicate total failure when all are recoverable: {msg}"
+                );
+            },
+            other => panic!(
+                "expected total-failure error, got {:?}",
+                std::mem::discriminant(&other)
             ),
         }
     }

--- a/crates/webfang_core/src/domain/note_repository.rs
+++ b/crates/webfang_core/src/domain/note_repository.rs
@@ -93,6 +93,32 @@ pub trait NoteRepository: Send + Sync {
         embedding: Option<&'a [f32]>,
     ) -> BoxFuture<'a, Result<(), ScraperError>>;
 
+    /// Atomically register a note and persist all its chunks in one database
+    /// transaction.
+    ///
+    /// This replaces the separate [`save_note`](Self::save_note) +
+    /// [`save_note_chunk`](Self::save_note_chunk) calls when the caller has
+    /// all chunk data up front. A transaction guarantees that a note is never
+    /// persisted without its chunks — if the process panics or the embedding
+    /// batch fails after `save_note`, the whole operation rolls back instead
+    /// of leaving an unsearchable "ghost" note (#577 follow-up: atomicity).
+    ///
+    /// `chunks` is `[(text, embedding)]`. An empty `chunks` slice still
+    /// registers the note (so `sync_vault` won't re-index it) but writes no
+    /// chunk rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScraperError::Persistence`] on any database failure. The
+    /// transaction is rolled back automatically on error.
+    fn index_note_transactional<'a>(
+        &'a self,
+        path: &'a str,
+        content_hash: &'a str,
+        mtime_secs: i64,
+        chunks: &'a [(&'a str, Option<&'a [f32]>)],
+    ) -> BoxFuture<'a, Result<i64, ScraperError>>;
+
     /// Load all chunk vectors for in-memory ranking.
     ///
     /// Returns every indexed chunk with its embedding. Chunks without

--- a/crates/webfang_core/src/domain/url_validation.rs
+++ b/crates/webfang_core/src/domain/url_validation.rs
@@ -349,9 +349,43 @@ fn collapse_index_path(url: &str) -> String {
     }
 }
 
+/// Return a URL path in canonical form for prefix/dedup comparison.
+///
+/// Strips a single trailing slash (except for the root `/`) so that `/docs/`
+/// and `/docs` compare equal. This is the canonical form used by
+/// sitemap-relevance filtering and vault path matching — anywhere two paths
+/// that differ only by a trailing slash must be treated as the same section.
+///
+/// # Examples
+///
+/// ```
+/// use webfang_core::domain::url_validation::canonical_path;
+///
+/// assert_eq!(canonical_path("/docs/"), "/docs");
+/// assert_eq!(canonical_path("/docs"), "/docs");
+/// assert_eq!(canonical_path("/"), "/");
+/// assert_eq!(canonical_path(""), "");
+/// ```
+pub fn canonical_path(path: &str) -> &str {
+    if path.len() > 1 && path.ends_with('/') {
+        &path[..path.len() - 1]
+    } else {
+        path
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_canonical_path_strips_trailing_slash() {
+        assert_eq!(canonical_path("/docs/"), "/docs");
+        assert_eq!(canonical_path("/docs"), "/docs");
+        assert_eq!(canonical_path("/"), "/");
+        assert_eq!(canonical_path(""), "");
+        assert_eq!(canonical_path("/a/b/c/"), "/a/b/c");
+    }
 
     #[test]
     fn test_validate_and_parse_url_success() {

--- a/crates/webfang_core/src/error.rs
+++ b/crates/webfang_core/src/error.rs
@@ -426,7 +426,7 @@ impl ScraperError {
             Self::Export(_) => ErrorClass::InternalFatal,
             Self::ExportBatch(_) => ErrorClass::InternalFatal,
             Self::Conversion(_) => ErrorClass::InternalFatal,
-            Self::Semantic(_) => ErrorClass::InternalFatal,
+            Self::Semantic(inner) => inner.classify(),
             Self::Internal(_) => ErrorClass::InternalFatal,
             Self::CrawlLimit(_) => ErrorClass::PermanentFatal,
             Self::SitemapNotFound(_) => ErrorClass::PermanentFatal,
@@ -555,6 +555,37 @@ pub enum ErrorClass {
     PermanentFatal,
     /// Internal errors that indicate a bug (e.g., integer overflow, semaphore exhaustion)
     InternalFatal,
+    /// Domain-level error against a single item — fall back and continue the job.
+    ///
+    /// Unlike `PermanentFatal` (which means "abort everything"), this means
+    /// "this one page failed but the pipeline is healthy, so use raw content
+    /// and keep crawling". Example: [`SemanticError::ChunkTooLarge`] where a
+    /// chunk exceeds the user's `--max-tokens` limit.
+    DomainRecoverable,
+}
+
+impl SemanticError {
+    /// Classify this error by operational severity using the unified
+    /// [`ErrorClass`] taxonomy shared with [`crate::error::ScraperError`].
+    ///
+    /// Used by the export orchestrator to decide fail-fast vs fallback.
+    #[must_use]
+    pub const fn classify(&self) -> ErrorClass {
+        match self {
+            // A broken model or inference stack is an internal failure — abort.
+            Self::ModelLoad(_) | Self::Inference(_) | Self::InvalidThreshold { .. } => {
+                ErrorClass::InternalFatal
+            },
+            // ChunkTooLarge is recoverable at the job level — fall back to raw.
+            Self::ChunkTooLarge { .. } => ErrorClass::DomainRecoverable,
+            // Tokenize/Download/CacheValidation/OfflineMode: domain-level issues
+            // that don't indicate a broken pipeline — fall back and continue.
+            Self::Tokenize(_)
+            | Self::Download { .. }
+            | Self::CacheValidation { .. }
+            | Self::OfflineMode { .. } => ErrorClass::DomainRecoverable,
+        }
+    }
 }
 
 impl From<WreqError> for ScraperError {

--- a/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
@@ -16,7 +16,7 @@
 
 use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
 use serde::Serialize;
@@ -78,6 +78,49 @@ pub struct JsonlExporter {
     config: ExporterConfig,
 }
 
+/// RAII wrapper around an exclusive file lock. While alive it holds the lock;
+/// on drop it releases the lock **and deletes the lock file** so no `.lock`
+/// orphan is left behind (issue #582).
+struct FileLock {
+    handle: std::fs::File,
+    lock_path: PathBuf,
+}
+
+impl FileLock {
+    /// Acquire an exclusive lock at `<path>.jsonl.lock`.
+    fn acquire(path: &Path) -> ExportResult<Self> {
+        let lock_path = path.with_extension("jsonl.lock");
+        // M1 FIX: Write PID metadata to lock file for debugging
+        let mut lock_file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&lock_path)
+            .map_err(|e| ExporterError::WriteError(format!("{}: {}", lock_path.display(), e)))?;
+        use std::io::Write;
+        let _ = writeln!(lock_file, "pid={} op=exclusive_write", std::process::id());
+        // allow: fs2::FileExt::lock_exclusive, clippy misidentifies as std::io::FileExt (1.89+)
+        #[allow(clippy::incompatible_msrv)]
+        lock_file
+            .lock_exclusive()
+            .map_err(|e| ExporterError::WriteError(format!("failed to acquire file lock: {e}")))?;
+        Ok(Self {
+            handle: lock_file,
+            lock_path,
+        })
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        // Release the OS-level exclusive lock, then delete the lock file. Both
+        // best-effort: a failure here must not mask the real export result.
+        #[allow(clippy::incompatible_msrv)]
+        let _ = self.handle.unlock();
+        let _ = fs::remove_file(&self.lock_path);
+    }
+}
+
 impl JsonlExporter {
     /// Create a new JsonlExporter with the given configuration
     #[must_use]
@@ -102,22 +145,12 @@ impl JsonlExporter {
             fs::create_dir_all(parent).map_err(ExporterError::DirectoryCreation)?;
         }
 
-        // Acquire exclusive file lock to prevent concurrent writes
-        let lock_path = path.with_extension("jsonl.lock");
-        // M1 FIX: Write PID metadata to lock file for debugging
-        let mut lock_file = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&lock_path)
-            .map_err(|e| ExporterError::WriteError(format!("{}: {}", lock_path.display(), e)))?;
-        use std::io::Write;
-        let _ = writeln!(lock_file, "pid={} op=exclusive_write", std::process::id());
-        // allow: fs2::FileExt::lock_exclusive, clippy misidentifies as std::io::FileExt (1.89+)
-        #[allow(clippy::incompatible_msrv)]
-        lock_file
-            .lock_exclusive()
-            .map_err(|e| ExporterError::WriteError(format!("failed to acquire file lock: {e}")))?;
+        // Acquire an exclusive file lock for the duration of this write, then
+        // release it (and delete the lock file) when the returned writer is
+        // dropped. A short-lived lock avoids blocking a second exporter pointing
+        // at the same file (e.g. the append path in `test_jsonl_exporter_append`),
+        // and deleting the file prevents orphaned `.lock` leftovers (issue #582).
+        let _lock = FileLock::acquire(&path)?;
 
         // Fix: Only truncate if file doesn't exist yet.
         // Prevents data loss when writer() is called multiple times
@@ -182,7 +215,7 @@ impl crate::domain::exporter::Exporter for JsonlExporter {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
     use crate::domain::config::ExportFormat;

--- a/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
@@ -81,6 +81,10 @@ pub struct JsonlExporter {
 /// RAII wrapper around an exclusive file lock. While alive it holds the lock;
 /// on drop it releases the lock **and deletes the lock file** so no `.lock`
 /// orphan is left behind (issue #582).
+///
+/// `#[must_use]` warns if a caller acquires the lock but lets it drop
+/// immediately (a likely bug — the lock would be released before any write).
+#[must_use]
 struct FileLock {
     handle: std::fs::File,
     lock_path: PathBuf,

--- a/crates/webfang_core/src/infrastructure/persistence/sqlite.rs
+++ b/crates/webfang_core/src/infrastructure/persistence/sqlite.rs
@@ -465,6 +465,64 @@ impl NoteRepository for SqliteVectorRepository {
         })
     }
 
+    fn index_note_transactional<'a>(
+        &'a self,
+        path: &'a str,
+        content_hash: &'a str,
+        mtime_secs: i64,
+        chunks: &'a [(&'a str, Option<&'a [f32]>)],
+    ) -> Pin<Box<dyn Future<Output = Result<i64, ScraperError>> + Send + 'a>> {
+        Box::pin(async move {
+            let path_owned = path.to_string();
+            let hash_owned = content_hash.to_string();
+            // Clone chunk data into owned Strings/BVecs so the closure can move
+            // them into the transaction without borrowing across the await.
+            let chunks_owned: Vec<(String, Option<Vec<u8>>)> = chunks
+                .iter()
+                .map(|(text, emb)| (text.to_string(), emb.map(f32_slice_to_bytes)))
+                .collect();
+
+            let conn = self.pool.get().await.map_err(|e| {
+                ScraperError::persistence(format!("obtener conexión del pool: {e}"))
+            })?;
+            // A single connection + one transaction: either the note and ALL its
+            // chunks land, or nothing does. No ghost notes if embedding fails.
+            conn.interact(move |c| {
+                let tx = c.transaction()?;
+                // UPSERT the note metadata and fetch its row id.
+                tx.execute(
+                    "INSERT INTO notes (path, content_hash, mtime_secs, created_at, updated_at) \
+                     VALUES (?1, ?2, ?3, datetime('now'), datetime('now')) \
+                     ON CONFLICT(path) DO UPDATE SET \
+                       content_hash = excluded.content_hash, \
+                       mtime_secs = excluded.mtime_secs, \
+                       updated_at = datetime('now')",
+                    rusqlite::params![&path_owned, &hash_owned, mtime_secs],
+                )?;
+                let id = tx.query_row(
+                    "SELECT id FROM notes WHERE path = ?1",
+                    rusqlite::params![&path_owned],
+                    |row| row.get::<_, i64>(0),
+                )?;
+                // Persist every chunk within the same transaction.
+                for (i, (text, emb_blob)) in chunks_owned.into_iter().enumerate() {
+                    tx.execute(
+                        "INSERT INTO note_chunks (note_id, chunk_index, content, embedding_vector, created_at) \
+                         VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+                        rusqlite::params![id, i as i64, &text, &emb_blob.as_deref()],
+                    )?;
+                }
+                tx.commit()?;
+                rusqlite::Result::<i64, rusqlite::Error>::Ok(id)
+            })
+            .await
+            .map_err(|e| {
+                ScraperError::persistence(format!("index_note_transactional (interact): {e}"))
+            })?
+            .map_err(|e| ScraperError::persistence(format!("index_note_transactional: {e}")))
+        })
+    }
+
     fn load_all_vectors(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<NoteChunkVector>, ScraperError>> + Send + '_>> {


### PR DESCRIPTION
Closes #577, Closes #580, Closes #581, Closes #582

## Summary

### Original fixes (4 commits)
- **#577**: vault notes below min_chunk_size produced 0 chunks and were never persisted, causing an infinite re-index loop on every `sync_vault`. `save_note` now runs before the empty-chunks early-return so notes are always registered.
- **#580**: `filter_relevant_urls` used `path().starts_with(target_path)` raw, so a seed `/docs/` dropped a sitemap URL `/docs` (trailing-slash mismatch). Added `normalized_path()` to strip a single trailing slash before comparison.
- **#581**: a single chunk exceeding `--max-tokens` (or a low threshold) aborted the whole export with exit 78. `ChunkTooLarge` is now recoverable — falls back to raw content for that page without counting toward the total-failure abort.
- **#582**: `--export-format auto` left an orphaned `export.jsonl.lock` file after a clean exit. Introduced an RAII `FileLock` wrapper that releases the exclusive lock and deletes the `.lock` on drop, scoped per `write()` call.

### THONY STARK follow-ups (refactor commit)
Architectural improvements from code review:

- **#577 follow-up**: `index_note_transactional()` in `NoteRepository` + SQLite impl registers a note and ALL its chunks in a single DB transaction, preventing ghost notes if embedding fails mid-way.
- **#580 follow-up**: `canonical_path()` added to `url_validation` domain as single source of truth for trailing-slash normalization. Sitemap filter now uses it.
- **#581 follow-up**: `ErrorClass::DomainRecoverable` added to existing taxonomy. `SemanticError::classify()` maps variants by operational severity. Export flow uses it: infrastructure-fatal errors (ModelLoad/Inference) abort the crawl immediately (fail-fast); recoverable errors fall back to raw. Fallback count tracked so an all-fallback job still surfaces an error (#543 guard).
- **#582 follow-up**: `#[must_use]` on `FileLock` so the compiler warns if a caller acquires and immediately drops the lock.

## Verification
- Real-web smoke tests on quotes.toscrape.com / books.toscrape.com for every AI flag + combinations.
- Unit tests: vault_search 14/14, sitemap 57/58, jsonl_exporter 23/3, export_flow 3/3, error 219/219, url_validation 26/26.
- CI gate: `cargo check` ✅, `cargo clippy --all-targets --all-features` ✅, `cargo fmt` ✅.