### PR TITLE
fix(crawler): apply seed filtering and decouple asset patterns (#634, #639)

### DIFF
--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -440,6 +440,16 @@ impl Engine {
         // Seed the scheduler (pushes onto the discovery queue and pending buffer)
         self.scheduler.seed(&config_clone.seed_url).await;
 
+        // Apply pattern filtering to seed — #634
+        let seed_str = config_clone.seed_url.as_str().to_string();
+        if !crate::application::url_filter::is_allowed(&seed_str, &config_clone) {
+            info!(
+                seed_url = %config_clone.seed_url,
+                "Seed URL excluded by pattern filters — exiting with empty result"
+            );
+            return Ok(CrawlResult::empty());
+        }
+
         let mut tasks = tokio::task::JoinSet::new();
 
         // Build shared task context once — all spawned tasks share this Arc
@@ -1197,6 +1207,70 @@ mod tests {
         assert!(
             result.total_pages < 20,
             "must not fetch all 20 links with max_pages=2, got {}",
+            result.total_pages
+        );
+    }
+
+    /// Regression test for #634: seed URL that matches an exclude pattern
+    /// MUST be filtered out — 0 pages crawled.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seed_excluded_by_host_pattern_returns_empty() {
+        let server = MockServer::start().await;
+        let port = server.address().port();
+        Mock::given(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("<html><body>seed</body></html>"),
+            )
+            .mount(&server)
+            .await;
+
+        let seed = Url::parse(&format!("http://127.0.0.1:{port}/")).expect("valid seed URL");
+        let config = CrawlerConfig::builder(seed)
+            .max_depth(0)
+            .max_pages(10)
+            .exclude_pattern("127.0.0.1") // Exclude the seed host
+            .ignore_robots(true)
+            .build();
+
+        let mut engine = Engine::new(config, true).expect("engine must build");
+        let result = engine.run().await.expect("engine run must succeed");
+        engine.shutdown().await;
+
+        assert_eq!(
+            result.total_pages, 0,
+            "seed matching exclude pattern must produce 0 pages, got {}",
+            result.total_pages
+        );
+    }
+
+    /// Regression test for #634: seed URL that does NOT match an exclude
+    /// pattern MUST still be crawled (sanity check).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seed_not_excluded_is_crawled() {
+        let server = MockServer::start().await;
+        let port = server.address().port();
+        Mock::given(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("<html><body>seed</body></html>"),
+            )
+            .mount(&server)
+            .await;
+
+        let seed = Url::parse(&format!("http://127.0.0.1:{port}/")).expect("valid seed URL");
+        let config = CrawlerConfig::builder(seed)
+            .max_depth(0)
+            .max_pages(10)
+            .exclude_pattern("other-host.com") // Does NOT match seed
+            .ignore_robots(true)
+            .build();
+
+        let mut engine = Engine::new(config, true).expect("engine must build");
+        let result = engine.run().await.expect("engine run must succeed");
+        engine.shutdown().await;
+
+        assert_eq!(
+            result.total_pages, 1,
+            "seed NOT matching exclude pattern must be crawled, got {} pages",
             result.total_pages
         );
     }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -318,12 +318,10 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
     }
 
     // Wire asset download config from CLI args
+    // NOTE: crawl include/exclude patterns are intentionally NOT forwarded to
+    // asset config — assets have their own filter scope (#639).
     scraper_config =
         scraper_config.with_asset_h2_profile(parse_asset_h2_profile(&opts.network.h2_profile));
-    scraper_config =
-        scraper_config.with_asset_include_patterns(opts.crawl.include_patterns.clone());
-    scraper_config =
-        scraper_config.with_asset_exclude_patterns(opts.crawl.exclude_patterns.clone());
     scraper_config = scraper_config.with_asset_naming(parse_asset_naming(&opts.asset_naming));
     scraper_config = scraper_config.with_download_concurrency(opts.download_concurrency);
 
@@ -1003,6 +1001,48 @@ mod tests {
         assert_eq!(
             parse_asset_h2_profile("NetscapeNavigator"),
             wreq_util::Profile::Chrome145
+        );
+    }
+
+    // ===== Asset pattern decoupling tests (#639) =====
+
+    /// Regression test for #639: crawl include/exclude patterns must NOT
+    /// be forwarded to asset download config — assets have their own scope.
+    #[tokio::test]
+    async fn crawl_patterns_not_forwarded_to_asset_config() {
+        use crate::application::crawl_options::{CrawlLimits, NetworkOptions};
+        use crate::cli::orchestrator::prepare_phase;
+
+        let url = url::Url::parse("https://example.com").expect("valid url");
+        let opts = CrawlOptions {
+            url,
+            crawl: CrawlLimits {
+                include_patterns: vec!["/catalogue/*".to_string()],
+                exclude_patterns: vec!["/media/*".to_string()],
+                single_page: true, // Skip network discovery
+                ..Default::default()
+            },
+            network: NetworkOptions::default(),
+            ..Default::default()
+        };
+
+        let result = prepare_phase(&opts).await;
+        assert!(
+            result.is_ok(),
+            "prepare_phase must succeed: {:?}",
+            result.err()
+        );
+        let prepare = result.unwrap();
+
+        assert!(
+            prepare.scraper_config.asset_include_patterns.is_empty(),
+            "crawl include_patterns must NOT leak into asset config, got: {:?}",
+            prepare.scraper_config.asset_include_patterns
+        );
+        assert!(
+            prepare.scraper_config.asset_exclude_patterns.is_empty(),
+            "crawl exclude_patterns must NOT leak into asset config, got: {:?}",
+            prepare.scraper_config.asset_exclude_patterns
         );
     }
 }


### PR DESCRIPTION
Closes #634
Closes #639

## Summary
- **#634**: Seed URL now respects `exclude-pattern` — `is_allowed()` checked before crawl loop; returns empty result if seed excluded
- **#639**: Crawl patterns no longer forwarded to asset download config — assets have orthogonal filter scope, preventing silent download suppression

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/crawler/engine.rs` | Added `is_allowed()` seed check before crawl loop; 2 new tests |
| `crates/webfang_core/src/cli/orchestrator.rs` | Removed lines forwarding crawl patterns to asset config; 1 new test |

## Test Plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo fmt` clean
- [x] `cargo test --package webfang_core --lib -- crawler` → 306 passed, 0 failed
- [x] New tests: `seed_excluded_by_host_pattern_returns_empty`, `seed_not_excluded_is_crawled`, `crawl_patterns_not_forwarded_to_asset_config` — all pass
- [x] Manually verified: `--exclude-pattern <seed>` → 0 pages; `--include-pattern /catalogue/*` no longer blocks asset downloads
