### PR TITLE
chore(infra): purge stale deny.toml advisory ignores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,17 +344,10 @@ jobs:
       - name: Audit (RustSec, redundant with cargo-deny)
         run: |
           cargo audit \
-            --ignore RUSTSEC-2026-0097 \
             --ignore RUSTSEC-2025-0141 \
             --ignore RUSTSEC-2025-0119 \
             --ignore RUSTSEC-2024-0436 \
-            --ignore RUSTSEC-2024-0320 \
-            --ignore RUSTSEC-2026-0183 \
-            --ignore RUSTSEC-2026-0184 \
-            --ignore RUSTSEC-2026-0186 \
-            --ignore RUSTSEC-2026-0002 \
-            --ignore RUSTSEC-2026-0194 \
-            --ignore RUSTSEC-2026-0195
+            --ignore RUSTSEC-2024-0320
 
   # ============================================================================
   # TIER 5: DOC QUALITY — Independent of tests

--- a/deny.toml
+++ b/deny.toml
@@ -1,12 +1,17 @@
 [advisories]
 # IMPORTANT: Keep this list synchronized with CI cargo audit --ignore flags.
 # Each entry must document: crate, version, severity, why safe to ignore, tracking, review date.
+#
+# NOTE: stale ignores purge (issue #727): removed the 6 entries that
+# `cargo deny` reported as advisory-not-detected on 2026-08-16:
+#   - RUSTSEC-2026-0194 / 0195 (quick-xml 0.39.4): root cause gone — plist
+#     is now 1.10.0, which pulls quick-xml 0.41.0; 0.39.4 no longer in the lock.
+#   - RUSTSEC-2026-0097 (tonic), RUSTSEC-2026-0002 (lru), RUSTSEC-2026-0183
+#     and RUSTSEC-2026-0184 (git2): crates are still locked, but the RustSec
+#     DB criteria no longer match these IDs against them (advisories revised).
+# If the DB re-matches one of the revised IDs, `cargo deny` will fail loudly
+# and the ignore is re-added here with fresh justification.
 ignore = [
-    # RUSTSEC-2026-0097 (tonic 0.12.3, severity: medium)
-    # Transitivo via console-subscriber (tokio-console, optional feature).
-    # Not in production binary unless tokio-console feature enabled.
-    "RUSTSEC-2026-0097",
-
     # RUSTSEC-2025-0141 (bincode 1.3.3, severity: medium)
     # Unmaintained. Transitivo via criterion (dev-only). Not in production binary.
     "RUSTSEC-2025-0141",
@@ -22,35 +27,6 @@ ignore = [
     # RUSTSEC-2024-0320 (yaml-rust 0.4.5, severity: medium)
     # Unmaintained. Transitivo via toml_edit→toml (config parsing). No runtime impact.
     "RUSTSEC-2024-0320",
-
-    # RUSTSEC-2026-0183 (git2 0.20.4, severity: medium)
-    # Unsound. Build-only via built crate. Not in production binary.
-    "RUSTSEC-2026-0183",
-
-    # RUSTSEC-2026-0184 (git2 0.20.4, severity: medium)
-    # Unsound. Build-only via built crate. Not in production binary.
-    "RUSTSEC-2026-0184",
-
-    # RUSTSEC-2026-0002 (lru 0.12.5, severity: low)
-    # Unsound. Transitivo via ratatui 0.29 (TUI). Cannot pin transitively.
-    # Impact: IterMut Stacked Borrows violation — theoretical, not exploitable in CLI.
-    "RUSTSEC-2026-0002",
-
-    # RUSTSEC-2026-0194 (quick-xml 0.39.4, severity: 7.5 HIGH)
-    # Quadratic attribute check. Transitivo via plist→syntect (plist 1.9.0 is latest).
-    # Our direct dep upgraded to 0.41.0. Transitive can't be fixed until plist updates.
-    # Ruta de codigo: syntect se usa SOLO para syntax highlighting de code blocks en
-    # output Markdown (infrastructure/converter/syntax_highlight.rs). NO procesa
-    # sitemap.xml descargado de sitios remotos — ruta completamente separada.
-    # Tracking: https://github.com/tafia/quick-xml/issues/969
-    # Re-check when plist updates past quick-xml 0.39 (tracking issues above).
-    "RUSTSEC-2026-0194",
-
-    # RUSTSEC-2026-0195 (quick-xml 0.39.4, severity: 7.5 HIGH)
-    # Unbounded namespace allocation. Mismo analysis que RUSTSEC-2026-0194.
-    # Tracking: https://github.com/tafia/quick-xml/issues/970
-    # Re-check when plist updates past quick-xml 0.39 (tracking issues above).
-    "RUSTSEC-2026-0195",
 ]
 
 [licenses]


### PR DESCRIPTION
## Linked Issue

Closes #727

## PR Type

- [x] Maintenance / tooling (`type:chore`)

## Summary

- `cargo deny check` reported `advisory-not-detected` for 6 of the 10 ignores in `deny.toml` (verified 2026-08-16 with deny 0.20.2). This PR removes the 6 dead ignores and syncs CI's `cargo audit --ignore` flags to match.
- Two stale classes: the quick-xml pair died because its root cause vanished (plist 1.9→1.10 now pulls quick-xml 0.41.0, the vulnerable 0.39.4 is gone from the lockfile); the remaining four (tonic, lru, git2 ×2) died because the RustSec DB revised the advisory criteria so they no longer match the locked versions.

## Changes

| File | Change |
|------|--------|
| `deny.toml` | Removed 6 not-detected ignores + their comment blocks; kept the 4 still-detected ones (bincode, number_prefix, paste, yaml-rust); added a NOTE block documenting what was purged and why, so re-added ignores always carry fresh justification |
| `.github/workflows/ci.yml` | Trimmed the `cargo audit --ignore` list from 11 to 4, mirroring deny.toml (also drops the orphan `RUSTSEC-2026-0186` flag left by #725) |

## Test Plan

- [x] `cargo deny check` exits 0 with **zero** `advisory-not-detected` warnings (`advisories ok, bans ok, licenses ok, sources ok`)
- [x] `cargo audit` with the trimmed list exits 0 — revised advisories now surface as non-fatal *warnings* (visibility restored), not suppressed silences
- [x] Pure config change — no Rust code touched, CI is the authoritative validator