### PR TITLE
fix(mcp): expose batch failures and honest Obsidian dispatch (issue #591)

### DIFF
--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -65,6 +65,64 @@ impl ScrapeOutcome {
     }
 }
 
+/// A failed URL in a batch scrape operation.
+///
+/// Carries the URL and a serializable error representation so the MCP layer
+/// can expose per-URL failures to the calling AI agent (issue #591).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ScrapeFailed {
+    /// The URL that failed to scrape.
+    pub url: String,
+    /// User-facing error message (Spanish, matching `ScraperError` Display).
+    pub error: String,
+    /// Operational classification of the error for retry/abort decisions.
+    pub category: ScrapeErrorCategory,
+}
+
+/// Serializable classification of a [`ScraperError`] for MCP consumers.
+///
+/// Mirrors [`crate::error::ErrorClass`] but owned (no lifetime) and
+/// serializable, so the MCP layer can embed it in JSON responses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScrapeErrorCategory {
+    /// Transient — safe to retry immediately (5xx, connection reset).
+    TransientRetriable,
+    /// Transient — wait before retry (429, rate limit, timeout).
+    TransientBackoff,
+    /// Permanent — retry will not help (404, invalid URL, WAF).
+    PermanentFatal,
+    /// Internal — indicates a bug, not a runtime condition.
+    InternalFatal,
+    /// Domain recoverable — single item failed but pipeline is healthy.
+    DomainRecoverable,
+}
+
+impl From<crate::error::ErrorClass> for ScrapeErrorCategory {
+    fn from(class: crate::error::ErrorClass) -> Self {
+        match class {
+            crate::error::ErrorClass::TransientRetriable => Self::TransientRetriable,
+            crate::error::ErrorClass::TransientBackoff => Self::TransientBackoff,
+            crate::error::ErrorClass::PermanentFatal => Self::PermanentFatal,
+            crate::error::ErrorClass::InternalFatal => Self::InternalFatal,
+            crate::error::ErrorClass::DomainRecoverable => Self::DomainRecoverable,
+        }
+    }
+}
+
+/// Outcome of [`scrape_multiple_with_limit`]: successes + per-URL failures.
+///
+/// Replaces the bare `Vec<ScrapedContent>` return so callers can report
+/// exactly which URLs failed and why (issue #591 — `scrape_batch` observability).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ScrapeBatchOutcome {
+    /// Successfully scraped content.
+    pub results: Vec<ScrapedContent>,
+    /// URLs that failed, with error details preserved.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub failed: Vec<ScrapeFailed>,
+}
+
 /// Scrape a URL with asset downloading configuration
 ///
 /// Correlation contract (#501): the caller owns the run-root identity
