### PR TITLE
fix(cli): run batch pipeline through full export/elastic/resume (#631, #637)

### DIFF
--- a/crates/webfang_core/src/application/batch/manager.rs
+++ b/crates/webfang_core/src/application/batch/manager.rs
@@ -27,6 +27,7 @@ use tracing::info;
 
 use super::processor::{BatchError, BatchProcessor, BatchResult};
 use super::{BatchJob, BatchJobStatus};
+use crate::application::crawler::content_sink::CrawlContentSink;
 use crate::domain::CrawlerConfig;
 use crate::error::ScraperError;
 
@@ -66,6 +67,16 @@ impl BatchManager {
             manager.jobs.push(job);
         }
         manager
+    }
+
+    /// Capture every fetched page body into `sink` (#631).
+    ///
+    /// Propagates to the underlying [`BatchProcessor`] so the CLI can export
+    /// the crawled content instead of discarding it with the crawl metadata.
+    #[must_use]
+    pub fn with_content_sink(mut self, sink: std::sync::Arc<dyn CrawlContentSink>) -> Self {
+        self.processor = self.processor.with_content_sink(sink);
+        self
     }
 
     /// Create a batch manager from a single batch job

--- a/crates/webfang_core/src/application/batch/processor.rs
+++ b/crates/webfang_core/src/application/batch/processor.rs
@@ -35,6 +35,7 @@ use tokio::task::JoinSet;
 use tracing::{error, info, instrument, warn};
 
 use super::BatchJob;
+use crate::application::crawler::content_sink::CrawlContentSink;
 use crate::domain::{CrawlError, CrawlErrorCategory, CrawlerConfig};
 use crate::error::ScraperError;
 
