### PR TITLE
fix(export): export edge-case audit — query/fragment filenames, -o -, output-vectors, metadata v2.1.0, dedup

### DIFF
--- a/crates/webfang_core/src/adapters/url_path.rs
+++ b/crates/webfang_core/src/adapters/url_path.rs
@@ -117,6 +117,42 @@ impl UrlPath {
         Ok(Self::from_url_path(parsed.path()))
     }
 
+    /// Create an [`UrlPath`] from a full URL, preserving query + fragment.
+    ///
+    /// Unlike [`Self::from_url`], this appends a sanitized query/fragment suffix
+    /// to `raw` so that URLs differing only only by query params or fragments
+    /// produce distinct filenames (no silent overwrite).
+    ///
+    /// Special characters (`?`, `&`, `:`, `=`, `#`, `/`) in the query/fragment
+    /// are replaced with `_`. `is_root` and `ends_with_slash` reflect the path only.
+    pub fn from_url_with_query(url: &str) -> Result<Self, UrlPathError> {
+        let parsed = url::Url::parse(url).map_err(|e| UrlPathError::InvalidUrl(e.to_string()))?;
+        let path = parsed.path();
+        let mut base = Self::from_url_path(path);
+
+        let query_part = parsed.query().unwrap_or("");
+        let fragment = parsed.fragment().unwrap_or("");
+
+        if query_part.is_empty() && fragment.is_empty() {
+            return Ok(base);
+        }
+
+        let mut suffix = String::new();
+        if !query_part.is_empty() {
+            suffix.push('_');
+            suffix.push_str(&Self::sanitize_query_part(query_part));
+        }
+        if !fragment.is_empty() {
+            suffix.push('_');
+            suffix.push_str(&Self::sanitize_query_part(fragment));
+        }
+
+        base.raw.push_str(&suffix);
+        base.is_root = false;
+        base.ends_with_slash = false;
+        Ok(base)
+    }
+
     /// Generate a unique filename from the full URL path, avoiding collisions.
     ///
     /// Unlike the old behavior that mapped ALL trailing-slash URLs to `index.md`
@@ -212,6 +248,18 @@ impl UrlPath {
         }
     }
 
