### PR TITLE
ci(infra): add merge_group support to required-check workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ on:
   push:
     branches: [main, develop]
   pull_request:
+  merge_group:
   schedule:
     - cron: "0 0 * * 1"  # Weekly Miri on Monday 00:00 UTC
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # event_name in the group key: merge_group runs must not cancel (or be
+  # canceled by) pull_request runs on the same head branch.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -35,6 +35,7 @@ on:
     # (docs, lints, CI) stay BLOCKED forever: GitHub treats a required check
     # that never ran as pending. The job decides internally via paths-filter
     # and reports SUCCESS when the diff has no gated hot-path changes.
+  merge_group:
   schedule:
     - cron: "0 3 * * 1"  # Mondays 03:00 UTC
   workflow_dispatch:
@@ -42,7 +43,7 @@ on:
 concurrency:
   # Bulkhead: PR runs and scheduled runs never cancel each other.
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -53,10 +54,11 @@ env:
 jobs:
   # ---------------------------------------------------------------------------
   # PR GATE — mutates only the diff. Any surviving mutant fails the job.
-  # Runs ONLY on pull_request (bulkhead: no base_ref on schedule).
+  # Runs on pull_request AND merge_group: the required check must be reported
+  # on the merge group too, or the queue blocks. Never on schedule (no base_ref).
   # ---------------------------------------------------------------------------
   mutants-pr:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     name: "cargo-mutants (PR diff)"
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -67,8 +69,13 @@ jobs:
           fetch-depth: 0
 
       - name: Generate PR diff
+        env:
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
-          git diff "origin/${{ github.base_ref }}"...HEAD > git.diff
+          # merge_group carries its own base_ref; fall back to main when absent.
+          BASE="${BASE_REF}"
+          [ -z "$BASE" ] && BASE="main"
+          git diff "origin/$BASE"...HEAD > git.diff
 
       # Always reported check: when the diff touches no gated hot path,
       # the job short-circuits to SUCCESS instead of silently not running.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -27,9 +27,10 @@ jobs:
             echo "::error::No se pudo resolver el head ref del PR (evento: ${{ github.event_name }})."
             exit 1
           fi
-          PR=$(gh pr list --repo "$REPO" --head "$HEAD_REF" --state open --json number -q '.[0].number' 2>/dev/null || true)
+          # REST API (deterministic): the "head" filter requires user:branch format.
+          PR=$(gh api "repos/$REPO/pulls?state=open&head=${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}:$HEAD_REF" --jq '.[0].number' 2>&1 || true)
           if ! printf '%s' "$PR" | grep -qE '^[0-9]+$'; then
-            echo "::error::No se pudo resolver el PR para la rama '$HEAD_REF' (evento: ${{ github.event_name }})."
+            echo "::error::No se pudo resolver el PR para la rama '$HEAD_REF' (evento: ${{ github.event_name }}). Detalle: $PR"
             exit 1
           fi
           echo "pr=$PR" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Resolve PR number
         id: prnum
         env:
+          GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,6 +3,7 @@ name: PR Validation
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+  merge_group:
 
 permissions:
   pull-requests: read
@@ -12,10 +13,36 @@ jobs:
     name: Validate PR metadata
     runs-on: ubuntu-latest
     steps:
+      # Resolve the real PR for both pull_request and merge_group runs.
+      # Fail closed: this is a required check — if the PR cannot be
+      # resolved, the check fails instead of silently passing.
+      - name: Resolve PR number
+        id: prnum
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HEAD_REF" ]; then
+            echo "::error::No se pudo resolver el head ref del PR (evento: ${{ github.event_name }})."
+            exit 1
+          fi
+          PR=$(gh pr list --repo "$REPO" --head "$HEAD_REF" --state open --json number -q '.[0].number' 2>/dev/null || true)
+          if ! printf '%s' "$PR" | grep -qE '^[0-9]+$'; then
+            echo "::error::No se pudo resolver el PR para la rama '$HEAD_REF' (evento: ${{ github.event_name }})."
+            exit 1
+          fi
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR #$PR"
+
       - name: Require linked issue
         env:
-          BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.prnum.outputs.pr }}
+          REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+          BODY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json body --jq '.body // ""')
           if ! printf '%s' "$BODY" | grep -qiE '(closes|fixes|resolves) #[0-9]+'; then
             echo "::error::El cuerpo del PR debe vincular una issue con 'Closes #N', 'Fixes #N' o 'Resolves #N'."
             exit 1
@@ -25,9 +52,10 @@ jobs:
       - name: Require exactly one type:* label
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.prnum.outputs.pr }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
           count=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
             --jq '[.labels[].name | select(startswith("type:"))] | length')
           if [ "$count" -ne 1 ]; then
@@ -38,8 +66,12 @@ jobs:
 
       - name: Require conventional branch name
         env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.prnum.outputs.pr }}
+          REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+          HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName')
           if ! printf '%s' "$HEAD_REF" | grep -qE '^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)/[a-z0-9._-]+$'; then
             echo "::error::La rama '$HEAD_REF' debe seguir el patron type/description (ej: fix/mi-bug)."
             exit 1


### PR DESCRIPTION
## Linked Issue

Closes #623

## PR Type

- [x] Maintenance / tooling (`type:chore`)

## Summary

- Adds the `merge_group` trigger to the 3 workflows that produce required status checks on `main`, so the checks are reported on the merge queue's temporary branch.
- Fixes `concurrency` in `ci.yml` (event_name in the group key) so pull_request and merge_group runs never cancel each other.
- Reworks `pr-validation.yml` to resolve the PR via `head_ref` + `gh pr list` (event-agnostic, fail-closed). Branch names in this repo do not embed `pr-N`, so regex-based resolution would always fail under `merge_group`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `merge_group` trigger; concurrency group includes `event_name` |
| `.github/workflows/mutants.yml` | `merge_group` trigger; `mutants-pr` runs on pull_request and merge_group; `base_ref` resolved from merge_group context with `main` fallback |
| `.github/workflows/pr-validation.yml` | `merge_group` trigger; PR resolution via `gh pr list --head` (fail-closed); metadata checks read via `gh pr view` |

## Test Plan

- [x] `actionlint` clean on all 3 workflows
- [x] YAML parsed (`yq`): `merge_group` present in all 3 `on:` blocks
- [x] Full diff reviewed
- [x] Cargo gates N/A (no Rust code touched)

## Contributor Checklist

- [x] Linked an approved issue (`status:approved`) with `Closes/Fixes/Resolves #N`
- [x] Branch name matches `type/description` (e.g. `fix/parser-crash`) — CI rejects others
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (N/A — workflows only)
- [x] Defensive error paths annotated with `// LCOV_EXCL_*` markers per docs/src/testing.md (issue #527) (N/A — workflows only)