@@ -70,6 +71,11 @@ pub struct BatchResult {
 pub struct BatchProcessor {
     max_concurrent_jobs: usize,
     semaphore: Arc<Semaphore>,
+    /// Optional sink that captures every fetched page body (#631).
+    ///
+    /// Shared across all concurrent crawls in the batch, so the CLI ends up
+    /// with one collection covering every URL in the run.
+    content_sink: Option<Arc<dyn CrawlContentSink>>,
 }
 
 impl BatchProcessor {
@@ -89,7 +95,18 @@ impl BatchProcessor {
         Ok(Self {
             max_concurrent_jobs: max_concurrent,
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            content_sink: None,
         })
+    }
+
+    /// Capture every fetched page body into `sink` (#631).
+    ///
+    /// Without a sink the batch crawl discards page content and the CLI has
+    /// nothing to export — the root cause of `--batch` writing zero files.
+    #[must_use]
+    pub fn with_content_sink(mut self, sink: Arc<dyn CrawlContentSink>) -> Self {
+        self.content_sink = Some(sink);
+        self
     }
 
     /// Get the maximum concurrency limit
@@ -130,6 +147,7 @@ impl BatchProcessor {
         for url_str in &job.urls {
             let url = url_str.clone();
             let config = base_config.clone();
+            let sink = self.content_sink.clone();
             let permit = self
                 .semaphore
                 .clone()
@@ -142,7 +160,7 @@ impl BatchProcessor {
 
             join_set.spawn(async move {
                 let _permit = permit; // Hold permit for duration of task
-                let result = process_single_url(&url, config).await;
+                let result = process_single_url(&url, config, sink).await;
                 (url, result)
             });
         }
@@ -205,6 +223,7 @@ impl BatchProcessor {
 async fn process_single_url(
     url: &str,
     base_config: CrawlerConfig,
+    content_sink: Option<Arc<dyn CrawlContentSink>>,
 ) -> Result<crate::domain::CrawlResult, CrawlError> {
     let parsed_url =
         url::Url::parse(url).map_err(|e| CrawlError::InvalidUrl(format!("{url}: {e}")))?;
@@ -221,7 +240,12 @@ async fn process_single_url(
         .include_patterns(base_config.include_patterns.clone())
         .build();
 
-    let result = crate::application::crawler::engine::crawl_site(config).await?;
+    let result = match content_sink {
+        Some(sink) => {
+            crate::application::crawler::engine::crawl_site_capturing(config, sink).await?
+        },
+        None => crate::application::crawler::engine::crawl_site(config).await?,
+    };
 
     // Treat any crawl errors (timeouts, etc.) as failures for batch processing,
     // but preserve severity (#537): the engine already partitioned them into

--- a/crates/webfang_core/src/application/crawler/content_sink.rs
+++ b/crates/webfang_core/src/application/crawler/content_sink.rs
@@ -1,0 +1,146 @@
+//! Page-body capture during a crawl.
+//!
+//! The crawl [`Engine`](super::engine::Engine) discards page bodies after link
+//! extraction: [`CrawlResult`](crate::domain::CrawlResult) is metadata only
+//! (URLs, counters). Batch mode therefore had no content to export, so
+//! `--batch` reported success while writing zero files (#631) and silently
+//! ignored `--elastic` / `--output-vectors` / `--resume` (#637).
+//!
+//! A [`CrawlContentSink`] lets a caller observe every fetched body without a
+//! second HTTP round-trip. The CLI collects the bodies, converts them to
+//! [`ScrapedContent`](crate::domain::ScrapedContent) via
+//! [`extract_content`](super::discovery::extract_content), and then runs the
+//! exact same export / vector-ingestion pipeline as single-page mode.
+
+use std::sync::Mutex;
+
+/// A page body captured mid-crawl, before extraction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapturedPage {
+    /// Absolute URL the body was fetched from.
+    pub url: String,
+    /// Raw response body as received from the fetch layer.
+    pub html: String,
+}
+
+/// Receives every page body fetched by the crawl engine.
+///
+/// Implementations MUST be cheap and non-blocking: `capture` runs inline on the
+/// per-page worker task, so it must never block the async runtime and never
+/// hold a lock across an `.await` (it is synchronous by design).
+pub trait CrawlContentSink: Send + Sync {
+    /// Record the body fetched for `url`.
+    fn capture(&self, url: &str, html: &str);
+}
+
+/// Thread-safe in-memory [`CrawlContentSink`].
+///
+/// Batch mode runs several engines concurrently against one shared sink, so
+/// the backing buffer is behind a [`Mutex`]. The critical section is a single
+/// `Vec::push` with no `.await` inside, so it cannot block the runtime.
+#[derive(Debug, Default)]
+pub struct InMemoryContentSink {
+    pages: Mutex<Vec<CapturedPage>>,
+}
+
+impl InMemoryContentSink {
+    /// Create an empty sink.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Drain every captured page, leaving the sink empty.
+    ///
+    /// A poisoned mutex (a worker panicked mid-`capture`) degrades to the
+    /// recovered buffer rather than panicking: losing the crawl's content on a
+    /// single worker panic would reintroduce the silent data loss of #631.
+    #[must_use]
+    pub fn take_pages(&self) -> Vec<CapturedPage> {
+        match self.pages.lock() {
+            Ok(mut guard) => std::mem::take(&mut *guard),
+            Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
+        }
+    }
+
+    /// Number of pages captured so far.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.pages
+            .lock()
+            .map_or_else(|poisoned| poisoned.into_inner().len(), |guard| guard.len())
+    }
+
+    /// Whether no page has been captured yet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl CrawlContentSink for InMemoryContentSink {
+    fn capture(&self, url: &str, html: &str) {
+        let page = CapturedPage {
+            url: url.to_string(),
+            html: html.to_string(),
+        };
+        match self.pages.lock() {
+            Ok(mut guard) => guard.push(page),
+            Err(poisoned) => poisoned.into_inner().push(page),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn new_sink_is_empty() {
+        let sink = InMemoryContentSink::new();
+        assert!(sink.is_empty());
+        assert_eq!(sink.len(), 0);
+    }
+
+    #[test]
+    fn capture_records_url_and_body() {
+        let sink = InMemoryContentSink::new();
+        sink.capture("https://example.com/", "<html>hi</html>");
+
+        let pages = sink.take_pages();
+        assert_eq!(
+            pages,
+            vec![CapturedPage {
+                url: "https://example.com/".to_string(),
+                html: "<html>hi</html>".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn take_pages_drains_the_buffer() {
+        let sink = InMemoryContentSink::new();
+        sink.capture("https://example.com/a", "<p>a</p>");
+        sink.capture("https://example.com/b", "<p>b</p>");
+
+        assert_eq!(sink.take_pages().len(), 2);
+        assert!(sink.take_pages().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_captures_are_all_recorded() {
+        let sink = Arc::new(InMemoryContentSink::new());
+        let mut tasks = tokio::task::JoinSet::new();
+
+        for i in 0..32 {
+            let sink = Arc::clone(&sink);
+            tasks.spawn(async move {
+                sink.capture(&format!("https://example.com/{i}"), "<p>body</p>");
+            });
+        }
+        while tasks.join_next().await.is_some() {}
+
+        assert_eq!(sink.take_pages().len(), 32);
+    }
+}

--- a/crates/webfang_core/src/application/crawler/crawl_task.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task.rs
@@ -148,6 +148,8 @@ async fn run_crawl_task_inner(
     ctx.pages_crawled
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
+    capture_content(&ctx, &url_str, &response);
+
     if !run_pipeline(&ctx, &url_str, &response).await {
         return Ok(());
     }
@@ -260,6 +262,18 @@ fn report_session_success(ctx: &CrawlTaskCtx, url_str: &str, session_id: Option<
             pool.report_success(domain, id);
         }
     }
+}
+
+/// Hand the fetched body to the content sink when one is configured (#631).
+///
+/// Capture happens right after a successful fetch and before pipeline gating,
+/// so a `Skip`/`Reject` outcome cannot silently drop the page from the export
+/// set. The sink is synchronous and must not block.
+fn capture_content(ctx: &CrawlTaskCtx, url_str: &str, response: &str) {
+    let Some(ref sink) = ctx.content_sink else {
+        return;
+    };
+    sink.capture(url_str, response);
 }
 
 /// Run the content pipeline if configured. Returns `true` when processing
@@ -655,6 +669,7 @@ mod tests {
                 link_extractor: self.link_extractor,
                 pipeline: self.pipeline,
                 output_stages: self.output_stages,
+                content_sink: None,
             })
         }
     }

--- a/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
+++ b/crates/webfang_core/src/application/crawler/crawl_task_ctx.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use crate::application::crawler::checkpoint::BannedDomain;
+use crate::application::crawler::content_sink::CrawlContentSink;
 use crate::application::crawler::ports::{
     ContentPipeline, CrawlResultCollector, LinkExtractorPort, PageFetcher, RobotsChecker,
 };
@@ -56,4 +57,10 @@ pub struct CrawlTaskCtx {
     // --- Pipeline ---
     pub(crate) pipeline: Option<Arc<dyn ContentPipeline>>,
     pub(crate) output_stages: Vec<Arc<Box<dyn OutputStage>>>,
+
+    /// Optional sink that captures every fetched page body (#631).
+    ///
+    /// `CrawlResult` is metadata only, so without this the crawl discards the
+    /// content and batch mode has nothing to export.
+    pub(crate) content_sink: Option<Arc<dyn CrawlContentSink>>,
 }

--- a/crates/webfang_core/src/application/crawler/engine.rs
+++ b/crates/webfang_core/src/application/crawler/engine.rs
@@ -19,6 +19,7 @@ use super::checkpoint::{
 };
 use super::collector::ResultsCollector;
 use super::concurrency_level::{ConcurrencyLevel, SharedConcurrencyLevel};
+use super::content_sink::CrawlContentSink;
 use super::crawl_scheduler::CrawlScheduler;
 use super::crawl_task::{handle_crawl_result, run_crawl_task};
 use super::fetch_router::{build_fetch_router, FetchRouter};
@@ -92,6 +93,8 @@ pub struct Engine {
     cookie_bridge: Arc<RwLock<CookieBridge>>,
     /// Domains currently banned due to WAF or rate limiting.
     banned_domains: Arc<RwLock<Vec<BannedDomain>>>,
+    /// Optional sink capturing every fetched page body (#631).
+    content_sink: Option<Arc<dyn CrawlContentSink>>,
     /// Optional item pipeline for processing scraped content.
     pipeline: Option<Arc<PipelineExecutor>>,
     /// Output stages that receive items after pipeline processing.
@@ -157,6 +160,7 @@ impl Engine {
             fetch_router: None,
             cookie_bridge: Arc::new(RwLock::new(CookieBridge::new())),
             banned_domains: Arc::new(RwLock::new(Vec::new())),
+            content_sink: None,
             pipeline: None,
             output_stages: Vec::new(),
             signal_handle: None,
@@ -293,6 +297,17 @@ impl Engine {
         if let Ok(mut banned) = self.banned_domains.write() {
             *banned = domains;
         }
+        self
+    }
+
+    /// Capture every fetched page body into `sink` (#631).
+    ///
+    /// [`CrawlResult`] is metadata only; without a sink the crawl discards the
+    /// bodies after link extraction and callers (batch mode) have nothing to
+    /// export. The sink is shared, so several engines can feed one collection.
+    #[must_use]
+    pub fn with_content_sink(mut self, sink: Arc<dyn CrawlContentSink>) -> Self {
+        self.content_sink = Some(sink);
         self
     }
 
@@ -559,6 +574,7 @@ impl Engine {
                 router: self.fetch_router.clone(),
             }),
             link_extractor: Arc::new(ports::ProductionLinkExtractor),
+            content_sink: self.content_sink.clone(),
             pipeline: self.pipeline.as_ref().map(|p| {
                 Arc::new(ports::ProductionPipeline {
                     executor: Arc::clone(p),
@@ -894,7 +910,26 @@ impl Default for EngineOptions {
 /// # }
 /// ```
 pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError> {
-    crawl_site_inner(config, CorrelationId::new()).await
+    crawl_site_inner(config, CorrelationId::new(), None).await
+}
+
+/// Crawl a website and capture every fetched page body into `sink`.
+///
+/// Same crawl semantics as [`crawl_site`], but the raw body of each fetched
+/// page is handed to the sink before link extraction discards it.
+/// [`CrawlResult`] carries metadata only, so this is the only way for a caller
+/// to obtain crawl content without a second HTTP round-trip — the gap that
+/// made `--batch` write zero files (#631).
+///
+/// # Errors
+///
+/// Returns [`CrawlError`] when the engine cannot be constructed or the crawl
+/// loop fails, exactly as [`crawl_site`] does.
+pub async fn crawl_site_capturing(
+    config: CrawlerConfig,
+    sink: Arc<dyn CrawlContentSink>,
+) -> Result<CrawlResult, CrawlError> {
+    crawl_site_inner(config, CorrelationId::new(), Some(sink)).await
 }
 
 /// Inner implementation of [`crawl_site`].
@@ -906,7 +941,7 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
 /// guard crosses an `.await` (#519).
 #[instrument(
     name = "crawl_site",
-    skip(config, correlation_id),
+    skip(config, correlation_id, content_sink),
     fields(
         correlation_id = %correlation_id,
         trace_id = %correlation_id.trace_id(),
@@ -920,6 +955,7 @@ pub async fn crawl_site(config: CrawlerConfig) -> Result<CrawlResult, CrawlError
 async fn crawl_site_inner(
     config: CrawlerConfig,
     correlation_id: CorrelationId,
+    content_sink: Option<Arc<dyn CrawlContentSink>>,
 ) -> Result<CrawlResult, CrawlError> {
     info!(
         "Starting crawl from {} with max_depth={} max_pages={}",
@@ -928,6 +964,9 @@ async fn crawl_site_inner(
 
     let ignore_robots = config.ignore_robots;
     let mut engine = Engine::new(config, ignore_robots)?.with_correlation_id(correlation_id);
+    if let Some(sink) = content_sink {
+        engine = engine.with_content_sink(sink);
+    }
     let result = engine.run().await;
     engine.shutdown().await;
     result

--- a/crates/webfang_core/src/application/crawler/mod.rs
+++ b/crates/webfang_core/src/application/crawler/mod.rs
@@ -5,6 +5,7 @@
 pub mod checkpoint;
 pub mod collector;
 pub mod concurrency_level;
+pub mod content_sink;
 pub(crate) mod crawl_scheduler;
 pub(crate) mod crawl_task;
 pub mod crawl_task_ctx;
@@ -17,10 +18,11 @@ pub mod sitemap_discovery;
 
 pub use collector::{ResultsAdapter, ResultsCollector};
 pub use concurrency_level::{ConcurrencyLevel, SharedConcurrencyLevel};
+pub use content_sink::{CapturedPage, CrawlContentSink, InMemoryContentSink};
 pub use discovery::{
     crawl_with_sitemap, discover_urls_for_tui, extract_content, parse_sitemap,
     scrape_single_url_for_tui,
 };
-pub use engine::{crawl_site, crawl_site_with_options, EngineOptions};
+pub use engine::{crawl_site, crawl_site_capturing, crawl_site_with_options, EngineOptions};
 pub use fetch_router::{build_fetch_router, FetchRouter};
 pub use progress::CrawlProgress;

--- a/crates/webfang_core/src/application/mod.rs
+++ b/crates/webfang_core/src/application/mod.rs
@@ -35,10 +35,11 @@ pub use batch::{
     BatchJob, BatchManager, BatchManagerSummary, BatchProcessor, BatchProgress, BatchResult,
 };
 pub use crawler::collector::{ResultsAdapter, ResultsCollector};
+pub use crawler::content_sink::{CapturedPage, CrawlContentSink, InMemoryContentSink};
 pub use crawler::engine::EngineOptions;
 pub use crawler::{
-    crawl_site, crawl_site_with_options, crawl_with_sitemap, discover_urls_for_tui,
-    extract_content, scrape_single_url_for_tui,
+    crawl_site, crawl_site_capturing, crawl_site_with_options, crawl_with_sitemap,
+    discover_urls_for_tui, extract_content, scrape_single_url_for_tui,
 };
 pub use deduplicator::UrlDeduplicator;
 pub use http_client::create_http_client;

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 
 use crate::application::batch::{BatchManager, BatchManagerSummary};
 use crate::application::crawl_options::CrawlOptions;
+use crate::application::crawler::InMemoryContentSink;
 use crate::cli::elastic::{build_elastic_ingestion, run_elastic_ingestion};
 use crate::cli::error::CliExit;
 use crate::cli::export_flow::{run_export, save_files, ExportConfig};
@@ -79,7 +80,13 @@ pub async fn run(
     if opts.batch.enabled {
         // Batch mode uses the crawl Engine, which mints its own run-root
         // identity per crawl — do not mint one here.
-        return run_batch(opts).await;
+        return run_batch(
+            opts,
+            #[cfg(feature = "ai")]
+            ai_cleaner,
+            vault_ports,
+        )
+        .await;
     }
 
     // Run-root correlation identity (#501): the whole operation owns ONE
@@ -471,8 +478,18 @@ fn scraper_failure_for_internal_fatal(
     })
 }
 
-/// Run batch processing mode: crawl multiple URLs from stdin or file
-async fn run_batch(opts: CrawlOptions) -> CliExit {
+/// Run batch processing mode: crawl multiple URLs from stdin or file.
+///
+/// The batch pipeline captures every fetched page body through a shared
+/// [`InMemoryContentSink`] and then runs the full export / elastic / resume
+/// pipeline — the same stages `run()` applies to single-page mode, so
+/// `--batch` actually writes `.md` + `.jsonl` and honors `--elastic` /
+/// `--resume` (#631, #637).
+async fn run_batch(
+    opts: CrawlOptions,
+    #[cfg(feature = "ai")] ai_cleaner: Option<std::sync::Arc<dyn SemanticCleaner>>,
+    vault_ports: crate::application::container::VaultAiPorts,
+) -> CliExit {
     // Resolve the TLS/H2 fingerprint once so the batch crawl engine honors
     // `--h2-profile` (#312). An unknown profile is a config error (exit 78),
     // matching the scrape phase — never silently crawl with a wrong fingerprint.
@@ -483,10 +500,12 @@ async fn run_batch(opts: CrawlOptions) -> CliExit {
 
     let crawler_config = build_batch_crawler_config(&opts, tls_emulation);
 
-    let manager = match load_batch_manager(&opts, crawler_config).await {
+    let sink = std::sync::Arc::new(InMemoryContentSink::new());
+    let mut manager = match load_batch_manager(&opts, crawler_config).await {
         Ok(m) => m,
         Err(e) => return e,
     };
+    manager = manager.with_content_sink(sink.clone());
 
     if manager.job_count() == 0 {
         error!("No URLs provided for batch processing");
@@ -500,10 +519,161 @@ async fn run_batch(opts: CrawlOptions) -> CliExit {
     );
 
     let summary = manager.process_all_summary().await;
-
     log_batch_summary(&summary);
 
-    batch_exit_code(summary.succeeded, summary.failed, &summary.errors)
+    let captured = sink.take_pages();
+    if captured.is_empty() {
+        error!("Batch captured no page bodies — nothing to export");
+        return CliExit::NetworkError("Batch produced no content".into());
+    }
+
+    let (results, failures) = match extract_batch_content(captured, &opts).await {
+        Ok(pair) => pair,
+        Err(e) => return e,
+    };
+
+    // Resume mode (#637): construct the state store so `export_phase` can mark
+    // each URL as processed — no URL filtering, they were already crawled.
+    let state_store: Option<StateStore> = if opts.crawl.resume {
+        let state_dir = opts.crawl.state_dir.clone().unwrap_or_else(|| {
+            let cache_base = std::env::var("XDG_CACHE_HOME")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| {
+                    dirs::home_dir()
+                        .unwrap_or_else(|| std::path::PathBuf::from("."))
+                        .join(".cache")
+                });
+            cache_base.join("webfang").join("state")
+        });
+
+        let domain = opts.url.host_str().unwrap_or("batch").to_string();
+        match crate::application::export_factory::create_state_store(state_dir, &domain) {
+            Ok(store) => Some(store),
+            Err(e) => {
+                return CliExit::IoError(format!(
+                    "No se pudo crear el almacén de estado para --resume: {e}",
+                ));
+            },
+        }
+    } else {
+        None
+    };
+
+    let elastic_ingestion = match build_elastic_ingestion(&opts, vault_ports).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    #[cfg(not(feature = "ai"))]
+    if opts.elastic.output_vectors.is_some() && opts.ai {
+        warn!(
+            "--output-vectors specified with --clean-ai but AI feature is not compiled in. \
+             The output file will be created but no embedding vectors will be written. \
+             Rebuild with --features ai to generate embeddings."
+        );
+    }
+
+    if let Some(ref ingestion) = elastic_ingestion {
+        if let Err(e) = run_elastic_ingestion(ingestion, &results).await {
+            return CliExit::IoError(format!("Falló la ingesta de vectores: {e}"));
+        }
+    }
+
+    drop(elastic_ingestion);
+    tokio::task::yield_now().await;
+
+    // Print extraction failures to stderr (crawl failures are already logged
+    // via `log_batch_summary`). Do NOT short-circuit here: always export the
+    // pages we did capture so `--batch` writes `.md` + `.jsonl` even on partial
+    // failure (#631).
+    let _ = report_phase(&results, &failures, opts.verbosity);
+
+    #[cfg(feature = "ai")]
+    {
+        export_phase(&results, &opts, state_store.as_ref(), ai_cleaner).await;
+    }
+    #[cfg(not(feature = "ai"))]
+    {
+        export_phase(&results, &opts, state_store.as_ref()).await;
+    }
+
+    // Final exit code aggregates BOTH crawl-level and extraction-level outcomes
+    // with `#537` severity routing: partial success -> 69, all-fail with an
+    // internal fatal error -> 3, otherwise 0. Crawl failures were only logged
+    // above, so this is the only place the batch's true status surfaces.
+    let total_failed = summary.failed + failures.len();
+    let mut all_errors = summary.errors;
+    all_errors.extend(failures);
+    batch_exit_code(results.len(), total_failed, &all_errors)
+}
+
+/// Convert the batch-captured pages into [`ScrapedContent`] and collect
+/// per-page extraction failures.
+///
+/// Each captured body goes through the same [`extract_content`] path as
+/// single-page mode: Readability → text fallback → binary detection. Pages
+/// that fail extraction are logged and reported; the `exit_code` decision
+/// is made afterwards by `report_phase`.
+///
+/// The batch crawl had one fetch per URL, so `CrawlTaskCtx` uses the default
+/// asset downloader (`None`) — the same behavior as `--no-images` /
+/// `--no-documents`.
+///
+/// # Errors
+///
+/// Returns [`CliExit`] when the first target URL cannot be parsed or the
+/// extraction encounters a fatal setup error. Per-page failures are
+/// collected in the `failures` vec instead of aborting the whole batch.
+async fn extract_batch_content(
+    pages: Vec<crate::application::crawler::CapturedPage>,
+    opts: &CrawlOptions,
+) -> Result<
+    (
+        Vec<domain::ScrapedContent>,
+        Vec<(String, crate::error::ScraperError)>,
+    ),
+    CliExit,
+> {
+    let scraper_config = ScraperConfig::default()
+        .with_output_dir(opts.export.output_dir.clone())
+        .with_selector(opts.crawl.selector.clone())
+        .with_ignore_waf(opts.crawl.ignore_waf);
+
+    let root_correlation = domain::CorrelationId::new();
+    let mut results = Vec::with_capacity(pages.len());
+    let mut failures: Vec<(String, crate::error::ScraperError)> = Vec::new();
+
+    for page in pages {
+        let page_correlation = root_correlation.child();
+        let url = match url::Url::parse(&page.url) {
+            Ok(u) => u,
+            Err(e) => {
+                failures.push((
+                    page.url,
+                    crate::error::ScraperError::invalid_url(format!(
+                        "No se pudo parsear la URL capturada: {e}",
+                    )),
+                ));
+                continue;
+            },
+        };
+
+        match crate::application::crawler::extract_content(
+            &page.html,
+            &url,
+            &scraper_config,
+            None,
+            None,
+            &page_correlation,
+        )
+        .await
+        {
+            Ok(content) => results.push(content),
+            Err(e) => failures.push((page.url, e)),
+        }
+    }
+
+    Ok((results, failures))
 }
 
 /// Print the batch completion summary and log each failed URL.

--- a/crates/webfang_core/tests/behavioral/cli/batch_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/batch_test.rs
@@ -56,6 +56,113 @@ fn batch_empty_stdin_exits_64() {
 }
 
 // ---------------------------------------------------------------------------
+// --batch file output (#631): the full pipeline must write .md + .jsonl, not
+// skip export with an early return.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn batch_stdin_writes_markdown_and_jsonl() {
+    let server = MockServer::start().await;
+    let out = TempDir::new().unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><article>\
+                 <h1>Batch File Output</h1>\
+                 <p>Body text that must be written to disk.</p>\
+             </article></body></html>",
+        ))
+        .mount(&server)
+        .await;
+
+    cmd()
+        .arg("--batch")
+        .arg("--output")
+        .arg(out.path())
+        .write_stdin(format!("{}\n", server.uri()))
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .success();
+
+    // `save_results` nests files under a per-host directory (e.g.
+    // `<output>/127.0.0.1/index.md`), so walk the tree rather than the top
+    // level only.
+    let md_files: Vec<_> = walk_dir(out.path())
+        .into_iter()
+        .filter(|p| p.extension().is_some_and(|x| x == "md"))
+        .collect();
+    let jsonl_path = out.path().join("export.jsonl");
+
+    assert!(
+        !md_files.is_empty(),
+        "--batch must write at least one .md file under --output (#631), dir: {:?}",
+        out.path()
+    );
+    assert!(
+        jsonl_path.exists(),
+        "--batch must write export.jsonl to --output (#631), dir: {:?}",
+        out.path()
+    );
+}
+
+/// Recursively collect files under `root` (depth-first, errors skipped).
+fn walk_dir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(walk_dir(&path));
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// --batch --resume (#637): the run must create a resume state file.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn batch_stdin_resume_creates_state_file() {
+    let server = MockServer::start().await;
+    let out = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><article><h1>Resume State</h1><p>x</p></article></body></html>",
+        ))
+        .mount(&server)
+        .await;
+
+    cmd()
+        .arg("--batch")
+        .arg("--resume")
+        .arg("--output")
+        .arg(out.path())
+        .env("XDG_CACHE_HOME", cache.path())
+        .write_stdin(format!("{}\n", server.uri()))
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .success();
+
+    let state_files: Vec<_> = walk_dir(&cache.path().join("webfang/state"))
+        .into_iter()
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    assert!(
+        !state_files.is_empty(),
+        "--batch --resume must create a state file (#637), cache: {:?}",
+        cache.path()
+    );
+}
+
+// ---------------------------------------------------------------------------
 // --batch-file
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Linked Issue

Closes #631
Closes #637

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `run_batch()` previously skipped the export/elastic/resume pipeline, so `--batch` reported success while writing zero files (#631) and silently ignored `--elastic`/`--output-vectors`/`--resume` (#637).
- Added `CrawlContentSink` + `InMemoryContentSink` to capture each fetched body mid-crawl and wired it through `engine -> crawl_task -> batch processor -> manager`, so the CLI runs the same export/elastic/resume stages as single-page mode.
- `batch_exit_code` now aggregates crawl + extraction failures into the final OS exit code (severity routing #537), so a partial/failed batch no longer exits 0.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/crawler/content_sink.rs` | New `CrawlContentSink` trait + `InMemoryContentSink` (thread-safe capture) |
| `crates/webfang_core/src/application/crawler/engine.rs` | `with_content_sink` + `crawl_site_capturing` |
| `crates/webfang_core/src/application/crawler/crawl_task.rs` | `capture_content` hook after fetch |
| `crates/webfang_core/src/application/batch/{manager,processor}.rs` | propagate sink to crawl |
| `crates/webfang_core/src/cli/orchestrator.rs` | `run_batch` full pipeline + `batch_exit_code` wiring |
| `crates/webfang_core/tests/behavioral/cli/batch_test.rs` | acceptance tests: .md+jsonl and --resume state file |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run --test behavioral batch` passes (new + existing)
- [x] Manually verified `--batch` writes `.md` + `export.jsonl` and `--batch --resume` creates `~/.cache/webfang/state/<domain>.json`

## Contributor Checklist

- [x] Linked approved issues (#631, #637) with `Closes`
- [x] Branch `fix/batch-pipeline` matches `type/description`
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers