### PR TITLE
fix(extraction): honest JS-only content errors + wire Tier 2 semantic (#706)

### DIFF
--- a/crates/webfang_ai/src/lib.rs
+++ b/crates/webfang_ai/src/lib.rs
@@ -21,7 +21,7 @@ pub use webfang_core::error::SemanticError;
 // Re-export key AI types for convenience
 #[cfg(feature = "ai")]
 pub use infrastructure_ai::{
-    AiModel, ChunkId, ContentPruner, EmbeddingAdapter, HtmlChunker, InferencePool,
-    LegibleContentPruner, MarkdownChunker, MiniLmTokenizer, ModelConfig, RelevanceScorer,
-    SemanticCleanerImpl, SentenceSplitter, ThresholdConfig, TokenBatch,
+    AiModel, ChunkId, ContentPruner, EmbeddingAdapter, GraniteDomInspector, HtmlChunker,
+    InferencePool, LegibleContentPruner, MarkdownChunker, MiniLmTokenizer, ModelConfig,
+    RelevanceScorer, SemanticCleanerImpl, SentenceSplitter, ThresholdConfig, TokenBatch,
 };

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -581,24 +581,174 @@ fn build_file_trace_layer(
     })
 }
 
-/// Build the adaptive selector engine when the feature and flag are both active.
-///
-/// Tier 1 (lexical) only — Tier 2 semantic repair would require the `ai` feature
-/// plus a GraniteDomInspector, so `semantic` is wired as None.
-#[cfg(feature = "adaptive-selectors")]
-fn build_adaptive_engine(opts: &CrawlOptions) -> Option<Arc<AdaptiveSelectorEngine>> {
-    if opts.adaptive_selectors {
-        Some(Arc::new(AdaptiveSelectorEngine::new(
-            Arc::new(DefaultDomInspector::new()),
+/// Tier 2 wiring regression tests (#702): the adaptive engine must expose the
+/// wired semantic provider, degrade to Tier 1 (lexical) when no provider is
+/// available, and resolve repairs through the semantic cascade.
+#[cfg(all(test, feature = "adaptive-selectors"))]
+mod wiring_tests {
+    use super::*;
+    use webfang_core::application::adaptive_engine::RepairStatus;
+    use webfang_core::domain::dom_inspector::SelectorErrorKind;
+    use webfang_core::domain::semantic_inspector::{
+        BoxFuture, SemanticContext, SemanticInspectorPort, SemanticMatch, TierSource,
+    };
+
+    /// Mock semantic inspector returning a configurable match.
+    struct MockSemanticInspector(Option<SemanticMatch>);
+
+    impl SemanticInspectorPort for MockSemanticInspector {
+        fn find_semantic_match<'a>(
+            &'a self,
+            _ctx: SemanticContext,
+        ) -> BoxFuture<'a, Result<Option<SemanticMatch>, SelectorErrorKind>> {
+            let response = self.0.clone();
+            Box::pin(async { Ok(response) })
+        }
+    }
+
+    fn opts_with_adaptive(enabled: bool) -> CrawlOptions {
+        CrawlOptions {
+            adaptive_selectors: enabled,
+            ..CrawlOptions::default()
+        }
+    }
+
+    #[test]
+    fn build_adaptive_engine_wires_semantic_provider_when_present() {
+        let engine = build_adaptive_engine(
+            &opts_with_adaptive(true),
+            Some(Arc::new(MockSemanticInspector(None))),
+            AdaptiveSelectorOptions::default(),
+        )
+        .expect("engine must exist when adaptive_selectors is enabled");
+
+        assert!(
+            engine.has_semantic_provider(),
+            "wired semantic provider must be visible on the engine"
+        );
+    }
+
+    #[test]
+    fn build_adaptive_engine_degrades_to_tier1_without_semantic() {
+        let engine = build_adaptive_engine(
+            &opts_with_adaptive(true),
             None,
             AdaptiveSelectorOptions::default(),
+        )
+        .expect("engine must exist when adaptive_selectors is enabled");
+
+        assert!(
+            !engine.has_semantic_provider(),
+            "no shared pool must leave a Tier-1-only engine"
+        );
+    }
+
+    #[test]
+    fn build_adaptive_engine_absent_when_flag_off() {
+        assert!(
+            build_adaptive_engine(
+                &opts_with_adaptive(false),
+                Some(Arc::new(MockSemanticInspector(None))),
+                AdaptiveSelectorOptions::default()
+            )
+            .is_none(),
+            "flag off must not build an engine even with a semantic provider available"
+        );
+    }
+
+    /// End-to-end wiring evidence (AS-2): the engine built by the production
+    /// wiring function resolves a repair through Tier 2. `trace.tier2_score`
+    /// is `Some` only on the semantic path — Tier 1 outcomes always carry
+    /// `None`, so this marker is equivalent to the trace field
+    /// `method = "tier2_semantic"` emitted by the cascade.
+    #[tokio::test]
+    async fn wired_engine_resolves_repair_through_tier2() {
+        let semantic_hit = Some(SemanticMatch {
+            selector: ".semantic-hit".to_owned(),
+            confidence: 0.9, // above semantic_threshold (0.75)
+            source: TierSource::Semantic,
+        });
+        let engine = build_adaptive_engine(
+            &opts_with_adaptive(true),
+            Some(Arc::new(MockSemanticInspector(semantic_hit))),
+            AdaptiveSelectorOptions::default(),
+        )
+        .expect("engine must exist when adaptive_selectors is enabled");
+
+        let html = "<div class='semantic-hit'>Contenido real</div>".to_owned();
+        let outcome = engine
+            .select_sync_aware(html, ".missing".to_owned(), None)
+            .await
+            .expect("tier2 repair must succeed with a confident semantic match");
+
+        assert_eq!(outcome.status, RepairStatus::Repaired);
+        assert_eq!(
+            outcome.suggestion.selector, ".semantic-hit",
+            "the repaired selector must come from the semantic provider"
+        );
+        let trace = outcome.trace.expect("tier2 repair carries a trace");
+        assert_eq!(
+            trace.tier2_score,
+            Some(0.9),
+            "the trace must record the tier2_semantic score"
+        );
+    }
+}
+
+/// Build the adaptive selector engine when the feature and flag are both active.
+///
+/// The `semantic` parameter carries the Tier 2 provider when the `ai` feature
+/// supplied one (shared ONNX pool + tokenizer); `None` degrades the engine to
+/// Tier 1 (lexical) repair. `options` is the shared engine configuration —
+/// the SAME instance that configured the Tier 2 threshold.
+#[cfg(feature = "adaptive-selectors")]
+fn build_adaptive_engine(
+    opts: &CrawlOptions,
+    semantic: Option<Arc<dyn webfang_core::domain::SemanticInspectorPort>>,
+    options: AdaptiveSelectorOptions,
+) -> Option<Arc<AdaptiveSelectorEngine>> {
+    if opts.adaptive_selectors {
+        tracing::info!(
+            semantic_wired = semantic.is_some(),
+            "building adaptive selector engine"
+        );
+        Some(Arc::new(AdaptiveSelectorEngine::new(
+            Arc::new(DefaultDomInspector::new()),
+            semantic,
+            options,
         )))
     } else {
         None
     }
 }
 
-/// Build the AI semantic cleaner and its vault-search ports.
+/// Build the Tier 2 semantic inspector from the cleaner's shared ONNX assets
+/// (#702).
+///
+/// Returns `None` when no shared pool is available (`--ai` off or dry-run),
+/// degrading the adaptive engine to Tier 1 lexical repair. The threshold comes
+/// from the single shared [`AdaptiveSelectorOptions`] — no duplicate constant.
+#[cfg(all(feature = "ai", feature = "adaptive-selectors"))]
+fn semantic_inspector(
+    shared: &Option<(
+        Arc<webfang_ai::InferencePool>,
+        Arc<webfang_ai::MiniLmTokenizer>,
+    )>,
+    options: &AdaptiveSelectorOptions,
+) -> Option<Arc<dyn webfang_core::domain::SemanticInspectorPort>> {
+    shared.as_ref().map(|(pool, tokenizer)| {
+        let inspector = webfang_ai::GraniteDomInspector::new(
+            Arc::clone(pool),
+            Arc::clone(tokenizer),
+            options.semantic_threshold,
+        );
+        Arc::new(inspector) as Arc<dyn webfang_core::domain::SemanticInspectorPort>
+    })
+}
+
+/// Build the AI semantic cleaner and its vault-search ports, surfacing the
+/// cleaner's shared ONNX assets (pool + tokenizer) so the adaptive engine can
+/// reuse them for Tier 2 semantic repair (#702) without a second model load.
 #[cfg(feature = "ai")]
 async fn build_ai_cleaner(
     opts: &CrawlOptions,
@@ -606,6 +756,10 @@ async fn build_ai_cleaner(
     (
         Option<Arc<dyn SemanticCleaner>>,
         webfang_core::application::container::VaultAiPorts,
+        Option<(
+            Arc<webfang_ai::InferencePool>,
+            Arc<webfang_ai::MiniLmTokenizer>,
+        )>,
     ),
     CliExit,
 > {
@@ -613,6 +767,7 @@ async fn build_ai_cleaner(
         return Ok((
             None,
             webfang_core::application::container::VaultAiPorts::default(),
+            None,
         ));
     }
 
@@ -646,10 +801,13 @@ async fn build_ai_cleaner(
                 // `resolve_model_assets` call, one `InferencePool` on `--ai`.
                 // Extracted before type-erasing the cleaner behind the trait.
                 let (pool, tokenizer) = cleaner.shared_inference();
+                // Surface a second Arc pair for Tier 2 wiring (#702); the vault
+                // ports consume the originals below.
+                let shared = Some((Arc::clone(&pool), Arc::clone(&tokenizer)));
                 let cleaner: Option<Arc<dyn SemanticCleaner>> = Some(Arc::new(cleaner));
                 let mut ports = build_vault_ports(pool, tokenizer).await;
                 ports.cleaner = cleaner.clone();
-                Ok((cleaner, ports))
+                Ok((cleaner, ports, shared))
             },
             Err(e) => {
                 let msg = format!("No se pudo inicializar el limpiador semántico AI: {e}");
@@ -667,19 +825,32 @@ async fn build_ai_cleaner(
 
 /// Build optional engines and dispatch to the orchestrator.
 ///
-/// The argument list depends on which optional features are compiled in, so each
-/// combination is spelled out explicitly.
+/// The AI cleaner is built FIRST (#702): the adaptive engine needs the
+/// cleaner's shared ONNX assets to wire Tier 2 semantic repair. The argument
+/// list passed to the orchestrator depends on which optional features are
+/// compiled in, so each combination is spelled out explicitly.
 async fn build_and_run(opts: CrawlOptions) -> CliExit {
-    #[cfg(feature = "adaptive-selectors")]
-    let adaptive_engine = build_adaptive_engine(&opts);
-
     #[cfg(feature = "ai")]
-    let (ai_cleaner, vault_ports) = match build_ai_cleaner(&opts).await {
+    let (ai_cleaner, vault_ports, shared) = match build_ai_cleaner(&opts).await {
         Ok(v) => v,
         Err(e) => return e,
     };
     #[cfg(not(feature = "ai"))]
     let vault_ports = webfang_core::application::container::VaultAiPorts::default();
+
+    #[cfg(feature = "adaptive-selectors")]
+    let engine_options = AdaptiveSelectorOptions::default();
+    #[cfg(all(feature = "ai", feature = "adaptive-selectors"))]
+    let semantic = semantic_inspector(&shared, &engine_options);
+    // Without the `ai` feature there is no ONNX pool — explicit Tier 1 degrade.
+    #[cfg(all(not(feature = "ai"), feature = "adaptive-selectors"))]
+    let semantic: Option<Arc<dyn webfang_core::domain::SemanticInspectorPort>> = None;
+    // No adaptive engine to feed — keep the shared assets from becoming an
+    // unused binding on the ai-only combo.
+    #[cfg(all(feature = "ai", not(feature = "adaptive-selectors")))]
+    let _ = shared;
+    #[cfg(feature = "adaptive-selectors")]
+    let adaptive_engine = build_adaptive_engine(&opts, semantic, engine_options);
 
     #[cfg(all(feature = "ai", feature = "adaptive-selectors"))]
     {

--- a/crates/webfang_core/src/application/adaptive_engine/mod.rs
+++ b/crates/webfang_core/src/application/adaptive_engine/mod.rs
@@ -133,6 +133,16 @@ impl AdaptiveSelectorEngine {
         }
     }
 
+    /// Whether a semantic (Tier 2) provider is wired into this engine.
+    ///
+    /// `false` means the engine degrades to Tier 1 (lexical) repair only —
+    /// the expected state when the `ai` feature is off or no ONNX assets are
+    /// available (`shared=None`).
+    #[must_use]
+    pub fn has_semantic_provider(&self) -> bool {
+        self.semantic.is_some()
+    }
+
     /// Sync-aware repair entry point — accepts raw HTML string (Send + Sync)
     /// instead of `&scraper::Html` (!Sync).
     ///
@@ -832,5 +842,127 @@ mod tests {
             SelectorErrorKind::RepairInconclusive(_) => {},
             other => panic!("expected RepairInconclusive, got {other:?}"),
         }
+    }
+
+    /// Mock semantic inspector that returns a configurable match — exercises
+    /// the Tier 2 success (method="tier2_semantic") and degraded paths.
+    struct MockSemanticMatch(Option<SemanticMatch>);
+
+    impl SemanticInspectorPort for MockSemanticMatch {
+        fn find_semantic_match<'a>(
+            &'a self,
+            _ctx: SemanticContext,
+        ) -> crate::domain::semantic_inspector::BoxFuture<
+            'a,
+            Result<Option<SemanticMatch>, SelectorErrorKind>,
+        > {
+            let response = self.0.clone();
+            Box::pin(async { Ok(response) })
+        }
+    }
+
+    /// Tier 2 returns a confident match → repaired via
+    /// method="tier2_semantic", trace carries the Tier 2 score.
+    #[tokio::test]
+    async fn test_repair_resolves_via_tier2_when_confidence_above_threshold() {
+        // Tier 1 stays ambiguous (0.65 ≤ 0.85) so the cascade escalates to Tier 2.
+        let inspector = Arc::new(MockInspector {
+            suggestions: vec![SelectorSuggestion {
+                selector: ".lexical-low".to_owned(),
+                score: 0.65,
+            }],
+        });
+        let semantic = Arc::new(MockSemanticMatch(Some(SemanticMatch {
+            selector: ".semantic-hit".to_owned(),
+            confidence: 0.9, // above semantic_threshold (0.75)
+            source: crate::domain::semantic_inspector::TierSource::Semantic,
+        })));
+
+        let engine = AdaptiveSelectorEngine::new(
+            inspector,
+            Some(semantic),
+            AdaptiveSelectorOptions::default(),
+        );
+        let html = "<div class='semantic-hit'>Hello</div>";
+        let document = scraper::Html::parse_document(html);
+
+        let result = engine.repair(&document, html, ".content", None).await;
+        assert!(result.is_ok(), "tier2 repair should succeed");
+        let outcome = result.unwrap();
+        assert_eq!(outcome.status, RepairStatus::Repaired);
+        assert_eq!(outcome.suggestion.selector, ".semantic-hit");
+        let trace = outcome
+            .trace
+            .as_ref()
+            .expect("tier2 repair carries a trace");
+        assert_eq!(
+            trace.tier2_score,
+            Some(0.9),
+            "trace must record the tier2_semantic score"
+        );
+        assert!(!trace.cache_hit);
+    }
+
+    /// Tier 2 returns a low-confidence match → Degraded, but the Tier 2 score
+    /// must still be visible in the trace (tier2_semantic ran).
+    #[tokio::test]
+    async fn test_repair_degraded_when_tier2_confidence_below_threshold() {
+        let inspector = Arc::new(MockInspector {
+            suggestions: vec![SelectorSuggestion {
+                selector: ".lexical-low".to_owned(),
+                score: 0.65,
+            }],
+        });
+        let semantic = Arc::new(MockSemanticMatch(Some(SemanticMatch {
+            selector: ".semantic-weak".to_owned(),
+            confidence: 0.6, // below semantic_threshold (0.75)
+            source: crate::domain::semantic_inspector::TierSource::Semantic,
+        })));
+
+        let engine = AdaptiveSelectorEngine::new(
+            inspector,
+            Some(semantic),
+            AdaptiveSelectorOptions::default(),
+        );
+        let html = "<div class='semantic-weak'>Hello</div>";
+        let document = scraper::Html::parse_document(html);
+
+        let result = engine.repair(&document, html, ".content", None).await;
+        assert!(result.is_ok(), "low-confidence tier2 still returns Ok");
+        let outcome = result.unwrap();
+        assert_eq!(
+            outcome.status,
+            RepairStatus::Degraded,
+            "confidence below 0.75 must mark the repair degraded"
+        );
+        assert_eq!(outcome.suggestion.selector, ".semantic-weak");
+        assert_eq!(outcome.trace.as_ref().unwrap().tier2_score, Some(0.6));
+    }
+
+    #[test]
+    fn has_semantic_provider_reflects_wiring() {
+        let inspector = Arc::new(MockInspector {
+            suggestions: vec![],
+        });
+
+        let tier1_only = AdaptiveSelectorEngine::new(
+            Arc::clone(&inspector) as Arc<dyn DomInspectorPort>,
+            None,
+            AdaptiveSelectorOptions::default(),
+        );
+        assert!(
+            !tier1_only.has_semantic_provider(),
+            "shared=None must leave a Tier-1-only engine"
+        );
+
+        let wired = AdaptiveSelectorEngine::new(
+            inspector,
+            Some(Arc::new(MockSemanticNoMatch)),
+            AdaptiveSelectorOptions::default(),
+        );
+        assert!(
+            wired.has_semantic_provider(),
+            "a semantic provider must be visible on the engine"
+        );
     }
 }

--- a/crates/webfang_core/src/application/adaptive_engine/mod.rs
+++ b/crates/webfang_core/src/application/adaptive_engine/mod.rs
@@ -861,22 +861,33 @@ mod tests {
         }
     }
 
+    /// Ambiguous Tier 1 engine (score 0.65 ≤ 0.85) — the cascade must escalate
+    /// to Tier 2 instead of settling for the lexical suggestion.
+    fn ambiguous_tier1() -> Arc<MockInspector> {
+        Arc::new(MockInspector {
+            suggestions: vec![SelectorSuggestion {
+                selector: ".lexical-low".to_owned(),
+                score: 0.65,
+            }],
+        })
+    }
+
+    /// Semantic mock returning a single match for `selector` at `confidence`.
+    fn semantic_match(selector: &str, confidence: f32) -> Arc<MockSemanticMatch> {
+        Arc::new(MockSemanticMatch(Some(SemanticMatch {
+            selector: selector.to_owned(),
+            confidence,
+            source: crate::domain::semantic_inspector::TierSource::Semantic,
+        })))
+    }
+
     /// Tier 2 returns a confident match → repaired via
     /// method="tier2_semantic", trace carries the Tier 2 score.
     #[tokio::test]
     async fn test_repair_resolves_via_tier2_when_confidence_above_threshold() {
         // Tier 1 stays ambiguous (0.65 ≤ 0.85) so the cascade escalates to Tier 2.
-        let inspector = Arc::new(MockInspector {
-            suggestions: vec![SelectorSuggestion {
-                selector: ".lexical-low".to_owned(),
-                score: 0.65,
-            }],
-        });
-        let semantic = Arc::new(MockSemanticMatch(Some(SemanticMatch {
-            selector: ".semantic-hit".to_owned(),
-            confidence: 0.9, // above semantic_threshold (0.75)
-            source: crate::domain::semantic_inspector::TierSource::Semantic,
-        })));
+        let inspector = ambiguous_tier1();
+        let semantic = semantic_match(".semantic-hit", 0.9); // above semantic_threshold (0.75)
 
         let engine = AdaptiveSelectorEngine::new(
             inspector,
@@ -907,17 +918,8 @@ mod tests {
     /// must still be visible in the trace (tier2_semantic ran).
     #[tokio::test]
     async fn test_repair_degraded_when_tier2_confidence_below_threshold() {
-        let inspector = Arc::new(MockInspector {
-            suggestions: vec![SelectorSuggestion {
-                selector: ".lexical-low".to_owned(),
-                score: 0.65,
-            }],
-        });
-        let semantic = Arc::new(MockSemanticMatch(Some(SemanticMatch {
-            selector: ".semantic-weak".to_owned(),
-            confidence: 0.6, // below semantic_threshold (0.75)
-            source: crate::domain::semantic_inspector::TierSource::Semantic,
-        })));
+        let inspector = ambiguous_tier1();
+        let semantic = semantic_match(".semantic-weak", 0.6); // below semantic_threshold (0.75)
 
         let engine = AdaptiveSelectorEngine::new(
             inspector,

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -269,6 +269,17 @@ pub async fn extract_content(
             )
             .await?;
 
+            // Shared minimum-content guard (#706): on the SUCCESS branch there
+            // was no content-size check before, so JS-shell pages returned Ok
+            // near-empty. The fallback branch keeps MIN_FALLBACK_CONTENT=100 as
+            // its SOLE authority — no second guard there (no double-error).
+            crate::application::spa_detection::validate_min_content(
+                url.as_str(),
+                &article.text_content,
+                html,
+                correlation_id,
+            )?;
+
             let author = crate::infrastructure::scraper::author_extractor::extract_author(
                 html,
                 article.byline.as_deref(),
@@ -439,5 +450,93 @@ mod tests {
             !results[0].title.is_empty(),
             "title must resolve to non-empty"
         );
+    }
+
+    // --- extract_content: the shared minimum-content guard (#706) ---
+
+    /// CLI funnel success branch (#684): readability succeeds but yields
+    /// sub-threshold text on a JS-shell page → typed `ExtractionFailed` with
+    /// the marker Spanish reason, never Ok near-empty.
+    #[tokio::test]
+    async fn test_extract_content_success_branch_below_threshold_errors() {
+        let html = "<html><head><title>App</title></head><body>\
+             <article><h1>Status</h1><p>Initializing…</p></article>\
+             <div id=\"root\"></div>\
+             </body></html>";
+        let url = url::Url::parse("https://spa.example.com/app").unwrap();
+        let corr = CorrelationId::new();
+
+        let result = extract_content(html, &url, &ScraperConfig::default(), None, None, &corr)
+            .await
+            .expect_err("sub-threshold success-branch content must fail honestly");
+
+        match &result {
+            ScraperError::ExtractionFailed {
+                url: failed_url,
+                reason,
+            } => {
+                assert_eq!(failed_url, url.as_str(), "url must be preserved");
+                assert!(
+                    reason.contains("contenido insuficiente"),
+                    "Spanish reason must state insufficient content: {reason}"
+                );
+                assert!(
+                    reason.contains("renderizado de JavaScript"),
+                    "marker-bearing shell must report the JS cause: {reason}"
+                );
+            },
+            other => panic!("expected ExtractionFailed, got: {other}"),
+        }
+    }
+
+    /// XC-2 legit fixture: a server-rendered page with ≥50 chars of extractable
+    /// text MUST still succeed — the guard never fires above the threshold.
+    #[tokio::test]
+    async fn test_extract_content_legit_page_above_threshold_succeeds() {
+        let html = "<html><head><title>Docs</title></head><body><article>\
+             <h1>Guide</h1>\
+             <p>This is a substantially long paragraph of server-rendered \
+             article content, easily over the fifty character extraction \
+             threshold, so the guard must let it through untouched.</p>\
+             </article></body></html>";
+        let url = url::Url::parse("https://example.com/guide").unwrap();
+        let corr = CorrelationId::new();
+
+        let result = extract_content(html, &url, &ScraperConfig::default(), None, None, &corr)
+            .await
+            .expect("a legit page must keep scraping successfully");
+
+        assert!(
+            result.content.chars().count() >= crate::application::spa_detection::MIN_CONTENT_CHARS,
+            "legit pages must yield substantial content"
+        );
+    }
+
+    /// CE-3 no double-gate: when readability FAILS, `MIN_FALLBACK_CONTENT=100`
+    /// stays the SOLE authority on the fallback branch — the 50-char guard must
+    /// NOT fire there (its Spanish text would be a duplicate signal).
+    #[tokio::test]
+    async fn test_extract_content_poor_fallback_keeps_min_fallback_authority() {
+        let html = "<html><body><a href=\"/x\"></a></body></html>";
+        let url = url::Url::parse("https://example.com/empty").unwrap();
+        let corr = CorrelationId::new();
+
+        let result = extract_content(html, &url, &ScraperConfig::default(), None, None, &corr)
+            .await
+            .expect_err("a content-less page must fail");
+
+        match &result {
+            ScraperError::ExtractionFailed { reason, .. } => {
+                assert!(
+                    reason.contains("contenido pobre del fallback"),
+                    "fallback branch error must come from MIN_FALLBACK_CONTENT, got: {reason}"
+                );
+                assert!(
+                    !reason.contains("contenido insuficiente"),
+                    "the 50-char guard must NOT double-fire on the fallback branch: {reason}"
+                );
+            },
+            other => panic!("expected ExtractionFailed, got: {other}"),
+        }
     }
 }

--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -440,7 +440,14 @@ async fn build_scraped_content(
             )
             .await?;
 
-            log_spa_warning(url.as_str(), &article.text_content, html);
+            // Shared minimum-content guard (#706): fail honestly on JS-shell
+            // or near-empty extraction instead of returning Ok near-empty.
+            crate::application::spa_detection::validate_min_content(
+                url.as_str(),
+                &article.text_content,
+                html,
+                correlation,
+            )?;
 
             let author = crate::infrastructure::scraper::author_extractor::extract_author(
                 html,
@@ -484,7 +491,16 @@ async fn build_scraped_content(
             )
             .await?;
 
-            log_spa_warning(url.as_str(), &fallback_content, html);
+            // Shared minimum-content guard (#706): the fallback branch has NO
+            // content-size check today (unlike extract_content's
+            // MIN_FALLBACK_CONTENT), so the guard is this branch's sole
+            // authority — fail honestly on sub-threshold content.
+            crate::application::spa_detection::validate_min_content(
+                url.as_str(),
+                &fallback_content,
+                html,
+                correlation,
+            )?;
 
             let fallback_title = url.host_str().unwrap_or("unknown_host").to_string();
             Ok(ScrapedContent {
@@ -507,24 +523,6 @@ async fn build_scraped_content(
                 correlation_id: Some(correlation.clone()),
             })
         },
-    }
-}
-
-/// Log a warning when extracted content is minimal (possible SPA requiring JS).
-fn log_spa_warning(url: &str, content: &str, html: &str) {
-    // SPA detection: check if extracted content is minimal
-    if let Some(spa_info) = detect_spa_content(url, content, html) {
-        if spa_info.has_spa_markers {
-            warn!(
-                "{} returned minimal content ({} chars) with SPA markers detected. This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
-                spa_info.url, spa_info.char_count
-            );
-        } else {
-            warn!(
-                "{} returned minimal content ({} chars). This site may require JavaScript rendering. This feature is not yet implemented. Track: https://github.com/XaviCode1000/webfang/issues/16",
-                spa_info.url, spa_info.char_count
-            );
-        }
     }
 }
 

--- a/crates/webfang_core/src/application/spa_detection.rs
+++ b/crates/webfang_core/src/application/spa_detection.rs
@@ -73,11 +73,11 @@ pub fn detect_spa_content(
 /// Shared minimum-content guard for BOTH extraction funnels (#706).
 ///
 /// Applies [`detect_spa_content`] to the freshly extracted content and fails
-/// the scrape with a typed [`ScraperError::ExtractionFailed`] instead of
-/// returning `Ok` on near-empty output. Both extraction funnels — the MCP
-/// funnel (`build_scraped_content`) and the CLI funnel (`extract_content`) —
-/// call this after extraction, so JS-shell pages fail honestly instead of
-/// producing near-empty Markdown.
+/// the scrape with a typed [`crate::error::ScraperError::ExtractionFailed`]
+/// instead of returning `Ok` on near-empty output. Both extraction funnels —
+/// the MCP funnel (`build_scraped_content`) and the CLI funnel
+/// (`extract_content`) — call this after extraction, so JS-shell pages fail
+/// honestly instead of producing near-empty Markdown.
 ///
 /// The Spanish `reason` distinguishes pages that carry SPA markers (likely
 /// requiring JavaScript rendering) from pages that simply returned very
@@ -85,8 +85,8 @@ pub fn detect_spa_content(
 ///
 /// # Errors
 ///
-/// Returns [`ScraperError::ExtractionFailed`] when the extracted text is below
-/// [`MIN_CONTENT_CHARS`] characters.
+/// Returns [`crate::error::ScraperError::ExtractionFailed`] when the extracted
+/// text is below [`MIN_CONTENT_CHARS`] characters.
 pub fn validate_min_content(
     url: &str,
     text_content: &str,

--- a/crates/webfang_core/src/application/spa_detection.rs
+++ b/crates/webfang_core/src/application/spa_detection.rs
@@ -54,9 +54,14 @@ pub fn detect_spa_content(
         return None;
     }
 
-    // Check for common SPA mount point markers in raw HTML (not stripped text)
-    let has_spa_markers =
-        raw_html.contains("<div id=\"root\">") || raw_html.contains("<div id=\"app\">");
+    // Check for common SPA mount point markers in raw HTML (not stripped text).
+    // The char gate above runs first, so server-rendered pages that also embed
+    // __NEXT_DATA__ / __INITIAL_STATE__ payloads but return substantial content
+    // are never flagged (SD-1: single 50-char threshold).
+    let has_spa_markers = raw_html.contains("<div id=\"root\">")
+        || raw_html.contains("<div id=\"app\">")
+        || raw_html.contains("__NEXT_DATA__")
+        || raw_html.contains("window.__INITIAL_STATE__");
 
     Some(SpaDetectionResult {
         url: url.to_string(),
@@ -65,9 +70,61 @@ pub fn detect_spa_content(
     })
 }
 
+/// Shared minimum-content guard for BOTH extraction funnels (#706).
+///
+/// Applies [`detect_spa_content`] to the freshly extracted content and fails
+/// the scrape with a typed [`ScraperError::ExtractionFailed`] instead of
+/// returning `Ok` on near-empty output. Both extraction funnels — the MCP
+/// funnel (`build_scraped_content`) and the CLI funnel (`extract_content`) —
+/// call this after extraction, so JS-shell pages fail honestly instead of
+/// producing near-empty Markdown.
+///
+/// The Spanish `reason` distinguishes pages that carry SPA markers (likely
+/// requiring JavaScript rendering) from pages that simply returned very
+/// little content. 50 (`MIN_CONTENT_CHARS`) stays the ONLY threshold.
+///
+/// # Errors
+///
+/// Returns [`ScraperError::ExtractionFailed`] when the extracted text is below
+/// [`MIN_CONTENT_CHARS`] characters.
+pub fn validate_min_content(
+    url: &str,
+    text_content: &str,
+    raw_html: &str,
+    correlation: &crate::domain::CorrelationId,
+) -> Result<(), crate::error::ScraperError> {
+    if let Some(spa_info) = detect_spa_content(url, text_content, raw_html) {
+        let reason = if spa_info.has_spa_markers {
+            format!(
+                "contenido insuficiente ({} caracteres) con marcadores SPA detectados — la página requiere renderizado de JavaScript",
+                spa_info.char_count
+            )
+        } else {
+            format!(
+                "contenido insuficiente ({} caracteres) — la página devolvió muy poco contenido extraíble",
+                spa_info.char_count
+            )
+        };
+        let err = crate::error::ScraperError::ExtractionFailed {
+            url: url.to_string(),
+            reason,
+        };
+        crate::infrastructure::observability::log_scrape_error(
+            &err,
+            url,
+            "extract",
+            Some(correlation),
+            "minimum-content guard",
+        );
+        return Err(err);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::CorrelationId;
 
     const URL: &str = "https://spa.example.com";
 
@@ -95,6 +152,50 @@ mod tests {
     }
 
     #[test]
+    fn test_below_threshold_with_next_data_marker_sets_flag() {
+        let result = detect_spa_content(
+            URL,
+            "loading",
+            "<html><body><script id=\"__NEXT_DATA__\" type=\"application/json\">{}</script></body></html>",
+        )
+        .expect("short content must be flagged");
+        assert!(
+            result.has_spa_markers,
+            "__NEXT_DATA__ payload must set marker"
+        );
+    }
+
+    #[test]
+    fn test_below_threshold_with_initial_state_marker_sets_flag() {
+        let result = detect_spa_content(
+            URL,
+            "loading",
+            "<html><body><script>window.__INITIAL_STATE__ = {};</script></body></html>",
+        )
+        .expect("short content must be flagged");
+        assert!(
+            result.has_spa_markers,
+            "window.__INITIAL_STATE__ must set marker"
+        );
+    }
+
+    #[test]
+    fn test_gated_markers_at_threshold_is_not_flagged() {
+        // Server-rendered __NEXT_DATA__ pages with substantial content must
+        // NOT be flagged: the char gate fires BEFORE the marker check.
+        let content = "a".repeat(MIN_CONTENT_CHARS);
+        for marker_html in [
+            "<html><script id=\"__NEXT_DATA__\">{}</script></html>",
+            "<html><script>window.__INITIAL_STATE__ = {};</script></html>",
+        ] {
+            assert!(
+                detect_spa_content(URL, &content, marker_html).is_none(),
+                "content at/above threshold must never be flagged, even with markers"
+            );
+        }
+    }
+
+    #[test]
     fn test_at_threshold_is_not_flagged() {
         let content = "a".repeat(MIN_CONTENT_CHARS);
         assert_eq!(content.chars().count(), MIN_CONTENT_CHARS);
@@ -119,5 +220,69 @@ mod tests {
             detect_spa_content(URL, &content, "<div id=\"root\"></div>").is_none(),
             "substantial content must not be flagged even with SPA markers"
         );
+    }
+
+    // --- validate_min_content: the shared two-funnel guard ---
+
+    #[test]
+    fn test_validate_min_content_ok_at_threshold() {
+        let correlation = CorrelationId::new();
+        let content = "a".repeat(MIN_CONTENT_CHARS);
+        assert!(
+            validate_min_content(URL, &content, "<div id=\"root\"></div>", &correlation).is_ok(),
+            "content at the threshold must pass the guard"
+        );
+    }
+
+    #[test]
+    fn test_validate_min_content_ok_above_threshold() {
+        let correlation = CorrelationId::new();
+        let content = "a".repeat(MIN_CONTENT_CHARS * 4);
+        assert!(
+            validate_min_content(URL, &content, "<html></html>", &correlation).is_ok(),
+            "substantial content must pass the guard"
+        );
+    }
+
+    #[test]
+    fn test_validate_min_content_err_with_markers_mentions_js() {
+        let correlation = CorrelationId::new();
+        let err = validate_min_content(URL, "loading", "<div id=\"root\"></div>", &correlation)
+            .expect_err("sub-threshold marker content must fail the guard");
+        match &err {
+            crate::error::ScraperError::ExtractionFailed { url, reason } => {
+                assert_eq!(url, URL, "url must be preserved on the error");
+                assert!(
+                    reason.contains("contenido insuficiente"),
+                    "Spanish reason must state insufficient content: {reason}"
+                );
+                assert!(
+                    reason.contains("renderizado de JavaScript"),
+                    "marker variant must mention JavaScript rendering: {reason}"
+                );
+            },
+            other => panic!("expected ExtractionFailed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_min_content_err_without_markers() {
+        let correlation = CorrelationId::new();
+        let err = validate_min_content(URL, "", "<html><body></body></html>", &correlation)
+            .expect_err("empty content must fail the guard");
+        match &err {
+            crate::error::ScraperError::ExtractionFailed { url, reason } => {
+                assert_eq!(url, URL, "url must be preserved on the error");
+                assert!(
+                    reason.contains("contenido insuficiente"),
+                    "Spanish reason must state insufficient content: {reason}"
+                );
+                assert!(
+                    !reason.contains("renderizado de JavaScript"),
+                    "no-marker variant must not claim JS requirement: {reason}"
+                );
+            },
+            other => panic!("expected ExtractionFailed, got: {other:?}"),
+        }
     }
 }

--- a/crates/webfang_core/src/application/spa_detection.rs
+++ b/crates/webfang_core/src/application/spa_detection.rs
@@ -244,25 +244,32 @@ mod tests {
         );
     }
 
+    /// Assert that `err` is the typed `ExtractionFailed` for [`URL`] and
+    /// return its Spanish reason for further assertions.
+    fn expect_extraction_failed(err: &crate::error::ScraperError) -> &str {
+        match err {
+            crate::error::ScraperError::ExtractionFailed { url, reason } => {
+                assert_eq!(url, URL, "url must be preserved on the error");
+                reason
+            },
+            other => panic!("expected ExtractionFailed, got: {other:?}"),
+        }
+    }
+
     #[test]
     fn test_validate_min_content_err_with_markers_mentions_js() {
         let correlation = CorrelationId::new();
         let err = validate_min_content(URL, "loading", "<div id=\"root\"></div>", &correlation)
             .expect_err("sub-threshold marker content must fail the guard");
-        match &err {
-            crate::error::ScraperError::ExtractionFailed { url, reason } => {
-                assert_eq!(url, URL, "url must be preserved on the error");
-                assert!(
-                    reason.contains("contenido insuficiente"),
-                    "Spanish reason must state insufficient content: {reason}"
-                );
-                assert!(
-                    reason.contains("renderizado de JavaScript"),
-                    "marker variant must mention JavaScript rendering: {reason}"
-                );
-            },
-            other => panic!("expected ExtractionFailed, got: {other:?}"),
-        }
+        let reason = expect_extraction_failed(&err);
+        assert!(
+            reason.contains("contenido insuficiente"),
+            "Spanish reason must state insufficient content: {reason}"
+        );
+        assert!(
+            reason.contains("renderizado de JavaScript"),
+            "marker variant must mention JavaScript rendering: {reason}"
+        );
     }
 
     #[test]
@@ -270,19 +277,14 @@ mod tests {
         let correlation = CorrelationId::new();
         let err = validate_min_content(URL, "", "<html><body></body></html>", &correlation)
             .expect_err("empty content must fail the guard");
-        match &err {
-            crate::error::ScraperError::ExtractionFailed { url, reason } => {
-                assert_eq!(url, URL, "url must be preserved on the error");
-                assert!(
-                    reason.contains("contenido insuficiente"),
-                    "Spanish reason must state insufficient content: {reason}"
-                );
-                assert!(
-                    !reason.contains("renderizado de JavaScript"),
-                    "no-marker variant must not claim JS requirement: {reason}"
-                );
-            },
-            other => panic!("expected ExtractionFailed, got: {other:?}"),
-        }
+        let reason = expect_extraction_failed(&err);
+        assert!(
+            reason.contains("contenido insuficiente"),
+            "Spanish reason must state insufficient content: {reason}"
+        );
+        assert!(
+            !reason.contains("renderizado de JavaScript"),
+            "no-marker variant must not claim JS requirement: {reason}"
+        );
     }
 }

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -584,13 +584,17 @@ fn format_failure(url: &str, error: &crate::error::ScraperError, verbosity: u8) 
 /// instead of the misleading "no pages scraped" network error. Any real
 /// failure or any scraped page keeps the historical routing below.
 ///
-/// Severity routing (#537): when every URL failed AND at least one failure
-/// classifies as [`crate::error::ErrorClass::InternalFatal`], the exit code is
-/// `CliExit::ScraperFailure` (3) rather than `NetworkError` (69) — an internal
-/// bug must not masquerade as a transient network outage. Purely
-/// transient/permanent all-fail runs keep exit 69. The partial-success case
-/// always reports `PartialSuccess` (69) regardless of failure severity: some
-/// content was scraped, which is the dominant signal.
+/// Severity routing (#537 + #706) applies when every URL failed:
+///
+/// 1. An internal-fatal failure wins → `CliExit::ScraperFailure` (3) — an
+///    internal bug must not masquerade as a transient network outage.
+/// 2. Any [`crate::error::ScraperError::ExtractionFailed`] is next →
+///    `CliExit::DataFormatError` (65) — the pages were fetched but carried
+///    no usable content (JS-only shells, poor fallback).
+/// 3. Anything else keeps `CliExit::NetworkError` (69).
+///
+/// The partial-success case always reports `PartialSuccess` (69) regardless of
+/// failure severity: some content was scraped, which is the dominant signal.
 fn report_phase(
     results: &[domain::ScrapedContent],
     failures: &[(String, crate::error::ScraperError)],
@@ -615,7 +619,13 @@ fn report_phase(
     }
 
     if results.is_empty() {
+        // Exit-code precedence in the all-fail arm: internal-fatal (3) outranks
+        // extraction-failed (65), which outranks the transient fallback (69)
+        // (#706). An internal bug must never masquerade as a data-format error.
         if let Some(exit) = scraper_failure_for_internal_fatal(failures) {
+            return Some(exit);
+        }
+        if let Some(exit) = data_format_error_for_extraction_failed(failures) {
             return Some(exit);
         }
         eprintln!("No pages were successfully scraped");
@@ -646,6 +656,32 @@ fn scraper_failure_for_internal_fatal(
         CliExit::ScraperFailure(format!(
             "Scraper failure: {internal_fatal} internal error(s) out of {} URLs",
             failures.len()
+        ))
+    })
+}
+
+/// Fold an all-failed error set into exit 65 when the failures are
+/// extraction failures (#706, Option A — typed variant match).
+///
+/// A run where every URL failed with
+/// [`crate::error::ScraperError::ExtractionFailed`] (JS-shell or near-empty
+/// content) is a DATA-FORMAT error (exit 65), not a network outage (69): the
+/// pages were fetched fine, they just carried no usable content. Typed
+/// `matches!` on the variant — never string-sniffing the reason, and
+/// `ErrorClass` stays untouched (PermanentFatal). Intentionally covers the
+/// poor-fallback 69→65 shift (CE-3): those failures are `ExtractionFailed`
+/// too, and empty output is exactly the data-format case. Returns `None`
+/// when no failure is an extraction failure.
+fn data_format_error_for_extraction_failed(
+    failures: &[(String, crate::error::ScraperError)],
+) -> Option<CliExit> {
+    let extraction_failed = failures
+        .iter()
+        .filter(|(_, e)| matches!(e, crate::error::ScraperError::ExtractionFailed { .. }))
+        .count();
+    (extraction_failed > 0).then(|| {
+        CliExit::DataFormatError(format!(
+            "extracción sin contenido útil: {extraction_failed} URL(s) devolvieron contenido insuficiente o requieren renderizado de JavaScript"
         ))
     })
 }
@@ -1048,19 +1084,28 @@ async fn load_batch_manager_from_stdin(
 
 /// Determine the CLI exit code from batch scrape results.
 ///
-/// Severity routing (#537): an all-failed batch containing at least one
-/// [`crate::error::ErrorClass::InternalFatal`] error yields
-/// `CliExit::ScraperFailure` (3); purely transient/permanent all-fail runs
-/// keep `CliExit::NetworkError` (69). Partial success remains
-/// `CliExit::PartialSuccess` (69) regardless of failure severity — some
-/// content was scraped, which is the dominant signal.
+/// Severity routing (#537 + #706) for all-fail runs
+/// (`failed > 0 && succeeded == 0`):
+///
+/// 1. An internal-fatal failure wins → `CliExit::ScraperFailure` (3).
+/// 2. Any [`crate::error::ScraperError::ExtractionFailed`] is next →
+///    `CliExit::DataFormatError` (65).
+/// 3. Anything else keeps `CliExit::NetworkError` (69).
+///
+/// Partial success remains `CliExit::PartialSuccess` (69) regardless of
+/// failure severity — some content was scraped, which is the dominant signal.
 fn batch_exit_code(
     succeeded: usize,
     failed: usize,
     errors: &[(String, crate::error::ScraperError)],
 ) -> CliExit {
     if failed > 0 && succeeded == 0 {
+        // Same precedence as `report_phase` (#706): internal-fatal (3) first,
+        // then extraction-failed (65), then the transient fallback (69).
         if let Some(exit) = scraper_failure_for_internal_fatal(errors) {
+            return exit;
+        }
+        if let Some(exit) = data_format_error_for_extraction_failed(errors) {
             return exit;
         }
         CliExit::NetworkError("All batch URLs failed".into())
@@ -1373,6 +1418,139 @@ mod tests {
 
     fn http_err(status: u16, url: &str) -> crate::error::ScraperError {
         crate::error::ScraperError::http(status, url)
+    }
+
+    fn extraction_failed(url: &str) -> crate::error::ScraperError {
+        crate::error::ScraperError::ExtractionFailed {
+            url: url.to_string(),
+            reason: "contenido insuficiente (0 caracteres) — la página devolvió muy poco contenido extraíble"
+                .to_string(),
+        }
+    }
+
+    // ===== extraction-failed exit-65 routing tests (#706) =====
+
+    #[test]
+    fn report_phase_all_extraction_failed_returns_data_format_error() {
+        // CE-1: a JS-only batch — every failure is the typed ExtractionFailed
+        // — must exit 65 (DataFormatError) with the Spanish message.
+        let failures = vec![
+            (
+                "https://js1.example.com".to_string(),
+                extraction_failed("https://js1.example.com"),
+            ),
+            (
+                "https://js2.example.com".to_string(),
+                extraction_failed("https://js2.example.com"),
+            ),
+        ];
+
+        let exit = report_phase(&[], &failures, 0, 0);
+
+        match exit {
+            Some(CliExit::DataFormatError(msg)) => {
+                assert!(
+                    msg.contains("extracción sin contenido útil"),
+                    "Spanish message expected, got: {msg}"
+                );
+                assert!(
+                    msg.contains("2 URL(s)"),
+                    "message must count the failures: {msg}"
+                );
+            },
+            other => panic!("expected DataFormatError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn report_phase_mixed_with_extraction_failed_keeps_partial_success() {
+        // CE-2: one success + one ExtractionFailed stays PartialSuccess (69) —
+        // extraction failures never outrank a successful scrape.
+        let results = vec![scraped("https://ok.example.com")];
+        let failures = vec![(
+            "https://js.example.com".to_string(),
+            extraction_failed("https://js.example.com"),
+        )];
+
+        let exit = report_phase(&results, &failures, 0, 0);
+
+        assert!(
+            matches!(
+                exit,
+                Some(CliExit::PartialSuccess {
+                    success: 1,
+                    failed: 1
+                })
+            ),
+            "expected PartialSuccess, got: {exit:?}"
+        );
+    }
+
+    #[test]
+    fn report_phase_internal_fatal_outranks_extraction_failed() {
+        // Precedence: internal-fatal (3) wins over extraction-failed (65) when
+        // both failure classes are present in an all-fail run.
+        let failures = vec![
+            ("https://bug.example.com".to_string(), internal_err("panic")),
+            (
+                "https://js.example.com".to_string(),
+                extraction_failed("https://js.example.com"),
+            ),
+        ];
+
+        let exit = report_phase(&[], &failures, 0, 0);
+
+        assert!(
+            matches!(exit, Some(CliExit::ScraperFailure(_))),
+            "internal-fatal must outrank extraction-failed, got: {exit:?}"
+        );
+    }
+
+    #[test]
+    fn batch_exit_code_all_extraction_failed_returns_data_format_error() {
+        // CE-3 (batch): poor-fallback all-fails are typed ExtractionFailed too,
+        // so an all-failed batch of them exits 65 instead of 69.
+        let errors = vec![
+            (
+                "https://js1.example.com".to_string(),
+                extraction_failed("https://js1.example.com"),
+            ),
+            (
+                "https://js2.example.com".to_string(),
+                extraction_failed("https://js2.example.com"),
+            ),
+        ];
+
+        let exit = batch_exit_code(0, 2, &errors);
+
+        match exit {
+            CliExit::DataFormatError(msg) => {
+                assert!(
+                    msg.contains("extracción sin contenido útil"),
+                    "Spanish message expected, got: {msg}"
+                );
+            },
+            other => panic!("expected DataFormatError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn batch_exit_code_internal_fatal_outranks_extraction_failed() {
+        // Same 3 > 65 precedence inside the batch code path.
+        let errors = vec![
+            ("https://bug.example.com".to_string(), internal_err("panic")),
+            (
+                "https://js.example.com".to_string(),
+                extraction_failed("https://js.example.com"),
+            ),
+        ];
+
+        let exit = batch_exit_code(0, 2, &errors);
+
+        assert!(
+            matches!(exit, CliExit::ScraperFailure(_)),
+            "internal-fatal must outrank extraction-failed, got: {exit:?}"
+        );
     }
 
     #[test]

--- a/crates/webfang_core/tests/behavioral/cli/batch_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/batch_test.rs
@@ -135,7 +135,7 @@ async fn batch_stdin_resume_creates_state_file() {
     Mock::given(method("GET"))
         .and(path("/"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><article><h1>Resume State</h1><p>x</p></article></body></html>",
+            "<html><body><article><h1>Resume State</h1><p>This body carries enough substantive text to pass the minimum-content guard.</p></article></body></html>",
         ))
         .mount(&server)
         .await;

--- a/crates/webfang_core/tests/behavioral/cli/crawl_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/crawl_test.rs
@@ -17,7 +17,9 @@ async fn max_depth_zero_only_scrapes_seed() {
     Mock::given(method("GET"))
         .and(path("/"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">Page A</a><a href=\"/page-b\">Page B</a></body></html>",
+            "<html><body><a href=\"/page-a\">Page A</a><a href=\"/page-b\">Page B</a>\
+             <p>This seed page carries plenty of substantive server-rendered text so it \
+             comfortably clears the fifty character minimum content guard.</p></body></html>",
         ))
         .mount(&t.server)
         .await;
@@ -28,7 +30,7 @@ async fn max_depth_zero_only_scrapes_seed() {
         .and(path("/page-a"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -37,7 +39,7 @@ async fn max_depth_zero_only_scrapes_seed() {
         .and(path("/page-b"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -136,7 +138,7 @@ async fn mount_subpath_scenario(server: &wiremock::MockServer) -> String {
         .and(path("/blog/post-1"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Post 1</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Post 1</h1><p>Post 1 carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(server)
         .await;
@@ -145,7 +147,7 @@ async fn mount_subpath_scenario(server: &wiremock::MockServer) -> String {
         .and(path("/blog/post-2"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Post 2</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Post 2</h1><p>Post 2 carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(server)
         .await;
@@ -256,7 +258,9 @@ async fn max_pages_limits_crawl_output() {
     Mock::given(method("GET"))
         .and(path("/"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a><a href=\"/page-c\">C</a><a href=\"/page-d\">D</a><a href=\"/page-e\">E</a></body></html>",
+            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a><a href=\"/page-c\">C</a><a href=\"/page-d\">D</a><a href=\"/page-e\">E</a>\
+             <p>This hub page carries plenty of substantive server-rendered text so it \
+             comfortably clears the fifty character minimum content guard.</p></body></html>",
         ))
         .mount(&t.server)
         .await;
@@ -269,7 +273,7 @@ async fn max_pages_limits_crawl_output() {
         .and(path("/page-a"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -278,7 +282,7 @@ async fn max_pages_limits_crawl_output() {
         .and(path("/page-b"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -287,7 +291,7 @@ async fn max_pages_limits_crawl_output() {
         .and(path("/page-c"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page C</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page C</h1><p>Page C carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -296,7 +300,7 @@ async fn max_pages_limits_crawl_output() {
         .and(path("/page-d"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page D</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page D</h1><p>Page D carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -305,7 +309,7 @@ async fn max_pages_limits_crawl_output() {
         .and(path("/page-e"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page E</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page E</h1><p>Page E carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -361,7 +365,9 @@ async fn exclude_pattern_skips_matching_urls() {
     Mock::given(method("GET"))
         .and(path("/"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a></body></html>",
+            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a>\
+             <p>This hub page carries plenty of substantive server-rendered text so it \
+             comfortably clears the fifty character minimum content guard.</p></body></html>",
         ))
         .mount(&t.server)
         .await;
@@ -370,7 +376,7 @@ async fn exclude_pattern_skips_matching_urls() {
         .and(path("/page-a"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -379,7 +385,7 @@ async fn exclude_pattern_skips_matching_urls() {
         .and(path("/page-b"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -453,7 +459,9 @@ async fn include_pattern_only_scrapes_matching_urls() {
     Mock::given(method("GET"))
         .and(path("/"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a></body></html>",
+            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a>\
+             <p>This hub page carries plenty of substantive server-rendered text so it \
+             comfortably clears the fifty character minimum content guard.</p></body></html>",
         ))
         .mount(&t.server)
         .await;
@@ -462,7 +470,7 @@ async fn include_pattern_only_scrapes_matching_urls() {
         .and(path("/page-a"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -471,7 +479,7 @@ async fn include_pattern_only_scrapes_matching_urls() {
         .and(path("/page-b"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(&t.server)
         .await;
@@ -620,7 +628,9 @@ async fn mount_dom_depth_scenario(server: &wiremock::MockServer) {
     Mock::given(method("GET"))
         .and(path("/"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page1\">Page 1</a><a href=\"/page2\">Page 2</a></body></html>",
+            "<html><body><a href=\"/page1\">Page 1</a><a href=\"/page2\">Page 2</a>\
+             <p>This seed page carries plenty of substantive server-rendered text so it \
+             comfortably clears the fifty character minimum content guard.</p></body></html>",
         ))
         .mount(server)
         .await;
@@ -629,7 +639,9 @@ async fn mount_dom_depth_scenario(server: &wiremock::MockServer) {
         .and(path("/page1"))
         .respond_with(
             ResponseTemplate::new(200).set_body_string(
-                "<html><body><a href=\"/deep\">Deep</a><h1>Page 1</h1></body></html>",
+                "<html><body><a href=\"/deep\">Deep</a><h1>Page 1</h1>\
+                 <p>Page 1 carries enough substantive server-rendered text to clear the \
+                 fifty character minimum content guard comfortably.</p></body></html>",
             ),
         )
         .mount(server)
@@ -639,7 +651,7 @@ async fn mount_dom_depth_scenario(server: &wiremock::MockServer) {
         .and(path("/page2"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page 2</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Page 2</h1><p>Page 2 carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(server)
         .await;
@@ -648,7 +660,7 @@ async fn mount_dom_depth_scenario(server: &wiremock::MockServer) {
         .and(path("/deep"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Deep</h1></article></body></html>"),
+                .set_body_string("<html><body><article><h1>Deep</h1><p>The deep page carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
         )
         .mount(server)
         .await;

--- a/crates/webfang_core/tests/behavioral/cli/crawl_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/crawl_test.rs
@@ -7,6 +7,72 @@ use tokio::time::timeout;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
+/// Pad sentence appended to fixture seed/hub pages so their extractable text
+/// clears the 50-char minimum-content guard (XC-2). `subject` is the sentence
+/// subject ("This seed page", "This hub page", …).
+fn hub_pad(subject: &str) -> String {
+    format!(
+        "{subject} carries plenty of substantive server-rendered text so it \
+         comfortably clears the fifty character minimum content guard."
+    )
+}
+
+/// Pad sentence for scrapeable article/child pages: "{subject} carries enough
+/// …" — padded text that clears the 50-char minimum-content guard (XC-2).
+fn article_pad(subject: &str) -> String {
+    format!(
+        "{subject} carries enough substantive server-rendered text to clear the \
+         fifty character minimum content guard comfortably."
+    )
+}
+
+/// A hub page whose body is `links_html` followed by a guard-clearing sentence.
+fn hub_page(links_html: &str, subject: &str) -> String {
+    format!(
+        "<html><body>{links_html}<p>{}</p></body></html>",
+        hub_pad(subject)
+    )
+}
+
+/// A scrapeable article page whose padded text clears the 50-char guard; the
+/// title doubles as the pad sentence subject.
+fn article_page(title: &str) -> String {
+    article_page_with_subject(title, title)
+}
+
+/// Like [`article_page`] but with a distinct pad subject (e.g. "The deep page").
+fn article_page_with_subject(subject: &str, title: &str) -> String {
+    format!(
+        "<html><body><article><h1>{title}</h1><p>{}</p></article></body></html>",
+        article_pad(subject)
+    )
+}
+
+/// Mock a scrapeable article page at `page_path` with the given title.
+async fn mock_article_page(server: &wiremock::MockServer, page_path: &str, title: &str) {
+    Mock::given(method("GET"))
+        .and(path(page_path))
+        .respond_with(ResponseTemplate::new(200).set_body_string(article_page(title)))
+        .mount(server)
+        .await;
+}
+
+/// Mount the two-page pattern scenario shared by the include/exclude tests:
+/// a hub `/` linking to `/page-a` and `/page-b`, both scrapeable articles.
+async fn mount_ab_pages(t: &BehavioralTest) {
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(hub_page(
+            "<a href=\"/page-a\">A</a><a href=\"/page-b\">B</a>",
+            "This hub page",
+        )))
+        .mount(&t.server)
+        .await;
+
+    mock_article_page(&t.server, "/page-a", "Page A").await;
+    mock_article_page(&t.server, "/page-b", "Page B").await;
+}
+
 /// --max-depth 0 with --use-sitemap only scrapes the seed URL;
 /// sitemap-discovered URLs are skipped.
 #[tokio::test]
@@ -16,33 +82,17 @@ async fn max_depth_zero_only_scrapes_seed() {
     // Seed page links to /page-a and /page-b as DOM-discovery fallback.
     Mock::given(method("GET"))
         .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">Page A</a><a href=\"/page-b\">Page B</a>\
-             <p>This seed page carries plenty of substantive server-rendered text so it \
-             comfortably clears the fifty character minimum content guard.</p></body></html>",
-        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(hub_page(
+            "<a href=\"/page-a\">Page A</a><a href=\"/page-b\">Page B</a>",
+            "This seed page",
+        )))
         .mount(&t.server)
         .await;
 
     // /page-a and /page-b are listed in the sitemap but must not be fetched
     // when max-depth is 0.
-    Mock::given(method("GET"))
-        .and(path("/page-a"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-b"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
+    mock_article_page(&t.server, "/page-a", "Page A").await;
+    mock_article_page(&t.server, "/page-b", "Page B").await;
 
     let base = t.server.uri();
     let sitemap_url = format!("{base}/sitemap.xml");
@@ -134,23 +184,8 @@ async fn mount_subpath_scenario(server: &wiremock::MockServer) -> String {
     );
     crate::common::mock_sitemap(server, &format!("{base}/blog/sitemap.xml"), &subpath_xml).await;
 
-    Mock::given(method("GET"))
-        .and(path("/blog/post-1"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Post 1</h1><p>Post 1 carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/blog/post-2"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Post 2</h1><p>Post 2 carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(server)
-        .await;
+    mock_article_page(server, "/blog/post-1", "Post 1").await;
+    mock_article_page(server, "/blog/post-2", "Post 2").await;
 
     base
 }
@@ -257,11 +292,10 @@ async fn max_pages_limits_crawl_output() {
 
     Mock::given(method("GET"))
         .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a><a href=\"/page-c\">C</a><a href=\"/page-d\">D</a><a href=\"/page-e\">E</a>\
-             <p>This hub page carries plenty of substantive server-rendered text so it \
-             comfortably clears the fifty character minimum content guard.</p></body></html>",
-        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(hub_page(
+            "<a href=\"/page-a\">A</a><a href=\"/page-b\">B</a><a href=\"/page-c\">C</a><a href=\"/page-d\">D</a><a href=\"/page-e\">E</a>",
+            "This hub page",
+        )))
         .mount(&t.server)
         .await;
 
@@ -269,50 +303,11 @@ async fn max_pages_limits_crawl_output() {
     // budget optimizer), so --max-pages 2 may pick any two of the six URLs.
     // Mock all of them so whichever two are scraped succeed; the `<= 2` .md
     // assertion below is what actually validates the max-pages cap.
-    Mock::given(method("GET"))
-        .and(path("/page-a"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-b"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-c"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page C</h1><p>Page C carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-d"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page D</h1><p>Page D carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-e"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page E</h1><p>Page E carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
+    mock_article_page(&t.server, "/page-a", "Page A").await;
+    mock_article_page(&t.server, "/page-b", "Page B").await;
+    mock_article_page(&t.server, "/page-c", "Page C").await;
+    mock_article_page(&t.server, "/page-d", "Page D").await;
+    mock_article_page(&t.server, "/page-e", "Page E").await;
 
     let base = t.server.uri();
     let sitemap_url = format!("{base}/sitemap.xml");
@@ -361,34 +356,7 @@ async fn max_pages_limits_crawl_output() {
 #[tokio::test]
 async fn exclude_pattern_skips_matching_urls() {
     let t = BehavioralTest::new().await;
-
-    Mock::given(method("GET"))
-        .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a>\
-             <p>This hub page carries plenty of substantive server-rendered text so it \
-             comfortably clears the fifty character minimum content guard.</p></body></html>",
-        ))
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-a"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-b"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
+    mount_ab_pages(&t).await;
 
     let base = t.server.uri();
     let sitemap_url = format!("{base}/sitemap.xml");
@@ -455,34 +423,7 @@ async fn exclude_pattern_skips_matching_urls() {
 #[tokio::test]
 async fn include_pattern_only_scrapes_matching_urls() {
     let t = BehavioralTest::new().await;
-
-    Mock::given(method("GET"))
-        .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page-a\">A</a><a href=\"/page-b\">B</a>\
-             <p>This hub page carries plenty of substantive server-rendered text so it \
-             comfortably clears the fifty character minimum content guard.</p></body></html>",
-        ))
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-a"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page A</h1><p>Page A carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/page-b"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page B</h1><p>Page B carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(&t.server)
-        .await;
+    mount_ab_pages(&t).await;
 
     let base = t.server.uri();
     let sitemap_url = format!("{base}/sitemap.xml");
@@ -627,38 +568,29 @@ async fn crawl_js_strategy_respects_timeout_secs() {
 async fn mount_dom_depth_scenario(server: &wiremock::MockServer) {
     Mock::given(method("GET"))
         .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/page1\">Page 1</a><a href=\"/page2\">Page 2</a>\
-             <p>This seed page carries plenty of substantive server-rendered text so it \
-             comfortably clears the fifty character minimum content guard.</p></body></html>",
-        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(hub_page(
+            "<a href=\"/page1\">Page 1</a><a href=\"/page2\">Page 2</a>",
+            "This seed page",
+        )))
         .mount(server)
         .await;
 
     Mock::given(method("GET"))
         .and(path("/page1"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><a href=\"/deep\">Deep</a><h1>Page 1</h1>\
-                 <p>Page 1 carries enough substantive server-rendered text to clear the \
-                 fifty character minimum content guard comfortably.</p></body></html>",
-        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+            "<html><body><a href=\"/deep\">Deep</a><h1>Page 1</h1><p>{}</p></body></html>",
+            article_pad("Page 1")
+        )))
         .mount(server)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/page2"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Page 2</h1><p>Page 2 carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
-        )
-        .mount(server)
-        .await;
+    mock_article_page(server, "/page2", "Page 2").await;
 
     Mock::given(method("GET"))
         .and(path("/deep"))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_string("<html><body><article><h1>Deep</h1><p>The deep page carries enough substantive server-rendered text to clear the fifty character minimum content guard comfortably.</p></article></body></html>"),
+                .set_body_string(article_page_with_subject("The deep page", "Deep")),
         )
         .mount(server)
         .await;

--- a/crates/webfang_core/tests/behavioral/cli/crawl_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/crawl_test.rs
@@ -637,13 +637,11 @@ async fn mount_dom_depth_scenario(server: &wiremock::MockServer) {
 
     Mock::given(method("GET"))
         .and(path("/page1"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_string(
-                "<html><body><a href=\"/deep\">Deep</a><h1>Page 1</h1>\
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><a href=\"/deep\">Deep</a><h1>Page 1</h1>\
                  <p>Page 1 carries enough substantive server-rendered text to clear the \
                  fifty character minimum content guard comfortably.</p></body></html>",
-            ),
-        )
+        ))
         .mount(server)
         .await;
 

--- a/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
@@ -428,11 +428,7 @@ async fn mixed_batch_with_js_shell_stays_69() {
     let output = t
         .scraper_cmd()
         .arg("--batch")
-        .write_stdin(format!(
-            "{}/ok\n{}/shell\n",
-            t.server.uri(),
-            t.server.uri()
-        ))
+        .write_stdin(format!("{}/ok\n{}/shell\n", t.server.uri(), t.server.uri()))
         .output()
         .expect("run webfang");
 

--- a/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
@@ -1,10 +1,7 @@
 //! Error paths: unreachable host, 404, 500 responses.
 
-use crate::assert_snapshot_redacted;
-use crate::cmd;
-use crate::BehavioralTest;
-use std::path::Path;
-use std::time::Duration;
+use crate::{assert_snapshot_redacted, cmd, BehavioralTest};
+use std::{path::Path, time::Duration};
 use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -352,6 +349,12 @@ mod output_vectors_without_clean_ai {
 // JS-shell content → exit 65 (EX_DATA) — honest data-format failure (#706)
 // ---------------------------------------------------------------------------
 
+/// Deterministic JS-shell body: `<div id="app">` mount point + `__NEXT_DATA__`
+/// payload, well under the 50-char extraction threshold (XC-2 fixture).
+const JS_SHELL_BODY: &str = "<!DOCTYPE html><html><head><title>App</title>\
+             <script id=\"__NEXT_DATA__\" type=\"application/json\">{\"page\":\"/\"}</script>\
+             </head><body><div id=\"app\"></div></body></html>";
+
 /// A JS-shell page (CE-1): fetch succeeds, extraction returns <50 chars with
 /// SPA markers → the run must exit 65 (DataFormatError) with the Spanish
 /// per-URL failure plus the Spanish summary, never exit 69 or a fake success.
@@ -367,11 +370,7 @@ async fn js_shell_single_page_exits_65_with_spanish_error() {
 
     Mock::given(method("GET"))
         .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<!DOCTYPE html><html><head><title>App</title>\
-             <script id=\"__NEXT_DATA__\" type=\"application/json\">{\"page\":\"/\"}</script>\
-             </head><body><div id=\"app\"></div></body></html>",
-        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(JS_SHELL_BODY))
         .mount(&t.server)
         .await;
 
@@ -417,11 +416,7 @@ async fn mixed_batch_with_js_shell_stays_69() {
         .await;
     Mock::given(method("GET"))
         .and(path("/shell"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<!DOCTYPE html><html><head><title>App</title>\
-             <script id=\"__NEXT_DATA__\" type=\"application/json\">{\"page\":\"/\"}</script>\
-             </head><body><div id=\"app\"></div></body></html>",
-        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(JS_SHELL_BODY))
         .mount(&t.server)
         .await;
 

--- a/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/error_path_test.rs
@@ -2,6 +2,7 @@
 
 use crate::assert_snapshot_redacted;
 use crate::cmd;
+use crate::BehavioralTest;
 use std::path::Path;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -345,6 +346,114 @@ mod output_vectors_without_clean_ai {
             "the vectors file must NOT be created when the flag gate rejects the run: {vectors_path:?}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// JS-shell content → exit 65 (EX_DATA) — honest data-format failure (#706)
+// ---------------------------------------------------------------------------
+
+/// A JS-shell page (CE-1): fetch succeeds, extraction returns <50 chars with
+/// SPA markers → the run must exit 65 (DataFormatError) with the Spanish
+/// per-URL failure plus the Spanish summary, never exit 69 or a fake success.
+/// Drives the real binary through `BehavioralTest` (wiremock + TempDir) so it
+/// exercises the full CLI funnel: extract_content guard → report_phase 65
+/// routing.
+///
+/// #706 contract: all-fail extraction runs shift from the misleading network
+/// error (69) to an honest data-format error (65).
+#[tokio::test]
+async fn js_shell_single_page_exits_65_with_spanish_error() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<!DOCTYPE html><html><head><title>App</title>\
+             <script id=\"__NEXT_DATA__\" type=\"application/json\">{\"page\":\"/\"}</script>\
+             </head><body><div id=\"app\"></div></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    let output = t
+        .scraper_cmd()
+        .arg("--single-page")
+        .arg("--max-retries")
+        .arg("0")
+        .arg("--quiet")
+        .output()
+        .expect("run webfang");
+
+    assert_eq!(
+        output.status.code(),
+        Some(65),
+        "a JS-only all-fail run must exit 65 (EX_DATA)"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("extracción falló"),
+        "stderr must carry the Spanish per-URL failure, got: {stderr}"
+    );
+    assert_snapshot_redacted("js_shell_exit_65_stderr", t.out.path(), stderr);
+}
+
+/// A mixed batch (CE-2): one legit page (≥50 chars) + one JS-shell → exit 69
+/// (PartialSuccess) regardless of the extraction failure. Some content was
+/// scraped, which is the dominant signal.
+#[tokio::test]
+async fn mixed_batch_with_js_shell_stays_69() {
+    let t = BehavioralTest::new().await;
+
+    Mock::given(method("GET"))
+        .and(path("/ok"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><head><title>Good Page</title></head><body><article>\
+             <h1>Good Page</h1>\
+             <p>This is a substantially long paragraph of server-rendered \
+             content, comfortably over the fifty character threshold.</p>\
+             </article></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/shell"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<!DOCTYPE html><html><head><title>App</title>\
+             <script id=\"__NEXT_DATA__\" type=\"application/json\">{\"page\":\"/\"}</script>\
+             </head><body><div id=\"app\"></div></body></html>",
+        ))
+        .mount(&t.server)
+        .await;
+
+    let output = t
+        .scraper_cmd()
+        .arg("--batch")
+        .write_stdin(format!(
+            "{}/ok\n{}/shell\n",
+            t.server.uri(),
+            t.server.uri()
+        ))
+        .output()
+        .expect("run webfang");
+
+    assert_eq!(
+        output.status.code(),
+        Some(69),
+        "a mixed batch must keep PartialSuccess exit 69"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // "Batch complete" counts CRAWL successes (both pages fetched fine); the
+    // JS-shell page fails later, at extraction time, via report_phase.
+    assert!(
+        stdout.contains("Batch complete: 2/2 succeeded"),
+        "both pages were crawled, got: {stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("extracción falló"),
+        "the extraction failure must be reported on stderr, got: {stderr}"
+    );
+    assert_snapshot_redacted("mixed_batch_stays_69_stderr", t.out.path(), stderr);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/webfang_core/tests/behavioral/cli/resume_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/resume_test.rs
@@ -22,14 +22,14 @@ async fn mount_resume_fixture(t: &BehavioralTest) -> String {
     Mock::given(method("GET"))
         .and(path("/page1"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><article><h1>Page One</h1><p>Body one.</p></article></body></html>",
+            "<html><body><article><h1>Page One</h1><p>Body one carries enough substantive text to pass the minimum-content guard.</p></article></body></html>",
         ))
         .mount(&t.server)
         .await;
     Mock::given(method("GET"))
         .and(path("/page2"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><article><h1>Page Two</h1><p>Body two.</p></article></body></html>",
+            "<html><body><article><h1>Page Two</h1><p>Body two carries enough substantive text to pass the minimum-content guard.</p></article></body></html>",
         ))
         .mount(&t.server)
         .await;

--- a/crates/webfang_core/tests/behavioral/cli/robots_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/robots_test.rs
@@ -6,6 +6,11 @@ use crate::BehavioralTest;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
+/// Seed page HTML linking to `/private/page`, padded so its extractable text
+/// clears the 50-char minimum-content guard (XC-2).
+const PRIVATE_SEED_PAGE: &str = r#"<html><body><a href="/private/page">Private</a>
+             <p>The seed page carries plenty of substantive server-rendered text so it comfortably clears the fifty character minimum content guard.</p></body></html>"#;
+
 /// Mock the seed page at `/` with the given HTML body.
 async fn mock_seed_page(t: &BehavioralTest, body: &str) {
     Mock::given(method("GET"))
@@ -83,12 +88,7 @@ async fn robots_txt_disallow_prevents_fetching() {
     crate::common::mock_robots(&t.server, "User-agent: *\nDisallow: /private/\n").await;
 
     // Seed page links to /private/page.
-    mock_seed_page(
-        &t,
-        r#"<html><body><a href="/private/page">Private</a>
-             <p>The seed page carries plenty of substantive server-rendered text so it comfortably clears the fifty character minimum content guard.</p></body></html>"#,
-    )
-    .await;
+    mock_seed_page(&t, PRIVATE_SEED_PAGE).await;
 
     // The /private/page endpoint is not mocked; if the crawler respects
     // robots.txt it will never reach it and wiremock returns 404 by default.
@@ -127,12 +127,7 @@ async fn ignore_robots_flag_allows_disallowed_fetch() {
 
     crate::common::mock_robots(&t.server, "User-agent: *\nDisallow: /private/\n").await;
 
-    mock_seed_page(
-        &t,
-        r#"<html><body><a href="/private/page">Private</a>
-             <p>The seed page carries plenty of substantive server-rendered text so it comfortably clears the fifty character minimum content guard.</p></body></html>"#,
-    )
-    .await;
+    mock_seed_page(&t, PRIVATE_SEED_PAGE).await;
 
     Mock::given(method("GET"))
         .and(path("/private/page"))

--- a/crates/webfang_core/tests/behavioral/cli/robots_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/robots_test.rs
@@ -85,7 +85,8 @@ async fn robots_txt_disallow_prevents_fetching() {
     // Seed page links to /private/page.
     mock_seed_page(
         &t,
-        r#"<html><body><a href="/private/page">Private</a></body></html>"#,
+        r#"<html><body><a href="/private/page">Private</a>
+             <p>The seed page carries plenty of substantive server-rendered text so it comfortably clears the fifty character minimum content guard.</p></body></html>"#,
     )
     .await;
 
@@ -128,7 +129,8 @@ async fn ignore_robots_flag_allows_disallowed_fetch() {
 
     mock_seed_page(
         &t,
-        r#"<html><body><a href="/private/page">Private</a></body></html>"#,
+        r#"<html><body><a href="/private/page">Private</a>
+             <p>The seed page carries plenty of substantive server-rendered text so it comfortably clears the fifty character minimum content guard.</p></body></html>"#,
     )
     .await;
 

--- a/crates/webfang_core/tests/behavioral/cli/single_page_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/single_page_test.rs
@@ -231,9 +231,9 @@ async fn selector_h3_extracts_only_h3() {
             "<html><body>\
                  <h1>Main Title</h1>\
                  <p>Paragraph to exclude.</p>\
-                 <h3>Section One</h3>\
+                 <h3>Section One Heading With Plenty of Lengthy Text</h3>\
                  <p>Details for section one.</p>\
-                 <h3>Section Two</h3>\
+                 <h3>Section Two Heading With Plenty of Lengthy Text</h3>\
                  <p>Details for section two.</p>\
                  </body></html>",
         ))
@@ -280,7 +280,7 @@ async fn selector_table_extracts_table() {
             "<html><body>\
                  <h1>Data Page</h1>\
                  <p>Intro text.</p>\
-                 <table><tr><td>Row1Col1</td><td>Row1Col2</td></tr></table>\
+                 <table><tr><td>Row One Column One Substantive Cell Text</td><td>Row One Column Two Substantive Text</td></tr></table>\
                  <p>More text.</p>\
                  </body></html>",
         ))

--- a/crates/webfang_core/tests/behavioral/cli/sitemap_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/sitemap_test.rs
@@ -52,7 +52,8 @@ async fn sitemap_url_scrapes_listed_urls() {
         .respond_with(ResponseTemplate::new(200).set_body_string(
             "<html><body><article>\
                  <h1>Page A</h1>\
-                 <p>Content from sitemap page A.</p>\
+                 <p>Substantive content from sitemap page A, long enough to clear the \
+                 fifty character minimum content guard comfortably.</p>\
                  </article></body></html>",
         ))
         .mount(&server)
@@ -63,7 +64,8 @@ async fn sitemap_url_scrapes_listed_urls() {
         .respond_with(ResponseTemplate::new(200).set_body_string(
             "<html><body><article>\
                  <h1>Page B</h1>\
-                 <p>Content from sitemap page B.</p>\
+                 <p>Substantive content from sitemap page B, long enough to clear the \
+                 fifty character minimum content guard comfortably.</p>\
                  </article></body></html>",
         ))
         .mount(&server)

--- a/crates/webfang_core/tests/behavioral/cli/trace_correlation_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/trace_correlation_test.rs
@@ -40,7 +40,10 @@ async fn mount_two_page_site(server: &wiremock::MockServer) -> String {
         Mock::given(method("GET"))
             .and(path(page_path))
             .respond_with(ResponseTemplate::new(200).set_body_string(format!(
-                "<html><body><article><h1>{title}</h1></article></body></html>"
+                "<html><body><article><h1>{title}</h1>\
+                 <p>Substantive body for {title}, long enough to clear the fifty character \
+                 minimum content guard so the scrape succeeds deterministically.</p>\
+                 </article></body></html>"
             )))
             .mount(server)
             .await;

--- a/crates/webfang_core/tests/behavioral/cli/waf_gauntlet_test.rs
+++ b/crates/webfang_core/tests/behavioral/cli/waf_gauntlet_test.rs
@@ -28,7 +28,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 // "captcha", etc. that would trip WafInspector on the 200 body).
 // ---------------------------------------------------------------------------
 
-const GAUNTLET_HTML: &str = r#"<html><body><article><h1>Gauntlet Passed</h1><p>The scraper survived the WAF.</p></article></body></html>"#;
+const GAUNTLET_HTML: &str = r#"<html><body><article><h1>Gauntlet Passed</h1><p>The scraper survived the WAF and this page carries enough substantive text to clear the minimum content guard.</p></article></body></html>"#;
 
 /// Mount the 403 → 429 → 200 sequence on `mock_path`.
 ///

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__js_shell_exit_65_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__js_shell_exit_65_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: crates/webfang_core/tests/behavioral/main.rs
+expression: redacted
+---
+  <TIMESTAMP>  WARN <MODULE>: Readability failed for http://127.0.0.1:<PORT>/: Error de extracción: Readability failed: Failed to extract article content from the document
+    at <FILE>.rs:<LINE>
+
+  <TIMESTAMP> ERROR <MODULE>: content extraction failed, error: contenido pobre del fallback: 3 bytes (mín 100 bytes). Readability: Error de extracción: Readability failed: Failed to extract article content from the document, url: http://127.0.0.1:<PORT>/, stage: extract, trace_id: "<TRACE_ID>"
+    at <FILE>.rs:<LINE>
+
+  <TIMESTAMP> ERROR <MODULE>: page scrape failed, error: extracción falló para http://127.0.0.1:<PORT>/: contenido pobre del fallback: 3 bytes (mín 100 bytes). Readability: Error de extracción: Readability failed: Failed to extract article content from the document, url: http://127.0.0.1:<PORT>/, stage: scrape, trace_id: "<TRACE_ID>"
+    at <FILE>.rs:<LINE>
+
+Failed to scrape http://127.0.0.1:<PORT>/: extracción falló para http://127.0.0.1:<PORT>/: contenido pobre del fallback: 3 bytes (mín 100 bytes). Readability: Error de extracción: Readability failed: Failed to extract article content from the document
+Error: extracción sin contenido útil: 1 URL(s) devolvieron contenido insuficiente o requieren renderizado de JavaScript

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__mixed_batch_stays_69_stderr.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__mixed_batch_stays_69_stderr.snap
@@ -1,0 +1,11 @@
+---
+source: crates/webfang_core/tests/behavioral/main.rs
+expression: redacted
+---
+  <TIMESTAMP>  WARN <MODULE>: Readability failed for http://127.0.0.1:<PORT>/shell: Error de extracción: Readability failed: Failed to extract article content from the document
+    at <FILE>.rs:<LINE>
+
+  <TIMESTAMP> ERROR <MODULE>: content extraction failed, error: contenido pobre del fallback: 3 bytes (mín 100 bytes). Readability: Error de extracción: Readability failed: Failed to extract article content from the document, url: http://127.0.0.1:<PORT>/shell, stage: extract, trace_id: "<TRACE_ID>"
+    at <FILE>.rs:<LINE>
+
+Failed to scrape http://127.0.0.1:<PORT>/shell: extracción falló para http://127.0.0.1:<PORT>/shell: contenido pobre del fallback: 3 bytes (mín 100 bytes). Readability: Error de extracción: Readability failed: Failed to extract article content from the document

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__selector_h3_extracts_only_h3.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__selector_h3_extracts_only_h3.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/webfang_core/../../tests/behavioral/main.rs
+source: crates/webfang_core/tests/behavioral/main.rs
 expression: redacted
 ---
 ---
@@ -8,6 +8,6 @@ url: http://127.0.0.1:<PORT>/
 date: [DATE]
 ---
 
-### Section One
+### Section One Heading With Plenty of Lengthy Text
 
-### Section Two
+### Section Two Heading With Plenty of Lengthy Text

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__selector_table_extracts_table.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__selector_table_extracts_table.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/webfang_core/../../tests/behavioral/main.rs
+source: crates/webfang_core/tests/behavioral/main.rs
 expression: redacted
 ---
 ---
@@ -8,6 +8,6 @@ url: http://127.0.0.1:<PORT>/
 date: [DATE]
 ---
 
-Row1Col1
+Row One Column One Substantive Cell Text
 
-Row1Col2
+Row One Column Two Substantive Text

--- a/crates/webfang_core/tests/exit_code_integration.rs
+++ b/crates/webfang_core/tests/exit_code_integration.rs
@@ -117,6 +117,8 @@ async fn test_dom_external_only_links_scrapes_seed() {
         .and(path("/"))
         .respond_with(ResponseTemplate::new(200).set_body_string(
             "<html><body><h1>Seed content</h1>\
+             <p>The seed page carries plenty of substantive server-rendered text so it \
+             comfortably clears the fifty character minimum content guard.</p>\
              <a href=\"https://iana.org\">external link</a></body></html>",
         ))
         .mount(&mock_server)
@@ -232,11 +234,10 @@ async fn test_valid_sitemap_returns_exit_0() {
     // Serve the page content
     Mock::given(method("GET"))
         .and(path("/page1"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_string(
-                "<html><body><h1>Hello World</h1><p>Test content</p></body></html>",
-            ),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><h1>Hello World</h1><p>Test content long enough to clear the \
+                 fifty character minimum content guard comfortably.</p></body></html>",
+        ))
         .mount(&mock_server)
         .await;
 

--- a/crates/webfang_core/tests/fixtures_root/js_shell.html
+++ b/crates/webfang_core/tests/fixtures_root/js_shell.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SPA App</title>
+    <script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{}},"page":"/","query":{}}</script>
+</head>
+<body>
+    <div id="root"></div>
+    <noscript>Loading…</noscript>
+</body>
+</html>

--- a/crates/webfang_core/tests/scraper_service_test.rs
+++ b/crates/webfang_core/tests/scraper_service_test.rs
@@ -440,6 +440,9 @@ async fn test_mock_404_returns_http_error() {
     );
 }
 
+/// An empty body must fail HONESTLY with the typed minimum-content error,
+/// not return Ok on near-empty content (#706, #694). Empty extraction is a
+/// data-format failure, not a success.
 #[cfg_attr(miri, ignore)] // legible/servo_arc Tree-Borrows UB
 #[tokio::test]
 async fn test_mock_empty_body_graceful_handling() {
@@ -447,10 +450,16 @@ async fn test_mock_empty_body_graceful_handling() {
     let mock = MockHttpClient::new().with_ok_response(url.as_str(), "");
 
     let result = scrape_with_readability(&mock, &url).await;
-    // Empty body should not panic — Readability or fallback handles it
-    match &result {
-        Ok(contents) => assert!(!contents.is_empty()),
-        Err(e) => panic!("empty body should succeed, got: {e}"),
+    let err = result.expect_err("empty body must fail honestly, not return Ok near-empty");
+
+    match &err {
+        ScraperError::ExtractionFailed { reason, .. } => {
+            assert!(
+                reason.contains("contenido insuficiente"),
+                "Spanish reason must state insufficient content: {reason}"
+            );
+        },
+        other => panic!("expected ExtractionFailed, got: {other}"),
     }
 }
 

--- a/crates/webfang_core/tests/scraper_service_test.rs
+++ b/crates/webfang_core/tests/scraper_service_test.rs
@@ -463,6 +463,39 @@ async fn test_mock_empty_body_graceful_handling() {
     }
 }
 
+/// MCP funnel over the deterministic `js_shell.html` fixture (#706): a JS-only
+/// shell (`<div id="root">` + `__NEXT_DATA__`, <50 text chars) must yield the
+/// typed `ExtractionFailed` error, and its Spanish reason must call out the
+/// JavaScript-rendering cause (marker variant) — never an Ok near-empty scrape.
+#[cfg_attr(miri, ignore)] // legible/servo_arc Tree-Borrows UB
+#[tokio::test]
+async fn test_js_shell_body_fails_with_typed_error() {
+    let html = std::fs::read_to_string(format!(
+        "{}/tests/fixtures_root/js_shell.html",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("load js_shell.html fixture");
+    let url = url::Url::parse("https://spa.example.com/app").unwrap();
+    let mock = MockHttpClient::new().with_ok_response(url.as_str(), &html);
+
+    let result = scrape_with_readability(&mock, &url).await;
+    let err = result.expect_err("a JS-shell body must fail honestly");
+
+    match &err {
+        ScraperError::ExtractionFailed {
+            reason,
+            url: failed_url,
+        } => {
+            assert_eq!(failed_url, url.as_str(), "url must be preserved");
+            assert!(
+                reason.contains("renderizado de JavaScript"),
+                "marker-bearing shell must report the JS-rendering cause: {reason}"
+            );
+        },
+        other => panic!("expected ExtractionFailed, got: {other}"),
+    }
+}
+
 #[cfg_attr(miri, ignore)] // legible/servo_arc Tree-Borrows UB
 #[tokio::test]
 async fn test_mock_timeout_error_propagation() {

--- a/crates/webfang_mcp/tests/scraping_coverage_test.rs
+++ b/crates/webfang_mcp/tests/scraping_coverage_test.rs
@@ -254,6 +254,62 @@ async fn test_scrape_url_http_error_is_honest_error() {
     );
 }
 
+/// A JS-shell page (`<div id="app">` mount point, <50 chars of extractable
+/// text, spec MCP-1 scenario) must surface as an honest tool error
+/// (isError:true) — never a fake `isError:false` success with near-empty
+/// content. The underlying `ScrapeError::ExtractionFailed` flows through the
+/// existing Err→`CallToolResult::error` mapping (#694, #706).
+#[tokio::test]
+async fn test_scrape_url_js_shell_is_error_result() {
+    let mock = MockServer::start().await;
+    // Deterministic JS shell: app mount point + Next.js payload, well under
+    // the 50-char content threshold once readability/fallback strips markup.
+    let html = r#"<!DOCTYPE html>
+<html><head><title>App</title>
+<script id="__NEXT_DATA__" type="application/json">{"page":"/"}</script>
+</head><body><div id="app"></div></body></html>"#;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(html))
+        .mount(&mock)
+        .await;
+
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "scrape_url",
+        json!({ "url": mock.uri() }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        is_tool_error(&result),
+        "a JS-shell scrape must return isError:true, got: {}",
+        tool_text(&result)
+    );
+
+    // Semantic invariant: the Spanish error text names the JS-rendering cause.
+    let text = tool_text(&result);
+    assert!(
+        text.contains("renderizado de JavaScript"),
+        "error text must explain the JS-rendering cause, got: {text}"
+    );
+
+    // Redacted snapshot (XC-2): the wiremock port is the only
+    // non-deterministic element — collapse it before snapshotting.
+    let redacted = text.replace(&mock.uri(), "http://127.0.0.1:<PORT>");
+    insta::assert_snapshot!("scrape_url_js_shell_is_error", redacted);
+}
+
 // ============================================================================
 // discover_urls
 // ============================================================================

--- a/crates/webfang_mcp/tests/scraping_coverage_test.rs
+++ b/crates/webfang_mcp/tests/scraping_coverage_test.rs
@@ -188,6 +188,28 @@ fn is_tool_error(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
+/// Call a single-URL tool against `target_uri` and return the extracted
+/// `result` object from the JSON-RPC envelope.
+async fn call_single_url_tool_result(
+    client: &Client,
+    base_url: &str,
+    session_id: &str,
+    tool: &str,
+    target_uri: &str,
+) -> Value {
+    let resp = call_tool(
+        client,
+        base_url,
+        session_id,
+        tool,
+        json!({ "url": target_uri }),
+    )
+    .await;
+    resp.get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone()
+}
+
 // ============================================================================
 // scrape_url
 // ============================================================================
@@ -234,19 +256,9 @@ async fn test_scrape_url_http_error_is_honest_error() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "scrape_url",
-        json!({ "url": mock.uri() }),
-    )
-    .await;
-
-    let result = resp
-        .get("result")
-        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
-        .clone();
+    let result =
+        call_single_url_tool_result(&client, &base_url, &session_id, "scrape_url", &mock.uri())
+            .await;
     assert!(
         is_tool_error(&result),
         "HTTP 500 must return isError:true, got: {}",
@@ -278,19 +290,9 @@ async fn test_scrape_url_js_shell_is_error_result() {
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
 
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "scrape_url",
-        json!({ "url": mock.uri() }),
-    )
-    .await;
-
-    let result = resp
-        .get("result")
-        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
-        .clone();
+    let result =
+        call_single_url_tool_result(&client, &base_url, &session_id, "scrape_url", &mock.uri())
+            .await;
     assert!(
         is_tool_error(&result),
         "a JS-shell scrape must return isError:true, got: {}",

--- a/crates/webfang_mcp/tests/snapshots/scraping_coverage_test__scrape_url_js_shell_is_error.snap
+++ b/crates/webfang_mcp/tests/snapshots/scraping_coverage_test__scrape_url_js_shell_is_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_mcp/tests/scraping_coverage_test.rs
+expression: redacted
+---
+extracción falló para http://127.0.0.1:<PORT>/: contenido insuficiente (3 caracteres) con marcadores SPA detectados — la página requiere renderizado de JavaScript


### PR DESCRIPTION
## Linked Issue

<!-- REQUIRED — use one of: Closes #N / Fixes #N / Resolves #N -->
Closes #706

Covers the remaining two epic pasos in a single PR: #684 (CLI honest JS-only errors) and #694 (MCP honest JS-only errors), plus the Tier 2 semantic wiring from #702.

## PR Type

<!-- Check exactly ONE, then add the matching label -->
- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- JS-shell / low-content pages no longer return "success with nothing" — both extraction funnels now fail with a typed `ExtractionFailed` error carrying a clear Spanish reason, and the CLI routes all-extraction-failed runs to exit code **65** (DataFormatError) instead of 69.
- Mixed batches (some success + some extraction-failed) intentionally stay at **69** (PartialSuccess). Precedence: internal-fatal (3) > extraction-failed (65) > network (69).
- Tier 2 semantic repair (#702) is now wired end-to-end: under `ai + adaptive-selectors`, the adaptive engine reuses the cleaner's shared ONNX pool + tokenizer to build ONE `GraniteDomInspector` (threshold 0.75, single source). Outside that combination the engine degrades to Tier 1 — unchanged behavior.

## Changes

| Area | Files | Change |
|------|--------|
| Shared guard | `core/application/spa_detection.rs` | Extended SPA markers (`<div id="root">`, `<div id="app">`, `__NEXT_DATA__`, `window.__INITIAL_STATE__`); new `validate_min_content` with typed error + `log_scrape_error` observability |
| MCP funnel | `core/application/scraper_service.rs` | Guard on both readability + fallback branches; dead `log_spa_warning` removed |
| CLI funnel | `core/application/extraction.rs` | Guard on readability success branch only (fallback keeps 100-char authority) |
| Exit routing | `core/cli/orchestrator.rs` | `data_format_error_for_extraction_failed` + typed exit-65 in `report_phase` / `batch_exit_code` |
| Engine accessor | `core/application/adaptive_engine/mod.rs` | `has_semantic_provider()` + Tier 2 test coverage |
| Tier 2 re-export | `ai/src/lib.rs` | `GraniteDomInspector` at crate root |
| Tier 2 wiring | `cli/src/main.rs` | `build_ai_cleaner` surfaces shared pool/tokenizer; `build_and_run` AI-first; `semantic_inspector` helper |
| Behavioral contracts | `tests/behavioral/cli/error_path_test.rs`, `mcp/tests/scraping_coverage_test.rs` | exit-65 JS-shell stderr snapshot; MCP `isError:true` on JS-shell |
| Fixtures | `fixtures_root/js_shell.html` + 20 legit fixtures padded ≥50 chars | Legitimate pages must survive the 50-char gate (XC-2) |

## Evidence

- **Exit codes:** `webfang scrape <js-shell>` → exit **65** with Spanish stderr; mixed batch (1 legit + 1 js-shell) → exit **69** (instabehavioral snapshots: `behavioral__js_shell_exit_65_stderr.snap`, `behavioral__mixed_batch_stays_69_stderr.snap`).
- **MCP contract:** `scrape_url` on a `<div id="app">` shell returns `isError: true` with reason mentioning "renderizado de JavaScript" (snapshot `scraping_coverage_test__scrape_url_js_shell_is_error.snap`).
- **Tier 2 trace fields:** wired-engine test resolves repair through Tier 2 with `trace.tier2_score = Some(0.9)` (equivalent of the `method = "tier2_semantic"` trace event from the cascade); 4 wiring unit tests + 4-way cfg matrix compile checks all green.
- **Full gate:** `cargo check` + `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` + `cargo fmt` clean; `cargo nextest run --workspace` → **2527 passed, 0 failed, 14 skipped**; zero pending `.snap.new`.

## Size Exception

This PR is 1224 changed lines (25 files) — exceeds the default 400-line budget and the 800-line session gate. Maintainer explicitly approved `size:exception` for this single-pr delivery. The bulk of the diff is mechanical legit-fixture padding (≥50 chars) forced by the new extraction gate (Design Risk 2: `Ok → Err` snapshot churn).

## Test Plan

<!-- Adapt to the change. For Rust work, use the exact CI gates (see AGENTS.md — a bare clippy passes locally but CI fails). -->
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run` passes (workspace: 2527/2527)
- [x] Manually verified the affected functionality

## Contributor Checklist

- [x] Linked an approved issue (`status:approved`) with `Closes/Fixes/Resolves #N`
- [x] Branch name matches `type/description` (e.g. `fix/parser-crash`) — CI rejects others
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed
- [x] Defensive error paths annotated with `// LCOV_EXCL_*` markers per docs/src/testing.md (issue #527)