### PR TITLE
fix(mcp): Fase 4 hardening — SSRF remanente, cota de métricas y auth fail-fast (#707)

### DIFF
--- a/crates/webfang_core/src/adapters/downloader/mod.rs
+++ b/crates/webfang_core/src/adapters/downloader/mod.rs
@@ -976,49 +976,66 @@ mod tests {
         assert!(results.is_empty());
     }
 
-    /// SSRF redirect guard (#703): a redirect whose `Location` is a literal
-    /// forbidden IP must be stopped even when the entry URL itself passed
-    /// validation. The terminal redirect response surfaces as an HTTP error
-    /// and the target is never requested (`expect(0)` proves wiremock saw
-    /// no hit). Clones the `wreq_downloader.rs` sibling test.
-    #[cfg_attr(miri, ignore = "boring-sys2 FFI (wreq Client) not supported by Miri")]
-    #[tokio::test]
-    async fn test_redirect_to_forbidden_literal_ip_is_stopped() {
-        // Defensive under shared-process harnesses: the escape hatch must be
-        // unset for this process so the guard is active. (nextest isolates
-        // each test in its own process, so this is a no-op there.)
-        std::env::remove_var(crate::infrastructure::ssrf::DISABLE_REDIRECT_GUARD_ENV);
+    /// Mount the entry route of a redirect-flow fixture plus its destination.
+    /// The `location` header targets a forbidden literal IP, so the guard must
+    /// stop the flow before `/target` is ever requested — `expect(0)` is the
+    /// wire-level proof of that.
+    async fn mount_redirect_with_untouched_target(
+        server: &MockServer,
+        from_path: &str,
+        to_location: &str,
+    ) {
+        let redirect = ResponseTemplate::new(301).insert_header("location", to_location);
+        let entry = ResponseTemplate::new(200).set_body_string("body-never-fetched");
 
-        let mock_server = MockServer::start().await;
-
-        // Location points at a different loopback literal — forbidden by the
-        // guard, unreachable in practice, and never requested.
         Mock::given(method("GET"))
-            .and(path("/download"))
-            .respond_with(
-                ResponseTemplate::new(301).insert_header("location", "http://127.0.0.2:9/target"),
-            )
-            .mount(&mock_server)
+            .and(path(from_path))
+            .respond_with(redirect)
+            .mount(server)
             .await;
 
         Mock::given(method("GET"))
             .and(path("/target"))
-            .respond_with(ResponseTemplate::new(200).set_body_string("binary-body"))
+            .respond_with(entry)
             .expect(0)
-            .mount(&mock_server)
+            .mount(server)
             .await;
+    }
+
+    /// SSRF redirect guard (#703): even an entry URL that passed validation
+    /// cannot hop onto a literal forbidden IP through a redirect — the 301
+    /// itself becomes a terminal HTTP error and `/target` is never fetched
+    /// (wire-level proof via `expect(0)`).
+    #[cfg_attr(miri, ignore = "boring-sys2 FFI (wreq Client) not supported by Miri")]
+    #[tokio::test]
+    async fn test_redirect_to_forbidden_literal_ip_is_stopped() {
+        // Keep the guard active: the escape hatch must be unset in this
+        // process (a no-op under nextest, which gives every test its own
+        // process; defensive against shared-process harnesses).
+        std::env::remove_var(crate::infrastructure::ssrf::DISABLE_REDIRECT_GUARD_ENV);
+        let mock_server = MockServer::start().await;
+
+        // Location points at a different loopback literal — forbidden by the
+        // guard, unreachable in practice, and never requested.
+        mount_redirect_with_untouched_target(
+            &mock_server,
+            "/download",
+            "http://127.0.0.2:9/target",
+        )
+        .await;
 
         let temp_dir = TempDir::new().unwrap();
-        let config = DownloadConfig {
+        let downloader = Downloader::new(DownloadConfig {
             output_dir: temp_dir.path().to_path_buf(),
             max_retries: 0,
             ..Default::default()
-        };
-        let downloader = Downloader::new(config).unwrap();
-        let url = format!("{}/download", mock_server.uri());
+        })
+        .unwrap();
 
-        let result = downloader.download(&url).await;
-        match result {
+        match downloader
+            .download(&format!("{}/download", mock_server.uri()))
+            .await
+        {
             Err(ScraperError::Http { status, .. }) => assert_eq!(status, 301),
             other => panic!("expected redirect to be stopped, got: {other:?}"),
         }

--- a/crates/webfang_core/src/adapters/downloader/mod.rs
+++ b/crates/webfang_core/src/adapters/downloader/mod.rs
@@ -143,6 +143,10 @@ impl Downloader {
             .emulation(config.h2_profile)
             .timeout(Duration::from_secs(config.timeout_secs))
             .user_agent(&config.user_agent)
+            // SSRF guard (#703): default 10-hop limit + stops redirects that
+            // target a literal forbidden IP. Hostname targets are validated
+            // at entry by the async SSRF guard.
+            .redirect(crate::infrastructure::ssrf::redirect_policy())
             .build()
             .map_err(|e| ScraperError::Config(format!("failed to build http client: {e}")))?;
 
@@ -257,16 +261,14 @@ impl Downloader {
             .await
             .map_err(|e| ScraperError::Network(Box::new(e)))?;
 
-        // Fail-fast on 4xx (client errors). 5xx (server errors) are transient and will be retried.
+        // Fail-fast on any non-success status. Covers 4xx (client errors),
+        // 5xx (transient, retried by `download`) and terminal redirect
+        // responses surfaced when the SSRF redirect guard `stop()`s following
+        // (#703): without this gate the stopped 301 body would be streamed
+        // into an asset file.
         let status = response.status();
-        if status.is_client_error() {
+        if !status.is_success() {
             return Err(ScraperError::http(status.as_u16(), url));
-        }
-        if status.is_server_error() {
-            return Err(ScraperError::Http {
-                status: status.as_u16(),
-                url: url.to_string(),
-            });
         }
 
         let mime_type = response
@@ -672,6 +674,8 @@ pub async fn quick_download(url: &str, output_dir: &Path) -> Result<DownloadedAs
 mod tests {
     use super::*;
     use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[cfg_attr(miri, ignore = "boring-sys2 FFI (wreq Client) not supported by Miri")]
     #[tokio::test]
@@ -970,5 +974,53 @@ mod tests {
         let downloader = Downloader::new(config).unwrap();
         let results = downloader.download_batch(&[]).await;
         assert!(results.is_empty());
+    }
+
+    /// SSRF redirect guard (#703): a redirect whose `Location` is a literal
+    /// forbidden IP must be stopped even when the entry URL itself passed
+    /// validation. The terminal redirect response surfaces as an HTTP error
+    /// and the target is never requested (`expect(0)` proves wiremock saw
+    /// no hit). Clones the `wreq_downloader.rs` sibling test.
+    #[cfg_attr(miri, ignore = "boring-sys2 FFI (wreq Client) not supported by Miri")]
+    #[tokio::test]
+    async fn test_redirect_to_forbidden_literal_ip_is_stopped() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var(crate::infrastructure::ssrf::DISABLE_REDIRECT_GUARD_ENV);
+
+        let mock_server = MockServer::start().await;
+
+        // Location points at a different loopback literal — forbidden by the
+        // guard, unreachable in practice, and never requested.
+        Mock::given(method("GET"))
+            .and(path("/download"))
+            .respond_with(
+                ResponseTemplate::new(301).insert_header("location", "http://127.0.0.2:9/target"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/target"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("binary-body"))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = DownloadConfig {
+            output_dir: temp_dir.path().to_path_buf(),
+            max_retries: 0,
+            ..Default::default()
+        };
+        let downloader = Downloader::new(config).unwrap();
+        let url = format!("{}/download", mock_server.uri());
+
+        let result = downloader.download(&url).await;
+        match result {
+            Err(ScraperError::Http { status, .. }) => assert_eq!(status, 301),
+            other => panic!("expected redirect to be stopped, got: {other:?}"),
+        }
     }
 }

--- a/crates/webfang_mcp/src/bin/mcp_server_http.rs
+++ b/crates/webfang_mcp/src/bin/mcp_server_http.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use clap::Parser;
 use webfang_core::adapters::downloader::{DownloadConfig, Downloader};
-use webfang_mcp::mcp_server::server::{start_mcp_server, ServerOptions, DEFAULT_MCP_ADDR};
+use webfang_mcp::mcp_server::server::{
+    require_auth_for_external_bind, start_mcp_server, ServerOptions, DEFAULT_MCP_ADDR,
+};
 use webfang_mcp::mcp_server::{build_container_with_ai, McpState};
 
 /// Webfang MCP Server — Streamable HTTP transport.
@@ -63,6 +65,13 @@ async fn main() -> Result<()> {
     #[cfg(not(feature = "ai"))]
     if args.enable_ai {
         tracing::warn!("--enable-ai requested but the `ai` feature is not compiled in; ignoring");
+    }
+
+    // REQ-06: fail fast on a tokenless non-loopback bind, before building any
+    // container/downloader. Loopback binds stay token-free (development mode).
+    require_auth_for_external_bind(args.bind, args.auth_token.is_some())?;
+    if args.bind.ip().is_loopback() && args.auth_token.is_none() {
+        tracing::warn!("MCP server starting on loopback without auth token (development mode)");
     }
 
     // Build container with optional AI wiring (shared with mcp_server_stdio.rs)

--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -40,6 +40,10 @@ impl McpHandler {
             )
         })?;
 
+        // REQ-03: reject forbidden base URLs at entry, BEFORE any asset fetch
+        // (guard ON unless disabled via env for tests).
+        crate::mcp_server::ssrf::validate_url_no_ssrf(&base_url).await?;
+
         let mut config = webfang_core::infrastructure::config::ScraperConfig {
             download_images: params.images.unwrap_or(true),
             download_documents: params.documents.unwrap_or(false),
@@ -147,6 +151,34 @@ mod tests {
         assert!(res.is_err(), "invalid base URL must be a protocol error");
     }
 
+    /// REQ-03: a loopback `base_url` is rejected at entry by the SSRF guard
+    /// (guard ON by default) with a "SSRF" error, BEFORE any asset fetch.
+    /// The loopback literal resolves locally (no DNS/network dependency).
+    #[tokio::test]
+    async fn download_assets_rejects_loopback_base_url() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
+
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .download_assets(Parameters(DownloadAssetsParams {
+                html: "<html><body><img src=\"/x.png\"></body></html>".to_string(),
+                base_url: "http://127.0.0.1/".to_string(),
+                images: Some(true),
+                documents: None,
+                output_dir: None,
+            }))
+            .await;
+        let err = res.expect_err("loopback base_url must be blocked by SSRF");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SSRF"),
+            "error must report SSRF protection, got: {msg}"
+        );
+    }
+
     #[tokio::test]
     async fn download_assets_no_assets_is_empty_success() {
         let (handler, _tmp) = test_handler().await;
@@ -173,6 +205,13 @@ mod tests {
 
     #[tokio::test]
     async fn download_assets_downloads_image_from_html() {
+        // REQ-03 (#707) validates `base_url` at entry. This test serves an
+        // asset from wiremock on 127.0.0.1, so lift the guard for this
+        // process (nextest isolates each test in its own process). The SSRF-
+        // rejection path is covered separately by
+        // `download_assets_rejects_loopback_base_url` above.
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1");
+
         let (handler, _tmp) = test_handler().await;
         // `output_dir` must be a safe relative path (params validation, #512).
         let out_dir = "test-output/download-assets-image";

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -311,7 +311,9 @@ impl McpHandler {
         let start = Instant::now();
         // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
-        let crawler_config = webfang_core::domain::CrawlerConfig::builder(seed_url)
+        // Clone: the builder consumes `seed_url` and the Ok arm re-uses it as
+        // the filter anchor (the config itself is moved into the crawl).
+        let crawler_config = webfang_core::domain::CrawlerConfig::builder(seed_url.clone())
             .max_depth(params.max_depth.unwrap_or(3))
             .max_pages(params.max_pages.unwrap_or(100) as usize)
             .build();
@@ -327,7 +329,10 @@ impl McpHandler {
                     start,
                     &root_correlation,
                 );
-                let urls: Vec<String> = result.urls.iter().map(|u| u.url.to_string()).collect();
+                // REQ-01: filter discovered URLs before responding — keep only
+                // seed-host-internal entries; exclusions warn with the URL.
+                let mut urls = Vec::with_capacity(result.urls.len());
+                filter_ssrf_safe(&result.urls, &seed_url, &mut urls);
                 let json = serde_json::json!({
                     "urls": urls,
                     "total_pages": result.total_pages,
@@ -378,10 +383,21 @@ impl McpHandler {
         })?;
         crate::mcp_server::ssrf::validate_url_no_ssrf(&seed_url).await?;
 
+        // REQ-02: validate the explicit sitemap URL at entry, BEFORE any
+        // sitemap fetch (guard ON unless disabled via env for tests).
+        if let Some(s) = &params.sitemap_url {
+            let sitemap = url::Url::parse(s).map_err(|e| {
+                McpError::invalid_params(format!("URL de sitemap inválida: {e}"), None)
+            })?;
+            crate::mcp_server::ssrf::validate_url_no_ssrf(&sitemap).await?;
+        }
+
         let start = Instant::now();
         // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
-        let config = webfang_core::domain::CrawlerConfig::new(seed_url);
+        // Clone: `CrawlerConfig::new` consumes `seed_url` and the Ok arm
+        // re-uses it as the filter anchor.
+        let config = webfang_core::domain::CrawlerConfig::new(seed_url.clone());
 
         match webfang_core::application::crawler::crawl_with_sitemap(
             &params.url,
@@ -401,7 +417,11 @@ impl McpHandler {
                     &root_correlation,
                 );
                 tracing::info!("sitemap crawl complete: {} urls found", urls.len());
-                let url_strings: Vec<String> = urls.iter().map(|u| u.url.to_string()).collect();
+                // REQ-01: filter discovered URLs before responding. Sitemap
+                // discovery is host-agnostic — the filter is the gate that
+                // drops external-domain and forbidden-literal-IP entries.
+                let mut url_strings = Vec::with_capacity(urls.len());
+                filter_ssrf_safe(&urls, &seed_url, &mut url_strings);
                 Ok(CallToolResult::success(vec![Content::text(
                     serde_json::to_string_pretty(&url_strings)
                         .expect("serializing JSON to a string cannot fail"),
@@ -650,6 +670,51 @@ impl McpHandler {
     }
 }
 
+/// Keep only seed-host-internal URLs in the discovery output (REQ-01, SSRF
+/// defense-in-depth).
+///
+/// The engine's internal-link gating already applies on the BFS crawl path,
+/// but sitemap discovery returns every `<loc>` host-agnostic. This post-hoc
+/// filter is the authoritative gate that ensures no external-domain or
+/// forbidden-literal-IP URL ever reaches an MCP response, complementing the
+/// entry-level SSRF validator. Each exclusion emits a structured `warn` with
+/// the `url` field (REQ-01/REQ-07).
+///
+/// Returns the number of excluded URLs. `total_pages` / crawl counts are NOT
+/// recomputed — they keep engine semantics (pages crawled, not links emitted).
+fn filter_ssrf_safe(
+    urls: &[webfang_core::domain::DiscoveredUrl],
+    seed: &url::Url,
+    out: &mut Vec<String>,
+) -> usize {
+    let seed_host = seed.host_str().unwrap_or(""); // mirrors crawl_task.rs internal-link anchor
+    let mut excluded = 0usize;
+    for d in urls {
+        let internal =
+            webfang_core::domain::url_validation::is_internal_link(d.url.as_str(), seed_host);
+        if internal {
+            // Hostnames compared here are non-literal hosts; literal IPs on a
+            // non-seed host fall through to the exclusion branch below.
+            out.push(d.url.to_string());
+            continue;
+        }
+        excluded += 1;
+        let reason = if webfang_core::infrastructure::ssrf::is_forbidden_literal_host(
+            d.url.host_str().unwrap_or(""),
+        ) {
+            "forbidden_literal_ip"
+        } else {
+            "external_domain"
+        };
+        tracing::warn!(
+            url = %d.url,
+            reason = %reason,
+            "discovered URL excluded from MCP response (SSRF defense-in-depth)"
+        );
+    }
+    excluded
+}
+
 /// Build the scraping core router (8 tools for URL scraping and crawling).
 ///
 /// Returns a partial router that is combined with the other category routers
@@ -886,6 +951,71 @@ mod tests {
             }))
             .await;
         assert!(res.is_err(), "invalid URL must be a protocol error");
+    }
+
+    /// REQ-01: the post-hoc filter keeps seed-host-internal URLs and drops
+    /// external-domain and forbidden-literal-IP URLs, reporting the exclusion
+    /// count. Empty input produces empty output with zero exclusions.
+    #[test]
+    fn filter_ssrf_safe_keeps_internal_drops_external_literal() {
+        let seed = url::Url::parse("https://example.com/").expect("valid seed");
+        let discovered = vec![
+            webfang_core::domain::DiscoveredUrl::html(
+                url::Url::parse("https://example.com/a").expect("valid url"),
+                1,
+                seed.clone(),
+            ),
+            webfang_core::domain::DiscoveredUrl::html(
+                url::Url::parse("https://other.com/x").expect("valid url"),
+                1,
+                seed.clone(),
+            ),
+            webfang_core::domain::DiscoveredUrl::html(
+                url::Url::parse("http://10.0.0.5/x").expect("valid url"),
+                1,
+                seed.clone(),
+            ),
+        ];
+
+        let mut out = Vec::new();
+        let excluded = filter_ssrf_safe(&discovered, &seed, &mut out);
+        assert_eq!(
+            out,
+            vec!["https://example.com/a".to_string()],
+            "only the seed-host URL survives"
+        );
+        assert_eq!(excluded, 2, "external + forbidden literal are excluded");
+
+        let mut empty_out = Vec::new();
+        assert_eq!(
+            filter_ssrf_safe(&[], &seed, &mut empty_out),
+            0,
+            "empty input excludes nothing"
+        );
+        assert!(
+            empty_out.is_empty(),
+            "empty input keeps the output empty (established as the filtered case above returns entries)"
+        );
+    }
+
+    /// REQ-02: an internal `sitemap_url` is rejected at entry (guard ON) with
+    /// the SSRF message, before any sitemap fetch. The seed uses a public
+    /// literal IP so its own validation resolves locally (no DNS dependency).
+    #[tokio::test]
+    async fn crawl_with_sitemap_rejects_internal_sitemap_url() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
+
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .crawl_with_sitemap(Parameters(CrawlWithSitemapParams {
+                url: "http://8.8.8.8/".to_string(),
+                sitemap_url: Some("http://127.0.0.1/".to_string()),
+            }))
+            .await;
+        assert_ssrf_rejected(res);
     }
 
     #[tokio::test]

--- a/crates/webfang_mcp/src/mcp_server/handlers/security.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/security.rs
@@ -102,7 +102,7 @@ impl McpHandler {
 
     /// Get scrape metrics (request timing, status codes, pages scraped)
     #[tool(
-        description = "Get scraping metrics including request timing, status code distribution, and pages scraped per domain."
+        description = "Get scraping metrics including request timing, status code distribution, and pages scraped per domain. Per-domain stats are capped at 500 domains; domains beyond the cap aggregate under \"otros\""
     )]
     #[instrument(skip(self))]
     async fn get_scrape_metrics(&self) -> Result<CallToolResult, McpError> {

--- a/crates/webfang_mcp/src/mcp_server/metrics.rs
+++ b/crates/webfang_mcp/src/mcp_server/metrics.rs
@@ -105,6 +105,15 @@ impl ScrapeEvent {
     }
 }
 
+/// Maximum number of distinct domains tracked in the per-domain breakdown
+/// (REQ-05). Beyond this cap, new domains aggregate into [`OVERFLOW_DOMAIN_KEY`].
+pub const MAX_TRACKED_DOMAINS: usize = 500;
+
+/// Overflow bucket key for domains recorded past [`MAX_TRACKED_DOMAINS`]
+/// (REQ-05). A domain literally named `"otros"` merges into this same bucket —
+/// documented, accepted.
+pub const OVERFLOW_DOMAIN_KEY: &str = "otros";
+
 /// Per-domain aggregate (REQ-02).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct DomainStats {
@@ -158,7 +167,17 @@ impl ScrapeMetrics {
             Outcome::Partial => self.partial_count += 1,
         }
 
-        let domain = self.domains.entry(event.domain.clone()).or_default();
+        // REQ-05: cap the per-domain map. Totals above are updated
+        // unconditionally; already-tracked domains keep their own key even
+        // at the cap so re-aggregation stays exact.
+        let key: &str = if self.domains.contains_key(&event.domain)
+            || self.domains.len() < MAX_TRACKED_DOMAINS
+        {
+            event.domain.as_str()
+        } else {
+            OVERFLOW_DOMAIN_KEY
+        };
+        let domain = self.domains.entry(key.to_string()).or_default();
         domain.events += 1;
         domain.pages += event.count;
         if matches!(event.outcome, Outcome::Error | Outcome::Partial) {
@@ -306,6 +325,152 @@ mod tests {
         );
         assert_eq!(snap.average_duration_ms, 200.0, "average_duration_ms");
         assert!(!m.is_empty(), "non-empty after recording");
+    }
+
+    /// REQ-05: the 501st distinct domain aggregates into the `"otros"`
+    /// overflow bucket while global totals (events, outcomes, duration mean)
+    /// stay exact — totals are updated unconditionally before the cap.
+    ///
+    /// 600 distinct domains, one event each, outcome cycling
+    /// Success/Error/Partial by `i % 3`, page count `(i % 5) + 1`, duration
+    /// cycling 10/20/30/40 ms. The first 500 keep their own keys; domains
+    /// 500..600 (100 events) merge: pages = 20 cycles × (1+2+3+4+5) = 300,
+    /// errors = the 67 events whose `i % 3 != 0`. Mean duration over all 600
+    /// events = exactly 25 ms.
+    #[test]
+    fn domains_capped_at_500_with_otros_overflow() {
+        let mut m = ScrapeMetrics::default();
+        for i in 0..600usize {
+            let outcome = match i % 3 {
+                0 => Outcome::Success,
+                1 => Outcome::Error,
+                _ => Outcome::Partial,
+            };
+            m.record(ScrapeEvent::new(
+                "scrape_url",
+                format!("d{i:04}.com"),
+                outcome,
+                (i % 5) + 1,
+                Duration::from_millis(((i % 4) + 1) as u64 * 10),
+            ));
+        }
+
+        let snap = m.snapshot();
+        assert_eq!(snap.total_events, 600, "global total unaffected by cap");
+        assert_eq!(snap.success_count, 200, "success_count exact");
+        assert_eq!(snap.error_count, 200, "error_count exact");
+        assert_eq!(snap.partial_count, 200, "partial_count exact");
+        assert_eq!(snap.average_duration_ms, 25.0, "duration mean exact");
+
+        assert_eq!(
+            snap.domains.len(),
+            501,
+            "500 tracked domains + one overflow bucket"
+        );
+        assert_eq!(
+            snap.domains.get("otros"),
+            Some(&DomainStats {
+                events: 100,
+                pages: 300,
+                errors: 67
+            }),
+            "overflow aggregates with identical semantics"
+        );
+        assert!(
+            !snap.domains.contains_key("d0500.com"),
+            "overflow domains must not get their own key"
+        );
+        assert_eq!(
+            snap.domains.get("d0000.com"),
+            Some(&DomainStats {
+                events: 1,
+                pages: 1,
+                errors: 0
+            }),
+            "first tracked domain keeps exact stats"
+        );
+    }
+
+    /// REQ-05: an already-tracked domain keeps aggregating under its own key
+    /// after the cap is reached (`contains_key` takes precedence); only NEW
+    /// domains past the cap land in `"otros"`.
+    #[test]
+    fn existing_domain_aggregates_after_cap_reached() {
+        let mut m = ScrapeMetrics::default();
+        for i in 0..500usize {
+            m.record(ScrapeEvent::new(
+                "scrape_url",
+                format!("d{i:04}.com"),
+                Outcome::Success,
+                1,
+                Duration::from_millis(1),
+            ));
+        }
+        let snap = m.snapshot();
+        assert_eq!(snap.domains.len(), 500, "cap not yet exceeded");
+        assert!(!snap.domains.contains_key("otros"), "no overflow yet");
+
+        // Domain #1 (already tracked) still aggregates under its own key.
+        m.record(ScrapeEvent::new(
+            "scrape_url",
+            "d0000.com".to_string(),
+            Outcome::Error,
+            3,
+            Duration::from_millis(1),
+        ));
+        let snap = m.snapshot();
+        assert_eq!(snap.domains.len(), 500, "re-record adds no key");
+        assert_eq!(
+            snap.domains.get("d0000.com"),
+            Some(&DomainStats {
+                events: 2,
+                pages: 4,
+                errors: 1
+            }),
+            "existing domain keeps aggregating under its own key"
+        );
+
+        // A brand-new domain #502 lands in the overflow bucket.
+        m.record(ScrapeEvent::new(
+            "scrape_url",
+            "newdomain.com".to_string(),
+            Outcome::Error,
+            7,
+            Duration::from_millis(1),
+        ));
+        let snap = m.snapshot();
+        assert_eq!(snap.domains.len(), 501, "cap + overflow bucket");
+        assert!(
+            !snap.domains.contains_key("newdomain.com"),
+            "new domain past the cap must not get its own key"
+        );
+        assert_eq!(
+            snap.domains.get("otros"),
+            Some(&DomainStats {
+                events: 1,
+                pages: 7,
+                errors: 1
+            }),
+            "first overflow event lands in otros"
+        );
+
+        // A second new domain keeps merging into the same bucket.
+        m.record(ScrapeEvent::new(
+            "scrape_url",
+            "anothernew.com".to_string(),
+            Outcome::Success,
+            2,
+            Duration::from_millis(1),
+        ));
+        assert_eq!(
+            m.snapshot().domains.get("otros"),
+            Some(&DomainStats {
+                events: 2,
+                pages: 9,
+                errors: 1
+            }),
+            "overflow keeps aggregating"
+        );
     }
 
     /// REQ-01: an unparseable domain is recorded as `"unknown"` and still counted.

--- a/crates/webfang_mcp/src/mcp_server/server.rs
+++ b/crates/webfang_mcp/src/mcp_server/server.rs
@@ -62,6 +62,27 @@ impl Default for ServerOptions {
     }
 }
 
+/// Fail-fast guard for tokenless binds on non-loopback interfaces (REQ-06).
+///
+/// Binding the MCP server to a routable address without an auth token would
+/// expose the scraper surface to the network; the binary must refuse to start
+/// before building the container. Loopback binds stay token-free (dev mode)
+/// and `IpAddr::is_loopback()` covers both `127.0.0.1` and `::1`.
+///
+/// # Errors
+///
+/// Returns a user-facing Spanish error naming the bind address when `bind`
+/// is non-loopback and no auth token is present, pointing the operator at
+/// `--auth-token` / `WEBFANG_MCP_AUTH_TOKEN`.
+pub fn require_auth_for_external_bind(bind: SocketAddr, token_present: bool) -> anyhow::Result<()> {
+    if !bind.ip().is_loopback() && !token_present {
+        return Err(anyhow::anyhow!(
+            "No se puede iniciar el servidor MCP en {bind} sin token de autenticación. Defina --auth-token o WEBFANG_MCP_AUTH_TOKEN."
+        ));
+    }
+    Ok(())
+}
+
 /// Build the Axum router with MCP endpoint and full middleware stack.
 pub fn build_mcp_router(state: McpState, options: &ServerOptions) -> Router {
     let service = StreamableHttpService::new(
@@ -427,5 +448,46 @@ mod tests {
         // Cancel through one clone, observe via the other.
         state.shutdown_signal();
         assert!(state2.cancel_token.is_cancelled());
+    }
+
+    /// REQ-06: loopback binds stay token-free by default (dev mode).
+    #[test]
+    fn require_auth_loopback_no_token_is_ok() {
+        let bind: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        assert!(require_auth_for_external_bind(bind, false).is_ok());
+    }
+
+    /// REQ-06: IPv6 loopback (`::1`) counts as loopback.
+    #[test]
+    fn require_auth_loopback_v6_no_token_is_ok() {
+        let bind: SocketAddr = "[::1]:8080".parse().unwrap();
+        assert!(require_auth_for_external_bind(bind, false).is_ok());
+    }
+
+    /// REQ-06: tokenless non-loopback binds fail fast with a Spanish message
+    /// that names the bind address and the token options.
+    #[test]
+    fn require_auth_non_loopback_no_token_is_err() {
+        for addr in ["0.0.0.0:8080", "192.168.1.10:8080"] {
+            let bind: SocketAddr = addr.parse().unwrap();
+            match require_auth_for_external_bind(bind, false) {
+                Err(e) => {
+                    let msg = e.to_string();
+                    assert!(msg.contains(addr), "message must name the bind: {msg}");
+                    assert!(
+                        msg.contains("token"),
+                        "message must mention the token: {msg}"
+                    );
+                },
+                Ok(()) => panic!("{addr} must be rejected without a token"),
+            }
+        }
+    }
+
+    /// REQ-06: a token present lifts the non-loopback restriction.
+    #[test]
+    fn require_auth_non_loopback_with_token_is_ok() {
+        let bind: SocketAddr = "0.0.0.0:8080".parse().unwrap();
+        assert!(require_auth_for_external_bind(bind, true).is_ok());
     }
 }

--- a/crates/webfang_mcp/tests/download_assets_test.rs
+++ b/crates/webfang_mcp/tests/download_assets_test.rs
@@ -29,6 +29,11 @@ use webfang_mcp::mcp_server::state::McpState;
 async fn start_server(
     downloader: Option<Arc<Downloader>>,
 ) -> (String, tokio::task::JoinHandle<()>) {
+    // Disable SSRF protection for tests (wiremock binds 127.0.0.1) — matches
+    // the shared `common::start_server` convention; required since REQ-03
+    // validates `base_url` at entry (#707).
+    std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1");
+
     let config = Config::default();
     let container = Container::new(config.crawler, config.scraper)
         .await

--- a/crates/webfang_mcp/tests/download_assets_test.rs
+++ b/crates/webfang_mcp/tests/download_assets_test.rs
@@ -8,60 +8,16 @@
 
 #![cfg(feature = "mcp")]
 
+mod common;
+
+use common::*;
 use serde_json::{json, Value};
-use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::net::TcpListener;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 use wreq::Client;
 
 use webfang_core::adapters::downloader::{DownloadConfig, Downloader};
-use webfang_core::config::Config;
-use webfang_core::di::Container;
-use webfang_mcp::mcp_server::server::build_mcp_router;
-use webfang_mcp::mcp_server::server::ServerOptions;
-use webfang_mcp::mcp_server::state::McpState;
-
-/// Start a test MCP server on a random port. Pass `Some(downloader)` to inject
-/// a shared `AssetDownloaderPort` (the production wiring in `mcp_server.rs`);
-/// pass `None` to exercise the per-call fallback downloader built from config.
-async fn start_server(
-    downloader: Option<Arc<Downloader>>,
-) -> (String, tokio::task::JoinHandle<()>) {
-    // Disable SSRF protection for tests (wiremock binds 127.0.0.1) — matches
-    // the shared `common::start_server` convention; required since REQ-03
-    // validates `base_url` at entry (#707).
-    std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1");
-
-    let config = Config::default();
-    let container = Container::new(config.crawler, config.scraper)
-        .await
-        .expect("container creation failed");
-    let state = match downloader {
-        Some(d) => McpState::new(container).with_downloader(d),
-        None => McpState::new(container),
-    };
-    let app = build_mcp_router(state, &ServerOptions::default());
-
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr: SocketAddr = listener.local_addr().unwrap();
-    let base_url = format!("http://{addr}");
-
-    let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-
-    // Wait for the server to accept TCP connections instead of a fixed sleep.
-    for _ in 0..20 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    }
-
-    (base_url, handle)
-}
 
 /// Build a JSON-RPC request body for MCP protocol.
 fn mcp_request(method: &str, params: Value) -> Value {

--- a/crates/webfang_mcp/tests/scraping_coverage_test.rs
+++ b/crates/webfang_mcp/tests/scraping_coverage_test.rs
@@ -210,6 +210,35 @@ async fn call_single_url_tool_result(
         .clone()
 }
 
+/// Mount a static page served with a `200` response (shared page fixture).
+async fn mount_page_200(mock: &MockServer, route: &str, body: &str) {
+    Mock::given(method("GET"))
+        .and(path(route))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(mock)
+        .await;
+}
+
+/// Run ONE tool call against a fresh MCP server, assert it succeeded, and
+/// return the parsed JSON payload of its text result. This file's crawl tests
+/// share this prologue as their single canonical copy.
+async fn crawl_tool_parsed(tool: &str, params: Value) -> Value {
+    let (base_url, _server) = start_test_server().await;
+    let client = Client::new();
+    let session = init_session(&client, &base_url).await;
+    let resp = call_tool(&client, &base_url, &session, tool, params).await;
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&result),
+        "{tool} should succeed: {}",
+        tool_text(&result)
+    );
+    serde_json::from_str(&tool_text(&result)).expect("tool result must be valid JSON")
+}
+
 // ============================================================================
 // scrape_url
 // ============================================================================
@@ -631,51 +660,12 @@ async fn test_crawl_site_max_depth_one_follows_internal_links() {
 <a href="/page_a">A</a>
 <a href="/page_b">B</a>
 </body></html>"#;
-    Mock::given(method("GET"))
-        .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(index_html))
-        .mount(&mock)
-        .await;
-    Mock::given(method("GET"))
-        .and(path("/page_a"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_string("<html><body>Page A</body></html>"),
-        )
-        .mount(&mock)
-        .await;
-    Mock::given(method("GET"))
-        .and(path("/page_b"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_string("<html><body>Page B</body></html>"),
-        )
-        .mount(&mock)
-        .await;
+    mount_page_200(&mock, "/", index_html).await;
+    mount_page_200(&mock, "/page_a", "<html><body>Page A</body></html>").await;
+    mount_page_200(&mock, "/page_b", "<html><body>Page B</body></html>").await;
 
-    let (base_url, _handle) = start_test_server().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "crawl_site",
-        json!({ "url": mock.uri(), "max_depth": 1 }),
-    )
-    .await;
-
-    let result = resp
-        .get("result")
-        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
-        .clone();
-    assert!(
-        !is_tool_error(&result),
-        "crawl_site should succeed: {}",
-        tool_text(&result)
-    );
-
-    let parsed: Value =
-        serde_json::from_str(&tool_text(&result)).expect("crawl result must be valid JSON");
+    let parsed =
+        crawl_tool_parsed("crawl_site", json!({ "url": mock.uri(), "max_depth": 1 })).await;
     assert_eq!(
         parsed.get("total_pages").and_then(|v| v.as_u64()),
         Some(3),
@@ -720,44 +710,11 @@ async fn test_crawl_site_output_excludes_external_links() {
 <a href="/page_a">A</a>
 <a href="https://external.example/x">External</a>
 </body></html>"#;
-    Mock::given(method("GET"))
-        .and(path("/"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(index_html))
-        .mount(&mock)
-        .await;
-    Mock::given(method("GET"))
-        .and(path("/page_a"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_string("<html><body>Page A</body></html>"),
-        )
-        .mount(&mock)
-        .await;
+    mount_page_200(&mock, "/", index_html).await;
+    mount_page_200(&mock, "/page_a", "<html><body>Page A</body></html>").await;
 
-    let (base_url, _handle) = start_test_server().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "crawl_site",
-        json!({ "url": mock.uri(), "max_depth": 1 }),
-    )
-    .await;
-
-    let result = resp
-        .get("result")
-        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
-        .clone();
-    assert!(
-        !is_tool_error(&result),
-        "crawl_site should succeed: {}",
-        tool_text(&result)
-    );
-
-    let parsed: Value =
-        serde_json::from_str(&tool_text(&result)).expect("crawl result must be valid JSON");
+    let parsed =
+        crawl_tool_parsed("crawl_site", json!({ "url": mock.uri(), "max_depth": 1 })).await;
     let urls = parsed
         .get("urls")
         .and_then(|v| v.as_array())
@@ -825,14 +782,7 @@ async fn test_crawl_with_sitemap_response_excludes_external_and_forbidden_urls()
         .mount(&mock)
         .await;
 
-    let (base_url, _handle) = start_test_server().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
+    let parsed = crawl_tool_parsed(
         "crawl_with_sitemap",
         json!({
             "url": mock.uri(),
@@ -841,18 +791,8 @@ async fn test_crawl_with_sitemap_response_excludes_external_and_forbidden_urls()
     )
     .await;
 
-    let result = resp
-        .get("result")
-        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
-        .clone();
-    assert!(
-        !is_tool_error(&result),
-        "crawl_with_sitemap should succeed: {}",
-        tool_text(&result)
-    );
-
     let urls: Vec<String> =
-        serde_json::from_str(&tool_text(&result)).expect("sitemap result must be a JSON array");
+        serde_json::from_value(parsed).expect("sitemap result must be a JSON array");
 
     let seed_host = url::Url::parse(&mock.uri())
         .expect("mock URI parses")

--- a/crates/webfang_mcp/tests/scraping_coverage_test.rs
+++ b/crates/webfang_mcp/tests/scraping_coverage_test.rs
@@ -706,3 +706,177 @@ async fn test_crawl_site_max_depth_one_follows_internal_links() {
         "no crawl errors expected, got: {parsed}"
     );
 }
+
+/// REQ-01 (SSRF defense-in-depth): `crawl_site` output contains only
+/// seed-host URLs — an external-domain link in the seed page never reaches
+/// the response `urls` array. Note: the crawl engine ALSO gates internal
+/// links (the external URL is neither crawled nor surfaced there); this test
+/// documents both layers at once, and the MCP post-hoc filter is the
+/// authoritative gate for non-crawl discovery paths (sitemap, see below).
+#[tokio::test]
+async fn test_crawl_site_output_excludes_external_links() {
+    let mock = MockServer::start().await;
+    let index_html = r#"<html><body>
+<a href="/page_a">A</a>
+<a href="https://external.example/x">External</a>
+</body></html>"#;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(index_html))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/page_a"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string("<html><body>Page A</body></html>"),
+        )
+        .mount(&mock)
+        .await;
+
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "crawl_site",
+        json!({ "url": mock.uri(), "max_depth": 1 }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&result),
+        "crawl_site should succeed: {}",
+        tool_text(&result)
+    );
+
+    let parsed: Value =
+        serde_json::from_str(&tool_text(&result)).expect("crawl result must be valid JSON");
+    let urls = parsed
+        .get("urls")
+        .and_then(|v| v.as_array())
+        .expect("urls array present");
+    assert!(
+        !urls.is_empty(),
+        "crawl must discover at least the seed, got: {parsed}"
+    );
+
+    // The engine internally gates non-internal links too (defense-in-depth),
+    // so this assert is the union of both layers: ONLY seed-host URLs surface.
+    let seed_host = url::Url::parse(&mock.uri())
+        .expect("mock URI parses")
+        .host_str()
+        .expect("mock URI has host")
+        .to_string();
+    let mut got: Vec<String> = urls
+        .iter()
+        .filter_map(|u| u.as_str().map(String::from))
+        .collect();
+    got.sort();
+    let mut expected = vec![format!("{}/", mock.uri()), format!("{}/page_a", mock.uri())];
+    expected.sort();
+    assert_eq!(
+        got, expected,
+        "urls array must contain only seed-host ({seed_host}) URLs, got: {got:?}"
+    );
+    let has_external = urls
+        .iter()
+        .filter_map(|u| u.as_str())
+        .any(|u| u.contains("external.example"));
+    assert!(
+        !has_external,
+        "external-domain URL must never reach the response, got: {parsed}"
+    );
+}
+
+/// REQ-01 (SSRF defense-in-depth): `crawl_with_sitemap` output contains only
+/// seed-host URLs. Sitemap discovery returns every `<loc>` host-agnostic (the
+/// engine does NOT apply internal-link gating there), so this test exercises
+/// the MCP post-hoc filter as the authoritative gate: an external-domain URL
+/// and a forbidden-literal-IP URL from the sitemap must both be excluded.
+/// Fully offline: only the sitemap XML is fetched (wiremock on the seed
+/// host); the listed pages are never fetched (discovery-only crawl).
+#[tokio::test]
+async fn test_crawl_with_sitemap_response_excludes_external_and_forbidden_urls() {
+    let mock = MockServer::start().await;
+
+    let sitemap = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>{base}/internal</loc></url>
+  <url><loc>https://external.example/x</loc></url>
+  <url><loc>http://10.0.0.5/forbidden</loc></url>
+</urlset>"#,
+        base = mock.uri(),
+    );
+    Mock::given(method("GET"))
+        .and(path("/sitemap.xml"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/xml")
+                .set_body_string(sitemap),
+        )
+        .mount(&mock)
+        .await;
+
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "crawl_with_sitemap",
+        json!({
+            "url": mock.uri(),
+            "sitemap_url": format!("{}/sitemap.xml", mock.uri()),
+        }),
+    )
+    .await;
+
+    let result = resp
+        .get("result")
+        .unwrap_or_else(|| panic!("expected result, got: {resp}"))
+        .clone();
+    assert!(
+        !is_tool_error(&result),
+        "crawl_with_sitemap should succeed: {}",
+        tool_text(&result)
+    );
+
+    let urls: Vec<String> =
+        serde_json::from_str(&tool_text(&result)).expect("sitemap result must be a JSON array");
+
+    let seed_host = url::Url::parse(&mock.uri())
+        .expect("mock URI parses")
+        .host_str()
+        .expect("mock URI has host")
+        .to_string();
+
+    assert!(
+        !urls.is_empty(),
+        "the internal seed-host URL must survive the filter, got: {urls:?}"
+    );
+    let mut got = urls.clone();
+    got.sort();
+    assert_eq!(
+        got,
+        vec![format!("{}/internal", mock.uri())],
+        "only the seed-host ({seed_host}) URL may surface, got: {got:?}"
+    );
+    assert!(
+        !urls.iter().any(|u| u.contains("external.example")),
+        "external-domain sitemap URLs must be excluded, got: {urls:?}"
+    );
+    assert!(
+        !urls.iter().any(|u| u.contains("10.0.0.5")),
+        "forbidden-literal-IP sitemap URLs must be excluded, got: {urls:?}"
+    );
+}

--- a/crates/webfang_mcp/tests/ssrf_probe_test.rs
+++ b/crates/webfang_mcp/tests/ssrf_probe_test.rs
@@ -20,7 +20,7 @@
 mod common;
 use common::*;
 
-use serde_json::json;
+use serde_json::{json, Value};
 use wreq::Client;
 
 /// JSON-RPC standard error code for "Invalid params" (JSON-RPC 2.0 spec) —
@@ -50,64 +50,41 @@ fn assert_ssrf_rejection(resp: serde_json::Value, url: &str) {
     );
 }
 
+/// Start an SSRF-enabled server and issue one JSON-RPC `tools/call`, returning
+/// the raw response envelope. Shared prologue of every probe in this suite —
+/// each test differs only in tool name and params.
+async fn probe_with_params(tool: &str, params: Value) -> Value {
+    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+    call_tool(&client, &base_url, &session_id, tool, params).await
+}
+
 /// IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`) must be caught by the guard
 /// before any fetch — a plain protocol error, never a tool error.
 #[tokio::test]
 async fn mapped_loopback_probe_returns_32602() {
-    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "scrape_url",
-        json!({ "url": "http://[::ffff:127.0.0.1]:9/" }),
-    )
-    .await;
-
-    assert_ssrf_rejection(resp, "http://[::ffff:127.0.0.1]:9/");
+    let url = "http://[::ffff:127.0.0.1]:9/";
+    let resp = probe_with_params("scrape_url", json!({ "url": url })).await;
+    assert_ssrf_rejection(resp, url);
 }
 
 /// IPv4-mapped IPv6 cloud-metadata endpoint (`::ffff:169.254.169.254`) — the
 /// canonical SSRF target — must be caught before any fetch.
 #[tokio::test]
 async fn mapped_metadata_probe_returns_32602() {
-    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "scrape_url",
-        json!({ "url": "http://[::ffff:169.254.169.254]:9/" }),
-    )
-    .await;
-
-    assert_ssrf_rejection(resp, "http://[::ffff:169.254.169.254]:9/");
+    let url = "http://[::ffff:169.254.169.254]:9/";
+    let resp = probe_with_params("scrape_url", json!({ "url": url })).await;
+    assert_ssrf_rejection(resp, url);
 }
 
 /// IPv4-mapped IPv6 CGNAT address (`::ffff:100.64.0.1`) must be caught before
 /// any fetch.
 #[tokio::test]
 async fn mapped_cgnat_probe_returns_32602() {
-    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "scrape_url",
-        json!({ "url": "http://[::ffff:100.64.0.1]:9/" }),
-    )
-    .await;
-
-    assert_ssrf_rejection(resp, "http://[::ffff:100.64.0.1]:9/");
+    let url = "http://[::ffff:100.64.0.1]:9/";
+    let resp = probe_with_params("scrape_url", json!({ "url": url })).await;
+    assert_ssrf_rejection(resp, url);
 }
 
 /// Negative control: plain IPv4 loopback (`127.0.0.1`) is also rejected, which
@@ -116,20 +93,9 @@ async fn mapped_cgnat_probe_returns_32602() {
 /// a protocol-level `-32602`.
 #[tokio::test]
 async fn plain_loopback_probe_returns_32602() {
-    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
-        "scrape_url",
-        json!({ "url": "http://127.0.0.1:9/" }),
-    )
-    .await;
-
-    assert_ssrf_rejection(resp, "http://127.0.0.1:9/");
+    let url = "http://127.0.0.1:9/";
+    let resp = probe_with_params("scrape_url", json!({ "url": url })).await;
+    assert_ssrf_rejection(resp, url);
 }
 
 /// REQ-02 (#707): `crawl_with_sitemap` validates the explicit `sitemap_url`
@@ -139,24 +105,18 @@ async fn plain_loopback_probe_returns_32602() {
 /// port 9 (discard) is closed, and the assertion proves nothing was reached.
 #[tokio::test]
 async fn crawl_with_sitemap_metadata_sitemap_url_returns_32602() {
-    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
-    let client = Client::new();
-    let session_id = init_session(&client, &base_url).await;
-
-    let resp = call_tool(
-        &client,
-        &base_url,
-        &session_id,
+    let sitemap_url = "http://169.254.169.254/sitemap.xml";
+    let resp = probe_with_params(
         "crawl_with_sitemap",
         json!({
             "url": "http://8.8.8.8/",
-            "sitemap_url": "http://169.254.169.254/sitemap.xml",
+            "sitemap_url": sitemap_url,
         }),
     )
     .await;
 
     assert_ssrf_rejection(
         resp,
-        "crawl_with_sitemap(sitemap_url=http://169.254.169.254/sitemap.xml)",
+        &format!("crawl_with_sitemap(sitemap_url={sitemap_url})"),
     );
 }

--- a/crates/webfang_mcp/tests/ssrf_probe_test.rs
+++ b/crates/webfang_mcp/tests/ssrf_probe_test.rs
@@ -131,3 +131,32 @@ async fn plain_loopback_probe_returns_32602() {
 
     assert_ssrf_rejection(resp, "http://127.0.0.1:9/");
 }
+
+/// REQ-02 (#707): `crawl_with_sitemap` validates the explicit `sitemap_url`
+/// at entry with the guard ON — a cloud-metadata sitemap is rejected with the
+/// protocol-level `-32602` BEFORE any fetch. The seed uses a public IP so its
+/// own validation resolves locally (no DNS/network beyond fail-before-fetch);
+/// port 9 (discard) is closed, and the assertion proves nothing was reached.
+#[tokio::test]
+async fn crawl_with_sitemap_metadata_sitemap_url_returns_32602() {
+    let (base_url, _handle) = start_test_server_ssrf_enabled().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "crawl_with_sitemap",
+        json!({
+            "url": "http://8.8.8.8/",
+            "sitemap_url": "http://169.254.169.254/sitemap.xml",
+        }),
+    )
+    .await;
+
+    assert_ssrf_rejection(
+        resp,
+        "crawl_with_sitemap(sitemap_url=http://169.254.169.254/sitemap.xml)",
+    );
+}


### PR DESCRIPTION
## Linked Issue

Closes #707

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

Cierra la épica Fase 4 (auditoría v2.0.0 F18/F20 — reporte en la issue). Implementa los tres hallazgos pendientes + los gaps nuevos que la auditoría no vio, en 4 commits de trabajo independientes y revertibles (entrega en una sola PR con `size:exception` aprobado por el maintainer):

- **SSRF remanente (#692)**: los redirects ya estaban cubiertos por #703 (`redirect_policy()`); faltaban los links descubiertos y dos call-sites nuevos.
- **Cota de ScrapeMetrics (#699)**: el `BTreeMap<Domain>` ya no crece sin techo en servidores de larga vida.
- **Auth fail-fast (#700)**: el servidor MCP ya no puede arrancar abierto en interfaces públicas.

Gaps nuevos descubiertos durante la exploración e incluidos en el mismo scope (misma superficie de la auditoría):
- `sitemap_url` en `crawl_with_sitemap` nunca se validaba contra SSRF (blind SSRF: el parser *fetchaba* hosts internos).
- `base_url` en `download_assets` tenía CERO validación SSRF (el call-site ausente de los "8 call-sites").
- `adapters/downloader::Downloader::new` (asset downloader) era el único cliente de producción sin el guard de redirects de #703 — además, un redirect interrumpido podía terminar streaming el body del 301 como asset (`download_once` ahora rechaza todo status no-2xx).

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/adapters/downloader/mod.rs` | `redirect_policy()` SSRF en el builder + guard `!is_success()` unificado en `download_once` + test wiremock de redirect bloqueado |
| `crates/webfang_mcp/src/mcp_server/handlers/scraping.rs` | helper `filter_ssrf_safe` (interno + literal-IP prohibido, warn estructurado por exclusión) en `crawl_site` y `crawl_with_sitemap`; validación SSRF de `sitemap_url` |
| `crates/webfang_mcp/src/mcp_server/handlers/assets.rs` | validación SSRF de `base_url` |
| `crates/webfang_mcp/src/mcp_server/metrics.rs` | `MAX_TRACKED_DOMAINS = 500` + agregación de overflow bajo `"otros"` (totales globales intactos) |
| `crates/webfang_mcp/src/mcp_server/handlers/security.rs` | descripción del tool `get_scrape_metrics` documenta la cota |
| `crates/webfang_mcp/src/mcp_server/server.rs` | `require_auth_for_external_bind()` puro y testeable |
| `crates/webfang_mcp/src/bin/mcp_server_http.rs` | fail-fast antes de construir el container + warn al arrancar en loopback sin token |
| `crates/webfang_mcp/tests/scraping_coverage_test.rs` | 2 tests wiremock de filtrado de URLs descubiertas |
| `crates/webfang_mcp/tests/ssrf_probe_test.rs` | probe guard-ON: `sitemap_url` interno → -32602 sin fetch |
| `crates/webfang_mcp/tests/download_assets_test.rs` | fix-forward de harness: el único starter al que le faltaba el env `WEBFANG_MCP_DISABLE_SSRF` |

## Behavior changes (call-out)

1. **MCP no arranca abierto**: bind no-loopback sin `--auth-token`/`WEBFANG_MCP_AUTH_TOKEN` → exit 1 con error en español. El default `127.0.0.1` sigue sin requerir token.
2. **Discovery tools pueden devolver menos URLs**: externas o con IP literal prohibida quedan filtradas (defense-in-depth); `total_pages` conserva la semántica del engine.
3. **Métricas**: posibles claves agregadas bajo `"otros"` al superar 500 dominios; totales globales siempre exactos.

## Test Plan

- [x] `cargo fmt --check` limpio
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` limpio (comando exacto de CI)
- [x] `cargo nextest run -p webfang_core -p webfang_mcp --all-features` — 2494/2498 pasan (ver nota abajo)
- [x] Strict TDD: cada fix con test RED primero + evidencia (ej. sin guard, el 301 se streamaba a un asset de 0 bytes)
- [x] Doce tests nuevos: redirect guard wiremock, cap de métricas (501 dominios + re-agregación), matriz auth bind completa (incl. `::1`), 3 filtros SSRF unit + 3 integraciones guard-ON/guard-OFF

Nota: 4 fallos de `vault_detector` (obsidian) son **preexistentes en esta workstation** (registros reales del usuario ganan sobre los paths inyectados — follow-up de hermeticidad de #724); CI los pasa y son ajenos a este diff.

## Contributor Checklist

- [x] Linked an approved issue (`status:approved`) with `Closes/Fixes/Resolves #N`
- [x] Branch name matches `type/description` (e.g. `fix/parser-crash`) — CI rejects others
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (tool description + mensajes en español)
- [x] Defensive error paths annotated with `// LCOV_EXCL_*` markers per docs/src/testing.md (issue #527)