+    /// Sanitize a query or fragment string for use in a filename.
+    ///
+    /// Replaces special characters (`?`, `&`, `:`, `=`, `#`, `/`) with `_`.
+    fn sanitize_query_part(s: &str) -> String {
+        s.chars()
+            .map(|c| match c {
+                '?' | '&' | ':' | '=' | '#' | '/' => '_',
+                c => c,
+            })
+            .collect()
+    }
+
     fn sanitize_path_segment(s: &str) -> String {
         // Whitelist: only alphanumeric + '-' '_' '.' survive. Everything else
         // (including path separators '/', '\\', and shell metacharacters) maps to '_'.
@@ -263,6 +311,16 @@ impl OutputPath {
         let parsed =
             url::Url::parse(url).map_err(|e| OutputPathError::InvalidUrl(e.to_string()))?;
         let path = UrlPath::from_url_path(parsed.path());
+        Ok(Self { domain, path })
+    }
+
+    /// Construct an [`OutputPath`] from a full URL, preserving query + fragment.
+    ///
+    /// Uses [`UrlPath::from_url_with_query`] so that URLs differing only by
+    /// query params or fragments produce distinct filenames.
+    pub fn from_url_with_query(url: &str) -> Result<Self, OutputPathError> {
+        let domain = Domain::from_url(url)?;
+        let path = UrlPath::from_url_with_query(url)?;
         Ok(Self { domain, path })
     }
 
@@ -340,6 +398,9 @@ pub enum OutputPathError {
     /// The domain portion of the URL is invalid.
     #[error("Domain error: {0}")]
     Domain(#[from] DomainError),
+    /// The path portion of the URL is invalid.
+    #[error("Path error: {0}")]
+    Path(#[from] UrlPathError),
 }
 
 // ============================================================================
@@ -647,5 +708,66 @@ mod tests {
         let dir = path.to_directory();
         assert!(!dir.contains(".."), "traversal segment leaked: {dir}");
         assert_eq!(dir, "a/_/b/");
+    }
+
+    // ========================================================================
+    // BUG-001: Query/Fragment Preservation Tests
+    // ========================================================================
+
+    #[test]
+    fn test_from_url_with_query_distinguishes_ids() {
+        let path1 = UrlPath::from_url_with_query("http://host/item.html?id=1").unwrap();
+        let path2 = UrlPath::from_url_with_query("http://host/item.html?id=2").unwrap();
+        let path3 = UrlPath::from_url_with_query("http://host/item.html?id=3").unwrap();
+
+        assert_ne!(path1.to_safe_filename(), path2.to_safe_filename());
+        assert_ne!(path1.to_safe_filename(), path3.to_safe_filename());
+        assert_ne!(path2.to_safe_filename(), path3.to_safe_filename());
+    }
+
+    #[test]
+    fn test_from_url_with_query_preserves_fragment() {
+        let path = UrlPath::from_url_with_query("http://host/page.html#section-a").unwrap();
+        let filename = path.to_safe_filename();
+        assert!(
+            filename.contains("section-a"),
+            "fragment not preserved in filename: {filename}"
+        );
+    }
+
+    #[test]
+    fn test_from_url_with_query_no_query_matches_from_url() {
+        // URLs without query/fragment behave identically to from_url
+        let with_query = UrlPath::from_url_with_query("http://host/docs/api").unwrap();
+        let plain = UrlPath::from_url("http://host/docs/api").unwrap();
+        assert_eq!(with_query.to_safe_filename(), plain.to_safe_filename());
+    }
+
+    #[test]
+    fn test_from_url_with_query_sanitizes_special_chars() {
+        let path = UrlPath::from_url_with_query("http://host/page.html?a=1&b=2").unwrap();
+        let filename = path.to_safe_filename();
+        // ? and & and = should be replaced with _
+        assert!(!filename.contains('?'), "? leaked: {filename}");
+        assert!(!filename.contains('&'), "& leaked: {filename}");
+        assert!(!filename.contains('='), "= leaked: {filename}");
+    }
+
+    #[test]
+    fn test_from_url_with_query_combined_query_and_fragment() {
+        let path = UrlPath::from_url_with_query("http://host/doc.html?v=2#changelog").unwrap();
+        let filename = path.to_safe_filename();
+        assert!(filename.contains("v_2"), "query not preserved: {filename}");
+        assert!(
+            filename.contains("changelog"),
+            "fragment not preserved: {filename}"
+        );
+    }
+
+    #[test]
+    fn test_output_path_from_url_with_query_distinguishes() {
+        let op1 = OutputPath::from_url_with_query("https://example.com/item?id=1").unwrap();
+        let op2 = OutputPath::from_url_with_query("https://example.com/item?id=2").unwrap();
+        assert_ne!(op1.to_full_path(), op2.to_full_path());
     }
 }

--- a/crates/webfang_core/src/application/elastic_ingestion.rs
+++ b/crates/webfang_core/src/application/elastic_ingestion.rs
@@ -36,6 +36,7 @@ use sha2::{Digest, Sha256};
 use tracing::{error, info, warn};
 
 use crate::domain::repository::VectorRepository;
+use crate::domain::url_validation::{normalize_url, NormalizeConfig, RemoveQueryParameters};
 use crate::error::ScraperError;
 use crate::infrastructure::bridge::CpuBridge;
 use crate::infrastructure::config::AutotuningConfig;
@@ -158,16 +159,38 @@ impl<R: VectorRepository + Send + Sync> ElasticIngestion<R> {
         Ok(())
     }
 
-    /// Dedup short-circuit: when the content hash is already persisted, log and
-    /// return `true` so the caller skips CPU cleaning and persistence.
+    /// Dedup short-circuit: when the content hash is already persisted for the
+    /// SAME URL, log and return `true` so the caller skips CPU cleaning and
+    /// persistence.
+    ///
+    /// Uses a composite key `(normalized_url, content_hash)`: a hash match alone
+    /// is insufficient — two different URLs with identical content (mirrored
+    /// pages, default server pages) must NOT deduplicate each other. When the
+    /// hash matches but the normalized URL differs, ingestion continues.
     async fn is_duplicate(&self, url: &str, hash: &str) -> Result<bool, ScraperError> {
-        if let Some(existing) = self.repository.resource_exists_by_hash(hash).await? {
-            info!(
-                %url,
-                existing_url = %existing,
-                "recurso ya persistido: omitiendo pipeline (dedup)"
+        if let Some(existing_url) = self.repository.resource_exists_by_hash(hash).await? {
+            let canonical_existing = normalize_url(
+                &existing_url,
+                &NormalizeConfig {
+                    strip_www: true,
+                    query_policy: RemoveQueryParameters::All,
+                },
             );
-            return Ok(true);
+            let canonical_current = normalize_url(
+                url,
+                &NormalizeConfig {
+                    strip_www: true,
+                    query_policy: RemoveQueryParameters::All,
+                },
+            );
+            if canonical_existing == canonical_current {
+                warn!(
+                    %url,
+                    existing_url = %existing_url,
+                    "recurso ya persistido: omitiendo pipeline (dedup)"
+                );
+                return Ok(true);
+            }
         }
         Ok(false)
     }
@@ -756,6 +779,46 @@ mod tests {
                 "dedup must prevent duplicate resource and chunk rows"
             );
         }
+
+        /// Regression test for #652 Bug 6: two DIFFERENT URLs with identical
+        /// content hash must NOT deduplicate each other.
+        /// Composite key is (normalized_url, content_hash) — hash collision
+        /// alone is insufficient.
+        #[tokio::test]
+        async fn test_is_duplicate_different_urls_same_hash_not_deduped() {
+            let repo = InMemoryRepo::default();
+            let hash = "abc123";
+
+            // Pre-populate the repo: hash exists for URL A.
+            {
+                let mut state = repo.state.lock().expect("repo mutex poisoned");
+                state.resources.insert(
+                    hash.to_string(),
+                    ("http://host:8942/index.html".to_string(), "title".to_string(), 100),
+                );
+            }
+
+            let orc = make_orchestrator(repo.clone());
+
+            // Same hash, different URL → NOT a duplicate.
+            let result = orc
+                .is_duplicate("http://host:8943/index.html", hash)
+                .await
+                .expect("is_duplicate must not error");
+            assert!(!result, "different URL with same hash must NOT dedup");
+
+            // Same hash, same URL → IS a duplicate.
+            let result = orc
+                .is_duplicate("http://host:8942/index.html", hash)
+                .await
+                .expect("is_duplicate must not error");
+            assert!(result, "same URL with same hash must dedup");
+
+            // Verify the repo state was unchanged (no ingestion happened).
+            let state = repo.state.lock().expect("repo mutex poisoned");
+            assert_eq!(state.resources.len(), 1, "no new resource inserted");
+            assert!(state.chunks.is_empty(), "no chunks inserted (is_duplicate is a read-only check)");
+        }
     }
 
     // ---- Task 5.1: static Send + Sync (orchestrator is shareable) ----
@@ -797,4 +860,5 @@ mod tests {
             "non-empty digest must also be lowercase hex, got: {sample}"
         );
     }
+
 }