@@ -455,9 +513,12 @@ pub async fn scrape_multiple_with_limit(
     urls: &[url::Url],
     config: &ScraperConfig,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
-) -> Result<Vec<ScrapedContent>> {
+) -> Result<ScrapeBatchOutcome> {
     if urls.is_empty() {
-        return Ok(Vec::new());
+        return Ok(ScrapeBatchOutcome {
+            results: Vec::new(),
+            failed: Vec::new(),
+        });
     }
 
     // One run-root identity for the whole batch (#501): every
@@ -476,31 +537,47 @@ pub async fn scrape_multiple_with_limit(
         config.scraper_concurrency
     );
 
-    let results: Vec<Result<ScrapeOutcome>> =
-        stream::iter(urls.to_vec())
-            .map(|url| {
-                let config = config.clone();
-                let root = root_correlation.clone();
-                async move {
-                    scrape_with_config(client, &url, &config, downloader, None, None, &root).await
-                }
-            })
-            .buffer_unordered(config.scraper_concurrency)
-            .collect()
-            .await;
+    // Pair each URL with its result so failures can report which URL failed
+    // (ScrapeOutcome doesn't carry the source URL).
+    let results: Vec<(url::Url, Result<ScrapeOutcome>)> = stream::iter(urls.to_vec())
+        .map(|url| {
+            let config = config.clone();
+            let root = root_correlation.clone();
+            async move {
+                let result =
+                    scrape_with_config(client, &url, &config, downloader, None, None, &root).await;
+                (url, result)
+            }
+        })
+        .buffer_unordered(config.scraper_concurrency)
+        .collect()
+        .await;
 
     let mut all_content = Vec::new();
-    for result in results {
+    let mut failed = Vec::new();
+    for (url, result) in results {
         match result {
             Ok(outcome) => all_content.extend(outcome.results),
-            Err(e) => warn!("⚠️  Failed to scrape URL: {}", e),
+            Err(e) => {
+                let url_str = url.to_string();
+                warn!("⚠️  Failed to scrape {url_str}: {e}");
+                failed.push(ScrapeFailed {
+                    url: url_str,
+                    error: e.to_string(),
+                    category: e.classify().into(),
+                });
+            },
         }
     }
 
     info!(
-        "✅ Scraped {} pages from {} URLs",
+        "✅ Scraped {} pages from {} URLs ({} failed)",
         all_content.len(),
-        urls.len()
+        urls.len(),
+        failed.len()
     );
-    Ok(all_content)
+    Ok(ScrapeBatchOutcome {
+        results: all_content,
+        failed,
+    })
 }

--- a/crates/webfang_core/src/infrastructure/obsidian/mod.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/mod.rs
@@ -15,6 +15,8 @@ pub use metadata::{
     compute_reading_time, compute_word_count, detect_content_type, detect_language,
     ObsidianRichMetadata,
 };
-pub use uri::{build_obsidian_uri, extract_vault_name, open_in_obsidian, open_note};
+pub use uri::{
+    build_obsidian_uri, extract_vault_name, open_in_obsidian, open_note, DispatchStatus,
+};
 pub use vault_detector::{detect_vault, detect_vault_with_root, is_valid_vault};
 pub use vault_reader::{read_vault_notes, VaultNote};

--- a/crates/webfang_core/src/infrastructure/obsidian/uri.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/uri.rs
@@ -73,17 +73,34 @@ pub fn validate_obsidian_input(vault_name: &str, file_path: &str) -> Result<(), 
     Ok(())
 }
 
-/// Open a note in Obsidian using the URI protocol (fire-and-forget).
+/// Result of dispatching an Obsidian URI to the OS handler (issue #591).
+///
+/// Replaces the bare `()` success value so callers can distinguish between
+/// "command dispatched" and "command failed to start".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchStatus {
+    /// The OS handler command was spawned and exited successfully.
+    /// The URI was delivered to the system's protocol handler.
+    Dispatched,
+    /// The handler command was spawned but exited with a non-zero status.
+    /// Obsidian may not be installed or the URI scheme is unregistered.
+    HandlerFailed,
+}
+
+/// Open a note in Obsidian using the URI protocol.
 ///
 /// Uses `xdg-open` on Linux, `open` on macOS, `start` on Windows.
-/// Non-blocking: spawns the process and returns immediately.
+/// Spawns the handler, waits briefly for exit, and reports whether the
+/// system's protocol handler accepted the URI (issue #591 — honest dispatch).
 ///
 /// # Arguments
 /// - `uri` — The obsidian:// URI to open
 ///
 /// # Returns
