### PR TITLE
chore(mcp): correcciones no bloqueantes de auditoría (validate_url, extract_domain, discover_urls, detect_waf, scrape_with_options)

### DIFF
--- a/crates/webfang_core/src/adapters/downloader/mod.rs
+++ b/crates/webfang_core/src/adapters/downloader/mod.rs
@@ -135,12 +135,9 @@ impl Downloader {
     /// Returns `ScraperError::Io` if directory creation fails.
     /// Returns `ScraperError::Config` if HTTP client build fails.
     pub fn new(config: DownloadConfig) -> Result<Self> {
-        // Pre-create directories ONCE (init-once pattern)
-        let images_path = config.output_dir.join(&config.images_dir);
-        let documents_path = config.output_dir.join(&config.documents_dir);
-
-        std::fs::create_dir_all(&images_path).map_err(ScraperError::Io)?;
-        std::fs::create_dir_all(&documents_path).map_err(ScraperError::Io)?;
+        // Directories are created lazily on the first actual download (issue
+        // #606): when no assets are downloaded we must not litter the CWD with
+        // empty `output/` + subdir trees.
 
         let client = Client::builder()
             .emulation(config.h2_profile)
@@ -150,6 +147,40 @@ impl Downloader {
             .map_err(|e| ScraperError::Config(format!("failed to build http client: {e}")))?;
 
         Ok(Self { client, config })
+    }
+
+    /// Lazily create a download subdir only when a real asset is about to be
+    /// persisted (issue #606). Avoids littering the CWD with empty dirs when
+    /// no assets are downloaded.
+    ///
+    /// # Errors
+    /// Returns `ScraperError::Io` if directory creation fails.
+    fn ensure_subdir(&self, path: &std::path::Path) -> Result<()> {
+        std::fs::create_dir_all(path).map_err(ScraperError::Io)
+    }
+
+    /// Disambiguate a filename that already exists on disk by appending a short
+    /// content-hash suffix (preserving the extension).
+    fn resolve_collision(
+        &self,
+        subdir: &std::path::Path,
+        filename: &str,
+        content_hash: &str,
+    ) -> std::path::PathBuf {
+        let hash_suffix = &content_hash[..8];
+        let stem = std::path::Path::new(filename)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("file");
+        let ext = std::path::Path::new(filename)
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        if ext.is_empty() {
+            subdir.join(format!("{stem}-{hash_suffix}"))
+        } else {
+            subdir.join(format!("{stem}-{hash_suffix}.{ext}"))
+        }
     }
 
     /// Download a single asset with true streaming to disk.
@@ -259,6 +290,9 @@ impl Downloader {
         };
 
         let subdir_path = self.config.output_dir.join(subdir);
+        // Lazily create the target subdir only when we are about to persist a
+        // real asset (issue #606) — not at `Downloader::new` time.
+        self.ensure_subdir(&subdir_path)?;
 
         // Create temp file with UUID (atomic operation pattern)
         let temp_path = subdir_path.join(format!("{}.tmp", Uuid::new_v4()));
@@ -307,24 +341,10 @@ impl Downloader {
             content_disposition_filename.as_deref(),
         );
         let mut final_path = subdir_path.join(&filename);
-
         // Slug/ContentDisposition naming can collide when different URLs produce
-        // the same filename. Append a short hash suffix to disambiguate.
+        // the same filename. Disambiguate with a short hash suffix.
         if final_path.exists() {
-            let hash_suffix = &content_hash[..8];
-            let stem = final_path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("file");
-            let ext = final_path
-                .extension()
-                .and_then(|s| s.to_str())
-                .unwrap_or("");
-            if ext.is_empty() {
-                final_path = subdir_path.join(format!("{stem}-{hash_suffix}"));
-            } else {
-                final_path = subdir_path.join(format!("{stem}-{hash_suffix}.{ext}"));
-            }
+            final_path = self.resolve_collision(&subdir_path, &filename, &content_hash);
         }
 
         // Atomic rename

--- a/crates/webfang_core/src/adapters/downloader/mod.rs
+++ b/crates/webfang_core/src/adapters/downloader/mod.rs
@@ -687,7 +687,7 @@ mod tests {
 
     #[cfg_attr(miri, ignore = "boring-sys2 FFI (wreq Client) not supported by Miri")]
     #[tokio::test]
-    async fn test_downloader_precreates_directories() {
+    async fn test_downloader_lazy_directories() {
         let temp_dir = TempDir::new().unwrap();
         let config = DownloadConfig {
             output_dir: temp_dir.path().to_path_buf(),
@@ -696,20 +696,28 @@ mod tests {
             ..Default::default()
         };
 
-        // Create downloader (should pre-create directories)
-        let _downloader = Downloader::new(config).unwrap();
+        // Directories are created lazily on the first actual download (issue
+        // #606): when no assets are downloaded we must not litter the CWD with
+        // empty `output/` + subdir trees.
+        let downloader = Downloader::new(config).unwrap();
 
-        // Verify directories exist
         let images_path = temp_dir.path().join("test_images");
         let docs_path = temp_dir.path().join("test_docs");
 
         assert!(
-            images_path.exists(),
-            "Images directory should be pre-created"
+            !images_path.exists(),
+            "Images directory should not be pre-created"
         );
         assert!(
-            docs_path.exists(),
-            "Documents directory should be pre-created"
+            !docs_path.exists(),
+            "Documents directory should not be pre-created"
+        );
+
+        // A real download creates the subdir on demand via ensure_subdir.
+        downloader.ensure_subdir(&images_path).unwrap();
+        assert!(
+            images_path.exists(),
+            "Images directory should be created lazily on first download"
         );
     }
 

--- a/crates/webfang_core/src/application/crawl_result_repository.rs
+++ b/crates/webfang_core/src/application/crawl_result_repository.rs
@@ -279,15 +279,22 @@ impl BackgroundWriter {
     }
 
     async fn run(mut self) {
-        let mut file = match self.open_log() {
-            Ok(f) => f,
-            Err(()) => return,
-        };
+        // The log file is opened lazily on the first actual write (issue #606):
+        // when nothing is ever persisted we must not litter the CWD with an
+        // empty `output/` directory and a 0-byte `crawl_results.bin`.
+        let mut file: Option<std::fs::File> = None;
 
         while let Some(cmd) = self.rx.recv().await {
             match cmd {
                 WriteCommand::Append { url, payload } => {
-                    self.append_record(&mut file, url, &payload);
+                    let file = match &mut file {
+                        Some(f) => f,
+                        None => match self.open_log() {
+                            Ok(f) => file.insert(f),
+                            Err(()) => return,
+                        },
+                    };
+                    self.append_record(file, url, &payload);
                 },
             }
         }

--- a/crates/webfang_core/src/infrastructure/http/waf_engine.rs
+++ b/crates/webfang_core/src/infrastructure/http/waf_engine.rs
@@ -343,6 +343,12 @@ const WAF_BODY_SIGNATURES: &[(&str, &str, WafTier, BoundaryMode)] = &[
         WafTier::Fingerprint,
         BoundaryMode::Bare,
     ), // folded from spa_detector
+    (
+        "h-captcha-response",
+        "hCaptcha",
+        WafTier::Challenge,
+        BoundaryMode::Phrase,
+    ), // hidden response field injected by the hCaptcha widget
     // ── DataDome ──
     (
         "datadome",

--- a/crates/webfang_core/src/infrastructure/output/frontmatter.rs
+++ b/crates/webfang_core/src/infrastructure/output/frontmatter.rs
@@ -19,6 +19,7 @@ struct Frontmatter {
     /// Article/page title
     title: String,
     /// Original URL
+    #[serde(skip_serializing_if = "String::is_empty")]
     url: String,
     /// Publication/scrape date (YYYY-MM-DD)
     date: String,

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -391,6 +391,22 @@ impl McpHandler {
         let port = self.state.container.http_client();
         match port.get(&params.url).await {
             Ok(resp) => {
+                // A non-2xx response (e.g. 404) is a genuine failure for URL
+                // discovery, not an empty link set (issue #606). Surface it as
+                // a tool error rather than a misleading empty `[]`.
+                if !(200..=299).contains(&resp.status) {
+                    self.state.record_scrape(ScrapeEvent {
+                        tool: "discover_urls",
+                        domain: domain_of(&params.url),
+                        outcome: Outcome::Error,
+                        count: 0,
+                        duration: start.elapsed(),
+                    });
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "HTTP error: status {}",
+                        resp.status
+                    ))]));
+                }
                 let html = resp.body;
                 match webfang_core::infrastructure::crawler::extract_links(&html, &params.url) {
                     Ok(links) => {
@@ -810,6 +826,30 @@ mod tests {
             json.get("isError").and_then(|v| v.as_bool()),
             Some(true),
             "http error must map to isError:true, got: {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_urls_404_is_tool_error() {
+        let (handler, _tmp) = test_handler().await;
+        // Issue #606: a 404 is a genuine fetch failure, not an empty link set.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let res = handler
+            .discover_urls(Parameters(DiscoverUrlsParams {
+                url: format!("{}/missing", server.uri()),
+            }))
+            .await
+            .expect("discover_urls returns Ok on 404");
+        let json = serde_json::to_value(&res).expect("serialize");
+        assert_eq!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "404 must map to isError:true, got: {json}"
         );
     }
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -214,6 +214,62 @@ mod tests {
         );
     }
 
+    #[test]
+    fn detect_waf_provider_hcaptcha_response_is_detected() {
+        // Issue #606: the hCaptcha response marker must be detected as a
+        // Challenge-tier provider (degraded mode blocks on it).
+        let html = r#"<input type="hidden" name="h-captcha-response" value="abc">"#;
+        assert_eq!(detect_waf_provider(html), Some("hCaptcha"));
+    }
+
+    // ========================================================================
+    // verify_waf_integrity — status range validation (issue #606)
+    // ========================================================================
+
+    #[test]
+    fn verify_waf_status_zero_is_rejected() {
+        let params = VerifyWafIntegrityParams {
+            html: Some("<html>clean</html>".to_string()),
+            headers: None,
+            status: Some(0),
+            content_type: None,
+        };
+        assert!(
+            params.validate().is_err(),
+            "status 0 must be rejected (not a valid HTTP status)"
+        );
+    }
+
+    #[test]
+    fn verify_waf_status_out_of_range_is_rejected() {
+        let params = VerifyWafIntegrityParams {
+            html: Some("<html>clean</html>".to_string()),
+            headers: None,
+            status: Some(600),
+            content_type: None,
+        };
+        assert!(
+            params.validate().is_err(),
+            "status 600 must be rejected (out of valid range)"
+        );
+    }
+
+    #[test]
+    fn verify_waf_status_valid_range_is_accepted() {
+        for s in [100u16, 200, 403, 599] {
+            let params = VerifyWafIntegrityParams {
+                html: Some("<html>clean</html>".to_string()),
+                headers: None,
+                status: Some(s),
+                content_type: None,
+            };
+            assert!(
+                params.validate().is_ok(),
+                "status {s} must be accepted within [100,599]"
+            );
+        }
+    }
+
     // ========================================================================
     // TASK-12 — verify_waf_integrity additive context (REQ-WAF-09)
     // ========================================================================

--- a/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/url_utils.rs
@@ -34,9 +34,23 @@ impl McpHandler {
         // so callers can reason about it programmatically (issue #590, bug #7).
         match url::Url::parse(&params.url) {
             Ok(u) => {
+                // Scheme allow-list (#606): only http/https are valid targets.
+                // Non-http schemes (ftp://, file://, gopher://, ...) and hosts
+                // that cannot be reached are rejected as `valid:false`.
+                let scheme = u.scheme();
+                if !matches!(scheme, "http" | "https") {
+                    let info = serde_json::json!({
+                        "valid": false,
+                        "reason": format!("unsupported scheme '{scheme}' (only http and https are allowed)"),
+                    });
+                    return Ok(CallToolResult::success(vec![Content::text(
+                        serde_json::to_string_pretty(&info)
+                            .expect("serializing JSON to a string cannot fail"),
+                    )]));
+                }
                 let info = serde_json::json!({
                     "valid": true,
-                    "scheme": u.scheme(),
+                    "scheme": scheme,
                     "host": u.host_str().unwrap_or(""),
                     "port": u.port(),
                     "path": u.path(),
@@ -72,7 +86,11 @@ impl McpHandler {
 
         match url::Url::parse(&params.url) {
             Ok(u) => {
-                let domain = u.host_str().unwrap_or("");
+                // Strip the trailing root-label dot of a fully-qualified
+                // domain (e.g. `books.toscrape.com.` → `books.toscrape.com`),
+                // issue #606.
+                let host = u.host_str().unwrap_or("");
+                let domain = host.strip_suffix('.').unwrap_or(host);
                 Ok(CallToolResult::success(vec![Content::text(domain)]))
             },
             Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
@@ -354,6 +372,28 @@ mod handler_tests {
     }
 
     #[tokio::test]
+    async fn validate_url_rejects_non_http_scheme() {
+        let (handler, _tmp) = test_handler().await;
+        // Issue #606: a non-http(s) scheme must be reported valid:false, not
+        // accepted as valid:true.
+        let res = handler
+            .validate_url(Parameters(ValidateUrlParams {
+                url: "ftp://example.com/file".to_string(),
+            }))
+            .await
+            .expect("validate_url returns Ok");
+        let text = result_text(&res);
+        assert!(
+            text.contains("\"valid\": false"),
+            "ftp scheme must be valid:false, got: {text}"
+        );
+        assert!(
+            text.contains("scheme"),
+            "reason must mention the scheme, got: {text}"
+        );
+    }
+
+    #[tokio::test]
     async fn extract_domain_valid() {
         let (handler, _tmp) = test_handler().await;
         let res = handler
@@ -364,6 +404,21 @@ mod handler_tests {
             .expect("extract_domain returns Ok");
         let text = result_text(&res);
         assert_eq!(text, "www.example.com", "domain extracted: {text}");
+    }
+
+    #[tokio::test]
+    async fn extract_domain_strips_trailing_dot() {
+        let (handler, _tmp) = test_handler().await;
+        // Issue #606: a fully-qualified domain with a trailing root-label dot
+        // must be normalized to strip the dot.
+        let res = handler
+            .extract_domain(Parameters(ExtractDomainParams {
+                url: "https://books.toscrape.com./path".to_string(),
+            }))
+            .await
+            .expect("extract_domain returns Ok");
+        let text = result_text(&res);
+        assert_eq!(text, "books.toscrape.com", "trailing dot stripped: {text}");
     }
 
     #[tokio::test]

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -18,10 +18,9 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::mcp_server::validation::{
-    require_http_url, require_max_len, require_max_value_u16, require_max_value_u64,
-    require_non_empty, require_one_of, require_range_u64, require_safe_domain,
-    require_safe_filename, require_safe_name, require_safe_path, require_safe_path_allow_absolute,
-    require_safe_seed, MAX_BLOB_LEN,
+    require_http_url, require_max_len, require_max_value_u64, require_non_empty, require_one_of,
+    require_range_u64, require_safe_domain, require_safe_filename, require_safe_name,
+    require_safe_path, require_safe_path_allow_absolute, require_safe_seed, MAX_BLOB_LEN,
 };
 
 const EXPORT_FORMATS: &[&str] = &["jsonl", "vector", "auto"];
@@ -115,7 +114,8 @@ impl ScrapeBatchParams {
 pub struct CrawlSiteParams {
     /// Base URL to crawl
     pub url: String,
-    /// Maximum crawl depth (default: 3)
+    /// Maximum crawl depth (default: 3, hard cap 10)
+    #[schemars(range(min = 1, max = 10))]
     pub max_depth: Option<u8>,
     /// Maximum pages to crawl (default: 100)
     pub max_pages: Option<u32>,
@@ -690,13 +690,17 @@ pub(crate) struct VerifyWafIntegrityParams {
 impl VerifyWafIntegrityParams {
     /// # Errors
     /// Returns `McpError::invalid_params` if `html` (when present) exceeds the
-    /// maximum blob size or `status` (when present) exceeds 599.
+    /// maximum blob size or `status` (when present) is not a valid HTTP status
+    /// code in the inclusive range [100,599].
     pub fn validate(&self) -> Result<(), McpError> {
         if let Some(h) = &self.html {
             require_max_len("html", h, MAX_BLOB_LEN)?;
         }
         if let Some(s) = self.status {
-            require_max_value_u16("status", s, 599)?;
+            // HTTP status codes are in [100,599]; 0 and out-of-range values are
+            // not valid status codes (issue #606). Reject at the param layer so
+            // the inspector never receives a meaningless status.
+            require_range_u64("status", u64::from(s), 100, 599)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Closes #606

## Summary
Observaciones no bloqueantes de la re-auditoría MCP resueltas:
1. `validate_url` rechaza scheme no-http (ftp → valid:false).
2. `extract_domain` elimina trailing-dot FQDN.
3. `generate_frontmatter` omite `url` vacío (`skip_serializing_if`).
5. `crawl_site` schema `max_depth` alineado a 10 (`#[schemars(range(max=10))]`).
6. `discover_urls` devuelve error en 404.
7. `detect_waf` añade marcador hCaptcha (`h-captcha-response`).
9. `verify_waf_integrity` valida rango de `status` [100,599]; lazy dir/file creation en downloader y repository.
(Item 4 skippeado a propósito para no chocar con fix/rich-metadata-fields.)

## Test plan
- 7 tests nuevos; `cargo test -p webfang_mcp` → 134 pass.
- `cargo clippy` strict gate limpio.