--- a/crates/webfang_core/src/application/elastic_ingestion.rs
+++ b/crates/webfang_core/src/application/elastic_ingestion.rs
@@ -794,7 +794,11 @@ mod tests {
                 let mut state = repo.state.lock().expect("repo mutex poisoned");
                 state.resources.insert(
                     hash.to_string(),
-                    ("http://host:8942/index.html".to_string(), "title".to_string(), 100),
+                    (
+                        "http://host:8942/index.html".to_string(),
+                        "title".to_string(),
+                        100,
+                    ),
                 );
             }
 
@@ -817,7 +821,10 @@ mod tests {
             // Verify the repo state was unchanged (no ingestion happened).
             let state = repo.state.lock().expect("repo mutex poisoned");
             assert_eq!(state.resources.len(), 1, "no new resource inserted");
-            assert!(state.chunks.is_empty(), "no chunks inserted (is_duplicate is a read-only check)");
+            assert!(
+                state.chunks.is_empty(),
+                "no chunks inserted (is_duplicate is a read-only check)"
+            );
         }
     }
 
@@ -860,5 +867,4 @@ mod tests {
             "non-empty digest must also be lowercase hex, got: {sample}"
         );
     }
-
 }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -120,11 +120,9 @@ pub async fn run(
     };
 
     #[cfg(not(feature = "ai"))]
