### PR TITLE
fix(cli): gate build_crawler_config_from_json behind ui feature

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -194,6 +194,7 @@ async fn run_url_selection_phase(
 }
 
 /// Build CrawlerConfig from TUI JSON config (manual bridge — CrawlerConfig has no Deserialize).
+#[cfg(feature = "ui")]
 fn build_crawler_config_from_json(
     seed_url: url::Url,
     config_values: &serde_json::Value,


### PR DESCRIPTION
Closes #705

Pre-existing dead_code warning when compiling webfang_cli without the `ui` feature.
The function `build_crawler_config_from_json` was the only caller of `run_url_selection_phase`,
which is already gated with `#[cfg(feature = "ui")]`, but the function itself lacked the gate.

Under default-feature builds `cargo check` emitted:
  `warning: function `build_crawler_config_from_json` is never used`

This also surfaces when compiling with `--no-default-features` for minimal/scraper-only
deployments.

## Fix
Add `#[cfg(feature = "ui")]` to `build_crawler_config_from_json` so it compiles only
when the TUI is enabled, matching its sole caller. Verified clean with both:
- `cargo check` (default features) — no warnings
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines`