### PR TITLE
fix(cli): structured log_scrape_error in scrape-phase error paths (#704 Paso 3, #688)

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -108,11 +108,17 @@ pub async fn run(
         Ok(p) => p,
     };
 
-    let (urls_to_scrape, state_store) =
-        match apply_resume_mode(prepare.urls_to_scrape, &opts, opts.url.as_str()).await {
-            Ok(v) => v,
-            Err(e) => return e,
-        };
+    let (urls_to_scrape, state_store) = match apply_resume_mode(
+        prepare.urls_to_scrape,
+        &opts,
+        opts.url.as_str(),
+        &root_correlation,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
     let elastic_ingestion = match build_elastic_ingestion(&opts, vault_ports).await {
         Ok(v) => v,

--- a/crates/webfang_core/src/cli/scrape_flow.rs
+++ b/crates/webfang_core/src/cli/scrape_flow.rs
@@ -19,6 +19,7 @@ use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::downloader::cookie_bridge::CookieBridge;
 use crate::infrastructure::downloader::Downloader;
 use crate::infrastructure::export::state_store::StateStore;
+use crate::infrastructure::observability::log_scrape_error;
 use crate::HttpClientConfig;
 use crate::ScraperConfig;
 
@@ -40,6 +41,7 @@ pub async fn apply_resume_mode(
     urls_to_scrape: Vec<Url>,
     opts: &CrawlOptions,
     target_url: &str,
+    root_correlation: &CorrelationId,
 ) -> Result<(Vec<Url>, Option<StateStore>), CliExit> {
     let state_store: Option<StateStore> = if opts.crawl.resume {
         info!("Resume mode enabled - tracking processed URLs");
@@ -64,7 +66,7 @@ pub async fn apply_resume_mode(
 
     let filtered = if opts.crawl.resume {
         match state_store.as_ref() {
-            Some(store) => filter_processed_urls(urls_to_scrape, store),
+            Some(store) => filter_processed_urls(urls_to_scrape, store, root_correlation),
             None => urls_to_scrape,
         }
     } else {
@@ -89,7 +91,11 @@ fn resolve_state_dir(opts: &CrawlOptions) -> PathBuf {
 }
 
 /// Drop URLs already processed by a prior run, degrading gracefully on error.
-fn filter_processed_urls(urls_to_scrape: Vec<Url>, store: &StateStore) -> Vec<Url> {
+fn filter_processed_urls(
+    urls_to_scrape: Vec<Url>,
+    store: &StateStore,
+    root_correlation: &CorrelationId,
+) -> Vec<Url> {
     match store.load_or_default() {
         Ok(state) => {
             let original_count = urls_to_scrape.len();
@@ -114,7 +120,13 @@ fn filter_processed_urls(urls_to_scrape: Vec<Url>, store: &StateStore) -> Vec<Ur
             filtered
         },
         Err(e) => {
-            warn!("Failed to load state: {}", e);
+            log_scrape_error(
+                &e,
+                "",
+                "state-load",
+                Some(root_correlation),
+                "could not load checkpoint state",
+            );
             urls_to_scrape
         },
     }
@@ -357,7 +369,13 @@ async fn scrape_one_url(
         },
         Err(e) => {
             let url_str = url.as_str().to_string();
-            warn!("Failed to scrape {}: {}", url_str, e);
+            log_scrape_error(
+                &e,
+                &url_str,
+                "scrape",
+                Some(page_correlation),
+                "page scrape failed",
+            );
             // ScraperError doesn't impl Clone, so we format for the observer
             // and keep the original for the failures vec (needed for error chain display).
             let scrape_err = ScrapeError::Other(format!("{e}"));
@@ -516,6 +534,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_resume_mode_disabled_returns_all_urls() {
+        let root = crate::domain::CorrelationId::new();
         let urls = vec![
             Url::parse("https://example.com/a").unwrap(),
             Url::parse("https://example.com/b").unwrap(),
@@ -528,9 +547,10 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) = apply_resume_mode(urls.clone(), &opts, "https://example.com")
-            .await
-            .expect("resume disabled should not fail");
+        let (filtered, state_store) =
+            apply_resume_mode(urls.clone(), &opts, "https://example.com", &root)
+                .await
+                .expect("resume disabled should not fail");
 
         assert_eq!(filtered.len(), 2);
         assert!(state_store.is_none());
@@ -538,6 +558,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_resume_mode_skips_previously_scraped_urls() {
+        let root = crate::domain::CorrelationId::new();
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path().to_path_buf();
 
@@ -563,7 +584,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com")
+        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com", &root)
             .await
             .expect("valid state dir should not fail");
 
@@ -583,6 +604,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_resume_mode_with_corrupted_state_returns_all_urls() {
+        let root = crate::domain::CorrelationId::new();
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path().to_path_buf();
 
@@ -604,9 +626,10 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) = apply_resume_mode(urls.clone(), &opts, "https://example.com")
-            .await
-            .expect("corrupted state file should not prevent store creation");
+        let (filtered, state_store) =
+            apply_resume_mode(urls.clone(), &opts, "https://example.com", &root)
+                .await
+                .expect("corrupted state file should not prevent store creation");
 
         // Corrupted state → fallback to all URLs (graceful degradation)
         assert_eq!(
@@ -619,6 +642,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_resume_mode_with_custom_state_dir() {
+        let root = crate::domain::CorrelationId::new();
         let tmp = TempDir::new().unwrap();
         let state_dir = tmp.path().join("custom_state");
         std::fs::create_dir_all(&state_dir).unwrap();
@@ -633,7 +657,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com")
+        let (filtered, state_store) = apply_resume_mode(urls, &opts, "https://example.com", &root)
             .await
             .expect("custom state dir should not fail");
 

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__slow_server_timeout_stderr.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/webfang_core/tests/behavioral/main.rs
-assertion_line: 43
 expression: redacted
 ---
-  <TIMESTAMP>  WARN <MODULE>: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
+  <TIMESTAMP> ERROR <MODULE>: page scrape failed, error: error de red: request timed out after 1s, url: http://127.0.0.1:<PORT>/slow, stage: scrape, trace_id: "<TRACE_ID>"
     at <FILE>.rs:<LINE>
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__unreachable_host_stderr.snap
@@ -8,7 +8,7 @@ expression: redacted
   <TIMESTAMP>  WARN <MODULE>: Transport failure fetching http://127.0.0.1:<PORT>/ — retrying, attempt: 0, max_retries: 0, error: I/O error: Connection refused (os error 111)
     at <FILE>.rs:<LINE>
 
-  <TIMESTAMP>  WARN <MODULE>: Failed to scrape http://127.0.0.1:<PORT>/: error de red: I/O error: Connection refused (os error 111)
+  <TIMESTAMP> ERROR <MODULE>: page scrape failed, error: error de red: I/O error: Connection refused (os error 111), url: http://127.0.0.1:<PORT>/, stage: scrape, trace_id: "<TRACE_ID>"
     at <FILE>.rs:<LINE>
 
 Failed to scrape http://127.0.0.1:<PORT>/: error de red: I/O error: Connection refused (os error 111)

--- a/crates/webfang_core/tests/common/cli_harness.rs
+++ b/crates/webfang_core/tests/common/cli_harness.rs
@@ -285,6 +285,12 @@ pub(crate) fn redact_nondeterministic(dir: &Path, text: &str) -> String {
     // so snapshots decouple from source location and survive function moves (#462).
     let module = Regex::new(r"((?:WARN|INFO|ERROR|DEBUG|TRACE)\s+)\w+(?:::\w+)+").unwrap();
     let text = module.replace_all(&text, "$1<MODULE>").into_owned();
+    // Normalize trace/correlation UUIDs emitted by log_scrape_error's trace_id
+    // field (#688) so trace snapshots stay deterministic run-to-run.
+    let trace_id =
+        Regex::new(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b")
+            .unwrap();
+    let text = trace_id.replace_all(&text, "<TRACE_ID>").into_owned();
     // Normalize tracing source file paths (e.g. "at crates/.../orchestrator.rs:<LINE>")
     // so moving a function between files does not break snapshots (#462).
     let file_path = Regex::new(r"(at\s+)\S+\.rs").unwrap();

--- a/crates/webfang_core/tests/snapshots/cli_binary_test__test_single_page_custom_timeout_is_used_by_scrape_client.snap
+++ b/crates/webfang_core/tests/snapshots/cli_binary_test__test_single_page_custom_timeout_is_used_by_scrape_client.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/webfang_core/tests/cli_binary_test.rs
-assertion_line: 230
 expression: "redact_nondeterministic(output_dir.path(), &stderr)"
 ---
-  <TIMESTAMP>  WARN <MODULE>: Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s
+  <TIMESTAMP> ERROR <MODULE>: page scrape failed, error: error de red: request timed out after 1s, url: http://127.0.0.1:<PORT>/slow, stage: scrape, trace_id: "<TRACE_ID>"
     at <FILE>.rs:<LINE>
 
 Failed to scrape http://127.0.0.1:<PORT>/slow: error de red: request timed out after 1s


### PR DESCRIPTION
## Linked Issue

Closes #688
Part of #704 (épica Fase 1 — trazabilidad, Paso 3 de 4)

#688 was consolidated into epic #704; this PR implements its fix: "Sustituir por `log_scrape_error` con contexto (url, stage, correlation_id)".

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- Scrape-phase failures emitted `warn!("Failed to scrape {}: {}")` — string-soup without structured `trace_id`, so errors in a `--trace-file` JSONL were not correlatable (audit F14: "campos no estructurados").
- Replaces the 2 string-soup sites with `log_scrape_error` (the repo helper that carries `error`/`url`/`stage`/`trace_id` as structured fields): `filter_processed_urls` state-load error (root correlation) and `scrape_one_url` page error (per-page correlation). The `:261` shutdown warn stays as-is (already structured, not a scrape error — per the audit note).
- Threads `root_correlation` from `orchestrator::run` through `apply_resume_mode` → `filter_processed_urls` so the state-load error carries the run-root `trace_id`.
- Adds trace_id UUID redaction (`<TRACE_ID>`) to `redact_nondeterministic` so trace snapshots stay deterministic (AGENTS.md: `correlation_id`/`trace_id` are internal and must be redacted).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/scrape_flow.rs` | `:117` state-load and `:360` page-error `warn!` → `log_scrape_error`; `root_correlation` param threaded through `apply_resume_mode`/`filter_processed_urls`; 4 test call sites updated |
| `crates/webfang_core/src/cli/orchestrator.rs` | passes `&root_correlation` (already in scope) to `apply_resume_mode` |
| `crates/webfang_core/tests/common/cli_harness.rs` | `<TRACE_ID>` UUID redaction in `redact_nondeterministic` |
| 3 snapshots | WARN→ERROR + structured fields with `<TRACE_ID>` (verified diffs are exactly the expected shape) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run` — behavioral + cli_binary_test + correlation_id_fidelity + trace_orphan_spawn_test + span_attribution_across_await: 117/117 PASS
- [x] Snapshot workflow followed: `.snap.new` reviewed → accepted → re-run PASS

## Contributor Checklist

- [x] Linked issue with `Closes #N`
- [x] Branch name matches `type/description`
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Error contexts in English per AGENTS.md (logs/tracing in English)
- [x] No defensive error paths introduced (no LCOV needed)