-    if opts.elastic.output_vectors.is_some() && opts.ai {
-        warn!(
-            "--output-vectors specified with --clean-ai but AI feature is not compiled in. \
-             The output file will be created but no embedding vectors will be written. \
-             Rebuild with --features ai to generate embeddings."
+    if opts.elastic.output_vectors.is_some() {
+        return CliExit::ConfigError(
+            "Se requiere compilar con '--features ai' para usar --output-vectors".to_string(),
         );
     }
 
@@ -217,6 +215,15 @@ async fn export_phase(
     state_store: Option<&StateStore>,
     #[cfg(feature = "ai")] ai_cleaner: Option<std::sync::Arc<dyn SemanticCleaner>>,
 ) -> CliExit {
+    if opts.export.output_dir == std::path::Path::new("-") {
+        return CliExit::UsageError(
+            "\"-o -\" no está soportado para exportación multi-archivo. \
+             Usa \"--output-vectors -\" para exportar vectores a stdout, \
+             o especifica un directorio de salida."
+                .to_string(),
+        );
+    }
+
     let output_dir = opts.export.output_dir.clone();
 
     let obsidian_options = ObsidianOptions {
@@ -560,6 +567,13 @@ async fn run_batch(
     vault_ports: crate::application::container::VaultAiPorts,
     cancel: &tokio_util::sync::CancellationToken,
 ) -> CliExit {
+    #[cfg(not(feature = "ai"))]
+    if opts.elastic.output_vectors.is_some() {
+        return CliExit::ConfigError(
+            "Se requiere compilar con '--features ai' para usar --output-vectors".to_string(),
+        );
+    }
+
     // Resolve the TLS/H2 fingerprint once so the batch crawl engine honors
     // `--h2-profile` (#312). An unknown profile is a config error (exit 78),
     // matching the scrape phase — never silently crawl with a wrong fingerprint.
@@ -591,15 +605,6 @@ async fn run_batch(
         Ok(v) => v,
         Err(e) => return e,
     };
-
-    #[cfg(not(feature = "ai"))]
-    if opts.elastic.output_vectors.is_some() && opts.ai {
-        warn!(
-            "--output-vectors specified with --clean-ai but AI feature is not compiled in. \
-             The output file will be created but no embedding vectors will be written. \
-             Rebuild with --features ai to generate embeddings."
-        );
-    }
 
     if let Err(e) = run_batch_elastic(&elastic_ingestion, &results).await {
         return e;
@@ -1020,6 +1025,9 @@ mod tests {
     use crate::application::crawl_options::CrawlOptions;
     use crate::cli::error::CliExit;
 
+    #[cfg(not(feature = "ai"))]
+    use super::{run, run_batch};
+
     // ===== build_batch_crawler_config tests (#653) =====
 
     #[test]
@@ -1417,6 +1425,34 @@ mod tests {
         );
     }
 
+    // ===== Bug #652: reject `-o -` for multi-file export =====
+
+    #[cfg_attr(
+        miri,
+        ignore = "export_phase touches filesystem (create_dir_all) unsupported by Miri"
+    )]
+    #[tokio::test]
+    async fn export_phase_rejects_stdout_as_output_dir() {
+        use crate::cli::orchestrator::export_phase;
+
+        let mut opts = CrawlOptions::default();
+        opts.export.output_dir = std::path::PathBuf::from("-");
+
+        let exit = export_phase(
+            &[],
+            &opts,
+            None,
+            #[cfg(feature = "ai")]
+            None,
+        )
+        .await;
+
+        assert!(
+            matches!(exit, CliExit::UsageError(_)),
+            "Expected UsageError when output_dir is '-', got: {exit:?}"
+        );
+    }
+
     // ===== Asset pattern decoupling tests (#639) =====
 
     /// Regression test for #639: crawl include/exclude patterns must NOT
@@ -1456,6 +1492,37 @@ mod tests {
             prepare.scraper_config.asset_exclude_patterns.is_empty(),
             "crawl exclude_patterns must NOT leak into asset config, got: {:?}",
             prepare.scraper_config.asset_exclude_patterns
+        );
+    }
+
+    // ===== output_vectors without ai feature (#652) =====
+
+    #[cfg(not(feature = "ai"))]
+    #[tokio::test]
+    async fn run_returns_config_error_when_output_vectors_without_ai() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.output_vectors = Some("vectors.jsonl".to_string());
+
+        let exit = run(opts, crate::application::container::VaultAiPorts::default()).await;
+
+        assert!(
+            matches!(exit, CliExit::ConfigError(_)),
+            "expected CliExit::ConfigError, got {exit:?}"
+        );
+    }
+
+    #[cfg(not(feature = "ai"))]
+    #[tokio::test]
+    async fn run_batch_returns_config_error_when_output_vectors_without_ai() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.output_vectors = Some("vectors.jsonl".to_string());
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let exit = run_batch(opts, crate::application::container::VaultAiPorts::default(), &cancel).await;
+
+        assert!(
+            matches!(exit, CliExit::ConfigError(_)),
+            "expected CliExit::ConfigError, got {exit:?}"
         );
     }
 }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -1518,7 +1518,12 @@ mod tests {
         opts.elastic.output_vectors = Some("vectors.jsonl".to_string());
         let cancel = tokio_util::sync::CancellationToken::new();
 
-        let exit = run_batch(opts, crate::application::container::VaultAiPorts::default(), &cancel).await;
+        let exit = run_batch(
+            opts,
+            crate::application::container::VaultAiPorts::default(),
+            &cancel,
+        )
+        .await;
 
         assert!(
             matches!(exit, CliExit::ConfigError(_)),

--- a/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
@@ -3,7 +3,7 @@
 //! Exports DocumentChunk to JSON Lines format (one JSON object per line).
 //! Optimized for streaming writes and large datasets.
 //!
-//! ## Metadata Schema (v2.0.0)
+//! ## Metadata Schema (v2.1.0)
 //!
 //! Each JSONL line includes:
 //! - `url`: Source URL
@@ -11,8 +11,14 @@
 //! - `title`: Document title (optional)
 //! - `content`: Extracted text content
 //! - `checksum_sha256`: SHA-256 hash of content for deduplication
-//! - `metadata_version`: Schema version ("2.0.0")
+//! - `metadata_version`: Schema version ("2.1.0")
 //! - `content_length`: Character count for quick filtering
+//! - `word_count`: Word count (optional, from metadata or computed)
+//! - `reading_time`: Estimated reading time in minutes (optional)
+//! - `language`: Detected language (optional)
+//! - `content_type`: Content type classification (optional)
+//! - `scrape_date`: Date of scrape (optional)
+//! - `extra_metadata`: Additional metadata HashMap (optional)
 
 use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Write};
@@ -72,7 +78,7 @@ impl Drop for FileLock {
     }
 }
 
