### PR TITLE
fix(cli): validate batch-concurrency > 0 at parser; map I/O errors to exit 74

### DIFF
--- a/crates/webfang_core/src/cli/args/export.rs
+++ b/crates/webfang_core/src/cli/args/export.rs
@@ -73,7 +73,7 @@ pub struct ExportArgs {
     pub batch_file: Option<std::path::PathBuf>,
 
     /// Maximum concurrent URLs in batch mode
-    #[arg(long, default_value = "5", env = "WEBFANG_BATCH_CONCURRENCY")]
+    #[arg(long, default_value = "5", env = "WEBFANG_BATCH_CONCURRENCY", value_parser = parse_batch_concurrency)]
     #[clap(next_help_heading = "Batch Processing")]
     pub batch_concurrency: usize,
 
@@ -92,4 +92,19 @@ pub struct ExportArgs {
     )]
     #[clap(next_help_heading = "Item Pipeline")]
     pub pipeline_output: PipelineOutputFormat,
+}
+
+/// Validate `--batch-concurrency` is greater than zero.
+///
+/// Clap's `value_parser!(usize)` does not expose `.range()` in the derive API,
+/// so a custom parser enforces the invariant at the system boundary (#640).
+fn parse_batch_concurrency(s: &str) -> Result<usize, String> {
+    let value: usize = s
+        .parse()
+        .map_err(|_| format!("`{s}` no es un número entero válido"))?;
+    if value == 0 {
+        Err("batch-concurrency debe ser > 0".to_string())
+    } else {
+        Ok(value)
+    }
 }

--- a/crates/webfang_core/src/cli/args/mod.rs
+++ b/crates/webfang_core/src/cli/args/mod.rs
@@ -355,4 +355,46 @@ mod tests {
         assert!(args.positional_url.is_none());
         assert!(args.crawler.url.is_none());
     }
+
+    // ========================================================================
+    // #640 — --batch-concurrency 0 must be rejected at parse time (exit 64)
+    // ========================================================================
+
+    #[test]
+    fn batch_concurrency_zero_is_rejected() {
+        clean_env();
+        let result = Args::try_parse_from([
+            "webfang",
+            "-u",
+            "https://example.com",
+            "--batch-concurrency",
+            "0",
+        ]);
+        assert!(
+            result.is_err(),
+            "--batch-concurrency 0 must fail clap validation, not panic at runtime"
+        );
+    }
+
+    #[test]
+    fn batch_concurrency_positive_is_accepted() {
+        clean_env();
+        let args = Args::try_parse_from([
+            "webfang",
+            "-u",
+            "https://example.com",
+            "--batch-concurrency",
+            "3",
+        ])
+        .expect("valid args");
+        assert_eq!(args.export.batch_concurrency, 3);
+    }
+
+    #[test]
+    fn batch_concurrency_default_is_five() {
+        clean_env();
+        let args =
+            Args::try_parse_from(["webfang", "-u", "https://example.com"]).expect("valid args");
+        assert_eq!(args.export.batch_concurrency, 5);
+    }
 }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -555,8 +555,8 @@ async fn load_batch_manager(
     if let Some(ref path) = opts.batch.batch_file {
         info!("Reading URLs from file: {}", path.display());
         BatchManager::from_file(path, crawler_config, opts.batch.concurrency).map_err(|e| {
-            error!(error = %e, "Failed to read URLs");
-            CliExit::NetworkError(format!("Failed to read URLs: {e}"))
+            error!(error = %e, "Failed to read URLs from file");
+            CliExit::IoError(format!("Failed to read URLs from file: {e}"))
         })
     } else {
         info!("Reading URLs from stdin");
@@ -575,14 +575,12 @@ async fn load_batch_manager_from_stdin(
         .await
     {
         Ok(result) => result.map_err(|e| {
-            error!(error = %e, "Failed to read URLs");
-            CliExit::NetworkError(format!("Failed to read URLs: {e}"))
+            error!(error = %e, "Failed to read URLs from stdin");
+            CliExit::IoError(format!("Failed to read URLs from stdin: {e}"))
         }),
         Err(join_err) => {
             error!(error = %join_err, "stdin read task panicked");
-            Err(CliExit::NetworkError(format!(
-                "Failed to read URLs: {join_err}"
-            )))
+            Err(CliExit::IoError(format!("Failed to read URLs: {join_err}")))
         },
     }
 }


### PR DESCRIPTION
Closes #640

## Summary
- `--batch-concurrency 0` causaba un panic en el runtime (BatchProcessor) porque clap aceptaba el valor inválido y la validación solo ocurría profundamente en el motor async. Ahora un `value_parser` custom (`parse_batch_concurrency`) rechaza 0 en la frontera del sistema → exit 64 (`UsageError`) antes de inicializar Tokio.
- `--batch-file` con archivo inexistente reportaba exit 69 (`NetworkError`) porque `load_batch_manager` y `load_batch_manager_from_stdin` colapsaban `std::io::Error` en `CliExit::NetworkError`. Ahora se mapea a `CliExit::IoError` (74) siguiendo sysexits.

## Changes
| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/args/export.rs` | Added `parse_batch_concurrency` validator; `batch_concurrency` uses `value_parser = parse_batch_concurrency` |
| `crates/webfang_core/src/cli/orchestrator.rs` | `load_batch_manager` and `load_batch_manager_from_stdin` map `std::io::Error` → `CliExit::IoError` (74) |
| `crates/webfang_core/src/cli/args/mod.rs` | 3 unit tests: zero-rejected, positive-accepted, default-is-five |

## Test Plan
- [x] `cargo check --package webfang_core` — compila
- [x] `cargo clippy --package webfang_core --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` — 0 warnings
- [x] `cargo fmt --package webfang_core -- --check` — limpio
- [x] `cargo nextest run --package webfang_core -- cli::args::tests::batch_concurrency` — 3/3 pass

## Checklist
- [x] Linked issue (`Closes #640`)
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Conventional branch name (`fix/batch-concurrency-validation`)
- [x] No `Co-Authored-By` trailers
- [x] Worktree branch matches directory name