### PR TITLE
refactor(vault): atomic note+chunks indexing via single transaction

### DIFF
--- a/crates/webfang_core/src/application/vault_search.rs
+++ b/crates/webfang_core/src/application/vault_search.rs
@@ -183,30 +183,28 @@ impl VaultSearchService {
             .chunk_text(content)
             .map_err(ScraperError::Semantic)?;
 
-        if chunk_texts.is_empty() {
-            debug!(path, "no chunks produced — skipping note");
-            return Ok(0);
-        }
+        // Step 2: Embed all chunks in a batch (skip when empty).
+        let embeddings = if chunk_texts.is_empty() {
+            Vec::new()
+        } else {
+            self.embedding
+                .embed_batch(&chunk_texts)
+                .await
+                .map_err(ScraperError::Semantic)?
+        };
 
-        // Step 2: Embed all chunks in a batch.
-        let embeddings = self
-            .embedding
-            .embed_batch(&chunk_texts)
-            .await
-            .map_err(ScraperError::Semantic)?;
-
-        // Step 3: Register the note.
-        let note_id = self
+        // Step 3: Atomically register the note and persist every chunk in one
+        // transaction. Empty `chunk_texts` still registers the note so
+        // sync_vault won't re-index it on every run (#577 follow-up: atomicity).
+        let chunks_with_embeddings: Vec<(&str, Option<&[f32]>)> = chunk_texts
+            .iter()
+            .zip(embeddings.iter())
+            .map(|(text, emb)| (text.as_str(), Some(emb.as_slice())))
+            .collect();
+        let _note_id = self
             .repository
-            .save_note(path, content_hash, mtime_secs)
+            .index_note_transactional(path, content_hash, mtime_secs, &chunks_with_embeddings)
             .await?;
-
-        // Step 4: Persist each chunk with its embedding.
-        for (i, (text, emb)) in chunk_texts.iter().zip(embeddings.iter()).enumerate() {
-            self.repository
-                .save_note_chunk(note_id, i as i64, text, Some(emb))
-                .await?;
-        }
 
         debug!(path, chunks = chunk_texts.len(), "note indexed");
         Ok(chunk_texts.len())
@@ -519,6 +517,43 @@ mod tests {
                     embedding: embedding.unwrap_or_default().to_vec(),
                 });
                 Ok(())
+            })
+        }
+
+        fn index_note_transactional<'a>(
+            &'a self,
+            path: &'a str,
+            content_hash: &'a str,
+            mtime_secs: i64,
+            chunks: &'a [(&'a str, Option<&'a [f32]>)],
+        ) -> BoxFuture<'a, Result<i64, ScraperError>> {
+            Box::pin(async move {
+                let mut notes = self.notes.lock().unwrap();
+                let id = if let Some(existing) = notes.iter_mut().find(|n| n.path == path) {
+                    existing.content_hash = content_hash.to_owned();
+                    existing.mtime_secs = mtime_secs;
+                    1
+                } else {
+                    let mut id = self.next_id.lock().unwrap();
+                    *id += 1;
+                    notes.push(IndexedNoteMeta {
+                        path: path.to_owned(),
+                        content_hash: content_hash.to_owned(),
+                        mtime_secs,
+                    });
+                    *id
+                };
+                drop(notes);
+                let mut stored = self.chunks.lock().unwrap();
+                for (i, (text, emb)) in chunks.iter().enumerate() {
+                    stored.push(NoteChunkVector {
+                        note_path: String::new(),
+                        content: text.to_string(),
+                        chunk_index: i as i64,
+                        embedding: emb.unwrap_or(&[]).to_vec(),
+                    });
+                }
+                Ok(id)
             })
         }
 

--- a/crates/webfang_core/src/domain/note_repository.rs
+++ b/crates/webfang_core/src/domain/note_repository.rs
@@ -93,6 +93,32 @@ pub trait NoteRepository: Send + Sync {
         embedding: Option<&'a [f32]>,
     ) -> BoxFuture<'a, Result<(), ScraperError>>;
 