-/// Webfang JSONL metadata schema (v2.0.0)
+/// Webfang JSONL metadata schema (v2.1.0)
 ///
 /// Wraps DocumentChunkValidated with additional fields for
 /// RAG pipeline integration and content deduplication.
@@ -92,6 +98,24 @@ pub struct WebfangMetadata<'a> {
     pub metadata_version: &'static str,
     /// Character count for quick filtering
     pub content_length: usize,
+    /// Word count (from metadata or computed from content)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub word_count: Option<usize>,
+    /// Estimated reading time in minutes (from metadata or computed)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reading_time: Option<usize>,
+    /// Detected language
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Content type classification
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    /// Date of scrape (ISO 8601)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scrape_date: Option<String>,
+    /// Additional metadata (excerpt, author, etc.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_metadata: Option<std::collections::HashMap<String, String>>,
 }
 
 impl<'a> WebfangMetadata<'a> {
@@ -103,14 +127,45 @@ impl<'a> WebfangMetadata<'a> {
         hasher.update(chunk.content.as_bytes());
         let checksum = format!("{:x}", hasher.finalize());
 
+        let word_count = chunk
+            .metadata
+            .get("word_count")
+            .and_then(|v| v.parse::<usize>().ok())
+            .or_else(|| {
+                let count = chunk.content.split_whitespace().count();
+                if count > 0 { Some(count) } else { None }
+            });
+
+        let reading_time = chunk
+            .metadata
+            .get("reading_time")
+            .and_then(|v| v.parse::<usize>().ok())
+            .or_else(|| word_count.map(|wc| (wc / 200).max(1)));
+
+        let language = chunk.metadata.get("language").cloned();
+        let content_type = chunk.metadata.get("content_type").cloned();
+        let scrape_date = chunk.metadata.get("scrape_date").cloned();
+
+        let extra_metadata = if chunk.metadata.is_empty() {
+            None
+        } else {
+            Some(chunk.metadata.clone())
+        };
+
         Self {
             url: &chunk.url,
             timestamp_utc: chunk.timestamp.to_rfc3339(),
             title: Some(&chunk.title),
             content: &chunk.content,
             checksum_sha256: checksum,
-            metadata_version: "2.0.0",
+            metadata_version: "2.1.0",
             content_length: chunk.content.chars().count(),
+            word_count,
+            reading_time,
+            language,
+            content_type,
+            scrape_date,
+            extra_metadata,
         }
     }
 }
