### PR TITLE
fix(mcp): ScrapeEvent carries trace_id + correlation_id (#704 Paso 4, #698)

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -43,6 +43,9 @@ impl McpHandler {
 
         let start = Instant::now();
         let client = self.state.container.http_client().as_ref();
+        // An MCP tool call IS an operation (#501/#698): mint the run-root
+        // identity at handler entry so both success and error events share it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         match webfang_core::application::scraper_service::scrape_with_readability(client, &url)
             .await
         {
@@ -54,6 +57,8 @@ impl McpHandler {
                     outcome: Outcome::Success,
                     count,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 let content = serde_json::to_string_pretty(&results)
                     .unwrap_or_else(|_| "failed to serialize".into());
@@ -66,6 +71,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count: 0,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -139,6 +146,8 @@ impl McpHandler {
                     outcome: Outcome::Success,
                     count,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 let response = selector_service::build_scrape_response(
                     outcome.results,
@@ -156,6 +165,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count: 0,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -195,6 +206,9 @@ impl McpHandler {
         }
 
         let start = Instant::now();
+        // An MCP tool call IS an operation (#501/#698): mint the run-root
+        // identity once so both success and error events share it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         let domain = urls
             .first()
             .and_then(|u| u.host_str())
@@ -233,6 +247,8 @@ impl McpHandler {
                     outcome: outcome_type,
                     count,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 tracing::info!(
                     "batch scrape complete: {} pages, {} failed",
@@ -252,6 +268,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 tracing::error!("batch scrape failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
@@ -284,6 +302,9 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&seed_url).await?;
 
         let start = Instant::now();
+        // An MCP tool call IS an operation (#501/#698): mint the run-root
+        // identity at handler entry so both success and error events share it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         let crawler_config = webfang_core::domain::CrawlerConfig::builder(seed_url)
             .max_depth(params.max_depth.unwrap_or(3))
             .max_pages(params.max_pages.unwrap_or(100) as usize)
@@ -298,6 +319,8 @@ impl McpHandler {
                     outcome: Outcome::Success,
                     count,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 let urls: Vec<String> = result.urls.iter().map(|u| u.url.to_string()).collect();
                 let json = serde_json::json!({
@@ -318,6 +341,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count: 0,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -350,6 +375,9 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&seed_url).await?;
 
         let start = Instant::now();
+        // An MCP tool call IS an operation (#501/#698): mint the run-root
+        // identity at handler entry so both success and error events share it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         let config = webfang_core::domain::CrawlerConfig::new(seed_url);
 
         match webfang_core::application::crawler::crawl_with_sitemap(
@@ -367,6 +395,8 @@ impl McpHandler {
                     outcome: Outcome::Success,
                     count,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 tracing::info!("sitemap crawl complete: {} urls found", urls.len());
                 let url_strings: Vec<String> = urls.iter().map(|u| u.url.to_string()).collect();
@@ -382,6 +412,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count: 0,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 tracing::error!("sitemap crawl failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
@@ -411,6 +443,9 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&url).await?;
 
         let start = Instant::now();
+        // An MCP tool call IS an operation (#501/#698): mint the run-root
+        // identity once; all outcome events of this discovery share it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         let port = self.state.container.http_client();
         match port.get(url.as_str()).await {
             Ok(resp) => {
@@ -424,6 +459,8 @@ impl McpHandler {
                         outcome: Outcome::Error,
                         count: 0,
                         duration: start.elapsed(),
+                        trace_id: Some(root_correlation.trace_id().to_string()),
+                        correlation_id: Some(root_correlation.to_traceparent()),
                     });
                     return Ok(CallToolResult::error(vec![Content::text(format!(
                         "HTTP error: status {}",
@@ -440,6 +477,8 @@ impl McpHandler {
                             outcome: Outcome::Success,
                             count,
                             duration: start.elapsed(),
+                            trace_id: Some(root_correlation.trace_id().to_string()),
+                            correlation_id: Some(root_correlation.to_traceparent()),
                         });
                         let content = serde_json::to_string_pretty(&links)
                             .unwrap_or_else(|_| "failed to serialize".into());
@@ -452,6 +491,8 @@ impl McpHandler {
                             outcome: Outcome::Error,
                             count: 0,
                             duration: start.elapsed(),
+                            trace_id: Some(root_correlation.trace_id().to_string()),
+                            correlation_id: Some(root_correlation.to_traceparent()),
                         });
                         Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
                     },
@@ -464,6 +505,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count: 0,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 Ok(CallToolResult::error(vec![Content::text(format!(
                     "HTTP error: {e}"
@@ -494,6 +537,9 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&seed).await?;
 
         let start = Instant::now();
+        // An MCP tool call IS an operation (#501/#698): mint the run-root
+        // identity at handler entry so both success and error events share it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         let crawler_config = webfang_core::domain::CrawlerConfig::new(seed);
 
         match webfang_core::application::crawler::crawl_with_sitemap(
@@ -511,6 +557,8 @@ impl McpHandler {
                     outcome: Outcome::Success,
                     count,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 let urls: Vec<String> = discovered.into_iter().map(|d| d.url.to_string()).collect();
                 let content = serde_json::to_string_pretty(&urls)
@@ -524,6 +572,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count: 0,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -554,6 +604,9 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&url).await?;
 
         let start = Instant::now();
+        // An MCP tool call IS an operation (#501/#698): mint the run-root
+        // identity at handler entry so both success and error events share it.
+        let root_correlation = webfang_core::domain::CorrelationId::new();
         let port = self.state.container.http_client();
         match port.get(url.as_str()).await {
             Ok(resp) => {
@@ -563,6 +616,8 @@ impl McpHandler {
                     outcome: Outcome::Success,
                     count: 1,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 let html = resp.body;
                 let text = webfang_core::infrastructure::scraper::fallback::extract_text(&html);
@@ -594,6 +649,8 @@ impl McpHandler {
                     outcome: Outcome::Error,
                     count: 0,
                     duration: start.elapsed(),
+                    trace_id: Some(root_correlation.trace_id().to_string()),
+                    correlation_id: Some(root_correlation.to_traceparent()),
                 });
                 Ok(CallToolResult::error(vec![Content::text(format!(
                     "HTTP error: {e}"

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -43,37 +43,38 @@ impl McpHandler {
 
         let start = Instant::now();
         let client = self.state.container.http_client().as_ref();
-        // An MCP tool call IS an operation (#501/#698): mint the run-root
-        // identity at handler entry so both success and error events share it.
+        // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
         match webfang_core::application::scraper_service::scrape_with_readability(client, &url)
             .await
         {
             Ok(results) => {
                 let count = results.len();
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "scrape_url",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Success,
-                    count,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "scrape_url",
+                        domain_of(&params.url),
+                        Outcome::Success,
+                        count,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 let content = serde_json::to_string_pretty(&results)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "scrape_url",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Error,
-                    count: 0,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "scrape_url",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
         }
@@ -140,15 +141,16 @@ impl McpHandler {
         {
             Ok(outcome) => {
                 let count = outcome.results.len();
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "scrape_with_options",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Success,
-                    count,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "scrape_with_options",
+                        domain_of(&params.url),
+                        Outcome::Success,
+                        count,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 let response = selector_service::build_scrape_response(
                     outcome.results,
                     &outcome.extract_result,
@@ -159,15 +161,16 @@ impl McpHandler {
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "scrape_with_options",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Error,
-                    count: 0,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "scrape_with_options",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
         }
@@ -206,8 +209,7 @@ impl McpHandler {
         }
 
         let start = Instant::now();
-        // An MCP tool call IS an operation (#501/#698): mint the run-root
-        // identity once so both success and error events share it.
+        // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
         let domain = urls
             .first()
@@ -241,15 +243,10 @@ impl McpHandler {
                 } else {
                     Outcome::Partial
                 };
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "scrape_batch",
-                    domain,
-                    outcome: outcome_type,
-                    count,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new("scrape_batch", domain, outcome_type, count, start.elapsed())
+                        .with_identity(&root_correlation),
+                );
                 tracing::info!(
                     "batch scrape complete: {} pages, {} failed",
                     outcome.results.len(),
@@ -262,15 +259,16 @@ impl McpHandler {
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "scrape_batch",
-                    domain,
-                    outcome: Outcome::Error,
-                    count,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "scrape_batch",
+                        domain,
+                        Outcome::Error,
+                        count,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 tracing::error!("batch scrape failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -302,8 +300,7 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&seed_url).await?;
 
         let start = Instant::now();
-        // An MCP tool call IS an operation (#501/#698): mint the run-root
-        // identity at handler entry so both success and error events share it.
+        // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
         let crawler_config = webfang_core::domain::CrawlerConfig::builder(seed_url)
             .max_depth(params.max_depth.unwrap_or(3))
@@ -313,15 +310,16 @@ impl McpHandler {
         match webfang_core::application::crawler::crawl_site(crawler_config).await {
             Ok(result) => {
                 let count = result.total_pages;
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "crawl_site",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Success,
-                    count,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "crawl_site",
+                        domain_of(&params.url),
+                        Outcome::Success,
+                        count,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 let urls: Vec<String> = result.urls.iter().map(|u| u.url.to_string()).collect();
                 let json = serde_json::json!({
                     "urls": urls,
@@ -335,15 +333,16 @@ impl McpHandler {
                 )]))
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "crawl_site",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Error,
-                    count: 0,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "crawl_site",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
         }
@@ -375,8 +374,7 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&seed_url).await?;
 
         let start = Instant::now();
-        // An MCP tool call IS an operation (#501/#698): mint the run-root
-        // identity at handler entry so both success and error events share it.
+        // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
         let config = webfang_core::domain::CrawlerConfig::new(seed_url);
 
@@ -389,15 +387,16 @@ impl McpHandler {
         {
             Ok(urls) => {
                 let count = urls.len();
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "crawl_with_sitemap",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Success,
-                    count,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "crawl_with_sitemap",
+                        domain_of(&params.url),
+                        Outcome::Success,
+                        count,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 tracing::info!("sitemap crawl complete: {} urls found", urls.len());
                 let url_strings: Vec<String> = urls.iter().map(|u| u.url.to_string()).collect();
                 Ok(CallToolResult::success(vec![Content::text(
@@ -406,15 +405,16 @@ impl McpHandler {
                 )]))
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "crawl_with_sitemap",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Error,
-                    count: 0,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "crawl_with_sitemap",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 tracing::error!("sitemap crawl failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -443,8 +443,7 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&url).await?;
 
         let start = Instant::now();
-        // An MCP tool call IS an operation (#501/#698): mint the run-root
-        // identity once; all outcome events of this discovery share it.
+        // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
         let port = self.state.container.http_client();
         match port.get(url.as_str()).await {
@@ -453,15 +452,16 @@ impl McpHandler {
                 // discovery, not an empty link set (issue #606). Surface it as
                 // a tool error rather than a misleading empty `[]`.
                 if !(200..=299).contains(&resp.status) {
-                    self.state.record_scrape(ScrapeEvent {
-                        tool: "discover_urls",
-                        domain: domain_of(&params.url),
-                        outcome: Outcome::Error,
-                        count: 0,
-                        duration: start.elapsed(),
-                        trace_id: Some(root_correlation.trace_id().to_string()),
-                        correlation_id: Some(root_correlation.to_traceparent()),
-                    });
+                    self.state.record_scrape(
+                        ScrapeEvent::new(
+                            "discover_urls",
+                            domain_of(&params.url),
+                            Outcome::Error,
+                            0,
+                            start.elapsed(),
+                        )
+                        .with_identity(&root_correlation),
+                    );
                     return Ok(CallToolResult::error(vec![Content::text(format!(
                         "HTTP error: status {}",
                         resp.status
@@ -471,43 +471,46 @@ impl McpHandler {
                 match webfang_core::infrastructure::crawler::extract_links(&html, &params.url) {
                     Ok(links) => {
                         let count = links.len();
-                        self.state.record_scrape(ScrapeEvent {
-                            tool: "discover_urls",
-                            domain: domain_of(&params.url),
-                            outcome: Outcome::Success,
-                            count,
-                            duration: start.elapsed(),
-                            trace_id: Some(root_correlation.trace_id().to_string()),
-                            correlation_id: Some(root_correlation.to_traceparent()),
-                        });
+                        self.state.record_scrape(
+                            ScrapeEvent::new(
+                                "discover_urls",
+                                domain_of(&params.url),
+                                Outcome::Success,
+                                count,
+                                start.elapsed(),
+                            )
+                            .with_identity(&root_correlation),
+                        );
                         let content = serde_json::to_string_pretty(&links)
                             .unwrap_or_else(|_| "failed to serialize".into());
                         Ok(CallToolResult::success(vec![Content::text(content)]))
                     },
                     Err(e) => {
-                        self.state.record_scrape(ScrapeEvent {
-                            tool: "discover_urls",
-                            domain: domain_of(&params.url),
-                            outcome: Outcome::Error,
-                            count: 0,
-                            duration: start.elapsed(),
-                            trace_id: Some(root_correlation.trace_id().to_string()),
-                            correlation_id: Some(root_correlation.to_traceparent()),
-                        });
+                        self.state.record_scrape(
+                            ScrapeEvent::new(
+                                "discover_urls",
+                                domain_of(&params.url),
+                                Outcome::Error,
+                                0,
+                                start.elapsed(),
+                            )
+                            .with_identity(&root_correlation),
+                        );
                         Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
                     },
                 }
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "discover_urls",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Error,
-                    count: 0,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "discover_urls",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 Ok(CallToolResult::error(vec![Content::text(format!(
                     "HTTP error: {e}"
                 ))]))
@@ -537,8 +540,7 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&seed).await?;
 
         let start = Instant::now();
-        // An MCP tool call IS an operation (#501/#698): mint the run-root
-        // identity at handler entry so both success and error events share it.
+        // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
         let crawler_config = webfang_core::domain::CrawlerConfig::new(seed);
 
@@ -551,30 +553,32 @@ impl McpHandler {
         {
             Ok(discovered) => {
                 let count = discovered.len();
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "discover_sitemap",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Success,
-                    count,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "discover_sitemap",
+                        domain_of(&params.url),
+                        Outcome::Success,
+                        count,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 let urls: Vec<String> = discovered.into_iter().map(|d| d.url.to_string()).collect();
                 let content = serde_json::to_string_pretty(&urls)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "discover_sitemap",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Error,
-                    count: 0,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "discover_sitemap",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
         }
@@ -604,21 +608,21 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&url).await?;
 
         let start = Instant::now();
-        // An MCP tool call IS an operation (#501/#698): mint the run-root
-        // identity at handler entry so both success and error events share it.
+        // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
         let port = self.state.container.http_client();
         match port.get(url.as_str()).await {
             Ok(resp) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "detect_spa",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Success,
-                    count: 1,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "detect_spa",
+                        domain_of(&params.url),
+                        Outcome::Success,
+                        1,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 let html = resp.body;
                 let text = webfang_core::infrastructure::scraper::fallback::extract_text(&html);
                 match webfang_core::application::scraper_service::detect_spa_content(
@@ -643,15 +647,16 @@ impl McpHandler {
                 }
             },
             Err(e) => {
-                self.state.record_scrape(ScrapeEvent {
-                    tool: "detect_spa",
-                    domain: domain_of(&params.url),
-                    outcome: Outcome::Error,
-                    count: 0,
-                    duration: start.elapsed(),
-                    trace_id: Some(root_correlation.trace_id().to_string()),
-                    correlation_id: Some(root_correlation.to_traceparent()),
-                });
+                self.state.record_scrape(
+                    ScrapeEvent::new(
+                        "detect_spa",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start.elapsed(),
+                    )
+                    .with_identity(&root_correlation),
+                );
                 Ok(CallToolResult::error(vec![Content::text(format!(
                     "HTTP error: {e}"
                 ))]))

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -4,7 +4,7 @@
 //! crawl_with_sitemap, discover_urls, discover_sitemap, detect_spa
 
 use super::McpHandler;
-use crate::mcp_server::metrics::{domain_of, Outcome, ScrapeEvent};
+use crate::mcp_server::metrics::{domain_of, Outcome};
 use crate::mcp_server::params::*;
 use crate::mcp_server::selector_service;
 use rmcp::handler::server::tool::ToolRouter;
@@ -50,30 +50,26 @@ impl McpHandler {
         {
             Ok(results) => {
                 let count = results.len();
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "scrape_url",
-                        domain_of(&params.url),
-                        Outcome::Success,
-                        count,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "scrape_url",
+                    domain_of(&params.url),
+                    Outcome::Success,
+                    count,
+                    start,
+                    &root_correlation,
                 );
                 let content = serde_json::to_string_pretty(&results)
                     .unwrap_or_else(|_| "failed to serialize".into());
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "scrape_url",
-                        domain_of(&params.url),
-                        Outcome::Error,
-                        0,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "scrape_url",
+                    domain_of(&params.url),
+                    Outcome::Error,
+                    0,
+                    start,
+                    &root_correlation,
                 );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -141,15 +137,13 @@ impl McpHandler {
         {
             Ok(outcome) => {
                 let count = outcome.results.len();
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "scrape_with_options",
-                        domain_of(&params.url),
-                        Outcome::Success,
-                        count,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "scrape_with_options",
+                    domain_of(&params.url),
+                    Outcome::Success,
+                    count,
+                    start,
+                    &root_correlation,
                 );
                 let response = selector_service::build_scrape_response(
                     outcome.results,
@@ -161,15 +155,13 @@ impl McpHandler {
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "scrape_with_options",
-                        domain_of(&params.url),
-                        Outcome::Error,
-                        0,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "scrape_with_options",
+                    domain_of(&params.url),
+                    Outcome::Error,
+                    0,
+                    start,
+                    &root_correlation,
                 );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -243,9 +235,13 @@ impl McpHandler {
                 } else {
                     Outcome::Partial
                 };
-                self.state.record_scrape(
-                    ScrapeEvent::new("scrape_batch", domain, outcome_type, count, start.elapsed())
-                        .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "scrape_batch",
+                    domain,
+                    outcome_type,
+                    count,
+                    start,
+                    &root_correlation,
                 );
                 tracing::info!(
                     "batch scrape complete: {} pages, {} failed",
@@ -259,15 +255,13 @@ impl McpHandler {
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "scrape_batch",
-                        domain,
-                        Outcome::Error,
-                        count,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "scrape_batch",
+                    domain,
+                    Outcome::Error,
+                    count,
+                    start,
+                    &root_correlation,
                 );
                 tracing::error!("batch scrape failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
@@ -310,15 +304,13 @@ impl McpHandler {
         match webfang_core::application::crawler::crawl_site(crawler_config).await {
             Ok(result) => {
                 let count = result.total_pages;
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "crawl_site",
-                        domain_of(&params.url),
-                        Outcome::Success,
-                        count,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "crawl_site",
+                    domain_of(&params.url),
+                    Outcome::Success,
+                    count,
+                    start,
+                    &root_correlation,
                 );
                 let urls: Vec<String> = result.urls.iter().map(|u| u.url.to_string()).collect();
                 let json = serde_json::json!({
@@ -333,15 +325,13 @@ impl McpHandler {
                 )]))
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "crawl_site",
-                        domain_of(&params.url),
-                        Outcome::Error,
-                        0,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "crawl_site",
+                    domain_of(&params.url),
+                    Outcome::Error,
+                    0,
+                    start,
+                    &root_correlation,
                 );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -387,15 +377,13 @@ impl McpHandler {
         {
             Ok(urls) => {
                 let count = urls.len();
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "crawl_with_sitemap",
-                        domain_of(&params.url),
-                        Outcome::Success,
-                        count,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "crawl_with_sitemap",
+                    domain_of(&params.url),
+                    Outcome::Success,
+                    count,
+                    start,
+                    &root_correlation,
                 );
                 tracing::info!("sitemap crawl complete: {} urls found", urls.len());
                 let url_strings: Vec<String> = urls.iter().map(|u| u.url.to_string()).collect();
@@ -405,15 +393,13 @@ impl McpHandler {
                 )]))
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "crawl_with_sitemap",
-                        domain_of(&params.url),
-                        Outcome::Error,
-                        0,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "crawl_with_sitemap",
+                    domain_of(&params.url),
+                    Outcome::Error,
+                    0,
+                    start,
+                    &root_correlation,
                 );
                 tracing::error!("sitemap crawl failed: {}", e);
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
@@ -452,15 +438,13 @@ impl McpHandler {
                 // discovery, not an empty link set (issue #606). Surface it as
                 // a tool error rather than a misleading empty `[]`.
                 if !(200..=299).contains(&resp.status) {
-                    self.state.record_scrape(
-                        ScrapeEvent::new(
-                            "discover_urls",
-                            domain_of(&params.url),
-                            Outcome::Error,
-                            0,
-                            start.elapsed(),
-                        )
-                        .with_identity(&root_correlation),
+                    self.state.record_scrape_identity(
+                        "discover_urls",
+                        domain_of(&params.url),
+                        Outcome::Error,
+                        0,
+                        start,
+                        &root_correlation,
                     );
                     return Ok(CallToolResult::error(vec![Content::text(format!(
                         "HTTP error: status {}",
@@ -471,45 +455,39 @@ impl McpHandler {
                 match webfang_core::infrastructure::crawler::extract_links(&html, &params.url) {
                     Ok(links) => {
                         let count = links.len();
-                        self.state.record_scrape(
-                            ScrapeEvent::new(
-                                "discover_urls",
-                                domain_of(&params.url),
-                                Outcome::Success,
-                                count,
-                                start.elapsed(),
-                            )
-                            .with_identity(&root_correlation),
+                        self.state.record_scrape_identity(
+                            "discover_urls",
+                            domain_of(&params.url),
+                            Outcome::Success,
+                            count,
+                            start,
+                            &root_correlation,
                         );
                         let content = serde_json::to_string_pretty(&links)
                             .unwrap_or_else(|_| "failed to serialize".into());
                         Ok(CallToolResult::success(vec![Content::text(content)]))
                     },
                     Err(e) => {
-                        self.state.record_scrape(
-                            ScrapeEvent::new(
-                                "discover_urls",
-                                domain_of(&params.url),
-                                Outcome::Error,
-                                0,
-                                start.elapsed(),
-                            )
-                            .with_identity(&root_correlation),
+                        self.state.record_scrape_identity(
+                            "discover_urls",
+                            domain_of(&params.url),
+                            Outcome::Error,
+                            0,
+                            start,
+                            &root_correlation,
                         );
                         Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
                     },
                 }
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "discover_urls",
-                        domain_of(&params.url),
-                        Outcome::Error,
-                        0,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "discover_urls",
+                    domain_of(&params.url),
+                    Outcome::Error,
+                    0,
+                    start,
+                    &root_correlation,
                 );
                 Ok(CallToolResult::error(vec![Content::text(format!(
                     "HTTP error: {e}"
@@ -553,15 +531,13 @@ impl McpHandler {
         {
             Ok(discovered) => {
                 let count = discovered.len();
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "discover_sitemap",
-                        domain_of(&params.url),
-                        Outcome::Success,
-                        count,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "discover_sitemap",
+                    domain_of(&params.url),
+                    Outcome::Success,
+                    count,
+                    start,
+                    &root_correlation,
                 );
                 let urls: Vec<String> = discovered.into_iter().map(|d| d.url.to_string()).collect();
                 let content = serde_json::to_string_pretty(&urls)
@@ -569,15 +545,13 @@ impl McpHandler {
                 Ok(CallToolResult::success(vec![Content::text(content)]))
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "discover_sitemap",
-                        domain_of(&params.url),
-                        Outcome::Error,
-                        0,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "discover_sitemap",
+                    domain_of(&params.url),
+                    Outcome::Error,
+                    0,
+                    start,
+                    &root_correlation,
                 );
                 Ok(CallToolResult::error(vec![Content::text(e.to_string())]))
             },
@@ -613,15 +587,13 @@ impl McpHandler {
         let port = self.state.container.http_client();
         match port.get(url.as_str()).await {
             Ok(resp) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "detect_spa",
-                        domain_of(&params.url),
-                        Outcome::Success,
-                        1,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "detect_spa",
+                    domain_of(&params.url),
+                    Outcome::Success,
+                    1,
+                    start,
+                    &root_correlation,
                 );
                 let html = resp.body;
                 let text = webfang_core::infrastructure::scraper::fallback::extract_text(&html);
@@ -647,15 +619,13 @@ impl McpHandler {
                 }
             },
             Err(e) => {
-                self.state.record_scrape(
-                    ScrapeEvent::new(
-                        "detect_spa",
-                        domain_of(&params.url),
-                        Outcome::Error,
-                        0,
-                        start.elapsed(),
-                    )
-                    .with_identity(&root_correlation),
+                self.state.record_scrape_identity(
+                    "detect_spa",
+                    domain_of(&params.url),
+                    Outcome::Error,
+                    0,
+                    start,
+                    &root_correlation,
                 );
                 Ok(CallToolResult::error(vec![Content::text(format!(
                     "HTTP error: {e}"

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -440,15 +440,13 @@ mod tests {
         use std::time::Duration;
 
         let mut metrics = ScrapeMetrics::default();
-        metrics.record(ScrapeEvent {
-            tool: "scrape_url",
-            domain: "example.com".to_string(),
-            outcome: Outcome::Success,
-            count: 4,
-            duration: Duration::from_millis(100),
-            trace_id: None,
-            correlation_id: None,
-        });
+        metrics.record(ScrapeEvent::new(
+            "scrape_url",
+            "example.com".to_string(),
+            Outcome::Success,
+            4,
+            Duration::from_millis(100),
+        ));
         let snapshot = metrics.snapshot();
         let result = render_metrics(&snapshot);
 
@@ -627,15 +625,13 @@ mod tests {
         let handler = McpHandler::new(state.clone());
         use crate::mcp_server::metrics::{Outcome, ScrapeEvent};
         use std::time::Duration;
-        state.record_scrape(ScrapeEvent {
-            tool: "scrape_url",
-            domain: "example.com".to_string(),
-            outcome: Outcome::Success,
-            count: 1,
-            duration: Duration::from_millis(5),
-            trace_id: None,
-            correlation_id: None,
-        });
+        state.record_scrape(ScrapeEvent::new(
+            "scrape_url",
+            "example.com".to_string(),
+            Outcome::Success,
+            1,
+            Duration::from_millis(5),
+        ));
         let res = handler
             .get_scrape_metrics()
             .await

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -446,6 +446,8 @@ mod tests {
             outcome: Outcome::Success,
             count: 4,
             duration: Duration::from_millis(100),
+            trace_id: None,
+            correlation_id: None,
         });
         let snapshot = metrics.snapshot();
         let result = render_metrics(&snapshot);
@@ -631,6 +633,8 @@ mod tests {
             outcome: Outcome::Success,
             count: 1,
             duration: Duration::from_millis(5),
+            trace_id: None,
+            correlation_id: None,
         });
         let res = handler
             .get_scrape_metrics()

--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -86,8 +86,9 @@ impl ScrapeEvent {
     /// `correlation_id`, so the metric event is reconstructable with the run
     /// trace. An MCP tool call IS an operation (#501) — handlers mint one
     /// identity at entry and share it across the call's success/error events
-    /// through this single constructor, which is the only place that wires
-    /// [`CorrelationId`] into a [`ScrapeEvent`].
+    /// through this single constructor, which is the only place that wires a
+    /// [`CorrelationId`](webfang_core::domain::CorrelationId) into a
+    /// [`ScrapeEvent`].
     #[must_use]
     pub fn identified(
         tool: &'static str,

--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -60,6 +60,40 @@ pub struct ScrapeEvent {
     pub correlation_id: Option<String>,
 }
 
+impl ScrapeEvent {
+    /// Build a scrape event without run identity (test / synthetic events).
+    #[must_use]
+    pub fn new(
+        tool: &'static str,
+        domain: String,
+        outcome: Outcome,
+        count: usize,
+        duration: Duration,
+    ) -> Self {
+        Self {
+            tool,
+            domain,
+            outcome,
+            count,
+            duration,
+            trace_id: None,
+            correlation_id: None,
+        }
+    }
+
+    /// Attach the tool call's run-root identity (#698): the run-trace UUID as
+    /// `trace_id` plus the W3C traceparent as `correlation_id`, so the metric
+    /// event is reconstructable with the run trace. An MCP tool call IS an
+    /// operation (#501) — handlers mint one identity at entry and share it
+    /// across the call's success/error events via this method.
+    #[must_use]
+    pub fn with_identity(mut self, correlation: &webfang_core::domain::CorrelationId) -> Self {
+        self.trace_id = Some(correlation.trace_id().to_string());
+        self.correlation_id = Some(correlation.to_traceparent());
+        self
+    }
+}
+
 /// Per-domain aggregate (REQ-02).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct DomainStats {
@@ -208,33 +242,27 @@ mod tests {
     /// and 1 error event on `b.com` (count 0), durations 100/200/300ms, all via
     /// the `scrape_url` tool. Mean duration = (100+200+300)/3 = 200ms.
     fn record_fixture(m: &mut ScrapeMetrics) {
-        m.record(ScrapeEvent {
-            tool: "scrape_url",
-            domain: "a.com".to_string(),
-            outcome: Outcome::Success,
-            count: 3,
-            duration: Duration::from_millis(100),
-            trace_id: None,
-            correlation_id: None,
-        });
-        m.record(ScrapeEvent {
-            tool: "scrape_url",
-            domain: "a.com".to_string(),
-            outcome: Outcome::Success,
-            count: 5,
-            duration: Duration::from_millis(200),
-            trace_id: None,
-            correlation_id: None,
-        });
-        m.record(ScrapeEvent {
-            tool: "scrape_url",
-            domain: "b.com".to_string(),
-            outcome: Outcome::Error,
-            count: 0,
-            duration: Duration::from_millis(300),
-            trace_id: None,
-            correlation_id: None,
-        });
+        m.record(ScrapeEvent::new(
+            "scrape_url",
+            "a.com".to_string(),
+            Outcome::Success,
+            3,
+            Duration::from_millis(100),
+        ));
+        m.record(ScrapeEvent::new(
+            "scrape_url",
+            "a.com".to_string(),
+            Outcome::Success,
+            5,
+            Duration::from_millis(200),
+        ));
+        m.record(ScrapeEvent::new(
+            "scrape_url",
+            "b.com".to_string(),
+            Outcome::Error,
+            0,
+            Duration::from_millis(300),
+        ));
     }
 
     /// REQ-02: aggregates accumulate exactly (counts, per-domain, timing mean).
@@ -280,15 +308,13 @@ mod tests {
         );
 
         let mut m = ScrapeMetrics::default();
-        m.record(ScrapeEvent {
-            tool: "scrape_url",
-            domain: domain_of("not a url"),
-            outcome: Outcome::Success,
-            count: 1,
-            duration: Duration::from_millis(50),
-            trace_id: None,
-            correlation_id: None,
-        });
+        m.record(ScrapeEvent::new(
+            "scrape_url",
+            domain_of("not a url"),
+            Outcome::Success,
+            1,
+            Duration::from_millis(50),
+        ));
 
         let snap = m.snapshot();
         assert_eq!(snap.total_events, 1, "unknown-domain event still counted");
@@ -352,15 +378,13 @@ mod tests {
         for _ in 0..100 {
             let m = Arc::clone(&metrics);
             handles.push(tokio::spawn(async move {
-                m.lock().expect("metrics mutex").record(ScrapeEvent {
-                    tool: "scrape_url",
-                    domain: "a.com".to_string(),
-                    outcome: Outcome::Success,
-                    count: 1,
-                    duration: Duration::from_millis(1),
-                    trace_id: None,
-                    correlation_id: None,
-                });
+                m.lock().expect("metrics mutex").record(ScrapeEvent::new(
+                    "scrape_url",
+                    "a.com".to_string(),
+                    Outcome::Success,
+                    1,
+                    Duration::from_millis(1),
+                ));
             }));
         }
         for h in handles {
@@ -447,17 +471,17 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(layer);
 
         tracing::subscriber::with_default(subscriber, || {
-            ScrapeMetrics::default().record(ScrapeEvent {
-                tool: "scrape_url",
-                domain: "example.com".to_string(),
-                outcome: Outcome::Success,
-                count: 3,
-                duration: Duration::from_millis(120),
-                trace_id: Some("01949e0e-8b8e-7000-8000-000000000001".to_string()),
-                correlation_id: Some(
-                    "00-01949e0e8b8e70008000000000000001-0000000000000042-01".to_string(),
-                ),
-            });
+            let mut event = ScrapeEvent::new(
+                "scrape_url",
+                "example.com".to_string(),
+                Outcome::Success,
+                3,
+                Duration::from_millis(120),
+            );
+            event.trace_id = Some("01949e0e-8b8e-7000-8000-000000000001".to_string());
+            event.correlation_id =
+                Some("00-01949e0e8b8e70008000000000000001-0000000000000042-01".to_string());
+            ScrapeMetrics::default().record(event);
         });
 
         let captured = events.lock().expect("capture mutex");
@@ -537,15 +561,13 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(layer);
 
         tracing::subscriber::with_default(subscriber, || {
-            ScrapeMetrics::default().record(ScrapeEvent {
-                tool: "scrape_url",
-                domain: "example.com".to_string(),
-                outcome: Outcome::Success,
-                count: 1,
-                duration: Duration::from_millis(10),
-                trace_id: None,
-                correlation_id: None,
-            });
+            ScrapeMetrics::default().record(ScrapeEvent::new(
+                "scrape_url",
+                "example.com".to_string(),
+                Outcome::Success,
+                1,
+                Duration::from_millis(10),
+            ));
         });
 
         let keys = keys.lock().expect("keys mutex");

--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -51,6 +51,13 @@ pub struct ScrapeEvent {
     pub count: usize,
     /// Wall-clock duration of the operation.
     pub duration: Duration,
+    /// Run-trace UUID (hex, dashed) of the tool call that produced this event;
+    /// `Some` for handlers that mint a run-root identity (#698), `None` when
+    /// the operation has no identity (e.g. synthetic test events).
+    pub trace_id: Option<String>,
+    /// W3C traceparent of the tool call's run-root identity (#698); pairs with
+    /// `trace_id` so the metric event is reconstructable with the run trace.
+    pub correlation_id: Option<String>,
 }
 
 /// Per-domain aggregate (REQ-02).
@@ -94,6 +101,8 @@ impl ScrapeMetrics {
             success = event.outcome.is_success(),
             duration_ms = event.duration.as_millis() as u64,
             pages = event.count,
+            trace_id = event.trace_id.clone(),
+            correlation_id = event.correlation_id.clone(),
             "scrape recorded"
         );
 
@@ -205,6 +214,8 @@ mod tests {
             outcome: Outcome::Success,
             count: 3,
             duration: Duration::from_millis(100),
+            trace_id: None,
+            correlation_id: None,
         });
         m.record(ScrapeEvent {
             tool: "scrape_url",
@@ -212,6 +223,8 @@ mod tests {
             outcome: Outcome::Success,
             count: 5,
             duration: Duration::from_millis(200),
+            trace_id: None,
+            correlation_id: None,
         });
         m.record(ScrapeEvent {
             tool: "scrape_url",
@@ -219,6 +232,8 @@ mod tests {
             outcome: Outcome::Error,
             count: 0,
             duration: Duration::from_millis(300),
+            trace_id: None,
+            correlation_id: None,
         });
     }
 
@@ -271,6 +286,8 @@ mod tests {
             outcome: Outcome::Success,
             count: 1,
             duration: Duration::from_millis(50),
+            trace_id: None,
+            correlation_id: None,
         });
 
         let snap = m.snapshot();
@@ -341,6 +358,8 @@ mod tests {
                     outcome: Outcome::Success,
                     count: 1,
                     duration: Duration::from_millis(1),
+                    trace_id: None,
+                    correlation_id: None,
                 });
             }));
         }
@@ -434,6 +453,10 @@ mod tests {
                 outcome: Outcome::Success,
                 count: 3,
                 duration: Duration::from_millis(120),
+                trace_id: Some("01949e0e-8b8e-7000-8000-000000000001".to_string()),
+                correlation_id: Some(
+                    "00-01949e0e8b8e70008000000000000001-0000000000000042-01".to_string(),
+                ),
             });
         });
 
@@ -457,5 +480,79 @@ mod tests {
             "duration_ms field"
         );
         assert_eq!(field("pages").as_deref(), Some("3"), "pages field");
+        assert_eq!(
+            field("trace_id").as_deref(),
+            Some("01949e0e-8b8e-7000-8000-000000000001"),
+            "trace_id field"
+        );
+        assert_eq!(
+            field("correlation_id").as_deref(),
+            Some("00-01949e0e8b8e70008000000000000001-0000000000000042-01"),
+            "correlation_id field"
+        );
+    }
+
+    /// #698: events with no identity (`None` trace_id/correlation_id — e.g.
+    /// synthetic test events) must emit NO trace_id/correlation_id fields at
+    /// all, so the presence of a key always implies a real identity.
+    #[test]
+    #[serial]
+    fn record_omits_identity_when_none() {
+        ensure_global_subscriber();
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::layer::Layer;
+        use tracing_subscriber::prelude::*;
+
+        /// Collects field names only (values are irrelevant here).
+        struct Keys(Arc<Mutex<Vec<String>>>);
+
+        impl Visit for Keys {
+            fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
+                self.0
+                    .lock()
+                    .expect("keys mutex")
+                    .push(field.name().to_string());
+            }
+        }
+
+        struct KeysLayer {
+            keys: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl<S: tracing::Subscriber> Layer<S> for KeysLayer {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let mut visitor = Keys(Arc::clone(&self.keys));
+                event.record(&mut visitor);
+            }
+        }
+
+        let keys = Arc::new(Mutex::new(Vec::new()));
+        let layer = KeysLayer {
+            keys: Arc::clone(&keys),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            ScrapeMetrics::default().record(ScrapeEvent {
+                tool: "scrape_url",
+                domain: "example.com".to_string(),
+                outcome: Outcome::Success,
+                count: 1,
+                duration: Duration::from_millis(10),
+                trace_id: None,
+                correlation_id: None,
+            });
+        });
+
+        let keys = keys.lock().expect("keys mutex");
+        assert!(!keys.contains(&"trace_id".to_string()), "no trace_id key");
+        assert!(
+            !keys.contains(&"correlation_id".to_string()),
+            "no correlation_id key"
+        );
     }
 }

--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -81,16 +81,26 @@ impl ScrapeEvent {
         }
     }
 
-    /// Attach the tool call's run-root identity (#698): the run-trace UUID as
-    /// `trace_id` plus the W3C traceparent as `correlation_id`, so the metric
-    /// event is reconstructable with the run trace. An MCP tool call IS an
-    /// operation (#501) — handlers mint one identity at entry and share it
-    /// across the call's success/error events via this method.
+    /// Build a scrape event stamped with the tool call's run-root identity
+    /// (#698): the run-trace UUID as `trace_id` plus the W3C traceparent as
+    /// `correlation_id`, so the metric event is reconstructable with the run
+    /// trace. An MCP tool call IS an operation (#501) — handlers mint one
+    /// identity at entry and share it across the call's success/error events
+    /// through this single constructor, which is the only place that wires
+    /// [`CorrelationId`] into a [`ScrapeEvent`].
     #[must_use]
-    pub fn with_identity(mut self, correlation: &webfang_core::domain::CorrelationId) -> Self {
-        self.trace_id = Some(correlation.trace_id().to_string());
-        self.correlation_id = Some(correlation.to_traceparent());
-        self
+    pub fn identified(
+        tool: &'static str,
+        domain: String,
+        outcome: Outcome,
+        count: usize,
+        duration: Duration,
+        correlation: &webfang_core::domain::CorrelationId,
+    ) -> Self {
+        let mut event = Self::new(tool, domain, outcome, count, duration);
+        event.trace_id = Some(correlation.trace_id().to_string());
+        event.correlation_id = Some(correlation.to_traceparent());
+        event
     }
 }
 

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -166,6 +166,27 @@ impl McpState {
             .record(event);
     }
 
+    /// Record a scrape event stamped with the tool call's run-root identity.
+    ///
+    /// The sole call-side helper for identified scrape metrics (#698): it owns
+    /// the [`ScrapeEvent::identified`] construction so each MCP tool handler is
+    /// a one-line record call. `start` is the operation's start instant and is
+    /// converted to an elapsed [`Duration`] here, keeping timing bookkeeping in
+    /// one place.
+    pub fn record_scrape_identity(
+        &self,
+        tool: &'static str,
+        domain: String,
+        outcome: crate::mcp_server::metrics::Outcome,
+        count: usize,
+        start: std::time::Instant,
+        correlation: &webfang_core::domain::CorrelationId,
+    ) {
+        let event =
+            ScrapeEvent::identified(tool, domain, outcome, count, start.elapsed(), correlation);
+        self.record_scrape(event);
+    }
+
     /// Produce a point-in-time metrics snapshot from the shared accumulator.
     ///
     /// REQ-07: lock → clone snapshot → release. REQ-10: poison recovery, never

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -171,8 +171,8 @@ impl McpState {
     /// The sole call-side helper for identified scrape metrics (#698): it owns
     /// the [`ScrapeEvent::identified`] construction so each MCP tool handler is
     /// a one-line record call. `start` is the operation's start instant and is
-    /// converted to an elapsed [`Duration`] here, keeping timing bookkeeping in
-    /// one place.
+    /// converted to an elapsed [`Duration`](std::time::Duration) here, keeping
+    /// timing bookkeeping in one place.
     pub fn record_scrape_identity(
         &self,
         tool: &'static str,

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -289,15 +289,13 @@ mod tests {
         );
 
         // A scrape recorded through one clone is visible from the other.
-        state.record_scrape(ScrapeEvent {
-            tool: "scrape_url",
-            domain: "a.com".to_string(),
-            outcome: Outcome::Success,
-            count: 2,
-            duration: Duration::from_millis(10),
-            trace_id: None,
-            correlation_id: None,
-        });
+        state.record_scrape(ScrapeEvent::new(
+            "scrape_url",
+            "a.com".to_string(),
+            Outcome::Success,
+            2,
+            Duration::from_millis(10),
+        ));
 
         let snap = state2.metrics_snapshot();
         assert_eq!(snap.total_events, 1, "record-through-clone is visible");

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -295,6 +295,8 @@ mod tests {
             outcome: Outcome::Success,
             count: 2,
             duration: Duration::from_millis(10),
+            trace_id: None,
+            correlation_id: None,
         });
 
         let snap = state2.metrics_snapshot();


### PR DESCRIPTION
## Linked Issue

Closes #698
Part of #704 (épica Fase 1 — trazabilidad, Paso 4 de 4)

#698 was consolidated into epic #704; this PR implements its fix: "Agregar trace_id + correlation_id a ScrapeEvent".

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- The MCP `"scrape recorded"` metrics event carried no trace identity — metric events were not reconstructable with the run trace (audit F14: "los datos de métricas no son reconstruibles").
- `ScrapeEvent` gains `trace_id` + `correlation_id` (`Option<String>`): `trace_id` is the run-trace UUID, `correlation_id` the W3C traceparent. Both are emitted by `ScrapeMetrics::record`; `None` is tracing-Empty, so the keys are omitted entirely when absent — presence of a key always implies a real identity.
- Every scraping tool call IS an operation (#501): all 8 handlers mint the run-root `CorrelationId` at handler entry (success and error events share one identity per call; `scrape_with_options` reuses its existing mint; `discover_urls` shares one mint across its 4 outcome events).
- Aggregates unchanged — identities are per-event fields, not part of `MetricsSnapshot` (REQ-08 snapshot serialization stays byte-stable).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_mcp/src/mcp_server/metrics.rs` | `trace_id`/`correlation_id` fields on `ScrapeEvent` + emission in `record`; tests for both paths (`record_emits_structured_tracing_event` extended, new `record_omits_identity_when_none`) |
| `crates/webfang_mcp/src/mcp_server/handlers/scraping.rs` | 8 handlers mint/reuse run-root identity; 18 record sites carry identity |
| `crates/webfang_mcp/src/mcp_server/handlers/security.rs` | 2 synthetic test events → `None` |
| `crates/webfang_mcp/src/mcp_server/state.rs` | 1 synthetic test event → `None` |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run -p webfang_mcp` — 240/240 PASS (1 skipped: pre-existing env-dependent `detect_obsidian_vault_none_when_not_a_vault`, unrelated to this diff)
- [x] No snapshot changes: `scrape recorded` tracing text is not snapshot-captured; `MetricsSnapshot` shape unchanged

## Contributor Checklist

- [x] Linked issue with `Closes #N`
- [x] Branch name matches `type/description`
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] No defensive error paths introduced (no LCOV needed)