-/// `Ok(())` on spawn, `Err(String)` if command fails to start
-pub fn open_in_obsidian(uri: &str) -> Result<(), String> {
+/// `Ok(DispatchStatus::Dispatched)` if the handler exited cleanly,
+/// `Ok(DispatchStatus::HandlerFailed)` if the handler exited non-zero
+/// (Obsidian likely not installed), `Err(String)` if the command failed to start.
+pub fn open_in_obsidian(uri: &str) -> Result<DispatchStatus, String> {
     // The URI is fully percent-encoded by `build_obsidian_uri` (no raw
     // metacharacters or quotes can appear), and on Windows the empty `""`
     // title prevents `start` from consuming the URI as a window title.
@@ -97,13 +114,21 @@ pub fn open_in_obsidian(uri: &str) -> Result<(), String> {
         ("xdg-open", vec![uri])
     };
 
-    // Fire-and-forget: spawn and don't wait
-    std::process::Command::new(cmd)
+    // Spawn and wait for the handler to complete — xdg-open/open/start
+    // exit quickly after dispatching the URI. This gives us honest feedback
+    // about whether the protocol handler accepted the URI (issue #591).
+    let output = std::process::Command::new(cmd)
         .args(&args)
-        .spawn()
-        .map_err(|e| format!("failed to open URI: {e}"))?;
+        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .output()
+        .map_err(|e| format!("failed to launch Obsidian handler: {e}"))?;
 
-    Ok(())
+    if output.status.success() {
+        Ok(DispatchStatus::Dispatched)
+    } else {
+        Ok(DispatchStatus::HandlerFailed)
+    }
 }
 
 /// Extract vault name from a vault path (last directory component).
@@ -128,8 +153,8 @@ pub fn extract_vault_name(vault_path: &Path) -> String {
 /// - `file_path` — Path to the note relative to the vault root
 ///
 /// # Returns
-/// `Ok(())` if URI was opened (or spawned), `Err(String)` on failure
-pub fn open_note(vault_path: &Path, file_path: &Path) -> Result<(), String> {
+/// `Ok(DispatchStatus)` with the dispatch outcome, `Err(String)` on spawn failure
+pub fn open_note(vault_path: &Path, file_path: &Path) -> Result<DispatchStatus, String> {
     let vault_name = extract_vault_name(vault_path);
 
     // Get relative path from vault root

--- a/crates/webfang_core/tests/scraper_service_test.rs
+++ b/crates/webfang_core/tests/scraper_service_test.rs
@@ -446,21 +446,27 @@ async fn test_scrape_multiple_with_limit_returns_results() {
         .with_ok_response(url2.as_str(), html);
 
     let config = ScraperConfig::default();
-    let result = scrape_multiple_with_limit(&mock, &[url1, url2], &config, None)
+    let outcome = scrape_multiple_with_limit(&mock, &[url1, url2], &config, None)
         .await
         .expect("scrape_multiple_with_limit should succeed");
 
-    assert_eq!(result.len(), 2, "should return content from both URLs");
+    assert_eq!(
+        outcome.results.len(),
+        2,
+        "should return content from both URLs"
+    );
+    assert!(outcome.failed.is_empty(), "no failures expected");
 }
 
 #[tokio::test]
 async fn test_scrape_multiple_with_limit_empty_urls() {
     let mock = MockHttpClient::new();
     let config = ScraperConfig::default();
-    let result = scrape_multiple_with_limit(&mock, &[], &config, None)
+    let outcome = scrape_multiple_with_limit(&mock, &[], &config, None)
         .await
         .expect("empty URL list should return Ok");
-    assert!(result.is_empty());
+    assert!(outcome.results.is_empty());
+    assert!(outcome.failed.is_empty());
 }
 
 #[test]
@@ -807,14 +813,57 @@ async fn test_scrape_multiple_partial_failure() {
         .with_response(url_fail.as_str(), Err(HttpError::ClientError(404)));
 
     let config = ScraperConfig::default();
-    let result = scrape_multiple_with_limit(&mock, &[url_ok, url_fail], &config, None)
+    let outcome = scrape_multiple_with_limit(&mock, &[url_ok, url_fail], &config, None)
         .await
         .expect("should not fail overall even with partial URL failures");
 
     assert_eq!(
-        result.len(),
+        outcome.results.len(),
         1,
         "only the successful URL should produce content"
+    );
+
+    // Issue #591: failed URLs must be reported with error details
+    assert_eq!(outcome.failed.len(), 1, "one URL should be in failed");
+    assert_eq!(outcome.failed[0].url, "https://example.com/fail");
+    assert!(
+        outcome.failed[0].error.contains("404"),
+        "error message should mention 404"
+    );
+    assert_eq!(
+        outcome.failed[0].category,
+        webfang_core::application::scraper_service::ScrapeErrorCategory::PermanentFatal,
+        "404 should classify as permanent_fatal"
+    );
+}
+
+#[cfg_attr(miri, ignore)]
+#[tokio::test]
+async fn test_scrape_multiple_all_failed_reports_all() {
+    let url1 = url::Url::parse("https://example.com/a").unwrap();
+    let url2 = url::Url::parse("https://example.com/b").unwrap();
+    let mock = MockHttpClient::new()
+        .with_response(url1.as_str(), Err(HttpError::ClientError(500)))
+        .with_response(url2.as_str(), Err(HttpError::ClientError(503)));
+
+    let config = ScraperConfig::default();
+    let outcome = scrape_multiple_with_limit(&mock, &[url1, url2], &config, None)
+        .await
+        .expect("batch with all failures should still succeed at batch level");
+
+    assert!(outcome.results.is_empty(), "no results when all fail");
+    assert_eq!(outcome.failed.len(), 2, "both URLs should be in failed");
+    assert_eq!(outcome.failed[0].url, "https://example.com/a");
+    assert_eq!(outcome.failed[1].url, "https://example.com/b");
+    // 5xx classifies as transient_retriable
+    use webfang_core::application::scraper_service::ScrapeErrorCategory;
+    assert_eq!(
+        outcome.failed[0].category,
+        ScrapeErrorCategory::TransientRetriable
+    );
+    assert_eq!(
+        outcome.failed[1].category,
+        ScrapeErrorCategory::TransientRetriable
     );
 }
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
@@ -95,12 +95,18 @@ impl McpHandler {
             &params.vault_name,
             &params.file_path,
         );
+        use webfang_core::infrastructure::obsidian::uri::DispatchStatus;
         match webfang_core::infrastructure::obsidian::uri::open_in_obsidian(&uri) {
-            Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
-                "Opened in Obsidian: {uri}"
-            ))])),
+            Ok(DispatchStatus::Dispatched) => Ok(CallToolResult::success(vec![Content::text(
+                format!("Abriendo en Obsidian: {uri}"),
+            )])),
+            Ok(DispatchStatus::HandlerFailed) => {
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "⚠️ El manejador de URI falló (Obsidian puede no estar instalado). URI: {uri}"
+                ))]))
+            },
             Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
