### PR TITLE
fix(cli): fail-fast exit 65 for --output-vectors without --clean-ai

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -53,6 +53,44 @@ pub fn prepare_progress_channel(
     (observer, rx)
 }
 
+/// Pre-flight gate for `--output-vectors` (#703, #652).
+///
+/// `--output-vectors` can only write embeddings when semantic cleaning is
+/// requested (`--clean-ai` / `opts.ai`). Every entry point (`run`,
+/// `run_batch`) must run this gate BEFORE `build_elastic_ingestion` wires the
+/// stream sink: `StreamRepository::new(path)` creates/truncates the target
+/// file as a construction side effect, so failing downstream of it leaks a
+/// 0-byte vectors file alongside a success exit (silent data loss for RAG
+/// pipelines, class S1).
+///
+/// - With the `ai` feature: `output_vectors && !opts.ai` → `DataFormatError`
+///   (exit 65, `EX_DATA`) with a Spanish user-facing message.
+/// - Without it: the flag is unusable → `ConfigError` (exit 78) telling the
+///   user to rebuild with `--features ai`.
+///
+/// Returns `Some(exit)` when the run must be aborted, `None` to proceed.
+fn output_vectors_gate(opts: &CrawlOptions) -> Option<CliExit> {
+    opts.elastic.output_vectors.as_ref()?;
+
+    #[cfg(feature = "ai")]
+    {
+        if opts.ai {
+            return None;
+        }
+        warn!("--output-vectors refused without --clean-ai; no vectors to export");
+        Some(CliExit::DataFormatError(
+            "No hay vectores para exportar: '--output-vectors' requiere '--clean-ai' para generar embeddings".to_string(),
+        ))
+    }
+
+    #[cfg(not(feature = "ai"))]
+    {
+        Some(CliExit::ConfigError(
+            "Se requiere compilar con '--features ai' para usar --output-vectors".to_string(),
+        ))
+    }
+}
+
 /// Main orchestration entry point.
 ///
 /// Coordinates the full scraping pipeline:
@@ -73,17 +111,11 @@ pub async fn run(
         return run_dry_run(opts).await;
     }
 