+    /// Atomically register a note and persist all its chunks in one database
+    /// transaction.
+    ///
+    /// This replaces the separate [`save_note`](Self::save_note) +
+    /// [`save_note_chunk`](Self::save_note_chunk) calls when the caller has
+    /// all chunk data up front. A transaction guarantees that a note is never
+    /// persisted without its chunks — if the process panics or the embedding
+    /// batch fails after `save_note`, the whole operation rolls back instead
+    /// of leaving an unsearchable "ghost" note (#577 follow-up: atomicity).
+    ///
+    /// `chunks` is `[(text, embedding)]`. An empty `chunks` slice still
+    /// registers the note (so `sync_vault` won't re-index it) but writes no
+    /// chunk rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ScraperError::Persistence`] on any database failure. The
+    /// transaction is rolled back automatically on error.
+    fn index_note_transactional<'a>(
+        &'a self,
+        path: &'a str,
+        content_hash: &'a str,
+        mtime_secs: i64,
+        chunks: &'a [(&'a str, Option<&'a [f32]>)],
+    ) -> BoxFuture<'a, Result<i64, ScraperError>>;
+
     /// Load all chunk vectors for in-memory ranking.
     ///
     /// Returns every indexed chunk with its embedding. Chunks without

--- a/crates/webfang_core/src/infrastructure/persistence/sqlite.rs
+++ b/crates/webfang_core/src/infrastructure/persistence/sqlite.rs
@@ -465,6 +465,58 @@ impl NoteRepository for SqliteVectorRepository {
         })
     }
 
+    fn index_note_transactional<'a>(
+        &'a self,
+        path: &'a str,
+        content_hash: &'a str,
+        mtime_secs: i64,
+        chunks: &'a [(&'a str, Option<&'a [f32]>)],
+    ) -> Pin<Box<dyn Future<Output = Result<i64, ScraperError>> + Send + 'a>> {
+        Box::pin(async move {
+            let path_owned = path.to_string();
+            let hash_owned = content_hash.to_string();
+            let chunks_owned: Vec<(String, Option<Vec<u8>>)> = chunks
+                .iter()
+                .map(|(text, emb)| (text.to_string(), emb.map(f32_slice_to_bytes)))
+                .collect();
+
+            let conn = self.pool.get().await.map_err(|e| {
+                ScraperError::persistence(format!("obtener conexión del pool: {e}"))
+            })?;
+            conn.interact(move |c| {
+                let tx = c.transaction()?;
+                tx.execute(
+                    "INSERT INTO notes (path, content_hash, mtime_secs, created_at, updated_at) \
+                     VALUES (?1, ?2, ?3, datetime('now'), datetime('now')) \
+                     ON CONFLICT(path) DO UPDATE SET \
+                       content_hash = excluded.content_hash, \
+                       mtime_secs = excluded.mtime_secs, \
+                       updated_at = datetime('now')",
+                    rusqlite::params![&path_owned, &hash_owned, mtime_secs],
+                )?;
+                let id = tx.query_row(
+                    "SELECT id FROM notes WHERE path = ?1",
+                    rusqlite::params![&path_owned],
+                    |row| row.get::<_, i64>(0),
+                )?;
+                for (i, (text, emb_blob)) in chunks_owned.into_iter().enumerate() {
+                    tx.execute(
+                        "INSERT INTO note_chunks (note_id, chunk_index, content, embedding_vector, created_at) \
+                         VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+                        rusqlite::params![id, i as i64, &text, &emb_blob.as_deref()],
+                    )?;
+                }
+                tx.commit()?;
+                rusqlite::Result::<i64, rusqlite::Error>::Ok(id)
+            })
+            .await
+            .map_err(|e| {
+                ScraperError::persistence(format!("index_note_transactional (interact): {e}"))
+            })?
+            .map_err(|e| ScraperError::persistence(format!("index_note_transactional: {e}")))
+        })
+    }
+
     fn load_all_vectors(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<NoteChunkVector>, ScraperError>> + Send + '_>> {


### PR DESCRIPTION
## Summary
- Add `index_note_transactional()` to `NoteRepository` trait + SQLite impl.
- `vault_search` now registers a note and ALL its chunks in one DB transaction.
- Prevents ghost notes if embedding fails mid-way. Empty chunks still registers the note so `sync_vault` won't re-index it.

Closes #577 follow-up (atomicity).