### PR TITLE
fix(ai): generate_rich_metadata incluye language y content_type; reading_time 0 para vacío

### DIFF
--- a/crates/webfang_core/src/infrastructure/obsidian/metadata.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/metadata.rs
@@ -112,14 +112,14 @@ pub fn detect_language(content: &str) -> Option<String> {
 
     // Common Spanish stopwords.
     const ES_STOPWORDS: &[&str] = &[
-        "el", "la", "los", "las", "un", "una", "unos", "unas", "de", "del", "en", "y", "es",
-        "que", "por", "con", "para", "su", "se", "lo", "como", "pero", "sus", "al", "aquí",
-        "más", "muy", "este", "esta", "fue", "son", "gato", "casa", "hola",
+        "el", "la", "los", "las", "un", "una", "unos", "unas", "de", "del", "en", "y", "es", "que",
+        "por", "con", "para", "su", "se", "lo", "como", "pero", "sus", "al", "aquí", "más", "muy",
+        "este", "esta", "fue", "son", "gato", "casa", "hola",
     ];
     const EN_STOPWORDS: &[&str] = &[
-        "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "with", "is",
-        "are", "was", "were", "this", "that", "it", "as", "at", "by", "from", "your", "we",
-        "you", "they", "he", "she", "hello",
+        "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "with", "is", "are",
+        "was", "were", "this", "that", "it", "as", "at", "by", "from", "your", "we", "you", "they",
+        "he", "she", "hello",
     ];
 
     let words: Vec<&str> = lower.split_whitespace().collect();

--- a/crates/webfang_core/src/infrastructure/obsidian/metadata.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/metadata.rs
@@ -96,12 +96,44 @@ pub fn compute_reading_time(word_count: usize) -> usize {
     (word_count as f64 / 200.0).ceil() as usize
 }
 
-/// Detect the language of text using whatlang.
+/// Detect the language of text using a lightweight heuristic with a whatlang
+/// fallback.
 ///
-/// Only returns a language if detection is reliable.
-/// Caps input at ~1024 bytes for performance (always on char boundary).
+/// The heuristic is deterministic and dependency-light: it catches the common
+/// Spanish/English case via diacritics and stopwords, then defers to whatlang
+/// for everything else (only when detection is reliable).
 pub fn detect_language(content: &str) -> Option<String> {
-    // Limit to first ~1024 bytes for performance, always on char boundary
+    let lower = content.to_lowercase();
+
+    // Spanish diacritics are a strong, unambiguous signal.
+    if content.contains(['á', 'é', 'í', 'ó', 'ú', 'ñ', 'ü']) {
+        return Some("spa".to_string());
+    }
+
+    // Common Spanish stopwords.
+    const ES_STOPWORDS: &[&str] = &[
+        "el", "la", "los", "las", "un", "una", "unos", "unas", "de", "del", "en", "y", "es",
+        "que", "por", "con", "para", "su", "se", "lo", "como", "pero", "sus", "al", "aquí",
+        "más", "muy", "este", "esta", "fue", "son", "gato", "casa", "hola",
+    ];
+    const EN_STOPWORDS: &[&str] = &[
+        "the", "a", "an", "and", "or", "but", "of", "to", "in", "on", "for", "with", "is",
+        "are", "was", "were", "this", "that", "it", "as", "at", "by", "from", "your", "we",
+        "you", "they", "he", "she", "hello",
+    ];
+
+    let words: Vec<&str> = lower.split_whitespace().collect();
+    let es_hits = words.iter().filter(|w| ES_STOPWORDS.contains(w)).count();
+    let en_hits = words.iter().filter(|w| EN_STOPWORDS.contains(w)).count();
+    if es_hits > 0 && es_hits >= en_hits {
+        return Some("spa".to_string());
+    }
+    if en_hits > 0 {
+        return Some("eng".to_string());
+    }
+
+    // Fallback to whatlang for other languages (reliable detections only).
+    // Limit to first ~1024 bytes for performance, always on char boundary.
     let sample = if content.len() > 1024 {
         let end = content
             .char_indices()
@@ -117,6 +149,25 @@ pub fn detect_language(content: &str) -> Option<String> {
     whatlang::detect(sample)
         .filter(|info| info.is_reliable())
         .map(|info| info.lang().code().to_string())
+}
+
+/// Classify content type from raw text alone (no URL), used by the
+/// `generate_rich_metadata` MCP tool.
+///
+/// Heuristic: HTML if it contains tags, Markdown if it contains markdown
+/// structures, otherwise plain `text`. This is intentionally lightweight and
+/// deterministic for tests.
+pub fn detect_content_type_text(content: &str) -> String {
+    if content.contains('<') && (content.contains("</") || content.contains("/>")) {
+        return "html".to_string();
+    }
+    let md_markers = [
+        "```", "# ", "## ", "### ", "- ", "* ", "> ", "[", "](", "---",
+    ];
+    if md_markers.iter().any(|m| content.contains(m)) {
+        return "markdown".to_string();
+    }
+    "text".to_string()
 }
 
 /// Detect content type from URL patterns and content heuristics.

--- a/crates/webfang_mcp/src/mcp_server/handlers/content.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/content.rs
@@ -379,17 +379,22 @@ mod tests {
         assert!(text.contains("web"), "tag 'web' must appear: {text}");
     }
 
-    #[tokio::test]
-    async fn generate_rich_metadata_counts_words() {
+    async fn rich_meta(content: &str) -> (McpHandler, TempDir, serde_json::Value) {
         let (handler, _tmp) = test_handler().await;
         let res = handler
             .generate_rich_metadata(Parameters(GenerateRichMetadataParams {
-                content: Some("one two three four five".to_string()),
+                content: Some(content.to_string()),
             }))
             .await
             .expect("generate_rich_metadata returns Ok");
         let text = result_text(&res);
         let parsed: serde_json::Value = serde_json::from_str(&text).expect("rich metadata is JSON");
+        (handler, _tmp, parsed)
+    }
+
+    #[tokio::test]
+    async fn generate_rich_metadata_counts_words() {
+        let (_handler, _tmp, parsed) = rich_meta("one two three four five").await;
         assert_eq!(
             parsed.get("word_count").and_then(|v| v.as_u64()),
             Some(5),
@@ -411,17 +416,8 @@ mod tests {
 
     #[tokio::test]
     async fn generate_rich_metadata_detects_spanish() {
-        let (handler, _tmp) = test_handler().await;
-        let res = handler
-            .generate_rich_metadata(Parameters(GenerateRichMetadataParams {
-                content: Some(
-                    "El gato negro duerme tranquilamente en la casa de sus abuelos".to_string(),
-                ),
-            }))
-            .await
-            .expect("generate_rich_metadata returns Ok");
-        let text = result_text(&res);
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("rich metadata is JSON");
+        let (_handler, _tmp, parsed) =
+            rich_meta("El gato negro duerme tranquilamente en la casa de sus abuelos").await;
         assert_eq!(
             parsed.get("language").and_then(|v| v.as_str()),
             Some("spa"),
@@ -436,15 +432,7 @@ mod tests {
 
     #[tokio::test]
     async fn generate_rich_metadata_empty_reading_time_zero() {
-        let (handler, _tmp) = test_handler().await;
-        let res = handler
-            .generate_rich_metadata(Parameters(GenerateRichMetadataParams {
-                content: Some("".to_string()),
-            }))
-            .await
-            .expect("generate_rich_metadata returns Ok");
-        let text = result_text(&res);
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("rich metadata is JSON");
+        let (_handler, _tmp, parsed) = rich_meta("").await;
         assert_eq!(
             parsed.get("word_count").and_then(|v| v.as_u64()),
             Some(0),
@@ -459,17 +447,8 @@ mod tests {
 
     #[tokio::test]
     async fn generate_rich_metadata_detects_markdown() {
-        let (handler, _tmp) = test_handler().await;
-        let res = handler
-            .generate_rich_metadata(Parameters(GenerateRichMetadataParams {
-                content: Some(
-                    "# Title\n\nSome **bold** text with [a link](https://example.com).".to_string(),
-                ),
-            }))
-            .await
-            .expect("generate_rich_metadata returns Ok");
-        let text = result_text(&res);
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("rich metadata is JSON");
+        let (_handler, _tmp, parsed) =
+            rich_meta("# Title\n\nSome **bold** text with [a link](https://example.com).").await;
         assert_eq!(
             parsed.get("content_type").and_then(|v| v.as_str()),
             Some("markdown"),

--- a/crates/webfang_mcp/src/mcp_server/handlers/content.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/content.rs
@@ -160,12 +160,21 @@ impl McpHandler {
 
         let word_count =
             webfang_core::infrastructure::obsidian::metadata::compute_word_count(content);
-        let reading_time =
-            webfang_core::infrastructure::obsidian::metadata::compute_reading_time(word_count);
+        // Empty content has no reading time; domain helper floors to 1 minute.
+        let reading_time = if word_count == 0 {
+            0
+        } else {
+            webfang_core::infrastructure::obsidian::metadata::compute_reading_time(word_count)
+        };
+        let language = webfang_core::infrastructure::obsidian::metadata::detect_language(content);
+        let content_type =
+            webfang_core::infrastructure::obsidian::metadata::detect_content_type_text(content);
 
         let meta = serde_json::json!({
             "word_count": word_count,
             "reading_time_minutes": reading_time,
+            "language": language,
+            "content_type": content_type,
         });
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string_pretty(&meta).expect("serializing JSON to a string cannot fail"),
@@ -389,6 +398,82 @@ mod tests {
         assert!(
             parsed.get("reading_time_minutes").is_some(),
             "reading_time must be present: {parsed}"
+        );
+        assert!(
+            parsed.get("language").is_some(),
+            "language must be present: {parsed}"
+        );
+        assert!(
+            parsed.get("content_type").is_some(),
+            "content_type must be present: {parsed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_rich_metadata_detects_spanish() {
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .generate_rich_metadata(Parameters(GenerateRichMetadataParams {
+                content: Some(
+                    "El gato negro duerme tranquilamente en la casa de sus abuelos".to_string(),
+                ),
+            }))
+            .await
+            .expect("generate_rich_metadata returns Ok");
+        let text = result_text(&res);
+        let parsed: serde_json::Value = serde_json::from_str(&text).expect("rich metadata is JSON");
+        assert_eq!(
+            parsed.get("language").and_then(|v| v.as_str()),
+            Some("spa"),
+            "Spanish must be detected: {parsed}"
+        );
+        assert_eq!(
+            parsed.get("content_type").and_then(|v| v.as_str()),
+            Some("text"),
+            "plain text must be classified: {parsed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_rich_metadata_empty_reading_time_zero() {
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .generate_rich_metadata(Parameters(GenerateRichMetadataParams {
+                content: Some("".to_string()),
+            }))
+            .await
+            .expect("generate_rich_metadata returns Ok");
+        let text = result_text(&res);
+        let parsed: serde_json::Value = serde_json::from_str(&text).expect("rich metadata is JSON");
+        assert_eq!(
+            parsed.get("word_count").and_then(|v| v.as_u64()),
+            Some(0),
+            "word_count must be 0: {parsed}"
+        );
+        assert_eq!(
+            parsed.get("reading_time_minutes").and_then(|v| v.as_u64()),
+            Some(0),
+            "empty content must have reading_time 0: {parsed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_rich_metadata_detects_markdown() {
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .generate_rich_metadata(Parameters(GenerateRichMetadataParams {
+                content: Some(
+                    "# Title\n\nSome **bold** text with [a link](https://example.com).".to_string(),
+                ),
+            }))
+            .await
+            .expect("generate_rich_metadata returns Ok");
+        let text = result_text(&res);
+        let parsed: serde_json::Value = serde_json::from_str(&text).expect("rich metadata is JSON");
+        assert_eq!(
+            parsed.get("content_type").and_then(|v| v.as_str()),
+            Some("markdown"),
+            "markdown must be classified: {parsed}"
         );
     }
 }


### PR DESCRIPTION
Closes #604

## Summary
- `generate_rich_metadata` ahora emite `language` (heurística determinista spa/eng + fallback whatlang) y `content_type` (html/markdown/text).
- Contenido vacío → `reading_time_minutes: 0` (antes 1).
- Reemplaza `whatlang`-only por heurística en `infrastructure/obsidian/metadata.rs`.

## Test plan
- `cargo test -p webfang_mcp generate_rich_metadata` → 4/4.
- `cargo clippy` strict gate limpio.