### PR TITLE
fix(cli): --elastic no descarta --output-vectors (MultiVectorRepository)

### DIFF
--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -27,7 +27,7 @@ use crate::domain::credentials::CredentialStore;
 use crate::domain::embedding_port::EmbeddingPort;
 use crate::domain::note_repository::NoteRepository;
 use crate::domain::ports::HttpClientPort;
-use crate::domain::repository::DynVectorRepository;
+use crate::domain::repository::{DynVectorRepository, MultiVectorRepository};
 use crate::domain::semantic_cleaner::SemanticCleaner;
 use crate::domain::text_chunker::TextChunker;
 use crate::domain::{repositories::CrawlResultRepository, CrawlerConfig};
@@ -403,8 +403,8 @@ impl Container {
     }
 
     /// Build an [`ElasticIngestion`] and attach the AI semantic cleaner when
-    /// present under the `ai` feature. Shared by [`with_elastic`] and
-    /// [`with_stream`] so the injection logic lives in exactly one place.
+    /// present under the `ai` feature. Shared by [`with_elastic_ingestion`]
+    /// so the injection logic lives in exactly one place.
     fn build_ingestion(
         repository: DynVectorRepository,
         config: &ElasticConfig,
@@ -421,18 +421,22 @@ impl Container {
         Ok(ingestion)
     }
 
-    /// Activate the elastic ingestion pipeline with SQLite persistence.
+    /// Activate elastic ingestion across every requested vector sink at once.
     ///
-    /// Resolves `ElasticConfig` from the provided options, then wires
-    /// `RayonCpuPool` → `CpuBridge` → `SqliteVectorRepository` →
-    /// `ResourceDownloader` → `ElasticIngestion`. Only available under the
-    /// `persistence` feature.
+    /// `--elastic` (SQLite persistence) and `--output-vectors` (dependency-free
+    /// JSONL stream) are orthogonal **data destinations**, so this wires them
+    /// into a single `ElasticIngestion` over a [`MultiVectorRepository`]
+    /// fan-out — replacing the former mutually-exclusive `with_elastic` /
+    /// `with_stream` branch that silently dropped the JSONL sink (issue #636).
+    ///
+    /// Returns `self` unchanged (ingestion stays `None`) when no sink is active.
     ///
     /// # Errors
     ///
-    /// Returns an error if the Rayon pool or SQLite pool fails to initialize.
-    #[cfg(feature = "persistence")]
-    pub async fn with_elastic(
+    /// Returns an error if a SQLite pool cannot be created (under `persistence`
+    /// with `--elastic`), the JSONL output cannot be opened, or the Rayon pool /
+    /// HTTP client fails to initialize.
+    pub(crate) async fn with_elastic_ingestion(
         mut self,
         opts: &CrawlOptions,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
@@ -444,37 +448,32 @@ impl Container {
         };
         let config = ElasticConfig::resolve(&overrides);
 
-        // 3. SQLite pool → repository (WAL mode, auto-creates parent dir)
-        let pool = sqlite_persistence::create_pool(&config.db_path, config.db_pool_size)?;
-        sqlite_persistence::setup_schema(&pool).await?;
-        let repository: DynVectorRepository = Arc::new(SqliteVectorRepository::new(pool));
+        // Collect every active sink — both can coexist (orthogonal destinations).
+        let mut repos: Vec<DynVectorRepository> = Vec::new();
 
-        let ingestion = Self::build_ingestion(repository, &config, self.cleaner.clone())?;
-        self.elastic_ingestion = Some(Arc::new(ingestion));
-        Ok(self)
-    }
+        #[cfg(feature = "persistence")]
+        if opts.elastic.enabled {
+            let pool = sqlite_persistence::create_pool(&config.db_path, config.db_pool_size)?;
+            sqlite_persistence::setup_schema(&pool).await?;
+            repos.push(Arc::new(SqliteVectorRepository::new(pool)));
+        }
 
-    /// Activate the elastic ingestion pipeline with the dependency-free
-    /// `StreamRepository` JSONL sink (no SQLite). Available in every build; use
-    /// this for RAG vector export via `--output-vectors`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the output path cannot be opened for writing.
-    pub fn with_stream(
-        mut self,
-        opts: &CrawlOptions,
-        path: &str,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let overrides = crate::infrastructure::autotuning::ElasticOverrides {
-            cpu_cores: opts.elastic.cpu_cores,
-            ram_budget_bytes: opts.elastic.ram_budget_bytes,
-            max_resource_bytes: opts.elastic.max_resource_bytes,
-            db_path: None,
+        if let Some(ref path) = opts.elastic.output_vectors {
+            repos.push(Arc::new(
+                crate::infrastructure::stream::StreamRepository::new(path)?,
+            ));
+        }
+
+        // No sink requested → leave the ingestion untouched (`None`).
+        if repos.is_empty() {
+            return Ok(self);
+        }
+
+        // One sink → use it directly; multiple → fan out via MultiVectorRepository.
+        let repository: DynVectorRepository = match repos.len() {
+            1 => repos.pop().ok_or("no repository to activate")?,
+            _ => Arc::new(MultiVectorRepository::new(repos)),
         };
-        let config = ElasticConfig::resolve(&overrides);
-        let repository: DynVectorRepository =
-            Arc::new(crate::infrastructure::stream::StreamRepository::new(path)?);
 
         let ingestion = Self::build_ingestion(repository, &config, self.cleaner.clone())?;
         self.elastic_ingestion = Some(Arc::new(ingestion));

--- a/crates/webfang_core/src/cli/elastic.rs
+++ b/crates/webfang_core/src/cli/elastic.rs
@@ -69,9 +69,14 @@ pub(super) async fn run_elastic_ingestion(
 
 /// Build the elastic ingestion pipeline for the run.
 ///
+/// `--elastic` and `--output-vectors` are orthogonal vector *destinations*
+/// (issue #636), so both can be active at once:
+///
 /// - `persistence` ON + `--elastic` → SQLite-backed `SqliteVectorRepository`.
 /// - `--output-vectors <path|->` → dependency-free `StreamRepository` JSONL sink
 ///   (available in every build, including the lightweight core binary).
+/// - both → a single `ElasticIngestion` over a `MultiVectorRepository` fan-out,
+///   persisting to SQLite **and** streaming JSONL in the same run.
 /// - otherwise → `None` (no ingestion).
 ///
 /// `vault_ports` (#433) carries the optional vault-search AI ports assembled by
@@ -106,31 +111,18 @@ pub(super) async fn build_elastic_ingestion(
         },
     };
 
-    let built = {
-        #[cfg(feature = "persistence")]
-        {
-            if opts.elastic.enabled {
-                container.with_elastic(opts).await
-            } else if let Some(ref path) = opts.elastic.output_vectors {
-                container.with_stream(opts, path)
-            } else {
-                Ok(container)
-            }
-        }
-        #[cfg(not(feature = "persistence"))]
-        {
-            if let Some(ref path) = opts.elastic.output_vectors {
-                container.with_stream(opts, path)
-            } else {
-                Ok(container)
-            }
-        }
+    // Wire every active sink (`--elastic` AND/OR `--output-vectors`) into a
+    // single ElasticIngestion over a MultiVectorRepository fan-out (issue #636).
+    // The Container returns itself untouched when no sink is active, so
+    // `elastic_ingestion` stays `None` and no ingestion runs.
+    let container = match container.with_elastic_ingestion(opts).await {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(CliExit::IoError(format!(
+                "no se pudo inicializar la ingesta de vectores: {e}"
+            )))
+        },
     };
 
-    match built {
-        Ok(c) => Ok(c.elastic_ingestion),
-        Err(e) => Err(CliExit::IoError(format!(
-            "no se pudo inicializar la ingesta de vectores: {e}"
-        ))),
-    }
+    Ok(container.elastic_ingestion)
 }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -903,6 +903,30 @@ mod tests {
         assert!(result.is_ok(), "should not error: {:?}", result.err());
     }
 
+    #[cfg_attr(
+        miri,
+        ignore = "Container::new creates HttpClient with boring-sys2 FFI (unsupported by Miri)"
+    )]
+    #[tokio::test]
+    async fn build_elastic_ingestion_wires_both_sinks_not_exclusive() {
+        // Regression for #636: `--elastic` must NOT silently drop `--output-vectors`.
+        let tmp = tempfile::tempdir().expect("tempdir for vector sink");
+        let vec_path = tmp.path().join("out.jsonl");
+        let mut opts = CrawlOptions::default();
+        opts.elastic.enabled = true;
+        opts.elastic.output_vectors = Some(vec_path.to_string_lossy().into_owned());
+        let result = build_elastic_ingestion(
+            &opts,
+            crate::application::container::VaultAiPorts::default(),
+        )
+        .await;
+        assert!(result.is_ok(), "should not error: {:?}", result.err());
+        assert!(
+            vec_path.exists(),
+            "--output-vectors JSONL sink must be created even with --elastic (issue #636 regression)"
+        );
+    }
+
     // ===== AiConfig → ExportConfig wiring tests (Scenario 2.3.S2) =====
 
     #[test]

--- a/crates/webfang_core/src/domain/repository.rs
+++ b/crates/webfang_core/src/domain/repository.rs
@@ -154,3 +154,323 @@ impl<T: VectorRepository + ?Sized> VectorRepository for std::sync::Arc<T> {
 /// to satisfy the `R: VectorRepository + Send + Sync` bound on
 /// [`crate::application::elastic_ingestion::ElasticIngestion`].
 pub type DynVectorRepository = std::sync::Arc<dyn VectorRepository + Send + Sync>;
+
+/// Composite [`VectorRepository`] that fans out every call to a set of inner
+/// repositories, so the elastic pipeline can persist to SQLite (`--elastic`)
+/// **and** emit JSONL (`--output-vectors`) simultaneously (issue #636).
+///
+/// Mirrors the `MultiSinkOutput` fan-out pattern:
+/// [`crate::application::pipeline::stages::multi_sink::MultiSinkOutput`]. Every
+/// write is attempted on all inner sinks, an individual failure is logged but
+/// the remaining sinks still run, and the composite reports success if *at
+/// least one* sink succeeded. Read-style lookups (`resource_exists_by_hash`,
+/// `get_vector`) return the first `Some` produced by any inner repository.
+///
+/// This is what turns `--elastic` and `--output-vectors` from mutually
+/// exclusive `if/else if` branches into orthogonal data destinations — the
+/// single `ElasticIngestion` is built over one of these fan-outs, so no vector
+/// output is silently dropped.
+pub struct MultiVectorRepository {
+    repos: Vec<DynVectorRepository>,
+}
+
+impl MultiVectorRepository {
+    /// Build a fan-out repository over the given inner sinks.
+    ///
+    /// An empty set is not an invariant violation here — it simply reports an
+    /// error on every write. The
+    /// [`Container`](crate::application::container::Container) never builds an
+    /// empty fan-out (it returns early when no sink is active).
+    pub fn new(repos: Vec<DynVectorRepository>) -> Self {
+        Self { repos }
+    }
+}
+
+impl VectorRepository for MultiVectorRepository {
+    fn save_resource<'a>(
+        &'a self,
+        url: &'a str,
+        title: &'a str,
+        content_hash: &'a str,
+        size_bytes: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<String, ScraperError>> + Send + 'a>> {
+        Box::pin(async move {
+            if self.repos.is_empty() {
+                return Err(ScraperError::persistence(
+                    "no hay sinks de vectores registrados",
+                ));
+            }
+            let mut first_url: Option<String> = None;
+            let mut first_err: Option<ScraperError> = None;
+            for repo in &self.repos {
+                match repo
+                    .save_resource(url, title, content_hash, size_bytes)
+                    .await
+                {
+                    Ok(u) => {
+                        if first_url.is_none() {
+                            first_url = Some(u);
+                        }
+                    },
+                    Err(e) => {
+                        tracing::error!(error = %e, "vector sink save_resource failed");
+                        if first_err.is_none() {
+                            first_err = Some(e);
+                        }
+                    },
+                }
+            }
+            match first_url {
+                Some(u) => Ok(u),
+                None => Err(first_err.unwrap_or_else(|| {
+                    ScraperError::persistence(
+                        "todos los sinks de vectores fallaron al guardar el recurso",
+                    )
+                })),
+            }
+        })
+    }
+
+    fn save_chunk<'a>(
+        &'a self,
+        id: &'a str,
+        resource_url: &'a str,
+        chunk_index: i64,
+        content: &'a str,
+        embedding: Option<&'a [f32]>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ScraperError>> + Send + 'a>> {
+        Box::pin(async move {
+            if self.repos.is_empty() {
+                return Err(ScraperError::persistence(
+                    "no hay sinks de vectores registrados",
+                ));
+            }
+            let mut any_ok = false;
+            let mut first_err: Option<ScraperError> = None;
+            for repo in &self.repos {
+                match repo
+                    .save_chunk(id, resource_url, chunk_index, content, embedding)
+                    .await
+                {
+                    Ok(()) => any_ok = true,
+                    Err(e) => {
+                        tracing::error!(error = %e, "vector sink save_chunk failed");
+                        if first_err.is_none() {
+                            first_err = Some(e);
+                        }
+                    },
+                }
+            }
+            if any_ok {
+                Ok(())
+            } else {
+                Err(first_err.unwrap_or_else(|| {
+                    ScraperError::persistence(
+                        "todos los sinks de vectores fallaron al guardar el chunk",
+                    )
+                }))
+            }
+        })
+    }
+
+    fn resource_exists_by_hash<'a>(
+        &'a self,
+        content_hash: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<String>, ScraperError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut first_err: Option<ScraperError> = None;
+            for repo in &self.repos {
+                match repo.resource_exists_by_hash(content_hash).await {
+                    Ok(Some(url)) => return Ok(Some(url)),
+                    Ok(None) => {},
+                    Err(e) => {
+                        tracing::error!(error = %e, "vector sink resource_exists_by_hash failed");
+                        if first_err.is_none() {
+                            first_err = Some(e);
+                        }
+                    },
+                }
+            }
+            match first_err {
+                Some(e) => Err(e),
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn get_vector<'a>(
+        &'a self,
+        chunk_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Vec<f32>>, ScraperError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut first_err: Option<ScraperError> = None;
+            for repo in &self.repos {
+                match repo.get_vector(chunk_id).await {
+                    Ok(Some(v)) => return Ok(Some(v)),
+                    Ok(None) => {},
+                    Err(e) => {
+                        tracing::error!(error = %e, "vector sink get_vector failed");
+                        if first_err.is_none() {
+                            first_err = Some(e);
+                        }
+                    },
+                }
+            }
+            match first_err {
+                Some(e) => Err(e),
+                None => Ok(None),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Minimal in-memory sink for asserting fan-out behavior and failures.
+    struct InMemoryRepo {
+        saves: Arc<AtomicUsize>,
+        chunks: Arc<AtomicUsize>,
+        fail_write: bool,
+    }
+
+    impl InMemoryRepo {
+        fn new(saves: Arc<AtomicUsize>, chunks: Arc<AtomicUsize>, fail_write: bool) -> Self {
+            Self {
+                saves,
+                chunks,
+                fail_write,
+            }
+        }
+    }
+
+    impl VectorRepository for InMemoryRepo {
+        fn save_resource<'a>(
+            &'a self,
+            url: &'a str,
+            _title: &'a str,
+            _content_hash: &'a str,
+            _size_bytes: u64,
+        ) -> Pin<Box<dyn Future<Output = Result<String, ScraperError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.saves.fetch_add(1, Ordering::SeqCst);
+                if self.fail_write {
+                    Err(ScraperError::persistence("mock save_resource failure"))
+                } else {
+                    Ok(url.to_string())
+                }
+            })
+        }
+
+        fn save_chunk<'a>(
+            &'a self,
+            _id: &'a str,
+            _resource_url: &'a str,
+            _chunk_index: i64,
+            _content: &'a str,
+            _embedding: Option<&'a [f32]>,
+        ) -> Pin<Box<dyn Future<Output = Result<(), ScraperError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.chunks.fetch_add(1, Ordering::SeqCst);
+                if self.fail_write {
+                    Err(ScraperError::persistence("mock save_chunk failure"))
+                } else {
+                    Ok(())
+                }
+            })
+        }
+
+        fn resource_exists_by_hash<'a>(
+            &'a self,
+            _content_hash: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<String>, ScraperError>> + Send + 'a>>
+        {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn get_vector<'a>(
+            &'a self,
+            _chunk_id: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<Option<Vec<f32>>, ScraperError>> + Send + 'a>>
+        {
+            Box::pin(async { Ok(None) })
+        }
+    }
+
+    fn repo(
+        saves: &Arc<AtomicUsize>,
+        chunks: &Arc<AtomicUsize>,
+        fail_write: bool,
+    ) -> DynVectorRepository {
+        Arc::new(InMemoryRepo::new(saves.clone(), chunks.clone(), fail_write))
+    }
+
+    #[tokio::test]
+    async fn fan_out_writes_to_all_inner_sinks() {
+        let s1 = Arc::new(AtomicUsize::new(0));
+        let c1 = Arc::new(AtomicUsize::new(0));
+        let s2 = Arc::new(AtomicUsize::new(0));
+        let c2 = Arc::new(AtomicUsize::new(0));
+
+        let multi = MultiVectorRepository::new(vec![repo(&s1, &c1, false), repo(&s2, &c2, false)]);
+
+        multi.save_resource("u", "t", "hash", 1).await.unwrap();
+        multi
+            .save_chunk("id", "u", 0, "c", Some(&[0.5]))
+            .await
+            .unwrap();
+
+        assert_eq!(s1.load(Ordering::SeqCst), 1);
+        assert_eq!(s2.load(Ordering::SeqCst), 1);
+        assert_eq!(c1.load(Ordering::SeqCst), 1);
+        assert_eq!(c2.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn continues_on_single_sink_failure() {
+        let s1 = Arc::new(AtomicUsize::new(0));
+        let c1 = Arc::new(AtomicUsize::new(0));
+        let s2 = Arc::new(AtomicUsize::new(0));
+        let c2 = Arc::new(AtomicUsize::new(0));
+
+        let multi = MultiVectorRepository::new(vec![
+            repo(&s1, &c1, true),  // fails
+            repo(&s2, &c2, false), // ok
+        ]);
+
+        assert!(multi
+            .save_chunk("id", "u", 0, "c", Some(&[0.5]))
+            .await
+            .is_ok());
+        assert!(multi.save_resource("u", "t", "h", 1).await.is_ok());
+        // Best-effort: the failing sink was still attempted.
+        assert_eq!(s1.load(Ordering::SeqCst), 1);
+        assert_eq!(s2.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn all_sinks_failing_returns_error() {
+        let s1 = Arc::new(AtomicUsize::new(0));
+        let c1 = Arc::new(AtomicUsize::new(0));
+        let s2 = Arc::new(AtomicUsize::new(0));
+        let c2 = Arc::new(AtomicUsize::new(0));
+
+        let multi = MultiVectorRepository::new(vec![repo(&s1, &c1, true), repo(&s2, &c2, true)]);
+
+        let err = multi
+            .save_chunk("id", "u", 0, "c", Some(&[0.5]))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ScraperError::Persistence(_)));
+    }
+
+    #[tokio::test]
+    async fn empty_fanout_reports_error() {
+        let multi = MultiVectorRepository::new(vec![]);
+        let err = multi.save_resource("u", "t", "h", 1).await.unwrap_err();
+        assert!(matches!(err, ScraperError::Persistence(_)));
+    }
+}


### PR DESCRIPTION
Closes #636

## Summary
- `--elastic` and `--output-vectors` are orthogonal vector destinations; they can now run simultaneously.
- Replaced the silent `if/else if` drop in `cli/elastic.rs` with a single `Container::with_elastic_ingestion` that wires every active sink into one `ElasticIngestion`.
- When both sinks are active, the ingestion uses `MultiVectorRepository` fan-out (mirrors existing `MultiSinkOutput`).
- Regression test added: `build_elastic_ingestion_wires_both_sinks_not_exclusive` asserts JSONL file creation with both flags.

## Files changed
- crates/webfang_core/src/domain/repository.rs
- crates/webfang_core/src/application/container.rs
- crates/webfang_core/src/cli/elastic.rs
- crates/webfang_core/src/cli/orchestrator.rs

## Validation
- cargo check -p webfang_core --all-features: OK
- domain::repository tests: 4 passed
- cli::orchestrator build_elastic_ingestion tests: 4 passed
- application::elastic_ingestion tests: 9 passed
- infrastructure::persistence::sqlite tests: 18 passed
