### PR TITLE
test(mcp): live SSRF probe integration test with guard enabled

### DIFF
--- a/crates/webfang_mcp/tests/common/mod.rs
+++ b/crates/webfang_mcp/tests/common/mod.rs
@@ -9,10 +9,12 @@
 //! are intentionally `pub` but only a subset is used by any given binary, so the
 //! module carries `#![allow(dead_code)]`.
 //!
-//! **SSRf Note**: `start_test_server()` and related functions disable SSRF
+//! **SSRF Note**: `start_test_server()` and related functions disable SSRF
 //! protection by setting `WEBFANG_MCP_DISABLE_SSRF=1` before building the router.
 //! This is required because wiremock uses 127.0.0.1 for its mock HTTP server,
-//! which SSRF protection blocks by design.
+//! which SSRF protection blocks by design. The single exception is
+//! `start_test_server_ssrf_enabled()`, which intentionally leaves the guard ON
+//! to exercise it against forbidden addresses (issue #703 integration probe).
 
 #![allow(dead_code)]
 
@@ -35,6 +37,31 @@ fn init_ssrf_disabled() {
     });
 }
 
+/// Bind `app` to a random 127.0.0.1 port, serve it, and wait until it accepts
+/// connections. Returns the base URL and the server handle.
+///
+/// This is the shared tail of every server starter in this module — do not
+/// duplicate the bind/serve/wait sequence.
+pub async fn serve_on_random_port(app: axum::Router) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Wait for the server to accept TCP connections instead of a fixed sleep.
+    for _ in 0..20 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    (base_url, handle)
+}
+
 /// Start a test MCP server on a random port and return the base URL.
 ///
 /// NOTE: `Container::new` creates real HTTP clients (wreq) and a real service
@@ -53,23 +80,7 @@ pub async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
 
     let app = build_mcp_router(state, &ServerOptions::default());
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr: SocketAddr = listener.local_addr().unwrap();
-    let base_url = format!("http://{addr}");
-
-    let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-
-    // Wait for the server to accept TCP connections instead of a fixed sleep.
-    for _ in 0..20 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
-
-    (base_url, handle)
+    serve_on_random_port(app).await
 }
 
 /// Start a test MCP server on a random port. Pass `Some(downloader)` to inject
@@ -92,22 +103,7 @@ pub async fn start_server(
 
     let app = build_mcp_router(state, &ServerOptions::default());
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr: SocketAddr = listener.local_addr().unwrap();
-    let base_url = format!("http://{addr}");
-
-    let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-
-    for _ in 0..20 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
-
-    (base_url, handle)
+    serve_on_random_port(app).await
 }
 
 /// Start a test MCP server whose crawl-result repository is pre-seeded with
@@ -172,22 +168,31 @@ pub async fn start_seeded_server(
 
     let app = build_mcp_router(state, &ServerOptions::default());
 
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr: SocketAddr = listener.local_addr().unwrap();
-    let base_url = format!("http://{addr}");
-
-    let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-
-    for _ in 0..20 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
+    let (base_url, handle) = serve_on_random_port(app).await;
 
     (base_url, handle, container_tmp)
+}
+
+/// Start a test MCP server with SSRF protection ENABLED.
+///
+/// Every other starter sets `WEBFANG_MCP_DISABLE_SSRF=1` because wiremock binds
+/// 127.0.0.1; this one exists precisely to exercise the guard against those
+/// forbidden addresses (issue #703 integration probe). Tests using it must
+/// target IPs that fail validation BEFORE any fetch, so no mock server is
+/// needed. Also actively removes the disable flag in case a shared CI/parent
+/// environment exported it.
+pub async fn start_test_server_ssrf_enabled() -> (String, tokio::task::JoinHandle<()>) {
+    std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
+
+    let config = Config::default();
+    let container = Container::new(config.crawler, config.scraper)
+        .await
+        .expect("container creation failed");
+    let state = McpState::new(container);
+
+    let app = build_mcp_router(state, &ServerOptions::default());
+
+    serve_on_random_port(app).await
 }
 
 /// Build a JSON-RPC request body for MCP protocol.

