### PR TITLE
fix(cli): exit 0 when resume finds nothing pending

### DIFF
--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -154,6 +154,7 @@ pub async fn run(
         Ok(p) => p,
     };
 
+    let discovered_count = prepare.urls_to_scrape.len();
     let (urls_to_scrape, state_store) = match apply_resume_mode(
         prepare.urls_to_scrape,
         &opts,
@@ -165,6 +166,14 @@ pub async fn run(
         Ok(v) => v,
         Err(e) => return e,
     };
+
+    // #705 Paso 2: a --resume run where every discovered URL was already
+    // processed by a prior run is a technical success ("nothing pending").
+    if let Some(exit) =
+        resume_nothing_pending(&opts, &urls_to_scrape, discovered_count, &root_correlation)
+    {
+        return exit;
+    }
 
     let elastic_ingestion = match build_elastic_ingestion(&opts, vault_ports).await {
         Ok(v) => v,
@@ -231,6 +240,34 @@ pub async fn run(
     {
         export_phase(&results, &opts, state_store.as_ref()).await
     }
+}
+
+/// #705 Paso 2: a `--resume` run where every discovered URL was already
+/// processed by a prior run is a technical success ("nothing pending"), not a
+/// network failure. Return `Some(CliExit::Success)` before the scrape phase so
+/// an empty filtered list never reaches `report_phase`'s false exit-69 path.
+/// The `discovered_count > 0` guard keeps a genuinely empty discovery on its
+/// existing route instead of masking it as resume success.
+fn resume_nothing_pending(
+    opts: &CrawlOptions,
+    urls_to_scrape: &[url::Url],
+    discovered_count: usize,
+    root_correlation: &domain::CorrelationId,
+) -> Option<CliExit> {
+    if opts.crawl.resume && urls_to_scrape.is_empty() && discovered_count > 0 {
+        info!(
+        skipped = discovered_count,
+        trace_id = %root_correlation.trace_id(),
+        "resume: all discovered URLs already processed, nothing pending"
+        );
+        if !opts.export.quiet {
+            println!(
+"Resume: nada pendiente — {discovered_count} URL(s) ya procesadas en ejecuciones anteriores."
+);
+        }
+        return Some(CliExit::Success);
+    }
+    None
 }
 
 /// Resolve the root directory that must contain the scraped Markdown AND the

--- a/crates/webfang_core/tests/behavioral/cli/resume_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/resume_test.rs
@@ -305,3 +305,46 @@ async fn corrupt_state_falls_back_to_full_scrape() {
         "corrupt state must still produce .md files"
     );
 }
+
+/// A `--resume` run where every discovered URL was already processed by a prior
+/// run is a technical success, not a failure: it must exit 0 with a "nothing
+/// pending" message instead of the false network-error exit 69 (#705 Paso 2).
+#[tokio::test]
+async fn resume_all_processed_exits_zero() {
+    let t = BehavioralTest::new().await;
+    let sitemap_url = mount_resume_fixture(&t).await;
+    let state_dir = TempDir::new().unwrap();
+
+    // First run processes every URL and persists state.
+    let run1 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+    assert!(
+        run1.status.success(),
+        "first run should succeed: {}",
+        String::from_utf8_lossy(&run1.stderr)
+    );
+
+    // Second run with the same state dir: every URL is already processed, so
+    // there is nothing pending. This is a success, not a network error.
+    let run2 = t
+        .state_dir_cmd(state_dir.path())
+        .arg("--use-sitemap")
+        .arg("--sitemap-url")
+        .arg(&sitemap_url)
+        .arg("--quiet")
+        .output()
+        .expect("run binary");
+
+    assert!(
+        run2.status.success(),
+        "resume with nothing pending must exit 0, got {:?}: {}",
+        run2.status.code(),
+        String::from_utf8_lossy(&run2.stderr)
+    );
+}


### PR DESCRIPTION
Closes #705 (Paso 2 de 5 — se reabre la epic tras el merge)

## Summary

`--resume` when every discovered URL was already processed by a prior run
returned exit 69 ("No pages were successfully scraped") — a false network
error for what is actually a technical success: nothing left to do.

## Changes

- `orchestrator.rs`: after `apply_resume_mode`, if `--resume` is active and
  the filtered URL list is empty (but discovery found URLs), exit 0 with a
  "nada pendiente" message instead of falling through to the scrape phase
  and its false exit-69 path. The `discovered_count > 0` guard keeps a
  genuinely empty discovery on its existing exit-2 route.
- `resume_test.rs`: new behavioral test `resume_all_processed_exits_zero` —
  two runs with the same `--state-dir`; the second must exit 0.

## Verification

- TDD: RED confirmed (exit 69 before fix) → GREEN (exit 0 after fix)
- All 7 resume behavioral tests pass
- `cargo check` + strict clippy + `cargo fmt --check` clean
- Duplication ratchet: 7684 < 7728 baseline
