### PR TITLE
refactor(crawler): centralize trailing-slash normalization in canonical_path

### DIFF
--- a/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
+++ b/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
@@ -202,9 +202,17 @@ async fn parse_sitemap(parser: &SitemapParser, sitemap_url: &str) -> Result<Vec<
 }
 
 /// Keep only sitemap URLs whose path shares the target's path prefix.
+///
+/// Paths are compared using the domain's [`canonical_path`] so that a seed of
+/// `/docs/` still matches a sitemap URL `/docs` (and vice-versa). Without this,
+/// `"/docs".starts_with("/docs/")` is `false` and the section index is silently
+/// dropped.
+///
+/// [`canonical_path`]: crate::domain::url_validation::canonical_path
 fn filter_relevant_urls(urls: Vec<Url>, target_path: &str) -> Vec<Url> {
+    let target = crate::domain::url_validation::canonical_path(target_path);
     urls.into_iter()
-        .filter(|url| url.path().starts_with(target_path))
+        .filter(|url| crate::domain::url_validation::canonical_path(url.path()).starts_with(target))
         .collect()
 }
 

--- a/crates/webfang_core/src/domain/url_validation.rs
+++ b/crates/webfang_core/src/domain/url_validation.rs
@@ -349,9 +349,43 @@ fn collapse_index_path(url: &str) -> String {
     }
 }
 
+/// Return a URL path in canonical form for prefix/dedup comparison.
+///
+/// Strips a single trailing slash (except for the root `/`) so that `/docs/`
+/// and `/docs` compare equal. This is the canonical form used by
+/// sitemap-relevance filtering — anywhere two paths that differ only by a
+/// trailing slash must be treated as the same section.
+///
+/// # Examples
+///
+/// ```
+/// use webfang_core::domain::url_validation::canonical_path;
+///
+/// assert_eq!(canonical_path("/docs/"), "/docs");
+/// assert_eq!(canonical_path("/docs"), "/docs");
+/// assert_eq!(canonical_path("/"), "/");
+/// assert_eq!(canonical_path(""), "");
+/// ```
+pub fn canonical_path(path: &str) -> &str {
+    if path.len() > 1 && path.ends_with('/') {
+        &path[..path.len() - 1]
+    } else {
+        path
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_canonical_path_strips_trailing_slash() {
+        assert_eq!(canonical_path("/docs/"), "/docs");
+        assert_eq!(canonical_path("/docs"), "/docs");
+        assert_eq!(canonical_path("/"), "/");
+        assert_eq!(canonical_path(""), "");
+        assert_eq!(canonical_path("/a/b/c/"), "/a/b/c");
+    }
 
     #[test]
     fn test_validate_and_parse_url_success() {


### PR DESCRIPTION
## Summary
- Add `canonical_path()` to `url_validation` domain as single source of truth for trailing-slash normalization.
- Sitemap filter now uses it instead of a local string helper.
- `/docs/` and `/docs` compare equal for prefix matching.

Closes #580 follow-up.