### PR TITLE
fix(tui): stop overwriting visible_height on every draw

### DIFF
--- a/crates/webfang_tui/src/tui/url_selector.rs
+++ b/crates/webfang_tui/src/tui/url_selector.rs
@@ -371,8 +371,6 @@ impl Component for UrlSelectorState {
     }
 
     fn draw(&mut self, f: &mut Frame, rect: Rect) -> Result<()> {
-        // Update visible height so auto-scroll works correctly
-        self.visible_height = rect.height as usize;
         let selector = UrlSelector::new(self);
         selector.render(f, rect);
         Ok(())


### PR DESCRIPTION
Closes #708

## Summary
- `draw()` pisaba `self.visible_height = rect.height` en cada frame
- `visible_height` ya la manejan reactivamente `init()` (línea 308) y `update()` ante `Action::Resize` (línea 365)
- Elimina la mutación de estado desde el render

## Verification
- `cargo check -p webfang_tui` ✅
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` ✅
- `cargo fmt --check` ✅