### PR TITLE
chore(infra): stop ignoring tracked scripts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ fuzz/coverage/
 openspec/
 sdd/
 specs/
-scripts/
 
 # MiMo Code
 .mimocode/


### PR DESCRIPTION
Closes #668

## Summary
- Removes the `scripts/` rule from `.gitignore` (line 41, 'SDD / Agent working directories' section).
- All 7 files under `scripts/` are tracked versioned infrastructure (CI gate #513, merge-when-green.sh, analyze-trace.sh, ...); zero untracked files exist, so the rule protected nothing.
- Observable effect of the rule: `git add` on tracked files under `scripts/` staged the file but emitted the ignored-path warning and exited 1, breaking `git add && git commit` pipelines (hit on the #667 worktree).

## Changes

| File | Change |
|------|--------|
| `.gitignore` | Removed `scripts/` rule (1 line) |

## Test Plan
- [x] `git check-ignore -v scripts/merge-when-green.sh` → `not ignored`
- [x] `git add -n` on tracked+modified script: `add 'scripts/merge-when-green.sh'`, no warning, `rc=0` (before: warning + rc=1)
- [x] `git add -n` on new untracked file under scripts/: addable, `rc=0`

## Checklist
- [x] Linked issue (#668)
- [x] Exactly one `type:*` label (`type:chore`)
- [x] Conventional commit, sin trailers
- [x] Conventional branch `chore/gitignore-scripts`