-                "failed to open Obsidian: {e}"
+                "error al abrir Obsidian: {e}"
             ))])),
         }
     }

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -208,16 +208,30 @@ impl McpHandler {
         )
         .await
         {
-            Ok(results) => {
+            Ok(outcome) => {
+                let failed_count = outcome.failed.len();
+                let outcome_type = if failed_count == 0 {
+                    Outcome::Success
+                } else if outcome.results.is_empty() {
+                    Outcome::Error
+                } else {
+                    Outcome::Partial
+                };
                 self.state.record_scrape(ScrapeEvent {
                     tool: "scrape_batch",
                     domain,
-                    outcome: Outcome::Success,
+                    outcome: outcome_type,
                     count,
                     duration: start.elapsed(),
                 });
-                tracing::info!("batch scrape complete: {} pages", results.len());
-                let content = serde_json::to_string_pretty(&results)
+                tracing::info!(
+                    "batch scrape complete: {} pages, {} failed",
+                    outcome.results.len(),
+                    failed_count
+                );
+                // Serialize the full outcome (results + failed) so the caller
+                // knows exactly which URLs failed and why (issue #591).
+                let content = serde_json::to_string_pretty(&outcome)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },

--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -20,13 +20,21 @@ pub enum Outcome {
     Success,
     /// The underlying scraping operation returned `Err`.
     Error,
+    /// Partial success — some URLs succeeded, some failed (batch operations).
+    Partial,
 }
 
 impl Outcome {
-    /// Whether this outcome is a success.
+    /// Whether this outcome is a full success.
     #[must_use]
     pub fn is_success(self) -> bool {
         matches!(self, Self::Success)
+    }
+
+    /// Whether this outcome is partial (some successes, some failures).
+    #[must_use]
+    pub fn is_partial(self) -> bool {
+        matches!(self, Self::Partial)
     }
 }
 
@@ -64,6 +72,8 @@ pub struct ScrapeMetrics {
     total_events: usize,
     success_count: usize,
     error_count: usize,
+    /// Partial-success events (batch with some failures).
+    partial_count: usize,
     /// Per-domain breakdown; `BTreeMap` for deterministic order (DD-6).
     domains: BTreeMap<String, DomainStats>,
     /// Per-tool event counts; `BTreeMap` for deterministic order (DD-6).
@@ -91,12 +101,13 @@ impl ScrapeMetrics {
         match event.outcome {
             Outcome::Success => self.success_count += 1,
             Outcome::Error => self.error_count += 1,
+            Outcome::Partial => self.partial_count += 1,
         }
 
         let domain = self.domains.entry(event.domain.clone()).or_default();
         domain.events += 1;
         domain.pages += event.count;
-        if event.outcome == Outcome::Error {
+        if matches!(event.outcome, Outcome::Error | Outcome::Partial) {
             domain.errors += 1;
         }
 
@@ -122,6 +133,7 @@ impl ScrapeMetrics {
             total_events: self.total_events,
             success_count: self.success_count,
             error_count: self.error_count,
+            partial_count: self.partial_count,
             domains: self.domains.clone(),
             tools: self.tools.clone(),
             average_duration_ms,
@@ -141,6 +153,8 @@ pub struct MetricsSnapshot {
     pub success_count: usize,
     /// Number of error-outcome events.
     pub error_count: usize,
+    /// Number of partial-success events (batch with some failures).
+    pub partial_count: usize,
     /// Per-domain breakdown (sorted keys).
     pub domains: BTreeMap<String, DomainStats>,
     /// Per-tool event counts (sorted keys).
@@ -269,6 +283,7 @@ mod tests {
             "  \"total_events\": 3,",
             "  \"success_count\": 2,",
             "  \"error_count\": 1,",
+            "  \"partial_count\": 0,",
             "  \"domains\": {",
             "    \"a.com\": {",
             "      \"events\": 2,",

--- a/crates/webfang_mcp/tests/scraping_coverage_test.rs
+++ b/crates/webfang_mcp/tests/scraping_coverage_test.rs
@@ -399,7 +399,8 @@ async fn test_detect_spa_sufficient_content_not_spa() {
 // ============================================================================
 
 /// Failed URLs are logged but do not stop the batch: 2 OK + 1 error → a
-/// successful result with exactly the 2 scraped pages.
+/// successful result with exactly the 2 scraped pages + the failed URL in the
+/// `failed` array (issue #591).
 #[tokio::test]
 async fn test_scrape_batch_partial_results_on_failure() {
     let mock = MockServer::start().await;
@@ -445,15 +446,35 @@ async fn test_scrape_batch_partial_results_on_failure() {
     );
 
     let text = tool_text(&result);
-    let pages: Vec<Value> = serde_json::from_str(&text).expect("batch result must be a JSON array");
+    // Issue #591: response is now { results: [...], failed: [...] }
+    let outcome: Value = serde_json::from_str(&text).expect("batch result must be valid JSON");
+    let pages = outcome
+        .get("results")
+        .and_then(|v| v.as_array())
+        .expect("batch result must have a 'results' array");
     assert_eq!(
         pages.len(),
         2,
         "only the 2 successful pages should be returned, got: {text}"
     );
+
+    let failed = outcome
+        .get("failed")
+        .and_then(|v| v.as_array())
+        .expect("batch result must have a 'failed' array");
+    assert_eq!(
+        failed.len(),
+        1,
+        "one URL should be in the failed array, got: {text}"
+    );
+    assert_eq!(
+        failed[0]["url"],
+        format!("{}/c", mock.uri()),
+        "failed URL must be /c, got: {text}"
+    );
     assert!(
-        !text.contains("/c"),
-        "failed URL must not appear in the result, got: {text}"
+        failed[0]["error"].as_str().unwrap().contains("500"),
+        "error message should mention 500, got: {text}"
     );
 }
 

--- a/crates/webfang_mcp/tests/snapshots/mcp_behavioral_test__scrape_metrics_cross_session.snap
+++ b/crates/webfang_mcp/tests/snapshots/mcp_behavioral_test__scrape_metrics_cross_session.snap
@@ -6,6 +6,7 @@ expression: "&text"
   "total_events": 1,
   "success_count": 1,
   "error_count": 0,
+  "partial_count": 0,
   "domains": {
     "127.0.0.1": {
       "events": 1,


### PR DESCRIPTION
Closes #591

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- **`scrape_batch` observability**: Now returns a `failed` array with per-URL error details (URL, message, error category) so the consuming AI agent can differentiate transient failures (retry) from permanent ones (abort).
- **`open_in_obsidian` honest dispatch**: Replaced fire-and-forget `spawn()` with `output()` that waits for the OS handler exit status, reporting success vs handler failure honestly.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/scraper_service.rs` | New `ScrapeBatchOutcome`, `ScrapeFailed`, `ScrapeErrorCategory` types; `scrape_multiple_with_limit` returns failures alongside successes |
| `crates/webfang_mcp/src/mcp_server/handlers/scraping.rs` | Serializes full `ScrapeBatchOutcome` including `failed` array |
| `crates/webfang_core/src/infrastructure/obsidian/uri.rs` | New `DispatchStatus` enum; `open_in_obsidian` waits for handler exit |
| `crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs` | Reports dispatch outcome honestly based on `DispatchStatus` |
| `crates/webfang_mcp/src/mcp_server/metrics.rs` | New `Outcome::Partial` variant for batch operations with partial failures |
| `crates/webfang_core/tests/scraper_service_test.rs` | Updated partial failure test + new all-failed test verifying error categories |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo check` clean (pre-existing clippy warnings in `container.rs` unrelated to this change)
- [x] `cargo nextest run` — 1583 passed (webfang_core) + 119 passed (webfang_mcp), 0 failed
- [ ] CI green (pending)