### PR TITLE
fix(ci): remove pull_request trigger from bug-discovery workflow

### DIFF
--- a/.github/workflows/bug-discovery.yml
+++ b/.github/workflows/bug-discovery.yml
@@ -3,8 +3,10 @@ on:
   schedule:
     - cron: "0 6 * * *"  # Diario 6AM
   workflow_dispatch: {}
-  pull_request:
-    paths: ["crates/**", "tests/**"]
+  # pull_request trigger removed: this workflow is for scheduled/on-demand
+  # production bug discovery, not PR validation. It downloads a ~372MB model
+  # and runs ignored tests, which causes mergeStateStatus=UNSTABLE while
+  # required checks are green (GitHub evaluates ALL checks, not just required).
 
 jobs:
   poisoned-env:


### PR DESCRIPTION
Closes #658

## Summary
- Removed pull_request trigger from Production Bug Discovery workflow
- This workflow downloads ~372MB ONNX model and runs ignored tests, causing mergeStateStatus=UNSTABLE while required checks are green
- GitHub evaluates ALL checks on PR, not just required ones
- Workflow is for scheduled/on-demand production bug discovery only; CI handles PR validation