@@ -329,5 +384,96 @@ mod tests {
         let content = fs::read_to_string(&output_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
         assert_eq!(lines.len(), 2);
+    }
+
+    #[test]
+    fn test_webfang_metadata_v210_schema_version() {
+        let chunk = create_test_chunk("Version Test");
+        let metadata = WebfangMetadata::from_chunk(&chunk);
+        assert_eq!(metadata.metadata_version, "2.1.0");
+    }
+
+    #[test]
+    fn test_webfang_metadata_v210_serialization_empty_metadata() {
+        let chunk = create_test_chunk("Empty Meta");
+        let metadata = WebfangMetadata::from_chunk(&chunk);
+        let json = serde_json::to_string(&metadata).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["metadata_version"], "2.1.0");
+        // word_count and reading_time are computed from content when not in metadata
+        assert!(value.get("word_count").is_some());
+        assert!(value.get("reading_time").is_some());
+        // These are only present when metadata provides them
+        assert!(value.get("language").is_none());
+        assert!(value.get("content_type").is_none());
+        assert!(value.get("scrape_date").is_none());
+        assert!(value.get("extra_metadata").is_none());
+    }
+
+    #[test]
+    fn test_webfang_metadata_v210_with_rich_metadata() {
+        use crate::domain::Validated;
+        use chrono::Utc;
+        use uuid::Uuid;
+
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("word_count".to_string(), "42".to_string());
+        meta.insert("reading_time".to_string(), "2".to_string());
+        meta.insert("language".to_string(), "es".to_string());
+        meta.insert("content_type".to_string(), "article".to_string());
+        meta.insert("scrape_date".to_string(), "2026-08-10".to_string());
+        meta.insert("author".to_string(), "Jane Doe".to_string());
+        meta.insert("excerpt".to_string(), "A summary".to_string());
+
+        let chunk = crate::domain::DocumentChunkValidated {
+            id: Uuid::new_v4(),
+            url: "https://example.com/rich".to_string(),
+            title: "Rich Metadata".to_string(),
+            content: "This is the main content body.".to_string(),
+            metadata: meta,
+            timestamp: Utc::now(),
+            embeddings: None,
+            correlation_id: None,
+            _state: std::marker::PhantomData::<Validated>,
+        };
+
+        let metadata = WebfangMetadata::from_chunk(&chunk);
+        let json = serde_json::to_string(&metadata).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["metadata_version"], "2.1.0");
+        assert_eq!(value["word_count"], 42);
+        assert_eq!(value["reading_time"], 2);
+        assert_eq!(value["language"], "es");
+        assert_eq!(value["content_type"], "article");
+        assert_eq!(value["scrape_date"], "2026-08-10");
+
+        let extra = value["extra_metadata"].as_object().unwrap();
+        assert_eq!(extra["author"], "Jane Doe");
+        assert_eq!(extra["excerpt"], "A summary");
+    }
+
+    #[test]
+    fn test_webfang_metadata_v210_computed_word_count() {
+        use crate::domain::Validated;
+        use chrono::Utc;
+        use uuid::Uuid;
+
+        let chunk = crate::domain::DocumentChunkValidated {
+            id: Uuid::new_v4(),
+            url: "https://example.com/auto".to_string(),
+            title: "Auto Word Count".to_string(),
+            content: "one two three four five".to_string(),
+            metadata: std::collections::HashMap::new(),
+            timestamp: Utc::now(),
+            embeddings: None,
+            correlation_id: None,
+            _state: std::marker::PhantomData::<Validated>,
+        };
+
+        let metadata = WebfangMetadata::from_chunk(&chunk);
+        assert_eq!(metadata.word_count, Some(5));
+        assert_eq!(metadata.reading_time, Some(1));
     }
 }

