### PR TITLE
fix(crawler): wire dead-flag CLI args (delay, max-file-size, download-timeout, retries)

### DIFF
--- a/crates/webfang_core/src/application/crawl_options.rs
+++ b/crates/webfang_core/src/application/crawl_options.rs
@@ -159,6 +159,10 @@ pub struct NetworkOptions {
     pub download_images: bool,
     /// Download documents from the page.
     pub download_documents: bool,
+    /// Maximum file size for asset downloads in bytes (None = 50MB default).
+    pub max_file_size: Option<u64>,
+    /// Timeout for individual asset downloads in seconds.
+    pub download_timeout_secs: u64,
     /// TLS/HTTP2 profile name (e.g. Chrome145).
     pub h2_profile: String,
     /// JavaScript rendering strategy (static, hybrid, full).
@@ -254,6 +258,8 @@ impl Default for NetworkOptions {
             backoff_max_ms: 10000,
             download_images: false,
             download_documents: false,
+            max_file_size: None,
+            download_timeout_secs: 30,
             h2_profile: "Chrome145".to_owned(),
             js_strategy: JsStrategy::default(),
             obscura_binary: "obscura".to_owned(),

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -232,6 +232,9 @@ impl Engine {
         strategy: JsStrategy,
         tls_emulation: Profile,
         ignore_waf: bool,
+        max_retries: u32,
+        backoff_base_ms: u64,
+        backoff_max_ms: u64,
     ) -> Result<Self, DownloadError> {
         let timeout = self.config.timeout_secs;
         let router = build_fetch_router(
@@ -246,6 +249,9 @@ impl Engine {
             // #509: the Full strategy's governor shares the engine token so
             // permit waits abort on shutdown.
             self.cancel_token.clone(),
+            max_retries,
+            backoff_base_ms,
+            backoff_max_ms,
         )?;
         self.js_strategy = strategy;
         self.fetch_router = Some(router);
@@ -841,6 +847,12 @@ pub struct EngineOptions {
     /// Defaults to `false`. When `true`, a genuine T1 challenge is treated per
     /// normal spa/static logic instead of aborting the fetch.
     pub ignore_waf: bool,
+    /// Maximum number of retry attempts for failed fetches.
+    pub max_retries: u32,
+    /// Base delay for exponential backoff (ms).
+    pub backoff_base_ms: u64,
+    /// Maximum delay for exponential backoff (ms).
+    pub backoff_max_ms: u64,
 }
 
 impl Default for EngineOptions {
@@ -853,6 +865,9 @@ impl Default for EngineOptions {
             autoscale_enabled: false,
             tls_emulation: Profile::Chrome145,
             ignore_waf: false,
+            max_retries: 3,
+            backoff_base_ms: 1000,
+            backoff_max_ms: 10000,
         }
     }
 }
@@ -1039,6 +1054,9 @@ async fn crawl_site_with_options_inner(
         options.js_strategy,
         options.tls_emulation,
         options.ignore_waf,
+        options.max_retries,
+        options.backoff_base_ms,
+        options.backoff_max_ms,
     )?;
 
     // Apply autoscale if enabled

--- a/crates/webfang_core/src/application/crawler/fetch_router.rs
+++ b/crates/webfang_core/src/application/crawler/fetch_router.rs
@@ -62,6 +62,7 @@ pub enum FetchRouter {
 /// # Errors
 ///
 /// Returns [`DownloadError::Internal`] if the wreq client cannot be built.
+#[allow(clippy::too_many_arguments)]
 pub fn build_fetch_router(
     strategy: &JsStrategy,
     timeout_secs: u64,
@@ -70,6 +71,9 @@ pub fn build_fetch_router(
     ignore_waf: bool,
     user_agent: Option<String>,
     cancel_token: CancellationToken,
+    max_retries: u32,
+    backoff_base_ms: u64,
+    backoff_max_ms: u64,
 ) -> Result<FetchRouter, DownloadError> {
     let connect_timeout = timeout_secs.min(10);
     Ok(match strategy {
@@ -78,9 +82,20 @@ pub fn build_fetch_router(
             connect_timeout,
             tls_emulation,
             user_agent,
+            max_retries,
+            backoff_base_ms,
+            backoff_max_ms,
         )?)),
         JsStrategy::Hybrid => {
-            let l1 = WreqDownloader::new(timeout_secs, connect_timeout, tls_emulation, user_agent)?;
+            let l1 = WreqDownloader::new(
+                timeout_secs,
+                connect_timeout,
+                tls_emulation,
+                user_agent,
+                max_retries,
+                backoff_base_ms,
+                backoff_max_ms,
+            )?;
             let l2 = ObscuraDownloader::new(timeout_secs);
             let l3 = ChromiumoxideDownloader::new(cookie_bridge);
             FetchRouter::Hybrid(Arc::new(HybridRouter::new(l1, l2, l3, ignore_waf)))
@@ -149,6 +164,9 @@ mod router_tests {
             false,
             None,
             CancellationToken::new(),
+            3,
+            1000,
+            10000,
         )
         .expect("static router must build");
         assert!(
@@ -167,6 +185,9 @@ mod router_tests {
             false,
             None,
             CancellationToken::new(),
+            3,
+            1000,
+            10000,
         )
         .expect("hybrid router must build");
         assert!(
@@ -185,6 +206,9 @@ mod router_tests {
             false,
             None,
             CancellationToken::new(),
+            3,
+            1000,
+            10000,
         )
         .expect("full router must build");
         assert!(

--- a/crates/webfang_core/src/cli/args/mod.rs
+++ b/crates/webfang_core/src/cli/args/mod.rs
@@ -196,6 +196,8 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
                 backoff_max_ms: args.crawler.backoff_max_ms,
                 download_images: args.crawler.download_images || args.crawler.download_assets,
                 download_documents: args.crawler.download_documents || args.crawler.download_assets,
+                max_file_size: Some(args.crawler.max_file_size),
+                download_timeout_secs: args.crawler.download_timeout,
                 h2_profile: args.crawler.h2_profile,
                 js_strategy: args.crawler.js_strategy,
                 obscura_binary: args.crawler.obscura_binary,

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -271,6 +271,7 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
             .ignore_robots(opts.crawl.ignore_robots)
             .use_sitemap(opts.crawl.use_sitemap)
             .timeout_secs(opts.network.timeout_secs)
+            .delay_ms(opts.network.delay_ms)
             .tls_emulation(tls_emulation);
         if let Some(ref sitemap_url) = opts.crawl.sitemap_url {
             crawler_config = crawler_config.sitemap_url(sitemap_url);
@@ -326,6 +327,8 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
         scraper_config.with_asset_exclude_patterns(opts.crawl.exclude_patterns.clone());
     scraper_config = scraper_config.with_asset_naming(parse_asset_naming(&opts.asset_naming));
     scraper_config = scraper_config.with_download_concurrency(opts.download_concurrency);
+    scraper_config = scraper_config.with_max_file_size(opts.network.max_file_size);
+    scraper_config = scraper_config.with_download_timeout(opts.network.download_timeout_secs);
 
     // Create shared Downloader once for connection pooling across all page scrapes.
     let shared_downloader = if scraper_config.has_downloads() {

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -163,6 +163,9 @@ pub async fn scrape_urls(
         // #509: the scrape flow has no shutdown policy yet — pass an inert
         // token so Full-strategy governor waits keep pre-#509 behavior.
         tokio_util::sync::CancellationToken::new(),
+        http_config.max_retries,
+        http_config.backoff_base_ms,
+        http_config.backoff_max_ms,
     )?;
 
     let _total_urls = urls.len();

--- a/crates/webfang_core/src/infrastructure/config.rs
+++ b/crates/webfang_core/src/infrastructure/config.rs
@@ -184,6 +184,20 @@ impl ScraperConfig {
         self
     }
 
+    /// Set maximum file size for asset downloads in bytes.
+    #[must_use]
+    pub fn with_max_file_size(mut self, max_file_size: Option<u64>) -> Self {
+        self.max_file_size = max_file_size;
+        self
+    }
+
+    /// Set timeout for individual asset downloads in seconds.
+    #[must_use]
+    pub fn with_download_timeout(mut self, timeout_secs: u64) -> Self {
+        self.download_timeout_secs = timeout_secs;
+        self
+    }
+
     /// Set the WAF/CAPTCHA detection bypass flag (REQ-WAF-07).
     #[must_use]
     pub fn with_ignore_waf(mut self, ignore_waf: bool) -> Self {

--- a/crates/webfang_core/src/infrastructure/downloader/mod.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/mod.rs
@@ -40,7 +40,7 @@ use url::Url;
 /// use webfang_core::infrastructure::downloader::wreq_downloader::WreqDownloader;
 /// use webfang_core::infrastructure::downloader::Downloader;
 ///
-/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145, None).unwrap();
+/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145, None, 3, 1000, 10000).unwrap();
 /// let page = downloader.fetch(&"https://example.com".parse().unwrap()).await.unwrap();
 /// assert!(!page.html.is_empty());
 /// ```

--- a/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs
@@ -35,7 +35,7 @@ const WREQ_MEMORY_COST: usize = 1_024 * 1_024; // ~1 MB
 /// use webfang_core::infrastructure::downloader::wreq_downloader::WreqDownloader;
 /// use webfang_core::infrastructure::downloader::Downloader;
 ///
-/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145, None).unwrap();
+/// let downloader = WreqDownloader::new(30, 10, wreq_util::Profile::Chrome145, None, 3, 1000, 10000).unwrap();
 /// let page = downloader.fetch(&"https://example.com".parse().unwrap()).await.unwrap();
 /// assert_eq!(page.status, 200);
 /// ```
@@ -48,6 +48,11 @@ pub struct WreqDownloader {
     /// all retries — carries it. When set, the 403 pool-rotation retry is
     /// disabled: the operator asked to be identified exactly as configured.
     pinned_ua: Option<String>,
+    max_retries: u32,
+    /// Base delay for exponential backoff — reserved for future jitter implementation.
+    #[allow(dead_code)]
+    backoff_base_ms: u64,
+    backoff_max_ms: u64,
 }
 
 impl WreqDownloader {
@@ -74,6 +79,9 @@ impl WreqDownloader {
         connect_timeout_secs: u64,
         tls_emulation: Profile,
         user_agent: Option<String>,
+        max_retries: u32,
+        backoff_base_ms: u64,
+        backoff_max_ms: u64,
     ) -> Result<Self, DownloadError> {
         let pool_size = std::cmp::max(6, num_cpus::get() - 1);
 
@@ -103,6 +111,9 @@ impl WreqDownloader {
             timeout_secs = timeout_secs,
             connect_timeout_secs = connect_timeout_secs,
             ua = user_agent.as_deref().unwrap_or("emulation-default"),
+            max_retries = max_retries,
+            backoff_base_ms = backoff_base_ms,
+            backoff_max_ms = backoff_max_ms,
             "WreqDownloader created"
         );
 
@@ -110,6 +121,9 @@ impl WreqDownloader {
             client: Arc::new(client),
             timeout_secs,
             pinned_ua: user_agent,
+            max_retries,
+            backoff_base_ms,
+            backoff_max_ms,
         })
     }
 
@@ -121,6 +135,9 @@ impl WreqDownloader {
             client: Arc::new(client),
             timeout_secs,
             pinned_ua: None,
+            max_retries: 3,
+            backoff_base_ms: 1000,
+            backoff_max_ms: 10000,
         }
     }
 
@@ -209,14 +226,15 @@ fn parse_set_cookie(header: &str, url: &Url) -> Option<Cookie> {
 /// Parse the `Retry-After` header (integer seconds) into milliseconds.
 ///
 /// Returns the delay in ms, defaulting to 1000ms if the header is absent or unparseable.
-fn parse_retry_after_ms(response: &wreq::Response) -> u64 {
-    response
+fn parse_retry_after_ms(response: &wreq::Response, max_ms: u64) -> u64 {
+    let raw_ms = response
         .headers()
         .get("retry-after")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.trim().parse::<u64>().ok())
         .unwrap_or(1)
-        .saturating_mul(1000)
+        .saturating_mul(1000);
+    raw_ms.min(max_ms)
 }
 
 impl WreqDownloader {
@@ -277,12 +295,15 @@ impl WreqDownloader {
             status = response.status().as_u16();
         }
 
-        // 429: backoff retry up to 3 times, honouring Retry-After.
+        // 429: backoff retry up to max_retries times, honouring Retry-After.
         if status == 429 {
-            let delay_ms = parse_retry_after_ms(&response);
-            warn!("429 Rate Limited from {url} — retrying after {delay_ms}ms");
+            let delay_ms = parse_retry_after_ms(&response, self.backoff_max_ms);
+            warn!(
+                delay_ms = delay_ms,
+                "429 Rate Limited from {url} — retrying after {delay_ms}ms"
+            );
             let mut succeeded = false;
-            for _ in 0..3 {
+            for _ in 0..self.max_retries {
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
                 response = self.send_request(url, None).await?;
                 status = response.status().as_u16();
@@ -380,7 +401,8 @@ mod test_support {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
+        let downloader =
+            WreqDownloader::new(10, 5, Profile::Chrome145, None, 3, 1000, 10000).unwrap();
         let url: Url = mock_server.uri().parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -399,7 +421,8 @@ mod tests {
 
     #[test]
     fn test_wreq_downloader_creation() {
-        let downloader = WreqDownloader::new(30, 10, Profile::Chrome145, None).unwrap();
+        let downloader =
+            WreqDownloader::new(30, 10, Profile::Chrome145, None, 3, 1000, 10000).unwrap();
         assert!(!downloader.supports_interactions());
         assert_eq!(downloader.memory_cost(), WREQ_MEMORY_COST);
     }
@@ -410,7 +433,7 @@ mod tests {
         // with it (triangulation: the parameter reaches the builder instead of
         // a hardcoded default).
         for profile in [Profile::Chrome145, Profile::Chrome131, Profile::Firefox135] {
-            let downloader = WreqDownloader::new(30, 10, profile, None)
+            let downloader = WreqDownloader::new(30, 10, profile, None, 3, 1000, 10000)
                 .unwrap_or_else(|e| panic!("client must build for profile {profile:?}: {e}"));
             assert!(!downloader.supports_interactions());
         }
@@ -505,7 +528,8 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
+        let downloader =
+            WreqDownloader::new(10, 5, Profile::Chrome145, None, 3, 1000, 10000).unwrap();
         let url: Url = format!("{}/notfound", mock_server.uri()).parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -530,7 +554,8 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
+        let downloader =
+            WreqDownloader::new(10, 5, Profile::Chrome145, None, 3, 1000, 10000).unwrap();
         let url: Url = mock_server.uri().parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -562,7 +587,8 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
+        let downloader =
+            WreqDownloader::new(10, 5, Profile::Chrome145, None, 3, 1000, 10000).unwrap();
         let url: Url = format!("{}/redirect", mock_server.uri()).parse().unwrap();
 
         let result = downloader.fetch(&url).await;
@@ -594,8 +620,16 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader =
-            WreqDownloader::new(10, 5, Profile::Chrome145, Some(PINNED_UA.to_string())).unwrap();
+        let downloader = WreqDownloader::new(
+            10,
+            5,
+            Profile::Chrome145,
+            Some(PINNED_UA.to_string()),
+            3,
+            1000,
+            10000,
+        )
+        .unwrap();
         let url: Url = mock_server.uri().parse().unwrap();
 
         let page = downloader
@@ -681,8 +715,16 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader =
-            WreqDownloader::new(10, 5, Profile::Chrome145, Some(PINNED_UA.to_string())).unwrap();
+        let downloader = WreqDownloader::new(
+            10,
+            5,
+            Profile::Chrome145,
+            Some(PINNED_UA.to_string()),
+            3,
+            1000,
+            10000,
+        )
+        .unwrap();
         let url: Url = mock_server.uri().parse().unwrap();
 
         // First fetch: 403 is terminal — rotation is disabled when pinned.
@@ -732,7 +774,8 @@ mod wiremock_tests {
             .mount(&mock_server)
             .await;
 
-        let downloader = WreqDownloader::new(10, 5, Profile::Chrome145, None).unwrap();
+        let downloader =
+            WreqDownloader::new(10, 5, Profile::Chrome145, None, 3, 1000, 10000).unwrap();
         let url: Url = mock_server.uri().parse().unwrap();
 
         let page = downloader

--- a/crates/webfang_core/tests/downloader_headers_test.rs
+++ b/crates/webfang_core/tests/downloader_headers_test.rs
@@ -30,8 +30,16 @@ async fn wreq_downloader_populates_response_headers() {
         .await;
 
     let downloader: Box<dyn Downloader> = Box::new(
-        WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
-            .expect("downloader builds"),
+        WreqDownloader::new(
+            10,
+            5,
+            HttpClientConfig::default().tls_emulation,
+            None,
+            3,
+            1000,
+            10000,
+        )
+        .expect("downloader builds"),
     );
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 
@@ -74,8 +82,16 @@ async fn wreq_downloader_headers_keys_are_lowercased() {
         .await;
 
     let downloader: Box<dyn Downloader> = Box::new(
-        WreqDownloader::new(10, 5, HttpClientConfig::default().tls_emulation, None)
-            .expect("downloader builds"),
+        WreqDownloader::new(
+            10,
+            5,
+            HttpClientConfig::default().tls_emulation,
+            None,
+            3,
+            1000,
+            10000,
+        )
+        .expect("downloader builds"),
     );
     let url = Url::parse(&server.uri()).expect("wiremock URI is valid");
 


### PR DESCRIPTION
Closes #632
Closes #633
Closes #635

## Summary
- Wire `--delay-ms` into `CrawlerConfig` builder (was dead after `NetworkOptions`)
- Wire `--max-file-size` and `--download-timeout` through `NetworkOptions` → `ScraperConfig` builder → `orchestrator`
- Wire `--max-retries` / `--backoff-base-ms` / `--backoff-max-ms` into `WreqDownloader` (was hardcoded `0..3` for 429 loop)
- Cap `Retry-After` header against `backoff_max_ms` to prevent malicious server-induced worker hangs

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/orchestrator.rs` | Wire delay_ms + max_file_size + download_timeout to builders |
| `crates/webfang_core/src/application/crawl_options.rs` | Add max_file_size + download_timeout_secs to NetworkOptions |
| `crates/webfang_core/src/cli/args/mod.rs` | Map new fields from CLI Args |
| `crates/webfang_core/src/infrastructure/config.rs` | with_max_file_size + with_download_timeout builder methods |
| `crates/webfang_core/src/infrastructure/downloader/wreq_downloader.rs` | Retry fields, 429 loop uses config, capped Retry-After |
| `crates/webfang_core/src/application/crawler/fetch_router.rs` | build_fetch_router accepts retry config |
| `crates/webfang_core/src/application/crawler/engine.rs` | EngineOptions propagates retry fields |
| `crates/webfang_core/src/cli/scrape_flow.rs` | Updated build_fetch_router call site |
| `crates/webfang_core/tests/downloader_headers_test.rs` | Adapted to new WreqDownloader::new signature |
| `crates/webfang_core/src/infrastructure/downloader/mod.rs` | Doctest updated |

## Test Plan
- [x] `cargo check --all-targets --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` passes
- [x] `cargo fmt --check` clean
- [x] 18/18 wreq_downloader unit tests pass
- [x] 15/15 args_test pass
- [x] 2/2 downloader_headers_test pass
- [x] 1/1 engine_js_strategy_timeout_test passes