--- a/crates/webfang_mcp/tests/ssrf_probe_test.rs
+++ b/crates/webfang_mcp/tests/ssrf_probe_test.rs
@@ -1,0 +1,133 @@
+//! SSRF integration probe — the guard tested LIVE with protection ENABLED.
+//!
+//! This is the ONLY MCP integration suite that runs with the SSRF guard ON
+//! (via `start_test_server_ssrf_enabled()`). Every other suite disables it
+//! through `WEBFANG_MCP_DISABLE_SSRF=1` because wiremock binds 127.0.0.1.
+//!
+//! Proves #703 Paso 1's "live criterion": IPv4-mapped IPv6 loopback,
+//! cloud-metadata, and CGNAT targets are rejected at the PROTOCOL level —
+//! JSON-RPC `error.code == -32602` (invalid params) — BEFORE any fetch is
+//! attempted. That is, a forbidden target can never surface as a tool result
+//! (`isError:true`) with the HTTP fetch already performed.
+//!
+//! No mock server, no network: the guard resolves the target host and fails
+//! during DNS validation. IP literals are resolved locally by
+//! `tokio::net::lookup_host`, so no listener is needed on the (closed)
+//! discarded port and the behavior is fully deterministic.
+
+#![cfg(feature = "mcp")]
+
+mod common;
+use common::*;
+
+use serde_json::json;
+use wreq::Client;
+
+/// JSON-RPC standard error code for "Invalid params" (JSON-RPC 2.0 spec) —
+/// the protocol-level code `McpError::invalid_params` maps to.
+const JSONRPC_INVALID_PARAMS: i64 = -32602;
+
+/// Exact Spanish prefix of the SSRF rejection message built in
+/// `src/mcp_server/ssrf.rs` ("SSRF detectado: IP {ip} prohibida ...").
+const SSRF_ERROR_PREFIX: &str = "SSRF detectado";
+
+/// Assert that `resp` is a JSON-RPC protocol error with code -32602 whose
+/// message carries the SSRF rejection text (same assertion style as
+/// `test_export_invalid_format_hard_error` in `mcp_behavioral_test.rs`).
+fn assert_ssrf_rejection(resp: serde_json::Value, url: &str) {
+    let error = resp
+        .get("error")
+        .unwrap_or_else(|| panic!("scrape_url({url}) must return a JSON-RPC error, got: {resp}"));
+    let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+    assert_eq!(
+        code, JSONRPC_INVALID_PARAMS,
+        "scrape_url({url}) must map to JSON-RPC invalid-params (-32602), got: {resp}"
+    );
+    let message = error.get("message").and_then(|m| m.as_str()).unwrap_or("");
+    assert!(
+        message.contains(SSRF_ERROR_PREFIX),
+        "scrape_url({url}) error message must contain {SSRF_ERROR_PREFIX:?}, got: {resp}"
+    );
+}
+
+/// IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`) must be caught by the guard
+/// before any fetch — a plain protocol error, never a tool error.
+#[tokio::test]
+async fn mapped_loopback_probe_returns_32602() {
+    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_url",
+        json!({ "url": "http://[::ffff:127.0.0.1]:9/" }),
+    )
+    .await;
+
+    assert_ssrf_rejection(resp, "http://[::ffff:127.0.0.1]:9/");
+}
+
+/// IPv4-mapped IPv6 cloud-metadata endpoint (`::ffff:169.254.169.254`) — the
+/// canonical SSRF target — must be caught before any fetch.
+#[tokio::test]
+async fn mapped_metadata_probe_returns_32602() {
+    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_url",
+        json!({ "url": "http://[::ffff:169.254.169.254]:9/" }),
+    )
+    .await;
+
+    assert_ssrf_rejection(resp, "http://[::ffff:169.254.169.254]:9/");
+}
+
+/// IPv4-mapped IPv6 CGNAT address (`::ffff:100.64.0.1`) must be caught before
+/// any fetch.
+#[tokio::test]
+async fn mapped_cgnat_probe_returns_32602() {
+    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_url",
+        json!({ "url": "http://[::ffff:100.64.0.1]:9/" }),
+    )
+    .await;
+
+    assert_ssrf_rejection(resp, "http://[::ffff:100.64.0.1]:9/");
+}
+
+/// Negative control: plain IPv4 loopback (`127.0.0.1`) is also rejected, which
+/// proves the guard is genuinely ENABLED in this binary. If the disable flag
+/// had leaked, this would fail with a connection-refused TOOL error instead of
+/// a protocol-level `-32602`.
+#[tokio::test]
+async fn plain_loopback_probe_returns_32602() {
+    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_url",
+        json!({ "url": "http://127.0.0.1:9/" }),
+    )
+    .await;
+
+    assert_ssrf_rejection(resp, "http://127.0.0.1:9/");
+}


