### PR TITLE
fix(crawler): Chrome preflight exit 78 + MCP robots.txt enforcement (#685, #697)

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -346,6 +346,12 @@ async fn __main() -> CliExit {
     let opts = CrawlOptions::from(args);
     let opts = preflight::apply_config_defaults(opts, &config_defaults);
 
+    // 6c. JS strategy dependency preflight (#685): --js-strategy full needs
+    // Chrome installed — fail fast with exit 78 before any crawl starts.
+    if let Err(exit) = preflight::check_js_dependencies(&opts) {
+        return exit;
+    }
+
     // 7. Initialize logging (stderr-only, respects quiet + NO_COLOR)
     let no_color = is_no_color();
     let log_level = resolve_log_level(opts.verbosity);

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -141,7 +141,9 @@ pub async fn scrape_with_readability(
     url: &url::Url,
 ) -> Result<Vec<ScrapedContent>> {
     // Standalone convenience entry: this call IS the operation, so it mints
-    // its own run-root identity (#501).
+    // its own run-root identity (#501). No robots fetcher is available at
+    // this standalone entry point (#697): enforcement is the caller's
+    // concern (the MCP/CLI paths wire their own robots handling).
     let root_correlation = CorrelationId::new();
     let outcome = scrape_with_config(
         client,
@@ -150,6 +152,8 @@ pub async fn scrape_with_readability(
         None,
         None,
         None,
+        None,
+        false,
         &root_correlation,
     )
     .await?;

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -16,6 +16,7 @@ use crate::application::http_client::HttpClientPort;
 use crate::domain::http_port::HttpResponse;
 use crate::domain::{CorrelationId, DomInspectorPort, ExtractResult, ScrapedContent, ValidUrl};
 use crate::error::{Result, ScraperError};
+use crate::infrastructure::crawler::robots_utils::RobotsFetcher;
 use crate::infrastructure::http::waf_engine::{InspectionContext, WafInspector};
 use crate::infrastructure::observability::log_scrape_error;
 use crate::ScraperConfig;
@@ -136,6 +137,9 @@ pub struct ScrapeBatchOutcome {
 /// * `config` - Scraper configuration with download options
 /// * `downloader` - Optional asset downloader
 /// * `inspector` - Optional DOM inspector for selector diagnostics (None for non-MCP paths)
+/// * `robots` - Optional robots.txt fetcher; when present (and `ignore_robots`
+///   is false), disallowed URLs are rejected BEFORE any page fetch (#697)
+/// * `ignore_robots` - Opt-out of robots.txt enforcement for this call (#697)
 /// * `root_correlation` - Run-root correlation identity of the enclosing operation
 ///
 /// # Returns
@@ -143,7 +147,13 @@ pub struct ScrapeBatchOutcome {
 ///
 /// # Errors
 /// Returns `ScraperError::Http` for HTTP errors, `ScraperError::Network` for
-/// connection errors.
+/// connection errors, and `ScraperError::WafBlocked` (provider `"robots.txt"`)
+/// when the URL is disallowed by robots.txt (#697 audit decision — the variant
+/// is reused because a dedicated robots variant does not exist).
+// The parameter list is this use case's full dependency set: the same
+// justification `scrape_urls` carries (#705) — bundling them into a struct
+// would only move the identical wiring one level up.
+#[allow(clippy::too_many_arguments)]
 pub async fn scrape_with_config(
     client: &dyn HttpClientPort,
     url: &url::Url,
@@ -151,8 +161,15 @@ pub async fn scrape_with_config(
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
     inspector: Option<&dyn DomInspectorPort>,
     engine: Option<&AdaptiveSelectorEngine>,
+    robots: Option<&RobotsFetcher>,
+    ignore_robots: bool,
     root_correlation: &CorrelationId,
 ) -> Result<ScrapeOutcome> {
+    // Robots.txt gate runs in the OUTER wrapper, before the span and before
+    // any fetch, so a disallowed URL never touches the network (#697) and the
+    // inner instrumented signature stays untouched.
+    enforce_robots_policy(url, robots, ignore_robots).await?;
+
     // Per-page identity derived from the run root BEFORE the span so the span
     // can declare it (`#[instrument]` only sees function parameters — #501).
     let page_correlation = root_correlation.child();
@@ -166,6 +183,37 @@ pub async fn scrape_with_config(
         page_correlation,
     )
     .await
+}
+
+/// Enforce the robots.txt policy for one URL before any page fetch (#697).
+///
+/// Keeps the crawl path's semantics: `ignore_robots` bypasses the check, a
+/// missing fetcher means "no enforcement available" (legacy behavior), and a
+/// denial returns [`ScraperError::waf_blocked`] with provider `"robots.txt"`
+/// — the WafBlocked variant is deliberately reused for robots.txt denials per
+/// the #705 audit decision (`ScraperError` has no dedicated robots variant).
+///
+/// [`RobotsFetcher::is_allowed`] is FAIL-OPEN: if the robots.txt fetch itself
+/// fails (network error, non-2xx, timeout), the URL is treated as allowed —
+/// matching the production crawl behavior.
+async fn enforce_robots_policy(
+    url: &url::Url,
+    robots: Option<&RobotsFetcher>,
+    ignore_robots: bool,
+) -> Result<()> {
+    if ignore_robots {
+        return Ok(());
+    }
+    let Some(fetcher) = robots else {
+        return Ok(());
+    };
+
+    let domain = url.host_str().unwrap_or("unknown");
+    if !fetcher.is_allowed(url.as_str(), domain).await {
+        tracing::warn!(url = %url, domain = %domain, "robots_txt_denied");
+        return Err(ScraperError::waf_blocked(url.to_string(), "robots.txt"));
+    }
+    Ok(())
 }
 
 #[instrument(
@@ -494,6 +542,10 @@ fn log_spa_warning(url: &str, content: &str, html: &str) {
 /// * `client` - HTTP client
 /// * `urls` - URLs to scrape
 /// * `config` - Scraper configuration
+/// * `downloader` - Optional asset downloader
+/// * `robots` - Optional robots.txt fetcher; when present (and `ignore_robots`
+///   is false), disallowed URLs fail their per-URL check (#697)
+/// * `ignore_robots` - Opt-out of robots.txt enforcement for this batch (#697)
 ///
 /// # Returns
 /// * `Vec<ScrapedContent>` - All successfully scraped content
@@ -502,7 +554,7 @@ fn log_spa_warning(url: &str, content: &str, html: &str) {
 /// Failed URLs are logged but don't stop the entire batch.
 #[instrument(
     name = "scrape_multiple_with_limit",
-    skip(client, urls, config, downloader),
+    skip(client, urls, config, downloader, robots),
     fields(
         urls = urls.len(),
         concurrency = config.scraper_concurrency
@@ -513,6 +565,8 @@ pub async fn scrape_multiple_with_limit(
     urls: &[url::Url],
     config: &ScraperConfig,
     downloader: Option<&dyn crate::domain::ports::AssetDownloaderPort>,
+    robots: Option<&RobotsFetcher>,
+    ignore_robots: bool,
 ) -> Result<ScrapeBatchOutcome> {
     if urls.is_empty() {
         return Ok(ScrapeBatchOutcome {
@@ -544,8 +598,18 @@ pub async fn scrape_multiple_with_limit(
             let config = config.clone();
             let root = root_correlation.clone();
             async move {
-                let result =
-                    scrape_with_config(client, &url, &config, downloader, None, None, &root).await;
+                let result = scrape_with_config(
+                    client,
+                    &url,
+                    &config,
+                    downloader,
+                    None,
+                    None,
+                    robots,
+                    ignore_robots,
+                    &root,
+                )
+                .await;
                 (url, result)
             }
         })

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -8,7 +8,8 @@ use tracing::warn;
 
 use crate::application::crawl_options::CrawlOptions;
 use crate::cli::config::ConfigDefaults;
-use crate::{Args, ConcurrencyConfig, ExportFormat, OutputFormat};
+use crate::domain::JsStrategy;
+use crate::{Args, CliExit, ConcurrencyConfig, ExportFormat, OutputFormat};
 
 // ============================================================================
 // Config Defaults Merge
@@ -117,6 +118,78 @@ pub fn apply_config_defaults(mut opts: CrawlOptions, config: &ConfigDefaults) ->
     }
 
     opts
+}
+
+// ============================================================================
+// JS strategy dependency preflight (#685)
+// ============================================================================
+
+/// Chrome binary candidates probed for `--js-strategy full` (#685).
+///
+/// The audit spec named `google-chrome` only, but Linux distributions ship
+/// the engine under several names, so one missing distro binary must not
+/// mask an installed Chrome. Order matters: the first binary that reports a
+/// version wins.
+const DEFAULT_CHROME_CANDIDATES: [&str; 4] = [
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium-browser",
+    "chromium",
+];
+
+/// Preflight: verify the local environment can satisfy the configured JS
+/// strategy before any crawl starts (#685).
+///
+/// `JsStrategy::Full` renders pages through Chromiumoxide, which spawns a
+/// real Chrome/Chromium binary. Probing the installed candidates here turns
+/// a missing browser into a clean config error (exit 78) instead of a
+/// confusing mid-crawl browser launch failure. Other strategies need no
+/// external binary and return immediately without spawning processes.
+///
+/// Runs once, in a synchronous context, before crawl start — a brief
+/// blocking `--version` probe is acceptable there.
+///
+/// # Errors
+///
+/// Returns [`crate::CliExit::ConfigError`] (exit 78) when the strategy is
+/// [`Full`](crate::domain::JsStrategy::Full) and no Chrome/Chromium
+/// candidate on `PATH` reports a version.
+pub fn check_js_dependencies(opts: &CrawlOptions) -> Result<(), CliExit> {
+    check_js_dependencies_with(&DEFAULT_CHROME_CANDIDATES, opts)
+}
+
+/// Candidate-injectable core of [`check_js_dependencies`] — tests probe
+/// binaries that exist deterministically in CI (e.g. `true`) instead of the
+/// real Chrome names.
+fn check_js_dependencies_with(candidates: &[&str], opts: &CrawlOptions) -> Result<(), CliExit> {
+    if opts.network.js_strategy != JsStrategy::Full {
+        return Ok(());
+    }
+
+    let chrome_present = candidates
+        .iter()
+        .any(|binary| matches!(binary_reports_version(binary), Ok(s) if s.success()));
+    if chrome_present {
+        tracing::info!(strategy = "full", "chrome_dependency_checked");
+        return Ok(());
+    }
+
+    Err(CliExit::ConfigError(
+        "--js-strategy full requiere Google Chrome instalado".into(),
+    ))
+}
+
+/// Spawn `<binary> --version` once and report its exit status.
+///
+/// A missing or non-executable binary surfaces as an `io::Error`, which the
+/// caller treats as "not installed". Output is discarded — only the exit
+/// status matters, and the probe must stay silent on the terminal.
+fn binary_reports_version(binary: &str) -> std::io::Result<std::process::ExitStatus> {
+    std::process::Command::new(binary)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
 }
 
 // ============================================================================
@@ -669,5 +742,53 @@ mod tests {
         assert!(args.export.batch);
         assert_eq!(args.crawler.verbose, 2);
         assert!(!args.crawler.quiet);
+    }
+
+    // ========================================================================
+    // #685 — --js-strategy full preflight Chrome dependency check
+    // ========================================================================
+
+    /// `Static` strategy never needs Chrome: the check must return `Ok`
+    /// without probing any binary, so the injected candidate list is
+    /// irrelevant.
+    #[test]
+    fn static_strategy_ok_without_spawn() {
+        let mut opts = CrawlOptions::default();
+        opts.network.js_strategy = JsStrategy::Static;
+        // A nonexistent candidate proves the check short-circuits before it
+        // could attempt to spawn anything for a non-Full strategy.
+        assert!(
+            check_js_dependencies_with(&["definitely-not-installed-9x4k"], &opts).is_ok(),
+            "Static strategy must not require Chrome or spawn processes"
+        );
+    }
+
+    /// `Full` strategy with a present, exit-0 binary (`true` exists in CI)
+    /// passes the preflight check.
+    #[test]
+    fn full_strategy_ok_when_binary_reports_version() {
+        let mut opts = CrawlOptions::default();
+        opts.network.js_strategy = JsStrategy::Full;
+        assert!(
+            check_js_dependencies_with(&["true"], &opts).is_ok(),
+            "a candidate that exits 0 must satisfy the Full-strategy check"
+        );
+    }
+
+    /// `Full` strategy with no working candidate yields a config error whose
+    /// message names Chrome (user-facing, Spanish).
+    #[test]
+    fn full_strategy_errors_when_no_binary_found() {
+        let mut opts = CrawlOptions::default();
+        opts.network.js_strategy = JsStrategy::Full;
+        let err = check_js_dependencies_with(&["definitely-not-installed-9x4k"], &opts)
+            .expect_err("no candidate binary present means the check must fail");
+        match err {
+            CliExit::ConfigError(msg) => assert!(
+                msg.contains("Chrome"),
+                "config error must name Chrome, got: {msg}"
+            ),
+            other => panic!("expected ConfigError, got: {other:?}"),
+        }
     }
 }

--- a/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/robots_utils.rs
@@ -164,6 +164,20 @@ impl RobotsFetcher {
         })
     }
 
+    /// Create a fetcher with the default production TLS fingerprint
+    /// (`Profile::Chrome145`), matching `HttpClientConfig::default()`.
+    ///
+    /// Lets callers build a robots.txt fetcher without depending on
+    /// `wreq-util` themselves (e.g. the MCP crate, which must not add that
+    /// dependency — issue #705).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InfraError::Network`] if the wreq client cannot be built.
+    pub fn with_default_profile(timeout_secs: u64) -> Result<Self, InfraError> {
+        Self::new(Profile::Chrome145, timeout_secs)
+    }
+
     /// Fetch and cache robots.txt rules for a domain.
     ///
     /// On cache miss, fetches `robots.txt` from the domain root using the shared

--- a/crates/webfang_core/tests/scraper_service_test.rs
+++ b/crates/webfang_core/tests/scraper_service_test.rs
@@ -127,6 +127,7 @@ async fn test_scrape_with_config_derives_child_from_run_root() {
 // =====================================================================
 mod robots {
     use super::*;
+    use webfang_core::application::scraper_service::ScrapeOutcome;
     use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -168,6 +169,36 @@ mod robots {
             .await;
     }
 
+    /// Scrape `/{path}` against `server` (site already mounted there) with a
+    /// wiremock-backed fetcher and robots enforcement configured as requested.
+    /// Single call site for the client + fetcher + 9-argument
+    /// `scrape_with_config` scaffold, so the jscpd ratchet never sees the
+    /// repeated wiring.
+    async fn scrape_with_fetcher(
+        server: &MockServer,
+        path: &str,
+        ignore_robots: bool,
+    ) -> Result<ScrapeOutcome, ScraperError> {
+        let client = webfang_core::application::create_http_client().expect("wreq client builds");
+        let fetcher = fetcher_for(server);
+        let url = url::Url::parse(&format!("{}/{path}", server.uri())).expect("valid URL");
+        let config = ScraperConfig::default();
+        let root = CorrelationId::new();
+
+        scrape_with_config(
+            &client,
+            &url,
+            &config,
+            None,
+            None,
+            None,
+            Some(&fetcher),
+            ignore_robots,
+            &root,
+        )
+        .await
+    }
+
     /// A URL disallowed by robots.txt must be rejected BEFORE any page fetch:
     /// the call fails with the robots denial and the wiremock page endpoint
     /// records zero hits (the only request is the robots.txt probe itself).
@@ -177,25 +208,9 @@ mod robots {
         let server = MockServer::start().await;
         mount_site(&server, "private/page").await;
 
-        let client = webfang_core::application::create_http_client().expect("wreq client builds");
-        let fetcher = fetcher_for(&server);
-        let url = url::Url::parse(&format!("{}/private/page", server.uri())).expect("valid URL");
-        let config = ScraperConfig::default();
-        let root = CorrelationId::new();
-
-        let err = scrape_with_config(
-            &client,
-            &url,
-            &config,
-            None,
-            None,
-            None,
-            Some(&fetcher),
-            false,
-            &root,
-        )
-        .await
-        .expect_err("robots-disallowed URL must fail the scrape");
+        let err = scrape_with_fetcher(&server, "private/page", false)
+            .await
+            .expect_err("robots-disallowed URL must fail the scrape");
 
         match err {
             ScraperError::WafBlocked { provider, .. } => assert!(
@@ -227,25 +242,9 @@ mod robots {
         let server = MockServer::start().await;
         mount_site(&server, "public-page").await;
 
-        let client = webfang_core::application::create_http_client().expect("wreq client builds");
-        let fetcher = fetcher_for(&server);
-        let url = url::Url::parse(&format!("{}/public-page", server.uri())).expect("valid URL");
-        let config = ScraperConfig::default();
-        let root = CorrelationId::new();
-
-        let outcome = scrape_with_config(
-            &client,
-            &url,
-            &config,
-            None,
-            None,
-            None,
-            Some(&fetcher),
-            false,
-            &root,
-        )
-        .await
-        .expect("robots-allowed URL must scrape successfully");
+        let outcome = scrape_with_fetcher(&server, "public-page", false)
+            .await
+            .expect("robots-allowed URL must scrape successfully");
 
         assert!(!outcome.results.is_empty(), "allowed URL must scrape");
         assert!(!outcome.results[0].content.is_empty(), "content extracted");
@@ -259,25 +258,9 @@ mod robots {
         let server = MockServer::start().await;
         mount_site(&server, "private/page").await;
 
-        let client = webfang_core::application::create_http_client().expect("wreq client builds");
-        let fetcher = fetcher_for(&server);
-        let url = url::Url::parse(&format!("{}/private/page", server.uri())).expect("valid URL");
-        let config = ScraperConfig::default();
-        let root = CorrelationId::new();
-
-        let outcome = scrape_with_config(
-            &client,
-            &url,
-            &config,
-            None,
-            None,
-            None,
-            Some(&fetcher),
-            true,
-            &root,
-        )
-        .await
-        .expect("ignore_robots must bypass the robots gate");
+        let outcome = scrape_with_fetcher(&server, "private/page", true)
+            .await
+            .expect("ignore_robots must bypass the robots gate");
 
         assert!(!outcome.results.is_empty(), "bypassed URL must scrape");
         let received = server

--- a/crates/webfang_core/tests/scraper_service_test.rs
+++ b/crates/webfang_core/tests/scraper_service_test.rs
@@ -28,7 +28,8 @@ async fn test_scrape_with_config_invalid_url() {
     );
 
     let root = CorrelationId::new();
-    let result = scrape_with_config(&mock, &url, &config, None, None, None, &root).await;
+    let result =
+        scrape_with_config(&mock, &url, &config, None, None, None, None, false, &root).await;
     assert!(result.is_err(), "connection error should propagate as Err");
 }
 
@@ -51,7 +52,7 @@ async fn test_scrape_with_config_returns_outcome() {
     let config = ScraperConfig::default();
 
     let root = CorrelationId::new();
-    let outcome = scrape_with_config(&mock, &url, &config, None, None, None, &root)
+    let outcome = scrape_with_config(&mock, &url, &config, None, None, None, None, false, &root)
         .await
         .expect("mock HTML should succeed");
     assert!(
@@ -96,7 +97,7 @@ async fn test_scrape_with_config_derives_child_from_run_root() {
         .expect("valid fixed UUID for the test root");
     let root = CorrelationId::new_with_ids(root_trace, 0x0000_0000_0000_0001);
 
-    let outcome = scrape_with_config(&mock, &url, &config, None, None, None, &root)
+    let outcome = scrape_with_config(&mock, &url, &config, None, None, None, None, false, &root)
         .await
         .expect("mock HTML should scrape");
 
@@ -119,6 +120,175 @@ async fn test_scrape_with_config_derives_child_from_run_root() {
         root.span_id(),
         "page identity must derive a fresh span_id via .child(), not reuse the root's"
     );
+}
+
+// =====================================================================
+// robots.txt enforcement at the scrape_with_config boundary (#697)
+// =====================================================================
+mod robots {
+    use super::*;
+    use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Minimal article HTML that Readability extracts deterministically.
+    const ARTICLE_HTML: &str = r#"<!DOCTYPE html>
+<html>
+<head><title>Private Page</title></head>
+<body>
+<article>
+<h1>Main Heading</h1>
+<p>This is the content of the article. It has enough text to be extracted by Readability.</p>
+</article>
+</body>
+</html>"#;
+
+    /// A fetcher whose internal wreq client talks to the wiremock origin
+    /// (`RobotsFetcher` keys its fetches off the page URL's origin, which
+    /// points at 127.0.0.1:PORT). Construction is offline — only the check
+    /// itself performs network I/O, entirely against the mock server.
+    fn fetcher_for(_server: &MockServer) -> RobotsFetcher {
+        RobotsFetcher::with_default_profile(5).expect("robot fetcher construction is offline")
+    }
+
+    /// Mount a robots.txt that disallows `/private/*` and an article page at
+    /// `/{name}`.
+    async fn mount_site(server: &MockServer, name: &str) {
+        Mock::given(method("GET"))
+            .and(path("/robots.txt"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("User-agent: *\nDisallow: /private\n"),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{name}")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(ARTICLE_HTML))
+            .mount(server)
+            .await;
+    }
+
+    /// A URL disallowed by robots.txt must be rejected BEFORE any page fetch:
+    /// the call fails with the robots denial and the wiremock page endpoint
+    /// records zero hits (the only request is the robots.txt probe itself).
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn scrape_disallowed_url_errors_before_page_fetch() {
+        let server = MockServer::start().await;
+        mount_site(&server, "private/page").await;
+
+        let client = webfang_core::application::create_http_client().expect("wreq client builds");
+        let fetcher = fetcher_for(&server);
+        let url = url::Url::parse(&format!("{}/private/page", server.uri())).expect("valid URL");
+        let config = ScraperConfig::default();
+        let root = CorrelationId::new();
+
+        let err = scrape_with_config(
+            &client,
+            &url,
+            &config,
+            None,
+            None,
+            None,
+            Some(&fetcher),
+            false,
+            &root,
+        )
+        .await
+        .expect_err("robots-disallowed URL must fail the scrape");
+
+        match err {
+            ScraperError::WafBlocked { provider, .. } => assert!(
+                provider.contains("robots"),
+                "robots denial must surface the robots.txt provider, got: {provider}"
+            ),
+            other => panic!("expected WafBlocked(robots.txt), got: {other}"),
+        }
+
+        let received = server
+            .received_requests()
+            .await
+            .expect("request recording is enabled");
+        let page_hits = received
+            .iter()
+            .filter(|r| r.url.path() != "/robots.txt")
+            .count();
+        assert_eq!(
+            page_hits, 0,
+            "the robots gate must short-circuit BEFORE any page fetch"
+        );
+    }
+
+    /// The same gate must NOT block a robots-allowed URL: the scrape
+    /// succeeds and its content is non-empty.
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn scrape_allowed_url_succeeds_with_fetcher() {
+        let server = MockServer::start().await;
+        mount_site(&server, "public-page").await;
+
+        let client = webfang_core::application::create_http_client().expect("wreq client builds");
+        let fetcher = fetcher_for(&server);
+        let url = url::Url::parse(&format!("{}/public-page", server.uri())).expect("valid URL");
+        let config = ScraperConfig::default();
+        let root = CorrelationId::new();
+
+        let outcome = scrape_with_config(
+            &client,
+            &url,
+            &config,
+            None,
+            None,
+            None,
+            Some(&fetcher),
+            false,
+            &root,
+        )
+        .await
+        .expect("robots-allowed URL must scrape successfully");
+
+        assert!(!outcome.results.is_empty(), "allowed URL must scrape");
+        assert!(!outcome.results[0].content.is_empty(), "content extracted");
+    }
+
+    /// `ignore_robots = true` bypasses the gate: a disallowed URL is scraped
+    /// and the fetcher never probes robots.txt at all.
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn ignore_robots_bypasses_the_gate() {
+        let server = MockServer::start().await;
+        mount_site(&server, "private/page").await;
+
+        let client = webfang_core::application::create_http_client().expect("wreq client builds");
+        let fetcher = fetcher_for(&server);
+        let url = url::Url::parse(&format!("{}/private/page", server.uri())).expect("valid URL");
+        let config = ScraperConfig::default();
+        let root = CorrelationId::new();
+
+        let outcome = scrape_with_config(
+            &client,
+            &url,
+            &config,
+            None,
+            None,
+            None,
+            Some(&fetcher),
+            true,
+            &root,
+        )
+        .await
+        .expect("ignore_robots must bypass the robots gate");
+
+        assert!(!outcome.results.is_empty(), "bypassed URL must scrape");
+        let received = server
+            .received_requests()
+            .await
+            .expect("request recording is enabled");
+        assert!(
+            received.iter().all(|r| r.url.path() != "/robots.txt"),
+            "ignore_robots must skip the robots.txt probe entirely"
+        );
+    }
 }
 
 // =====================================================================
@@ -446,7 +616,7 @@ async fn test_scrape_multiple_with_limit_returns_results() {
         .with_ok_response(url2.as_str(), html);
 
     let config = ScraperConfig::default();
-    let outcome = scrape_multiple_with_limit(&mock, &[url1, url2], &config, None)
+    let outcome = scrape_multiple_with_limit(&mock, &[url1, url2], &config, None, None, false)
         .await
         .expect("scrape_multiple_with_limit should succeed");
 
@@ -462,7 +632,7 @@ async fn test_scrape_multiple_with_limit_returns_results() {
 async fn test_scrape_multiple_with_limit_empty_urls() {
     let mock = MockHttpClient::new();
     let config = ScraperConfig::default();
-    let outcome = scrape_multiple_with_limit(&mock, &[], &config, None)
+    let outcome = scrape_multiple_with_limit(&mock, &[], &config, None, None, false)
         .await
         .expect("empty URL list should return Ok");
     assert!(outcome.results.is_empty());
@@ -813,9 +983,10 @@ async fn test_scrape_multiple_partial_failure() {
         .with_response(url_fail.as_str(), Err(HttpError::ClientError(404)));
 
     let config = ScraperConfig::default();
-    let outcome = scrape_multiple_with_limit(&mock, &[url_ok, url_fail], &config, None)
-        .await
-        .expect("should not fail overall even with partial URL failures");
+    let outcome =
+        scrape_multiple_with_limit(&mock, &[url_ok, url_fail], &config, None, None, false)
+            .await
+            .expect("should not fail overall even with partial URL failures");
 
     assert_eq!(
         outcome.results.len(),
@@ -847,7 +1018,7 @@ async fn test_scrape_multiple_all_failed_reports_all() {
         .with_response(url2.as_str(), Err(HttpError::ClientError(503)));
 
     let config = ScraperConfig::default();
-    let outcome = scrape_multiple_with_limit(&mock, &[url1, url2], &config, None)
+    let outcome = scrape_multiple_with_limit(&mock, &[url1, url2], &config, None, None, false)
         .await
         .expect("batch with all failures should still succeed at batch level");
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -121,6 +121,10 @@ impl McpHandler {
             .as_deref()
             .map(|d| d as &dyn webfang_core::domain::ports::AssetDownloaderPort);
         let inspector = self.state.inspector.as_deref();
+        // robots.txt enforcement (#697): shared fetcher from the state; the
+        // tool-level opt-out is `params.ignore_robots`.
+        let robots = self.state.robots_fetcher.as_deref();
+        let ignore_robots = params.ignore_robots.unwrap_or(false);
         // An MCP tool call IS an operation (#501): mint the run-root identity
         // at the handler entry; the use case derives the page child from it.
         let root_correlation = webfang_core::domain::CorrelationId::new();
@@ -131,6 +135,8 @@ impl McpHandler {
             dl,
             inspector,
             None,
+            robots,
+            ignore_robots,
             &root_correlation,
         )
         .await
@@ -221,8 +227,17 @@ impl McpHandler {
             .downloader
             .as_deref()
             .map(|d| d as &dyn webfang_core::domain::ports::AssetDownloaderPort);
+        // robots.txt enforcement (#697): shared fetcher from the state; the
+        // tool-level opt-out is `params.ignore_robots`.
+        let robots = self.state.robots_fetcher.as_deref();
+        let ignore_robots = params.ignore_robots.unwrap_or(false);
         match webfang_core::application::scraper_service::scrape_multiple_with_limit(
-            client, &urls, &config, dl,
+            client,
+            &urls,
+            &config,
+            dl,
+            robots,
+            ignore_robots,
         )
         .await
         {
@@ -666,7 +681,11 @@ mod tests {
         let container = Container::new(crawler_config, scraper_config)
             .await
             .expect("create container");
-        let state = McpState::new(container);
+        let mut state = McpState::new(container);
+        // Determinism (#705): handler tests must stay offline — the robots
+        // check performs a real robots.txt fetch, so unit tests drop the
+        // fetcher instead of risking network access through loopback URLs.
+        state.robots_fetcher = None;
         (McpHandler::new(state), tmp)
     }
 
@@ -715,6 +734,7 @@ mod tests {
                 download_images: Some(false),
                 download_documents: Some(false),
                 selector: None,
+                ignore_robots: None,
             }))
             .await;
         assert_ssrf_rejected(res);
@@ -730,6 +750,7 @@ mod tests {
                 download_images: None,
                 download_documents: None,
                 selector: None,
+                ignore_robots: None,
             }))
             .await;
         assert!(res.is_err(), "invalid URL must be a protocol error");
@@ -743,6 +764,7 @@ mod tests {
             .scrape_batch(Parameters(ScrapeBatchParams {
                 urls: vec!["http://127.0.0.1/".to_string()],
                 concurrency: Some(2),
+                ignore_robots: None,
             }))
             .await;
         assert_ssrf_rejected(res);
@@ -756,6 +778,7 @@ mod tests {
             .scrape_batch(Parameters(ScrapeBatchParams {
                 urls: vec!["not a url".to_string()],
                 concurrency: None,
+                ignore_robots: None,
             }))
             .await;
         assert!(
@@ -772,6 +795,7 @@ mod tests {
         let batch = ScrapeBatchParams {
             urls: vec!["https://example.com".to_string()],
             concurrency: Some(0),
+            ignore_robots: None,
         }
         .validate();
         assert!(batch.is_err(), "concurrency 0 must be rejected: {batch:?}");

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -62,6 +62,12 @@ pub struct ScrapeWithOptionsParams {
     /// full page HTML is returned with a diagnostic explaining the failure.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selector: Option<String>,
+    /// Bypass the robots.txt check for this request (default: false).
+    ///
+    /// When false or omitted, the scrape is rejected with an error when the
+    /// target site's robots.txt disallows the URL (#697).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignore_robots: Option<bool>,
 }
 
 impl ScrapeWithOptionsParams {
@@ -85,6 +91,12 @@ pub struct ScrapeBatchParams {
     pub urls: Vec<String>,
     /// Concurrency limit (default: 4)
     pub concurrency: Option<usize>,
+    /// Bypass the robots.txt check for every URL in the batch (default: false).
+    ///
+    /// When false or omitted, URLs disallowed by robots.txt fail their
+    /// individual scrape with an error (#697).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignore_robots: Option<bool>,
 }
 
 impl ScrapeBatchParams {

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -13,6 +13,7 @@ use crate::mcp_server::metrics::{MetricsSnapshot, ScrapeEvent, ScrapeMetrics};
 use webfang_core::adapters::downloader::Downloader;
 use webfang_core::di::Container;
 use webfang_core::domain::DomInspectorPort;
+use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
 
 /// Per-category semaphore limits for backpressure.
 /// Tuned for Intel i5-4590 (4C), 8GB DDR3, HDD.
@@ -67,6 +68,10 @@ pub struct McpState {
     pub downloader: Option<Arc<Downloader>>,
     /// DOM inspector for CSS selector diagnostics (None = no diagnostics)
     pub inspector: Option<Arc<dyn DomInspectorPort>>,
+    /// Shared robots.txt fetcher for the scrape tools (#697). Construction
+    /// failure is non-fatal: `None` leaves enforcement disabled, mirroring
+    /// the rate-limiter pattern in the core container.
+    pub robots_fetcher: Option<Arc<RobotsFetcher>>,
     /// Process-lifetime scrape metrics, shared across all per-session clones
     /// (REQ-06). Locked only in short synchronous sections (REQ-07).
     pub metrics: Arc<Mutex<ScrapeMetrics>>,
@@ -100,12 +105,14 @@ impl McpState {
     pub fn new(container: Container) -> Self {
         let limits = Arc::new(CategoryLimits::default());
         let semaphores = Arc::new(CategorySemaphores::from_limits(&limits));
+        let robots_fetcher = build_robots_fetcher(&container);
         Self {
             container: Arc::new(container),
             limits,
             semaphores,
             downloader: None,
             inspector: None,
+            robots_fetcher,
             metrics: Arc::new(Mutex::new(ScrapeMetrics::default())),
             cancel_token: CancellationToken::new(),
         }
@@ -115,12 +122,14 @@ impl McpState {
     pub fn with_limits(container: Container, limits: CategoryLimits) -> Self {
         let limits = Arc::new(limits);
         let semaphores = Arc::new(CategorySemaphores::from_limits(&limits));
+        let robots_fetcher = build_robots_fetcher(&container);
         Self {
             container: Arc::new(container),
             limits,
             semaphores,
             downloader: None,
             inspector: None,
+            robots_fetcher,
             metrics: Arc::new(Mutex::new(ScrapeMetrics::default())),
             cancel_token: CancellationToken::new(),
         }
@@ -138,6 +147,17 @@ impl McpState {
     #[must_use]
     pub fn with_downloader(mut self, downloader: Arc<Downloader>) -> Self {
         self.downloader = Some(downloader);
+        self
+    }
+
+    /// Set a shared robots.txt fetcher for the scrape tools (#697).
+    ///
+    /// Parity with [`with_downloader`](Self::with_downloader) and
+    /// [`with_inspector`](Self::with_inspector): lets tests and composition
+    /// roots wire a deterministic or pre-built fetcher.
+    #[must_use]
+    pub fn with_robots_fetcher(mut self, fetcher: Arc<RobotsFetcher>) -> Self {
+        self.robots_fetcher = Some(fetcher);
         self
     }
 
@@ -198,6 +218,22 @@ impl McpState {
             // LCOV_EXCL_LINE defensive: lock-poisoning — poison is recovered via into_inner, never a panic
             .unwrap_or_else(|e| e.into_inner())
             .snapshot()
+    }
+}
+
+/// Build the shared robots.txt fetcher for the scrape tools (#697).
+///
+/// Uses the container's configured download timeout. Construction failure is
+/// NON-FATAL — the fetcher stays `None` and robots enforcement degrades to
+/// "no fetcher available", mirroring the rate-limiter pattern in the core
+/// container.
+fn build_robots_fetcher(container: &Container) -> Option<Arc<RobotsFetcher>> {
+    match RobotsFetcher::with_default_profile(container.config().download_timeout_secs) {
+        Ok(fetcher) => Some(Arc::new(fetcher)),
+        Err(e) => {
+            tracing::warn!(error = %e, "robots_fetcher_init_failed_non_fatal");
+            None
+        },
     }
 }
 

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -103,23 +103,19 @@ pub struct CategorySemaphores {
 impl McpState {
     /// Create a new McpState with the given container and default limits.
     pub fn new(container: Container) -> Self {
-        let limits = Arc::new(CategoryLimits::default());
-        let semaphores = Arc::new(CategorySemaphores::from_limits(&limits));
-        let robots_fetcher = build_robots_fetcher(&container);
-        Self {
-            container: Arc::new(container),
-            limits,
-            semaphores,
-            downloader: None,
-            inspector: None,
-            robots_fetcher,
-            metrics: Arc::new(Mutex::new(ScrapeMetrics::default())),
-            cancel_token: CancellationToken::new(),
-        }
+        Self::from_parts(container, CategoryLimits::default())
     }
 
     /// Create with custom category limits.
     pub fn with_limits(container: Container, limits: CategoryLimits) -> Self {
+        Self::from_parts(container, limits)
+    }
+
+    /// Shared construction for [`new`](Self::new) / [`with_limits`](Self::with_limits):
+    /// builds the semaphores, metrics accumulator, cancellation token, and the
+    /// non-fatal robots.txt fetcher ([`build_robots_fetcher`]) from the given
+    /// container and limits.
+    fn from_parts(container: Container, limits: CategoryLimits) -> Self {
         let limits = Arc::new(limits);
         let semaphores = Arc::new(CategorySemaphores::from_limits(&limits));
         let robots_fetcher = build_robots_fetcher(&container);

--- a/crates/webfang_mcp/tests/mcp_params_validation_test.rs
+++ b/crates/webfang_mcp/tests/mcp_params_validation_test.rs
@@ -278,6 +278,7 @@ fn scrape_batch_params_rejects_empty_list() {
     let p = ScrapeBatchParams {
         urls: vec![],
         concurrency: None,
+        ignore_robots: None,
     };
     let err = p.validate().unwrap_err();
     assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
@@ -288,6 +289,7 @@ fn scrape_batch_params_rejects_one_bad_url() {
     let p = ScrapeBatchParams {
         urls: vec!["https://ok.example".into(), "file:///etc/passwd".into()],
         concurrency: None,
+        ignore_robots: None,
     };
     let err = p.validate().unwrap_err();
     assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
@@ -298,6 +300,7 @@ fn scrape_batch_params_rejects_oversize_concurrency() {
     let p = ScrapeBatchParams {
         urls: vec!["https://example.com".into()],
         concurrency: Some(65),
+        ignore_robots: None,
     };
     let err = p.validate().unwrap_err();
     assert!(matches!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS));
@@ -311,6 +314,7 @@ fn scrape_batch_params_accepts_valid() {
             "https://other.example/path".into(),
         ],
         concurrency: Some(8),
+        ignore_robots: None,
     };
     p.validate().expect("valid batch");
 }


### PR DESCRIPTION
## Linked Issue

Closes #705

> Note: #705 is currently CLOSED (auto-closed again at 17:01 UTC by the #719 squash "Closes #705" link; the earlier manual reopen at 03:07 UTC was because 3/5 audit findings were still pending). This PR implements the two remaining findings (#685 and #697), so the squash-merge reopening/closing flow ends with all 5/5 findings resolved.

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- **Finding #685** — `--js-strategy full` without Google Chrome installed no longer surfaces as a confusing mid-crawl browser launch failure (exit 3): `preflight::check_js_dependencies` now probes Chrome candidates (`google-chrome`, `google-chrome-stable`, `chromium-browser`, `chromium`) before crawl start and exits 78 (`CliExit::ConfigError`) with an actionable Spanish message. Wired in `main.rs` right after `apply_config_defaults`.
- **Finding #697** — MCP scrape tools ignore robots.txt no more: `scrape_with_config` / `scrape_multiple_with_limit` accept `robots: Option<&RobotsFetcher>` + `ignore_robots: bool`; `McpState` constructs a shared fetcher (non-fatal on failure, mirroring the rate-limiter pattern) and `scrape_with_options` / `scrape_batch` enforce it BEFORE any page fetch. Denials reuse `ScraperError::WafBlocked` with provider `"robots.txt"` per the audit decision (no new error variant). Both tools gain an opt-in `ignore_robots` param.

This completes all 5 findings of the #705 audit report (#682 via PR #712, #683 via PR #716, #689 already code-resolved).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/preflight.rs` | `check_js_dependencies` (+ candidate-injectable core for deterministic tests), 4 Chrome candidates, exit 78 on Full strategy without browser; 3 unit tests |
| `crates/webfang_cli/src/main.rs` | Wire `check_js_dependencies` after `apply_config_defaults` |
| `crates/webfang_core/src/application/scraper_service.rs` | `robots` + `ignore_robots` params on `scrape_with_config` / `scrape_multiple_with_limit`; `enforce_robots_policy` helper (gate runs in the outer wrapper, before span + fetch) |
| `crates/webfang_core/src/application/extraction.rs` | Standalone `scrape_with_readability` entry passes `None, false` with rationale comment |
| `crates/webfang_core/src/infrastructure/crawler/robots_utils.rs` | `RobotsFetcher::with_default_profile(timeout)` — Chrome145 default, no new `wreq-util` dep for MCP |
| `crates/webfang_core/tests/scraper_service_test.rs` | 3 new wiremock behavioral tests: disallowed URL errors before page fetch (0 page hits), allowed URL succeeds, `ignore_robots` bypasses with zero robots probes |
| `crates/webfang_mcp/src/mcp_server/state.rs` | `robots_fetcher: Option<Arc<RobotsFetcher>>` field, `build_robots_fetcher` (non-fatal), `with_robots_fetcher` builder |
| `crates/webfang_mcp/src/mcp_server/handlers/scraping.rs` | Wire fetcher into both scrape tools; handler tests set `robots_fetcher = None` for offline determinism |
| `crates/webfang_mcp/src/mcp_server/params.rs` | `ignore_robots: Option<bool>` on both scrape param structs (`serde(default)`) |
| `crates/webfang_mcp/tests/mcp_params_validation_test.rs` | Call-site updates for new param |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run -p webfang_core` — 2112 passed, 0 failed (14 skipped)
- [x] `cargo nextest run -p webfang_mcp` — 241 passed, 0 failed
- [x] `cargo test --doc` — 70 passed, 0 failed
- [ ] CI run (auto-triggered on push)

Note: `vault_detector` tests fail on machines with a real Obsidian vault registry (they read `~/.config/obsidian/obsidian.json`) — pre-existing environmental leak, unrelated to this change; passes under isolated `XDG_CONFIG_HOME`.

## Contributor Checklist

- [x] Linked an approved issue with `Closes #705`
- [x] Branch name matches `type/description` — `fix/issue-705-js-preflight-mcp-robots`
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format — 2 commits, one per finding
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed — doc comments on all new/changed public items
- [x] User-facing errors in Spanish; tracing fields/logs in English