-    // #703: `--output-vectors` without `--clean-ai` can never produce vectors —
-    // embeddings only exist when semantic cleaning runs. Fail fast with exit 65
-    // (EX_DATA) here, BEFORE `build_elastic_ingestion` below: its sink wiring
-    // creates/truncates the output file as a construction side effect, which
-    // would leak an empty 0-byte file into RAG pipelines.
-    #[cfg(feature = "ai")]
-    if opts.elastic.output_vectors.is_some() && !opts.ai {
-        warn!("--output-vectors refused without --clean-ai; no vectors to export");
-        return CliExit::DataFormatError(
-            "No hay vectores para exportar: '--output-vectors' requiere '--clean-ai' para generar embeddings".to_string(),
-        );
+    // #703/#652: pre-flight gate for `--output-vectors` — single source of
+    // truth shared with `run_batch()` (see `output_vectors_gate`), and it must
+    // run BEFORE `build_elastic_ingestion` wires the stream sink below.
+    if let Some(exit) = output_vectors_gate(&opts) {
+        return exit;
     }
 
     // Process-level graceful shutdown (#653). The guard owns ONE signal
@@ -132,13 +164,6 @@ pub async fn run(
         Ok(v) => v,
         Err(e) => return e,
     };
-
-    #[cfg(not(feature = "ai"))]
-    if opts.elastic.output_vectors.is_some() {
-        return CliExit::ConfigError(
-            "Se requiere compilar con '--features ai' para usar --output-vectors".to_string(),
-        );
-    }
 
     // Create observer with stderr fallback (no channel) for non-TUI mode.
     // For TUI mode, call `prepare_progress_channel()` from main.rs and pass
@@ -595,24 +620,11 @@ async fn run_batch(
     vault_ports: crate::application::container::VaultAiPorts,
     cancel: &tokio_util::sync::CancellationToken,
 ) -> CliExit {
-    // #703: `--output-vectors` without `--clean-ai` produces no embeddings —
-    // exit 65 (EX_DATA) before any crawl, spool, or sink wiring runs. First
-    // statement here (above the legacy not-ai check), mirroring `run()`, whose
-    // own early placement prevents `build_elastic_ingestion` from truncating an
-    // empty vectors file as a construction side effect.
-    #[cfg(feature = "ai")]
-    if opts.elastic.output_vectors.is_some() && !opts.ai {
-        warn!("--output-vectors refused without --clean-ai; no vectors to export");
-        return CliExit::DataFormatError(
-            "No hay vectores para exportar: '--output-vectors' requiere '--clean-ai' para generar embeddings".to_string(),
-        );
-    }
-
-    #[cfg(not(feature = "ai"))]
-    if opts.elastic.output_vectors.is_some() {
-        return CliExit::ConfigError(
-            "Se requiere compilar con '--features ai' para usar --output-vectors".to_string(),
-        );
+    // #703/#652: pre-flight gate for `--output-vectors` — same single source of
+    // truth as `run()` (see `output_vectors_gate`). First statement here so the
+    // exit fires before any crawl, spool, or sink wiring runs.
+    if let Some(exit) = output_vectors_gate(&opts) {
+        return exit;
     }
 
     // Resolve the TLS/H2 fingerprint once so the batch crawl engine honors

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -72,6 +72,20 @@ pub async fn run(
     if opts.export.dry_run {
         return run_dry_run(opts).await;
     }
+
+    // #703: `--output-vectors` without `--clean-ai` can never produce vectors —
+    // embeddings only exist when semantic cleaning runs. Fail fast with exit 65
+    // (EX_DATA) here, BEFORE `build_elastic_ingestion` below: its sink wiring
+    // creates/truncates the output file as a construction side effect, which
+    // would leak an empty 0-byte file into RAG pipelines.
+    #[cfg(feature = "ai")]
+    if opts.elastic.output_vectors.is_some() && !opts.ai {
+        warn!("--output-vectors refused without --clean-ai; no vectors to export");
+        return CliExit::DataFormatError(
+            "No hay vectores para exportar: '--output-vectors' requiere '--clean-ai' para generar embeddings".to_string(),
+        );
+    }
+
     // Process-level graceful shutdown (#653). The guard owns ONE signal
     // listener for the whole run; every phase observes its token cooperatively
     // so a SIGINT drains in-flight work and still exports it, instead of being
@@ -567,6 +581,19 @@ async fn run_batch(
     vault_ports: crate::application::container::VaultAiPorts,
     cancel: &tokio_util::sync::CancellationToken,
 ) -> CliExit {
+    // #703: `--output-vectors` without `--clean-ai` produces no embeddings —
+    // exit 65 (EX_DATA) before any crawl, spool, or sink wiring runs. First
+    // statement here (above the legacy not-ai check), mirroring `run()`, whose
+    // own early placement prevents `build_elastic_ingestion` from truncating an
+    // empty vectors file as a construction side effect.
+    #[cfg(feature = "ai")]
+    if opts.elastic.output_vectors.is_some() && !opts.ai {
+        warn!("--output-vectors refused without --clean-ai; no vectors to export");
+        return CliExit::DataFormatError(
+            "No hay vectores para exportar: '--output-vectors' requiere '--clean-ai' para generar embeddings".to_string(),
+        );
+    }
+
     #[cfg(not(feature = "ai"))]
     if opts.elastic.output_vectors.is_some() {
         return CliExit::ConfigError(
@@ -1025,7 +1052,6 @@ mod tests {
     use crate::application::crawl_options::CrawlOptions;
     use crate::cli::error::CliExit;
 
-    #[cfg(not(feature = "ai"))]
     use super::{run, run_batch};
 
     // ===== build_batch_crawler_config tests (#653) =====
@@ -1528,6 +1554,61 @@ mod tests {
         assert!(
             matches!(exit, CliExit::ConfigError(_)),
             "expected CliExit::ConfigError, got {exit:?}"
+        );
+    }
+
+    // ===== output_vectors without clean-ai flag (ai feature on, #703) =====
+
+    #[cfg(feature = "ai")]
+    #[tokio::test]
+    async fn run_returns_data_error_when_output_vectors_without_clean_ai() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.output_vectors = Some("vectors.jsonl".to_string());
+        // opts.ai stays false → no semantic cleaning requested
+
+        // The cfg-gated `ai_cleaner` / `adaptive_engine` parameters make the
+        // arity depend on both features — dispatch the call exactly like
+        // `build_and_run` does in webfang_cli/src/main.rs.
+        #[cfg(feature = "adaptive-selectors")]
+        let exit = run(
+            opts,
+            None,
+            None,
+            crate::application::container::VaultAiPorts::default(),
+        )
+        .await;
+        #[cfg(not(feature = "adaptive-selectors"))]
+        let exit = run(
+            opts,
+            None,
+            crate::application::container::VaultAiPorts::default(),
+        )
+        .await;
+
+        assert!(
+            matches!(exit, CliExit::DataFormatError(_)),
+            "expected CliExit::DataFormatError, got {exit:?}"
+        );
+    }
+
+    #[cfg(feature = "ai")]
+    #[tokio::test]
+    async fn run_batch_returns_data_error_when_output_vectors_without_clean_ai() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.output_vectors = Some("vectors.jsonl".to_string());
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let exit = run_batch(
+            opts,
+            None,
+            crate::application::container::VaultAiPorts::default(),
+            &cancel,
+        )
+        .await;
+
+        assert!(
+            matches!(exit, CliExit::DataFormatError(_)),
+            "expected CliExit::DataFormatError, got {exit:?}"
         );
     }
 }

--- a/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
@@ -273,6 +273,81 @@ async fn server_error_response_exit_code_nonzero() {
 }
 
 // ---------------------------------------------------------------------------
+// --output-vectors without --clean-ai → exit 65, no file written (#703)
+// ---------------------------------------------------------------------------
+
+/// `webfang --output-vectors <file>` WITHOUT `--clean-ai` must fail fast with
+/// exit 65 (EX_DATA) and a Spanish explanation — never run the scrape and drop
+/// a 0-byte vectors file into a RAG pipeline (issue #703, class S1).
+///
+/// The check runs BEFORE any network I/O or sink wiring, so a live mock server
+/// is mounted to prove the gate fires even when the page is perfectly
+/// scrape-able: if the guard regressed, the run would succeed and create the
+/// 0-byte file this test forbids. (No `.expect()` on the mock — with the
+/// fail-fast in place the request never lands, and wiremock would fail the
+/// test on drop over the unmet expectation.)
+///
+/// No `#[ignore]`: the gate fires before any ONNX model could load.
+#[cfg(feature = "ai")]
+mod output_vectors_without_clean_ai {
+    use crate::assert_snapshot_redacted;
+    use crate::BehavioralTest;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    const PAGE_HTML: &str = r#"
+<html><head><title>Vector Gate Test</title></head>
+<body><main><article>
+<h1>Gate Me</h1>
+<p>Small valid page so a regression letting the run proceed would scrape it.</p>
+</article></main></body></html>
+"#;
+
+    #[tokio::test]
+    async fn output_vectors_without_clean_ai_exits_65_and_writes_no_file() {
+        let t = BehavioralTest::new().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(PAGE_HTML))
+            .mount(&t.server)
+            .await;
+
+        let vectors_path = t.out.path().join("vectors.jsonl");
+        let output = t
+            .scraper_cmd()
+            .arg("--single-page")
+            .arg("--output-vectors")
+            .arg(&vectors_path)
+            .arg("--quiet")
+            .output()
+            .expect("run webfang");
+
+        // Semantic invariants (the contract under test): exit 65 (EX_DATA), the
+        // Spanish message, and — the core invariant — NO vectors file created.
+        assert_eq!(
+            output.status.code(),
+            Some(65),
+            "--output-vectors without --clean-ai must exit 65 (EX_DATA)"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("No hay vectores para exportar"),
+            "stderr must carry the Spanish error, got: {stderr}"
+        );
+        assert_snapshot_redacted(
+            "output_vectors_without_clean_ai_stderr",
+            t.out.path(),
+            stderr,
+        );
+        assert!(
+            !vectors_path.exists(),
+            "the vectors file must NOT be created when the flag gate rejects the run: {vectors_path:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // --output-dir flag
 // ---------------------------------------------------------------------------
 

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__output_vectors_without_clean_ai_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__output_vectors_without_clean_ai_stderr.snap
@@ -1,0 +1,8 @@
+---
+source: crates/webfang_core/tests/behavioral/main.rs
+expression: redacted
+---
+  <TIMESTAMP>  WARN <MODULE>: --output-vectors refused without --clean-ai; no vectors to export
+    at <FILE>.rs:<LINE>
+
+Error: No hay vectores para exportar: '--output-vectors' requiere '--clean-ai' para generar embeddings


### PR DESCRIPTION
## Linked Issue

Closes #703 — Paso 2 (final) of the Fase 0 release-blocker epic. Paso 1 (#710) already merged. Closes the work formerly tracked as #681.

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `--output-vectors` WITHOUT `--clean-ai` used to run the full scrape, wire the stream sink (which creates/truncates the output file as a construction side effect), and exit **0 with a 0-byte vectors file** — a silent data loss for downstream RAG pipelines (class S1).
- This gates both `run()` and `run_batch()` to fail fast with **exit 65 (EX_DATA)** and a Spanish message *before* `build_elastic_ingestion` creates/truncates the file, so no partial state leaks. Mirrors the MCP side, which already returns an honest "no hay resultados" error.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/orchestrator.rs` | `#[cfg(feature = "ai")]` gate in `run()` + `run_batch()`: `output_vectors.is_some() && !opts.ai` → `CliExit::DataFormatError` (exit 65) with Spanish message + English `warn!`; placed before sink wiring to avoid the 0-byte file |
| `crates/webfang_core/tests/behavioral/cli/error_path_test.rs` | New `#[cfg(feature = "ai")]` regression test: exit 65 + Spanish stderr + **no vectors file created** (core invariant) |
| `.../snapshots/behavioral__output_vectors_without_clean_ai_stderr.snap` | Accepted snapshot (redacted) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run -p webfang_core --features ai` — 2094 passed (2 new unit tests pass; 3 pre-existing obsidian-vault env failures fail identically on clean main)
- [x] `cargo nextest run -p webfang_core` — 2089 passed (unchanged behavior on default features)
- [x] `cargo nextest run -p webfang_core --features ai --test behavioral` — **92 passed, 0 failed**; new behavioral test proves exit 65 and that the vectors file is never created

## Notes

- **Critical placement deviation (by design):** `StreamRepository::new()` creates/truncates the target path as a construction side effect inside `build_elastic_ingestion`, so the gate is placed *at the top* of `run()` / `run_batch()` — before that sink is wired. A later placement (e.g. next to the existing not-ai feature check) would still leak the empty file.
- Reuses the already-defined `EXIT_DATA_ERROR = 65`; no new exit codes added.
- The gate is feature-gated on `ai` (a pure marker feature in `webfang_core`); the single `output_vectors_gate()` helper also carries the not-ai `ConfigError` (exit 78) for builds where the flag doesn't exist.
- Behavioral test is NOT `#[ignore]`: the gate fires before any ONNX model load.

## Contributor Checklist

- [x] Linked epic #703 with `Closes`
- [x] Branch name `fix/empty-export-vectors` (conventional)
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No AI attribution trailers
- [x] Snapshot committed, no pending `.snap.new`

## Follow-up: gate deduplicated into a single helper

A follow-up commit extracts the pre-flight check into one shared
`output_vectors_gate()` covering both feature variants, instead of
duplicating it verbatim in `run()` and `run_batch()`. This keeps the
jscpd duplication ratchet clean AND fixes the legacy not-ai ConfigError
in `run()`, which previously fired *after* sink wiring had already
created the target file. All unit + behavioral tests still pass (exit 65,
Spanish stderr, no file created).