### PR DESCRIPTION
## Linked Issue

Closes #703 — final acceptance criterion of the Fase 0 epic (Paso 1 'criterio de done': *probe en vivo devolviendo -32602*), which landed without this integration probe. The fixes themselves are already in main via #710 and #714.

## PR Type

- [x] Maintenance / tooling (`type:chore`) — test-only, no production behavior change

## Summary

- The #703 audit (comments §4 and Paso 1 'Evidencia') required a **live probe**: an MCP request targeting `http://[::ffff:127.0.0.1]:<port>/...` with SSRF protection ON must return JSON-RPC `-32602`. Every existing MCP integration suite sets `WEBFANG_MCP_DISABLE_SSRF=1` (wiremock binds 127.0.0.1), so the guard had only ever been proven at unit + proptest level — never end-to-end against a live server.
- This PR adds the only MCP integration suite that runs with the guard **enabled**, closing the 100% evidence requirement of #703.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_mcp/tests/ssrf_probe_test.rs` | **New**: 4 probes — `scrape_url` against `::ffff:127.0.0.1`, `::ffff:169.254.169.254`, `::ffff:100.64.0.1`, plus a plain `127.0.0.1` negative control proving the guard is genuinely ON. Each asserts wire-level `error.code == -32602` + Spanish `SSRF detectado` message. No mock server/network needed: IP literals resolve locally and the guard fires before any fetch (deterministic, no `#[ignore]`) |
| `crates/webfang_mcp/tests/common/mod.rs` | Extracted `serve_on_random_port()` — the duplicated bind/serve/wait tail shared by all starters is now a single function; added `start_test_server_ssrf_enabled()` (the only starter leaving the guard on, with `remove_var` to harden against a leaked env flag); zero behavior change for existing suites |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run -p webfang_mcp --test ssrf_probe_test --features mcp` — **4/4 passed**
- [x] `cargo nextest run -p webfang_mcp --all-features` — 314 passed, 5 skipped; the single failure is the pre-existing environment-specific obsidian-vault detection test (fails identically on clean main)
- [x] Duplication ratchet: 7715 lines vs baseline 7728 — the harness dedupe *lowers* the count

## Notes

- Test-only: zero production-code changes; the guard behavior being asserted is exactly what #710 shipped.
- Pattern mirrors `test_export_invalid_format_hard_error` (protocol-level `-32602` assertions, plain asserts, deterministic messages).
- Suite gated `#![cfg(feature = "mcp")]` like all MCP integration binaries — exercised by CI's all-features job.

## Contributor Checklist

- [x] Linked epic #703 with `Closes`
- [x] Branch `test/ssrf-mcp-probe` (conventional)
- [x] One `type:*` label (`type:chore` — test-only isn't in the label vocabulary)
- [x] Conventional commit (`test(mcp): ...`)
- [x] No AI attribution trailers