### PR TITLE
fix(mcp): prevent tracing callsite Interest poisoning in metrics test

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -179,6 +179,22 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
+    static GLOBAL_SUBSCRIBER_INIT: std::sync::Once = std::sync::Once::new();
+
+    /// Set a global fmt subscriber (sink writer) so every `tracing` callsite
+    /// registers with `Interest::always()` instead of the `Interest::never()`
+    /// that gets cached process-wide when a thread hits a callsite with no
+    /// subscriber active (see [`record_emits_structured_tracing_event`]).
+    fn ensure_global_subscriber() {
+        GLOBAL_SUBSCRIBER_INIT.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(
+                tracing_subscriber::fmt()
+                    .with_writer(std::io::sink)
+                    .finish(),
+            );
+        });
+    }
+
     /// Build the canonical fixture: 2 success events on `a.com` (counts 3, 5)
     /// and 1 error event on `b.com` (count 0), durations 100/200/300ms, all via
     /// the `scrape_url` tool. Mean duration = (100+200+300)/3 = 200ms.
@@ -339,13 +355,23 @@ mod tests {
     /// REQ-09: each record emits ONE structured tracing event carrying
     /// tool/domain/success/duration_ms/pages (English field names/values).
     ///
-    /// Captures via a SCOPED `with_default` subscriber (no global state).
-    /// `#[serial]` keeps this test exclusive under `cargo test` (libtest runs
-    /// tests on shared threads; nextest isolates per process, cargo test does
-    /// not) so the capturing subscriber can never be shadowed by another test.
+    /// `tracing` caches per-callsite `Interest` process-wide: if a NON-serial
+    /// test calls [`ScrapeMetrics::record`] without a subscriber active, its
+    /// thread registers the `"scrape recorded"` callsite as `Interest::never()`
+    /// and that decision is cached forever — this test's scoped `with_default`
+    /// subscriber would then never receive the event, even with `#[serial]`
+    /// (serial_test only excludes other `#[serial]` tests).
+    ///
+    /// Fix: [`ensure_global_subscriber`] (invoked before capture) installs a
+    /// global fmt subscriber writing to sink, so every callsite registers with
+    /// `Interest::always()`; `set_global_default` also triggers a global
+    /// interest rebuild that recovers already-poisoned callsites. The global is
+    /// a fallback only — the per-test `with_default` below still overrides it
+    /// for capture on the test thread.
     #[test]
     #[serial]
     fn record_emits_structured_tracing_event() {
+        ensure_global_subscriber();
         use tracing::field::{Field, Visit};
         use tracing_subscriber::layer::Layer;
         use tracing_subscriber::prelude::*;


### PR DESCRIPTION
## Linked Issue

Closes #664

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- Fixes flaky `mcp_server::metrics::tests::record_emits_structured_tracing_event` (tracing callsite `Interest` poisoning under shared-thread libtest runs, e.g. the CI Coverage job).
- Adds a module-level `ensure_global_subscriber()` guard (pattern from #418): a global fmt subscriber to sink forces every callsite to register with `Interest::always()`; `set_global_default` additionally triggers a global interest rebuild that recovers already-poisoned callsites.
- Reproduced the flake locally (2 failures in ~55 runs of `cargo test -p webfang_mcp --lib`); post-fix: 30+ consecutive runs with 0 failures.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_mcp/src/mcp_server/metrics.rs` | Added `GLOBAL_SUBSCRIBER_INIT`/`ensure_global_subscriber()` guard in the test module; invoked before capture in `record_emits_structured_tracing_event`; doc comment updated with the poison mechanism |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo test -p webfang_mcp --lib` — 20 consecutive runs, 0 failures (acceptance criterion #664)
- [x] `cargo test --all-features --workspace -- --skip test_mcp` passes (Coverage-job command)
- [x] Manually verified the affected functionality

## Contributor Checklist

- [x] Linked issue #664 with `Closes #664`
- [x] Branch name matches `type/description` (`fix/mcp-tracing-flake`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format (`fix(mcp): ...`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed
- [x] Defensive error paths annotated with `// LCOV_EXCL_*` markers per docs/src/testing.md (issue #527) — N/A, test-only change
