### PR TITLE
fix(cli): --quick-save + --download-images mantiene el vault autocontenido (#638)

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -179,6 +179,26 @@ pub async fn run(
     }
 }
 
+/// Resolve the root directory that must contain the scraped Markdown AND the
+/// downloaded assets.
+///
+/// When Obsidian `--quick-save` is active, both must share the vault as their
+/// base so the vault stays self-contained (#638): if the `Downloader` keeps
+/// using `output_dir` (`-o`) while the Markdown goes to the vault, relative
+/// asset paths escape the vault and images stop rendering. The Downloader is a
+/// slave of the config — the orchestrator is responsible for converging the
+/// two persistence roots before handing them to the crawl/export engines.
+fn resolve_persistence_root(opts: &CrawlOptions) -> std::path::PathBuf {
+    if opts.export.quick_save {
+        opts.export
+            .obsidian_vault
+            .clone()
+            .unwrap_or_else(|| opts.export.output_dir.clone())
+    } else {
+        opts.export.output_dir.clone()
+    }
+}
+
 /// Export scraped results to files and run AI cleaning if requested.
 async fn export_phase(
     results: &[domain::ScrapedContent],
@@ -198,8 +218,7 @@ async fn export_phase(
     };
 
     let file_output_dir = if opts.export.quick_save {
-        let base = opts.export.obsidian_vault.as_deref().unwrap_or(&output_dir);
-        let inbox = base.join("_inbox");
+        let inbox = resolve_persistence_root(opts).join("_inbox");
         if !inbox.exists() {
             let _ = std::fs::create_dir_all(&inbox);
         }
@@ -304,7 +323,7 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
     };
 
     let mut scraper_config = ScraperConfig::default()
-        .with_output_dir(opts.export.output_dir.clone())
+        .with_output_dir(resolve_persistence_root(opts))
         .with_scraper_concurrency(opts.network.concurrency.resolve())
         .with_max_pages(opts.crawl.max_pages)
         .with_selector(opts.crawl.selector.clone())

--- a/crates/webfang_core/tests/behavioral/cli/obsidian_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/obsidian_test.rs
@@ -214,3 +214,130 @@ async fn quick_save_creates_files_in_inbox() {
         "--quick-save should place files in _inbox directory"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #638: --quick-save + --download-images must keep the vault self-contained.
+// Regression: the Downloader was wiring assets to `-o` (via ScraperConfig)
+// while the Markdown went to the vault, so relative paths escaped the vault.
+// ---------------------------------------------------------------------------
+
+// Small 1x1 PNG (valid PNG header).
+const PNG_BYTES: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+    0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+    0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+    0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+const PAGE_WITH_IMG: &str = r#"
+<html><body><article>
+<h1>Obsidian Vault Image Test</h1>
+<p>Embedded image that must land inside the vault.</p>
+<img src="/photo.png" alt="vault photo">
+</article></body></html>
+"#;
+
+#[tokio::test]
+async fn quick_save_download_images_stay_inside_vault() {
+    let server = wiremock::MockServer::start().await;
+    // `-o` is deliberately distinct from the vault, reproducing the #638 setup.
+    let cli_out = tempfile::TempDir::new().unwrap();
+    let vault_dir = cli_out.path().join("vault");
+    std::fs::create_dir_all(vault_dir.join(".obsidian")).unwrap();
+    std::fs::write(
+        vault_dir.join(".obsidian").join("obsidian.json"),
+        r#"{"vault":{"fsPath":"/tmp/test","id":"test","name":"Test"}}"#,
+    )
+    .unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(PAGE_WITH_IMG))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/photo.png"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(PNG_BYTES.to_vec()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    crate::cmd()
+        .arg("--url")
+        .arg(format!("{}/page", server.uri()))
+        .arg("--single-page")
+        .arg("--format")
+        .arg("markdown")
+        .arg("--output")
+        .arg(cli_out.path())
+        .arg("--quick-save")
+        .arg("--vault")
+        .arg(&vault_dir)
+        .arg("--download-images")
+        .arg("--obsidian-relative-assets")
+        .arg("--quiet")
+        .assert()
+        .success();
+
+    // 1) Images must land INSIDE the vault (self-contained output).
+    let vault_images = vault_dir.join("images");
+    assert!(
+        vault_images.exists(),
+        "downloaded images should live inside the vault, but {vault_images:?} is missing"
+    );
+    let image_files: Vec<_> = std::fs::read_dir(&vault_images)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_ok_and(|ft| ft.is_file()))
+        .collect();
+    assert!(
+        !image_files.is_empty(),
+        "at least one image should be saved inside the vault"
+    );
+
+    // 2) Regression: `-o` must NOT receive the downloaded assets anymore.
+    let cli_out_images = cli_out.path().join("images");
+    assert!(
+        !cli_out_images.exists(),
+        "-o/images must not contain assets when --quick-save targets a vault (#638)"
+    );
+
+    // 3) Semantic: every relative asset reference written into the vault's
+    // Markdown must resolve to a path INSIDE the vault (self-contained).
+    let vault_canon = vault_dir.canonicalize().unwrap();
+    for entry in WalkDir::new(&vault_dir).into_iter().filter_map(|e| e.ok()) {
+        if !entry.file_type().is_file()
+            || entry.path().extension().and_then(|e| e.to_str()) != Some("md")
+        {
+            continue;
+        }
+        let md_dir = entry.path().parent().unwrap();
+        let content = std::fs::read_to_string(entry.path()).unwrap();
+        // Find Markdown image references: ![alt](target)
+        for captures in content.match_indices("](") {
+            let after = &content[captures.0 + 2..];
+            let end = after.find(')').unwrap_or(after.len());
+            let target = &after[..end];
+            // Skip remote/absolute URLs and wiki-links.
+            if target.contains("://") || target.starts_with('#') || target.contains("[[") {
+                continue;
+            }
+            let resolved = md_dir.join(target);
+            let canonical = resolved.canonicalize().unwrap_or_else(|_| {
+                panic!(
+                    "Obsidian asset ref `{target}` in {} does not resolve to an existing file",
+                    entry.path().display()
+                )
+            });
+            assert!(
+                canonical.starts_with(&vault_canon),
+                "asset ref `{target}` in {} escapes the vault: {}",
+                entry.path().display(),
+                canonical.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #638

## Summary
`--quick-save` + `--download-images` partía el output entre el vault y `-o`:
el `.md` iba a `<vault>/_inbox/` pero el `Downloader` escribía las imágenes en
`<output>/images/` (vía `ScraperConfig.output_dir`, derivado siempre de `-o`).
Con `--obsidian-relative-assets`, los paths relativos calculados desde el
`_inbox` del vault apuntaban fuera del perímetro Obsidian (`../../../cli_out/...`),
rompiendo el vault.

## Qué cambió
- `crates/webfang_core/src/cli/orchestrator.rs`: nuevo helper `resolve_persistence_root(opts)`.
  Cuando `--quick-save` está activo, **el vault manda**: tanto el `ScraperConfig.output_dir`
  (base del `Downloader`) como el directorio del Markdown parten de la misma raíz
  (el vault). Sin quick-save, el comportamiento queda intacto (`-o`).
- Test de regresión en `crates/webfang_core/tests/behavioral/cli/obsidian_test.rs`
  (`quick_save_download_images_stay_inside_vault`): vault distinto de `-o` +
  `--download-images` + `--obsidian-relative-assets`. Verifica que las imágenes
  quedan **dentro** del vault, que `-o` no recibe assets, y que cada referencia
  relativa resuelve dentro del vault.

## Validación
- `cargo check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` ✅
- `cargo nextest run --test behavioral cli::obsidian_test::` → 6/6 PASS (5 preexistentes + regresión) ✅
- `cargo fmt` ✅