--- a/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
+++ b/crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs
@@ -133,7 +133,11 @@ impl<'a> WebfangMetadata<'a> {
             .and_then(|v| v.parse::<usize>().ok())
             .or_else(|| {
                 let count = chunk.content.split_whitespace().count();
-                if count > 0 { Some(count) } else { None }
+                if count > 0 {
+                    Some(count)
+                } else {
+                    None
+                }
             });
 
         let reading_time = chunk

--- a/crates/webfang_core/src/infrastructure/output/file_saver.rs
+++ b/crates/webfang_core/src/infrastructure/output/file_saver.rs
@@ -96,7 +96,7 @@ fn save_as_markdown(
     use std::fs;
 
     for item in results {
-        let output_path: OutputPath = match OutputPath::from_url(item.url.as_str()) {
+        let output_path: OutputPath = match OutputPath::from_url_with_query(item.url.as_str()) {
             Ok(p) => p,
             Err(e) => {
                 warn!("Failed to parse URL {}: {}, using fallback", item.url, e);
@@ -284,12 +284,24 @@ fn save_as_text(
     Ok(())
 }
 
-/// Save results as JSON
+/// Save results as JSON, appending to any existing `results.json`.
+///
+/// Two runs into the same output directory accumulate entries instead of
+/// overwriting, matching the `export.jsonl` append behavior (#652).
 fn save_as_json(results: &[ScrapedContent], output_dir: &Path) -> Result<()> {
     use std::fs;
 
     let json_path = output_dir.join("results.json");
-    let json = serde_json::to_string_pretty(results)?;
+
+    let mut merged = if json_path.exists() {
+        let existing = fs::read_to_string(&json_path)?;
+        serde_json::from_str::<Vec<ScrapedContent>>(&existing)?
+    } else {
+        Vec::new()
+    };
+    merged.extend_from_slice(results);
+
+    let json = serde_json::to_string_pretty(&merged)?;
     fs::write(&json_path, json)?;
     tracing::info!("💾 Saved: {}", json_path.display());
 
@@ -354,6 +366,48 @@ mod tests {
 
         let json_path = output_dir.join("results.json");
         assert!(json_path.exists());
+    }
+
+    /// #652: second save must append, not overwrite.
+    #[test]
+    fn test_save_as_json_appends_on_second_call() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = temp_dir.path();
+
+        let first = vec![ScrapedContent {
+            title: "First".to_string(),
+            content: "First content".to_string(),
+            url: ValidUrl::parse("https://a.com").unwrap(),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: Vec::new(),
+            correlation_id: None,
+        }];
+
+        let second = vec![ScrapedContent {
+            title: "Second".to_string(),
+            content: "Second content".to_string(),
+            url: ValidUrl::parse("https://b.com").unwrap(),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: Vec::new(),
+            correlation_id: None,
+        }];
+
+        save_as_json(&first, output_dir).unwrap();
+        save_as_json(&second, output_dir).unwrap();
+
+        let json_path = output_dir.join("results.json");
+        let content = std::fs::read_to_string(&json_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "both runs must be present");
+        assert_eq!(arr[0]["title"], "First");
+        assert_eq!(arr[1]["title"], "Second");
     }
 
     // === rewrite_image_urls_to_relative tests ===

--- a/crates/webfang_mcp/tests/mcp_behavioral_test.rs
+++ b/crates/webfang_mcp/tests/mcp_behavioral_test.rs
@@ -649,7 +649,7 @@ async fn test_export_jsonl_writes_real_file() {
         let obj: Value = serde_json::from_str(line).expect("each JSONL line must be valid JSON");
         assert_eq!(
             obj.get("metadata_version").and_then(|v| v.as_str()),
-            Some("2.0.0"),
+            Some("2.1.0"),
             "JSONL line must carry the webfang metadata schema"
         );
         if obj


### PR DESCRIPTION
Closes #652

## Summary

- **Bug 1 (HIGH — data loss)**: Query/fragment preservados en filenames para evitar colisiones silenciosas (`item.html?id=1` vs `?id=2` ya no se sobrescriben)
- **Bug 2 (MEDIUM)**: `-o -` retorna `UsageError` claro en vez de crear directorio literal `-`
- **Bug 3 (MEDIUM)**: `--output-vectors` sin feature `ai` retorna `ConfigError` temprano en vez de producir archivo 0-byte silencioso
- **Bug 4 (MEDIUM)**: `WebfangMetadata` bump a v2.1.0 con 6 campos opcionales enriched (word_count, reading_time, language, content_type, scrape_date, extra_metadata) — `#[serde(skip_serializing_if)]` para retrocompatibilidad
- **Bug 5 (LOW)**: `results.json` ahora hace append en vez de overwrite (acumula entre runs, consistente con `export.jsonl`)
- **Bug 6 (LOW)**: Dedup por clave compuesta `(normalized_url, hash)` — evita que URLs distintas con mismo contenido (mirrored pages) se omitan

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/adapters/url_path.rs` | `UrlPath::from_url_with_query()` + `OutputPath::from_url_with_query()` preservan query+fragment |
| `crates/webfang_core/src/infrastructure/output/file_saver.rs` | `save_as_markdown` usa `from_url_with_query`; `save_as_json` hace append |
| `crates/webfang_core/src/cli/orchestrator.rs` | Rechaza `-o -` con `UsageError`; error temprano `--output-vectors` sin `ai` |
| `crates/webfang_core/src/infrastructure/export/jsonl_exporter.rs` | `WebfangMetadata` v2.1.0 con 6 campos opcionales enriched |
| `crates/webfang_core/src/application/elastic_ingestion.rs` | Dedup por `(normalized_url, hash)` + log elevado a `warn!` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run` — 2067/2067 pass
- [x] Tests unitarios nuevos para cada bug (query uniqueness, -o - rejection, output-vectors error, metadata v2.1.0 serialization, dedup composite key)

## Contributor Checklist

- [x] Linked approved issue with `Closes #652`
- [x] Branch name matches `type/description` — `fix/export-edge-cases`
- [x] Added exactly one `type:*` label — `type:bug`
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Defensive error paths annotated per existing patterns