### PR TITLE
docs(ai,mcp): fix stale cache path and align rate-limit defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,8 @@ An agent suggesting "clean up duplicate dependencies" must be stopped. These con
 
 ### AI feature (`--features ai`)
 
-- ONNX models cached in `~/.cache/webfang/ai_models/`: Granite-97M (default, ~390MB, 384d) or Granite-311M (~1.25GB) via `AI_MODEL_ID` / `--ai-model`.
-- `cleaner.clean(html)` → `Vec<DocumentChunk>` with embeddings.
+- ONNX models cached in the native hf_hub cache (`~/.cache/huggingface/hub/`): Granite-97M (default, ~390MB, 384d) or Granite-311M (~1.25GB) via `AI_MODEL_ID` / `--ai-model`. `--clean-ai` uses hf_hub natively: cache-first when online, strict cache-only when offline.
+- `cleaner.clean(html)` → `Vec<DocumentChunk>` with embeddings. Embeddings only appear in exports with `--output-vectors`.
 
 ### Build requirement
 

--- a/crates/webfang_ai/tests/ai_integration.rs
+++ b/crates/webfang_ai/tests/ai_integration.rs
@@ -325,8 +325,8 @@ fn test_matryoshka_identity_for_384d() {
 
 /// Builds an offline-mode semantic cleaner from the default config.
 ///
-/// The default config resolves the model from the local cache at
-/// `~/.cache/webfang/ai_models`. The cleaner is `.expect()`ed to initialize so
+/// The default config resolves the model from the native hf_hub cache at
+/// `~/.cache/huggingface/hub`. The cleaner is `.expect()`ed to initialize so
 /// that an absent model makes the test FAIL LOUDLY rather than silently
 /// passing. These pipeline tests are `#[ignore]`'d (require the cached ONNX
 /// model and must run serially to avoid OOM in CI).

--- a/crates/webfang_mcp/src/mcp_server/server.rs
+++ b/crates/webfang_mcp/src/mcp_server/server.rs
@@ -40,9 +40,11 @@ pub struct ServerOptions {
     pub request_timeout_secs: u64,
     /// Maximum request body size in bytes (default: 10 MB).
     pub body_limit_bytes: usize,
-    /// Maximum requests per second (default: 60).
+    /// Maximum requests per second (default: 10, matching the `webfang-mcp`
+    /// HTTP binary's `--rate` default).
     pub rate_per_second: u32,
-    /// Maximum burst size for rate limiting (default: 10).
+    /// Maximum burst size for rate limiting (default: 20, matching the
+    /// `webfang-mcp` HTTP binary's `--burst` default).
     pub rate_burst: u32,
     /// Expected Bearer token. When `None`, auth is disabled.
     pub auth_token: Option<String>,
@@ -53,8 +55,8 @@ impl Default for ServerOptions {
         Self {
             request_timeout_secs: 30,
             body_limit_bytes: 10 * 1024 * 1024,
-            rate_per_second: 60,
-            rate_burst: 10,
+            rate_per_second: 10,
+            rate_burst: 20,
             auth_token: None,
         }
     }
@@ -382,8 +384,8 @@ mod tests {
         let opts = ServerOptions::default();
         assert_eq!(opts.request_timeout_secs, 30);
         assert_eq!(opts.body_limit_bytes, 10 * 1024 * 1024);
-        assert_eq!(opts.rate_per_second, 60);
-        assert_eq!(opts.rate_burst, 10);
+        assert_eq!(opts.rate_per_second, 10);
+        assert_eq!(opts.rate_burst, 20);
         assert!(opts.auth_token.is_none());
     }
 


### PR DESCRIPTION
Closes #701
Closes #693

## Summary

Fixes two stale-doc findings from the v2.0.0 audit (verified still present against current code before fixing):

- **#701** — `AGENTS.md` claimed ONNX models cache in `~/.cache/webfang/ai_models/`, but the code uses the native hf_hub cache (`~/.cache/huggingface/hub/`). Updated AGENTS.md and a stale doc comment in `crates/webfang_ai/tests/ai_integration.rs`. Also added notes that `--clean-ai` is cache-first online / strict offline, and that embeddings only appear in exports with `--output-vectors`.
- **#693** — `ServerOptions::default()` declared 60 req/s burst 10 while the `webfang-mcp` HTTP binary effectively starts with 10 req/s burst 20. Aligned the library defaults to the shipped binary behavior (10/s, burst 20) so no runtime behavior changes; doc comments and the default test updated accordingly.

Also closed #691 as not-planned: `--ai-threshold` no longer appears anywhere in the repo, so that finding is stale.

## Verification

- `cargo check -p webfang_mcp` ✅
- `cargo clippy -p webfang_mcp --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` ✅
- `cargo fmt` ✅
- `cargo nextest run -p webfang_mcp --lib` server options + rate limiter tests ✅