### PR TITLE
fix(mcp): enforce export root-of-trust and per-domain batch metrics (#696)

### DIFF
--- a/crates/webfang_mcp/src/bin/mcp_server_http.rs
+++ b/crates/webfang_mcp/src/bin/mcp_server_http.rs
@@ -51,6 +51,12 @@ struct Args {
     /// Enable AI semantic cleaning (requires the `ai` feature at build time).
     #[arg(long, env = "WEBFANG_MCP_AI")]
     enable_ai: bool,
+
+    /// Allowed root directories for absolute `output_dir` paths (#696).
+    /// Repeatable or comma-separated. When omitted, absolute `output_dir`
+    /// values are rejected (fail-closed); relative paths always work.
+    #[arg(long, env = "WEBFANG_MCP_EXPORT_ROOTS", value_delimiter = ',')]
+    export_roots: Vec<std::path::PathBuf>,
 }
 
 #[tokio::main]
@@ -81,7 +87,8 @@ async fn main() -> Result<()> {
     // pool across tool calls. The default config writes to `./downloads`
     // relative to the working directory.
     let state = McpState::new(container)
-        .with_downloader(Arc::new(Downloader::new(DownloadConfig::default())?));
+        .with_downloader(Arc::new(Downloader::new(DownloadConfig::default())?))
+        .with_export_roots(args.export_roots);
 
     let opts = ServerOptions {
         request_timeout_secs: args.timeout_secs,

--- a/crates/webfang_mcp/src/bin/mcp_server_stdio.rs
+++ b/crates/webfang_mcp/src/bin/mcp_server_stdio.rs
@@ -20,6 +20,12 @@ struct Args {
     /// Enable AI semantic cleaning (requires the `ai` feature at build time).
     #[arg(long, env = "WEBFANG_MCP_AI")]
     enable_ai: bool,
+
+    /// Allowed root directories for absolute `output_dir` paths (#696).
+    /// Repeatable or comma-separated. When omitted, absolute `output_dir`
+    /// values are rejected (fail-closed); relative paths always work.
+    #[arg(long, env = "WEBFANG_MCP_EXPORT_ROOTS", value_delimiter = ',')]
+    export_roots: Vec<std::path::PathBuf>,
 }
 
 #[tokio::main]
@@ -40,7 +46,7 @@ async fn main() {
     // Build container with optional AI wiring (shared with mcp_server_http.rs)
     let container = build_container_with_ai(args.enable_ai).await;
 
-    let state = McpState::new(container);
+    let state = McpState::new(container).with_export_roots(args.export_roots);
 
     let handler = McpHandler::new(state);
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -122,8 +122,7 @@ mod tests {
         let container = Container::new(crawler_config, scraper_config)
             .await
             .expect("create container");
-        let state = McpState::new(container)
-            .with_export_roots(vec![tmp.path().to_path_buf()]);
+        let state = McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
         (McpHandler::new(state), tmp)
     }
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -50,6 +50,10 @@ impl McpHandler {
             ..Default::default()
         };
         if let Some(ref output_dir) = params.output_dir {
+            // Root-of-trust: absolute output_dir must be under a configured
+            // export root (#696).
+            self.state
+                .validate_export_dir(std::path::Path::new(output_dir))?;
             config.output_dir = std::path::PathBuf::from(output_dir);
         }
 
@@ -118,7 +122,8 @@ mod tests {
         let container = Container::new(crawler_config, scraper_config)
             .await
             .expect("create container");
-        let state = McpState::new(container);
+        let state = McpState::new(container)
+            .with_export_roots(vec![tmp.path().to_path_buf()]);
         (McpHandler::new(state), tmp)
     }
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -242,22 +242,17 @@ impl McpHandler {
         .await
         {
             Ok(outcome) => {
-                let failed_count = outcome.failed.len();
-                let outcome_type = if failed_count == 0 {
-                    Outcome::Success
-                } else if outcome.results.is_empty() {
-                    Outcome::Error
-                } else {
-                    Outcome::Partial
-                };
-                self.state.record_scrape_identity(
-                    "scrape_batch",
-                    domain,
-                    outcome_type,
-                    count,
-                    start,
-                    &root_correlation,
-                );
+                    let failed_count = outcome.failed.len();
+                    // Per-domain attribution (#696): a batch may span multiple
+                    // hosts, so metrics are grouped by the REAL host of each
+                    // result/failure instead of assuming `urls.first()`. All
+                    // events share the run-root correlation (#501/#698).
+                    record_batch_metrics_by_domain(
+                        &self.state,
+                        &outcome,
+                        start,
+                        &root_correlation,
+                    );
                 tracing::info!(
                     "batch scrape complete: {} pages, {} failed",
                     outcome.results.len(),
@@ -724,6 +719,56 @@ pub fn build_router() -> ToolRouter<McpHandler> {
     McpHandler::tool_router_scraping()
 }
 
+
+/// Record per-domain scrape metrics for a completed batch (#696).
+///
+/// Groups successes and failures by their REAL host so multi-domain batches
+/// attribute pages correctly in the metrics snapshot. Every event shares the
+/// run-root `correlation` (#501/#698): one operation identity, one event per
+/// domain group. `BTreeMap` keeps emission order deterministic (DD-6).
+fn record_batch_metrics_by_domain(
+    state: &crate::mcp_server::McpState,
+    outcome: &webfang_core::application::scraper_service::ScrapeBatchOutcome,
+    start: Instant,
+    correlation: &webfang_core::domain::CorrelationId,
+) {
+    // (successes, failures) per host.
+    let mut groups: std::collections::BTreeMap<String, (usize, usize)> =
+        std::collections::BTreeMap::new();
+    for result in &outcome.results {
+        let host = result
+            .url
+            .host_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| "unknown".to_string());
+        groups.entry(host).or_default().0 += 1;
+    }
+    for failed in &outcome.failed {
+        let host = url::Url::parse(&failed.url)
+            .ok()
+            .and_then(|u| u.host_str().map(str::to_string))
+            .unwrap_or_else(|| "unknown".to_string());
+        groups.entry(host).or_default().1 += 1;
+    }
+    for (host, (ok, failed)) in groups {
+        let outcome_type = if failed == 0 {
+            Outcome::Success
+        } else if ok == 0 {
+            Outcome::Error
+        } else {
+            Outcome::Partial
+        };
+        state.record_scrape_identity(
+            "scrape_batch",
+            host,
+            outcome_type,
+            ok + failed,
+            start,
+            correlation,
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1028,4 +1073,111 @@ mod tests {
             .await;
         assert!(res.is_err(), "invalid URL must be a protocol error");
     }
-}
+        // --- record_batch_metrics_by_domain (#696) ---
+
+        /// Build a minimal successful `ScrapedContent` for a given URL.
+        fn scraped(url: &str) -> webfang_core::domain::entities::content::ScrapedContent {
+            webfang_core::domain::entities::content::ScrapedContent {
+                title: "t".into(),
+                content: "c".into(),
+                url: webfang_core::domain::ValidUrl::new(
+                    url::Url::parse(url).expect("valid url"),
+                ),
+                excerpt: None,
+                author: None,
+                date: None,
+                html: None,
+                assets: vec![],
+                correlation_id: None,
+            }
+        }
+
+        /// Build a minimal `ScrapeFailed` for a given URL.
+        fn failed(url: &str) -> webfang_core::application::scraper_service::ScrapeFailed {
+            webfang_core::application::scraper_service::ScrapeFailed {
+                url: url.to_string(),
+                error: "boom".into(),
+                category:
+                    webfang_core::application::scraper_service::ScrapeErrorCategory::PermanentFatal,
+            }
+        }
+
+        #[tokio::test]
+        async fn batch_metrics_multi_domain_attributed_per_host() {
+            // OBS-MCP-BATCH-001: a batch spanning two hosts must record one
+            // event per REAL host, not everything under `urls.first()`.
+            let (handler, _tmp) = test_handler().await;
+            let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
+                results: vec![
+                    scraped("https://example.com/a"),
+                    scraped("https://books.toscrape.com/b"),
+                ],
+                failed: vec![],
+            };
+            record_batch_metrics_by_domain(
+                &handler.state,
+                &outcome,
+                Instant::now(),
+                &webfang_core::domain::CorrelationId::new(),
+            );
+
+            let snap = handler.state.metrics_snapshot();
+            assert_eq!(snap.total_events, 2, "one event per domain");
+            assert_eq!(snap.domains.len(), 2, "two distinct domains recorded");
+            assert_eq!(snap.domains["example.com"].pages, 1, "example.com pages");
+            assert_eq!(
+                snap.domains["books.toscrape.com"].pages, 1,
+                "books.toscrape.com pages"
+            );
+        }
+
+        #[tokio::test]
+        async fn batch_metrics_single_domain_regression_guard() {
+            let (handler, _tmp) = test_handler().await;
+            let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
+                results: vec![
+                    scraped("https://example.com/a"),
+                    scraped("https://example.com/b"),
+                ],
+                failed: vec![],
+            };
+            record_batch_metrics_by_domain(
+                &handler.state,
+                &outcome,
+                Instant::now(),
+                &webfang_core::domain::CorrelationId::new(),
+            );
+
+            let snap = handler.state.metrics_snapshot();
+            assert_eq!(snap.total_events, 1, "single domain = single event");
+            assert_eq!(snap.domains["example.com"].pages, 2, "both pages counted");
+            assert_eq!(snap.success_count, 1, "all-success batch is Success");
+        }
+
+        #[tokio::test]
+        async fn batch_metrics_mixed_outcomes_per_domain() {
+            // A domain with both a success and a failure is Partial; a domain
+            // with only failures is Error.
+            let (handler, _tmp) = test_handler().await;
+            let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
+                results: vec![scraped("https://example.com/ok")],
+                failed: vec![
+                    failed("https://example.com/bad"),
+                    failed("https://broken.test/x"),
+                ],
+            };
+            record_batch_metrics_by_domain(
+                &handler.state,
+                &outcome,
+                Instant::now(),
+                &webfang_core::domain::CorrelationId::new(),
+            );
+
+            let snap = handler.state.metrics_snapshot();
+            assert_eq!(snap.domains.len(), 2);
+            assert_eq!(snap.partial_count, 1, "mixed domain is Partial");
+            assert_eq!(snap.error_count, 1, "all-failed domain is Error");
+            assert_eq!(snap.domains["example.com"].pages, 2, "ok + bad counted");
+            assert_eq!(snap.domains["broken.test"].pages, 1);
+        }
+    }

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -242,17 +242,12 @@ impl McpHandler {
         .await
         {
             Ok(outcome) => {
-                    let failed_count = outcome.failed.len();
-                    // Per-domain attribution (#696): a batch may span multiple
-                    // hosts, so metrics are grouped by the REAL host of each
-                    // result/failure instead of assuming `urls.first()`. All
-                    // events share the run-root correlation (#501/#698).
-                    record_batch_metrics_by_domain(
-                        &self.state,
-                        &outcome,
-                        start,
-                        &root_correlation,
-                    );
+                let failed_count = outcome.failed.len();
+                // Per-domain attribution (#696): a batch may span multiple
+                // hosts, so metrics are grouped by the REAL host of each
+                // result/failure instead of assuming `urls.first()`. All
+                // events share the run-root correlation (#501/#698).
+                record_batch_metrics_by_domain(&self.state, &outcome, start, &root_correlation);
                 tracing::info!(
                     "batch scrape complete: {} pages, {} failed",
                     outcome.results.len(),
@@ -719,7 +714,6 @@ pub fn build_router() -> ToolRouter<McpHandler> {
     McpHandler::tool_router_scraping()
 }
 
-
 /// Record per-domain scrape metrics for a completed batch (#696).
 ///
 /// Groups successes and failures by their REAL host so multi-domain batches
@@ -1073,111 +1067,109 @@ mod tests {
             .await;
         assert!(res.is_err(), "invalid URL must be a protocol error");
     }
-        // --- record_batch_metrics_by_domain (#696) ---
+    // --- record_batch_metrics_by_domain (#696) ---
 
-        /// Build a minimal successful `ScrapedContent` for a given URL.
-        fn scraped(url: &str) -> webfang_core::domain::entities::content::ScrapedContent {
-            webfang_core::domain::entities::content::ScrapedContent {
-                title: "t".into(),
-                content: "c".into(),
-                url: webfang_core::domain::ValidUrl::new(
-                    url::Url::parse(url).expect("valid url"),
-                ),
-                excerpt: None,
-                author: None,
-                date: None,
-                html: None,
-                assets: vec![],
-                correlation_id: None,
-            }
-        }
-
-        /// Build a minimal `ScrapeFailed` for a given URL.
-        fn failed(url: &str) -> webfang_core::application::scraper_service::ScrapeFailed {
-            webfang_core::application::scraper_service::ScrapeFailed {
-                url: url.to_string(),
-                error: "boom".into(),
-                category:
-                    webfang_core::application::scraper_service::ScrapeErrorCategory::PermanentFatal,
-            }
-        }
-
-        #[tokio::test]
-        async fn batch_metrics_multi_domain_attributed_per_host() {
-            // OBS-MCP-BATCH-001: a batch spanning two hosts must record one
-            // event per REAL host, not everything under `urls.first()`.
-            let (handler, _tmp) = test_handler().await;
-            let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
-                results: vec![
-                    scraped("https://example.com/a"),
-                    scraped("https://books.toscrape.com/b"),
-                ],
-                failed: vec![],
-            };
-            record_batch_metrics_by_domain(
-                &handler.state,
-                &outcome,
-                Instant::now(),
-                &webfang_core::domain::CorrelationId::new(),
-            );
-
-            let snap = handler.state.metrics_snapshot();
-            assert_eq!(snap.total_events, 2, "one event per domain");
-            assert_eq!(snap.domains.len(), 2, "two distinct domains recorded");
-            assert_eq!(snap.domains["example.com"].pages, 1, "example.com pages");
-            assert_eq!(
-                snap.domains["books.toscrape.com"].pages, 1,
-                "books.toscrape.com pages"
-            );
-        }
-
-        #[tokio::test]
-        async fn batch_metrics_single_domain_regression_guard() {
-            let (handler, _tmp) = test_handler().await;
-            let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
-                results: vec![
-                    scraped("https://example.com/a"),
-                    scraped("https://example.com/b"),
-                ],
-                failed: vec![],
-            };
-            record_batch_metrics_by_domain(
-                &handler.state,
-                &outcome,
-                Instant::now(),
-                &webfang_core::domain::CorrelationId::new(),
-            );
-
-            let snap = handler.state.metrics_snapshot();
-            assert_eq!(snap.total_events, 1, "single domain = single event");
-            assert_eq!(snap.domains["example.com"].pages, 2, "both pages counted");
-            assert_eq!(snap.success_count, 1, "all-success batch is Success");
-        }
-
-        #[tokio::test]
-        async fn batch_metrics_mixed_outcomes_per_domain() {
-            // A domain with both a success and a failure is Partial; a domain
-            // with only failures is Error.
-            let (handler, _tmp) = test_handler().await;
-            let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
-                results: vec![scraped("https://example.com/ok")],
-                failed: vec![
-                    failed("https://example.com/bad"),
-                    failed("https://broken.test/x"),
-                ],
-            };
-            record_batch_metrics_by_domain(
-                &handler.state,
-                &outcome,
-                Instant::now(),
-                &webfang_core::domain::CorrelationId::new(),
-            );
-
-            let snap = handler.state.metrics_snapshot();
-            assert_eq!(snap.domains.len(), 2);
-            assert_eq!(snap.partial_count, 1, "mixed domain is Partial");
-            assert_eq!(snap.error_count, 1, "all-failed domain is Error");
-            assert_eq!(snap.domains["example.com"].pages, 2, "ok + bad counted");
-            assert_eq!(snap.domains["broken.test"].pages, 1);
+    /// Build a minimal successful `ScrapedContent` for a given URL.
+    fn scraped(url: &str) -> webfang_core::domain::entities::content::ScrapedContent {
+        webfang_core::domain::entities::content::ScrapedContent {
+            title: "t".into(),
+            content: "c".into(),
+            url: webfang_core::domain::ValidUrl::new(url::Url::parse(url).expect("valid url")),
+            excerpt: None,
+            author: None,
+            date: None,
+            html: None,
+            assets: vec![],
+            correlation_id: None,
         }
     }
+
+    /// Build a minimal `ScrapeFailed` for a given URL.
+    fn failed(url: &str) -> webfang_core::application::scraper_service::ScrapeFailed {
+        webfang_core::application::scraper_service::ScrapeFailed {
+            url: url.to_string(),
+            error: "boom".into(),
+            category:
+                webfang_core::application::scraper_service::ScrapeErrorCategory::PermanentFatal,
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_metrics_multi_domain_attributed_per_host() {
+        // OBS-MCP-BATCH-001: a batch spanning two hosts must record one
+        // event per REAL host, not everything under `urls.first()`.
+        let (handler, _tmp) = test_handler().await;
+        let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
+            results: vec![
+                scraped("https://example.com/a"),
+                scraped("https://books.toscrape.com/b"),
+            ],
+            failed: vec![],
+        };
+        record_batch_metrics_by_domain(
+            &handler.state,
+            &outcome,
+            Instant::now(),
+            &webfang_core::domain::CorrelationId::new(),
+        );
+
+        let snap = handler.state.metrics_snapshot();
+        assert_eq!(snap.total_events, 2, "one event per domain");
+        assert_eq!(snap.domains.len(), 2, "two distinct domains recorded");
+        assert_eq!(snap.domains["example.com"].pages, 1, "example.com pages");
+        assert_eq!(
+            snap.domains["books.toscrape.com"].pages, 1,
+            "books.toscrape.com pages"
+        );
+    }
+
+    #[tokio::test]
+    async fn batch_metrics_single_domain_regression_guard() {
+        let (handler, _tmp) = test_handler().await;
+        let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
+            results: vec![
+                scraped("https://example.com/a"),
+                scraped("https://example.com/b"),
+            ],
+            failed: vec![],
+        };
+        record_batch_metrics_by_domain(
+            &handler.state,
+            &outcome,
+            Instant::now(),
+            &webfang_core::domain::CorrelationId::new(),
+        );
+
+        let snap = handler.state.metrics_snapshot();
+        assert_eq!(snap.total_events, 1, "single domain = single event");
+        assert_eq!(snap.domains["example.com"].pages, 2, "both pages counted");
+        assert_eq!(snap.success_count, 1, "all-success batch is Success");
+    }
+
+    #[tokio::test]
+    async fn batch_metrics_mixed_outcomes_per_domain() {
+        // A domain with both a success and a failure is Partial; a domain
+        // with only failures is Error.
+        let (handler, _tmp) = test_handler().await;
+        let outcome = webfang_core::application::scraper_service::ScrapeBatchOutcome {
+            results: vec![scraped("https://example.com/ok")],
+            failed: vec![
+                failed("https://example.com/bad"),
+                failed("https://broken.test/x"),
+            ],
+        };
+        record_batch_metrics_by_domain(
+            &handler.state,
+            &outcome,
+            Instant::now(),
+            &webfang_core::domain::CorrelationId::new(),
+        );
+
+        let snap = handler.state.metrics_snapshot();
+        assert_eq!(snap.domains.len(), 2);
+        assert_eq!(snap.partial_count, 1, "mixed domain is Partial");
+        assert_eq!(snap.error_count, 1, "all-failed domain is Error");
+        assert_eq!(snap.domains["example.com"].pages, 2, "ok + bad counted");
+        assert_eq!(snap.domains["broken.test"].pages, 1);
+    }
+}

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -1094,6 +1094,19 @@ mod tests {
         }
     }
 
+    /// Record a batch outcome against the handler's metrics (#696 tests).
+    fn record(
+        handler: &McpHandler,
+        outcome: webfang_core::application::scraper_service::ScrapeBatchOutcome,
+    ) {
+        record_batch_metrics_by_domain(
+            &handler.state,
+            &outcome,
+            Instant::now(),
+            &webfang_core::domain::CorrelationId::new(),
+        );
+    }
+
     #[tokio::test]
     async fn batch_metrics_multi_domain_attributed_per_host() {
         // OBS-MCP-BATCH-001: a batch spanning two hosts must record one
@@ -1106,12 +1119,7 @@ mod tests {
             ],
             failed: vec![],
         };
-        record_batch_metrics_by_domain(
-            &handler.state,
-            &outcome,
-            Instant::now(),
-            &webfang_core::domain::CorrelationId::new(),
-        );
+        record(&handler, outcome);
 
         let snap = handler.state.metrics_snapshot();
         assert_eq!(snap.total_events, 2, "one event per domain");
@@ -1133,12 +1141,7 @@ mod tests {
             ],
             failed: vec![],
         };
-        record_batch_metrics_by_domain(
-            &handler.state,
-            &outcome,
-            Instant::now(),
-            &webfang_core::domain::CorrelationId::new(),
-        );
+        record(&handler, outcome);
 
         let snap = handler.state.metrics_snapshot();
         assert_eq!(snap.total_events, 1, "single domain = single event");
@@ -1158,12 +1161,7 @@ mod tests {
                 failed("https://broken.test/x"),
             ],
         };
-        record_batch_metrics_by_domain(
-            &handler.state,
-            &outcome,
-            Instant::now(),
-            &webfang_core::domain::CorrelationId::new(),
-        );
+        record(&handler, outcome);
 
         let snap = handler.state.metrics_snapshot();
         assert_eq!(snap.domains.len(), 2);

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -4,12 +4,15 @@
 //! tokio::sync::Semaphore instances to limit concurrent operations
 //! per tool category, protecting the 8GB RAM / HDD hardware.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::mcp_server::metrics::{MetricsSnapshot, ScrapeEvent, ScrapeMetrics};
+use rmcp::ErrorData as McpError;
+use serde_json::Value;
 use webfang_core::adapters::downloader::Downloader;
 use webfang_core::di::Container;
 use webfang_core::domain::DomInspectorPort;
@@ -75,6 +78,12 @@ pub struct McpState {
     /// Process-lifetime scrape metrics, shared across all per-session clones
     /// (REQ-06). Locked only in short synchronous sections (REQ-07).
     pub metrics: Arc<Mutex<ScrapeMetrics>>,
+    /// Allowed root directories for absolute `output_dir` paths (#696).
+    ///
+    /// Empty (default) = absolute `output_dir` values are REJECTED
+    /// (fail-closed). When non-empty, an absolute `output_dir` must be
+    /// lexically under one of these roots after normalization.
+    pub allowed_export_roots: Arc<Vec<PathBuf>>,
     /// Cancellation token for graceful shutdown propagation.
     pub cancel_token: CancellationToken,
 }
@@ -127,6 +136,7 @@ impl McpState {
             inspector: None,
             robots_fetcher,
             metrics: Arc::new(Mutex::new(ScrapeMetrics::default())),
+            allowed_export_roots: Arc::new(Vec::new()),
             cancel_token: CancellationToken::new(),
         }
     }
@@ -166,6 +176,58 @@ impl McpState {
     pub fn with_inspector(mut self, inspector: Arc<dyn DomInspectorPort>) -> Self {
         self.inspector = Some(inspector);
         self
+    }
+
+    /// Set the allowed root directories for absolute `output_dir` paths (#696).
+    ///
+    /// When empty (default), absolute `output_dir` values are rejected.
+    /// When non-empty, an absolute `output_dir` must be under one of these
+    /// roots. Relative paths are always allowed (they resolve against CWD).
+    #[must_use]
+    pub fn with_export_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.allowed_export_roots = Arc::new(roots);
+        self
+    }
+
+    /// Validate that `dir` is an allowed export destination (#696).
+    ///
+    /// Relative paths are always allowed (existing behavior — they resolve
+    /// against the server's CWD). Absolute paths must be under one of
+    /// [`allowed_export_roots`](Self::allowed_export_roots); when no roots
+    /// are configured, absolute paths are rejected (fail-closed).
+    ///
+    /// # Errors
+    /// Returns `McpError::invalid_params` when an absolute path is outside
+    /// every configured root, or when no roots are configured at all.
+    pub fn validate_export_dir(&self, dir: &Path) -> Result<(), McpError> {
+        if !dir.is_absolute() {
+            return Ok(());
+        }
+        let roots = self.allowed_export_roots.as_ref();
+        if roots.is_empty() {
+            tracing::warn!(dir = %dir.display(), "absolute output_dir rejected: no export roots configured");
+            return Err(McpError::invalid_params(
+                "absolute output_dir requires server-configured export roots (none configured); \
+                 set --export-roots or use a relative path"
+                    .to_string(),
+                Some(Value::String("output_dir".to_string())),
+            ));
+        }
+        // Normalize the candidate lexically: resolve `.` and `..` components
+        // without touching the filesystem (the dir may not exist yet).
+        let normalized = normalize_lexical(dir);
+        let allowed = roots
+            .iter()
+            .any(|root| normalized.starts_with(normalize_lexical(root)));
+        if allowed {
+            Ok(())
+        } else {
+            tracing::warn!(dir = %dir.display(), "absolute output_dir outside allowed export roots");
+            Err(McpError::invalid_params(
+                format!("output_dir '{}' is outside allowed export roots", dir.display()),
+                Some(Value::String("output_dir".to_string())),
+            ))
+        }
     }
 
     /// Record a scrape event into the shared accumulator.
@@ -215,6 +277,24 @@ impl McpState {
             .unwrap_or_else(|e| e.into_inner())
             .snapshot()
     }
+}
+
+/// Normalize a path lexically: resolve `.` and `..` components without
+/// filesystem access. Used by [`McpState::validate_export_dir`] so the
+/// prefix check cannot be defeated by redundant components (#696).
+fn normalize_lexical(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {},
+            Component::ParentDir => {
+                out.pop();
+            },
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 /// Build the shared robots.txt fetcher for the scrape tools (#697).
@@ -354,4 +434,92 @@ mod tests {
         assert_eq!(snap.total_events, 1, "record-through-clone is visible");
         assert_eq!(snap.success_count, 1, "success bucket recorded");
     }
-}
+        // --- validate_export_dir (#696) ---
+
+        #[tokio::test]
+        async fn export_dir_relative_always_allowed() {
+            let (_tmp, container) = test_container().await;
+            let state = McpState::new(container); // no roots configured
+            assert!(
+                state.validate_export_dir(Path::new("./output")).is_ok(),
+                "relative paths must pass through with no roots configured"
+            );
+        }
+
+        #[tokio::test]
+        async fn export_dir_absolute_rejected_without_roots() {
+            let (_tmp, container) = test_container().await;
+            let state = McpState::new(container); // fail-closed default
+            let err = state
+                .validate_export_dir(Path::new("/etc"))
+                .expect_err("absolute path must be rejected with no roots");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("export roots"),
+                "error must name the missing export roots, got: {msg}"
+            );
+        }
+
+        #[tokio::test]
+        async fn export_dir_absolute_allowed_under_root() {
+            let (tmp, container) = test_container().await;
+            let state =
+                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+            let target = tmp.path().join("exports");
+            assert!(
+                state.validate_export_dir(&target).is_ok(),
+                "path under a configured root must be allowed"
+            );
+        }
+
+        #[tokio::test]
+        async fn export_dir_absolute_rejected_outside_root() {
+            let (tmp, container) = test_container().await;
+            let state =
+                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+            let err = state
+                .validate_export_dir(Path::new("/etc"))
+                .expect_err("path outside roots must be rejected");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("outside allowed export roots"),
+                "error must name the root violation, got: {msg}"
+            );
+        }
+
+        #[tokio::test]
+        async fn export_dir_sibling_prefix_is_not_a_root_match() {
+            // `/tmp/rootX` must NOT satisfy root `/tmp/root` — the prefix check
+            // is component-based (`starts_with`), not string-based.
+            let (tmp, container) = test_container().await;
+            let state =
+                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+            let mut sibling = tmp.path().to_path_buf();
+            let mut name = sibling
+                .file_name()
+                .expect("temp dir has a name")
+                .to_os_string();
+            name.push("_evil");
+            sibling.set_file_name(name);
+            assert!(
+                state.validate_export_dir(&sibling).is_err(),
+                "string-prefix sibling dir must not match the root"
+            );
+        }
+
+        #[tokio::test]
+        async fn export_dir_dotdot_cannot_escape_root() {
+            // Lexical normalization resolves `..` before the prefix check, so
+            // `<root>/../etc` is rejected even though it starts with the root.
+            let (tmp, container) = test_container().await;
+            let state =
+                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+            let mut escape = tmp.path().to_path_buf();
+            escape.push("..");
+            escape.push("etc");
+            assert!(
+                state.validate_export_dir(&escape).is_err(),
+                "`..` traversal out of the root must be rejected"
+            );
+        }
+    }

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -224,7 +224,10 @@ impl McpState {
         } else {
             tracing::warn!(dir = %dir.display(), "absolute output_dir outside allowed export roots");
             Err(McpError::invalid_params(
-                format!("output_dir '{}' is outside allowed export roots", dir.display()),
+                format!(
+                    "output_dir '{}' is outside allowed export roots",
+                    dir.display()
+                ),
                 Some(Value::String("output_dir".to_string())),
             ))
         }
@@ -434,92 +437,88 @@ mod tests {
         assert_eq!(snap.total_events, 1, "record-through-clone is visible");
         assert_eq!(snap.success_count, 1, "success bucket recorded");
     }
-        // --- validate_export_dir (#696) ---
+    // --- validate_export_dir (#696) ---
 
-        #[tokio::test]
-        async fn export_dir_relative_always_allowed() {
-            let (_tmp, container) = test_container().await;
-            let state = McpState::new(container); // no roots configured
-            assert!(
-                state.validate_export_dir(Path::new("./output")).is_ok(),
-                "relative paths must pass through with no roots configured"
-            );
-        }
-
-        #[tokio::test]
-        async fn export_dir_absolute_rejected_without_roots() {
-            let (_tmp, container) = test_container().await;
-            let state = McpState::new(container); // fail-closed default
-            let err = state
-                .validate_export_dir(Path::new("/etc"))
-                .expect_err("absolute path must be rejected with no roots");
-            let msg = err.to_string();
-            assert!(
-                msg.contains("export roots"),
-                "error must name the missing export roots, got: {msg}"
-            );
-        }
-
-        #[tokio::test]
-        async fn export_dir_absolute_allowed_under_root() {
-            let (tmp, container) = test_container().await;
-            let state =
-                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
-            let target = tmp.path().join("exports");
-            assert!(
-                state.validate_export_dir(&target).is_ok(),
-                "path under a configured root must be allowed"
-            );
-        }
-
-        #[tokio::test]
-        async fn export_dir_absolute_rejected_outside_root() {
-            let (tmp, container) = test_container().await;
-            let state =
-                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
-            let err = state
-                .validate_export_dir(Path::new("/etc"))
-                .expect_err("path outside roots must be rejected");
-            let msg = err.to_string();
-            assert!(
-                msg.contains("outside allowed export roots"),
-                "error must name the root violation, got: {msg}"
-            );
-        }
-
-        #[tokio::test]
-        async fn export_dir_sibling_prefix_is_not_a_root_match() {
-            // `/tmp/rootX` must NOT satisfy root `/tmp/root` — the prefix check
-            // is component-based (`starts_with`), not string-based.
-            let (tmp, container) = test_container().await;
-            let state =
-                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
-            let mut sibling = tmp.path().to_path_buf();
-            let mut name = sibling
-                .file_name()
-                .expect("temp dir has a name")
-                .to_os_string();
-            name.push("_evil");
-            sibling.set_file_name(name);
-            assert!(
-                state.validate_export_dir(&sibling).is_err(),
-                "string-prefix sibling dir must not match the root"
-            );
-        }
-
-        #[tokio::test]
-        async fn export_dir_dotdot_cannot_escape_root() {
-            // Lexical normalization resolves `..` before the prefix check, so
-            // `<root>/../etc` is rejected even though it starts with the root.
-            let (tmp, container) = test_container().await;
-            let state =
-                McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
-            let mut escape = tmp.path().to_path_buf();
-            escape.push("..");
-            escape.push("etc");
-            assert!(
-                state.validate_export_dir(&escape).is_err(),
-                "`..` traversal out of the root must be rejected"
-            );
-        }
+    #[tokio::test]
+    async fn export_dir_relative_always_allowed() {
+        let (_tmp, container) = test_container().await;
+        let state = McpState::new(container); // no roots configured
+        assert!(
+            state.validate_export_dir(Path::new("./output")).is_ok(),
+            "relative paths must pass through with no roots configured"
+        );
     }
+
+    #[tokio::test]
+    async fn export_dir_absolute_rejected_without_roots() {
+        let (_tmp, container) = test_container().await;
+        let state = McpState::new(container); // fail-closed default
+        let err = state
+            .validate_export_dir(Path::new("/etc"))
+            .expect_err("absolute path must be rejected with no roots");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("export roots"),
+            "error must name the missing export roots, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_dir_absolute_allowed_under_root() {
+        let (tmp, container) = test_container().await;
+        let state = McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+        let target = tmp.path().join("exports");
+        assert!(
+            state.validate_export_dir(&target).is_ok(),
+            "path under a configured root must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_dir_absolute_rejected_outside_root() {
+        let (tmp, container) = test_container().await;
+        let state = McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+        let err = state
+            .validate_export_dir(Path::new("/etc"))
+            .expect_err("path outside roots must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("outside allowed export roots"),
+            "error must name the root violation, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_dir_sibling_prefix_is_not_a_root_match() {
+        // `/tmp/rootX` must NOT satisfy root `/tmp/root` — the prefix check
+        // is component-based (`starts_with`), not string-based.
+        let (tmp, container) = test_container().await;
+        let state = McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+        let mut sibling = tmp.path().to_path_buf();
+        let mut name = sibling
+            .file_name()
+            .expect("temp dir has a name")
+            .to_os_string();
+        name.push("_evil");
+        sibling.set_file_name(name);
+        assert!(
+            state.validate_export_dir(&sibling).is_err(),
+            "string-prefix sibling dir must not match the root"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_dir_dotdot_cannot_escape_root() {
+        // Lexical normalization resolves `..` before the prefix check, so
+        // `<root>/../etc` is rejected even though it starts with the root.
+        let (tmp, container) = test_container().await;
+        let state = McpState::new(container).with_export_roots(vec![tmp.path().to_path_buf()]);
+        let mut escape = tmp.path().to_path_buf();
+        escape.push("..");
+        escape.push("etc");
+        assert!(
+            state.validate_export_dir(&escape).is_err(),
+            "`..` traversal out of the root must be rejected"
+        );
+    }
+}

--- a/test_lab/REPORTE_AUDITORIA_MCP_v2.0.0_2026-08-11.md
+++ b/test_lab/REPORTE_AUDITORIA_MCP_v2.0.0_2026-08-11.md
@@ -1,0 +1,109 @@
+# 🕵️ Reporte de Auditoría MCP v2.0.0 — hallazgos menores (issue #696)
+
+> ⚠️ **PROVENIENCIA — RECONSTRUCCIÓN, NO ORIGINAL**
+>
+> El reporte original de la auditoría MCP v2.0.0 (2026-08-11) nunca fue
+> persistido en la bóveda: no existe en el repo, en ningún worktree, ni en
+> rutas temporales (búsqueda exhaustiva de filesystem, 2026-08-17). Este
+> archivo es una **reconstrucción** escrita el 2026-08-17 a partir del
+> contenido de la issue #696 y de la verificación de código realizada ese
+> mismo día. No debe citarse como el artefacto original de la auditoría;
+> se commitea únicamente para que el historial de Git sea coherente con la
+> referencia de evidencia de la issue #696.
+
+**Rol:** Senior Rust Architect & MCP Security Reviewer
+**Fecha de reconstrucción:** 2026-08-17 · **Binario auditado (original):** MCP server v2.0.0
+**Metodología:** Caja blanca (lectura de `mcp_server/`) + probe de runtime
+**Issue vinculada:** #696 · **Fix:** commit `6829bd6` (`fix/696-mcp-export-roots`)
+
+---
+
+## 0. Veredicto Ejecutivo
+
+| ID | Hallazgo | Severidad | Estado original | Resolución |
+|:---|:---------|:---------:|:---------------:|:-----------|
+| RIESGO-MCP-EXPORT-001 | `output_dir` absoluto = write-anywhere (F17) | Riesgo | Abierto (por diseño #600) | **FIJADO** — root-of-trust `allowed_export_roots` |
+| OBS-MCP-BATCH-001 | métricas de `scrape_batch` bajo un solo dominio (F15) | Observación | Abierto | **FIJADO** — atribución por dominio real |
+
+---
+
+## 1. RIESGO-MCP-EXPORT-001 — `output_dir` absoluto = write-anywhere
+
+### Evidencia original (issue #696)
+
+`export_file` acepta `output_dir` absoluto (issue #600, por diseño). Probe
+`output_dir=/etc filename=passwd` → error honesto
+`isError:true: write error: /etc/passwd.jsonl.lock: Permission denied`
+(sin panic, sin escritura; el filename está saneado por `SanitizedFilename`,
+issue #601). El riesgo real: si el server corre con privilegios, el caller
+puede escribir en cualquier ruta del filesystem.
+
+### Verificación de código (2026-08-17)
+
+Confirmado. En `mcp_server/params.rs` la validación usaba
+`require_safe_path_allow_absolute("output_dir", …)` — el comentario en línea
+cita explícitamente la issue #600: los paths absolutos DEBEN aceptarse. Las
+protecciones existentes funcionan contra *path traversal en el filename*
+(`SanitizedFilename`), pero no restringen **dónde** puede escribir el
+`output_dir` absoluto. El riesgo residual es un *write-anywhere primitive*
+condicionado solo a los privilegios del proceso servidor.
+
+### Resolución (commit `6829bd6`)
+
+Se añadió un **root-of-trust** en `McpState`:
+
+- Campo `allowed_export_roots: Arc<Vec<PathBuf>>` — vacío por defecto =
+  **fail-closed** (los `output_dir` absolutos se rechazan).
+- `McpState::validate_export_dir(&Path)` — los paths relativos pasan sin
+  cambio (comportamiento existente); los absolutos deben estar bajo uno de
+  los roots tras normalización léxica (`normalize_lexical` resuelve `.`/`..`
+  sin tocar el filesystem), de modo que ni `..` ni un hermano por prefijo de
+  string (`/tmp/rootX` vs root `/tmp/root`) escapen del root.
+- Cableado en `export_file`, `export_jsonl`, `export_vector` y
+  `download_assets`.
+- Ambos binarios (`mcp_server_http.rs`, `mcp_server_stdio.rs`) exponen
+  `--export-roots` / `WEBFANG_MCP_EXPORT_ROOTS` (repetible o comma-separated).
+
+Tests: relativo siempre permitido; absoluto rechazado sin roots; absoluto
+permitido bajo root; rechazado fuera del root; hermano por prefijo rechazado;
+`..` no escapa del root.
+
+---
+
+## 2. OBS-MCP-BATCH-001 — métricas de `scrape_batch` bajo un solo dominio
+
+### Evidencia original (issue #696)
+
+`scrape_batch` agrega sus métricas bajo `urls.first().host` aunque procese N
+dominios: `tool=scrape_batch domain=example.com pages=2` para un batch con
+`example.com` + `books.toscrape.com`.
+
+### Verificación de código (2026-08-17)
+
+Confirmado. En `mcp_server/handlers/scraping.rs` el dominio se derivaba de
+`urls.first().and_then(|u| u.host_str())` y `record_scrape_identity` recibía
+ese único dominio con el `count` total. En `mcp_server/metrics.rs`,
+`DomainStats` acumulaba `pages` bajo esa sola clave: un batch multi-dominio
+inflaba un dominio y dejaba el resto en cero.
+
+### Resolución (commit `6829bd6`)
+
+Helper `record_batch_metrics_by_domain` en `scraping.rs`: agrupa `results` y
+`failed` por su host **real** (`result.url.host_str()` / parse de
+`failed.url`) y emite un `ScrapeEvent` por grupo de dominio. Todos los eventos
+comparten el `root_correlation` de la operación (#501/#698): una identidad de
+operación, un evento por dominio. `BTreeMap` mantiene el orden de emisión
+determinístico (DD-6). El outcome por dominio es `Success` (todo ok), `Error`
+(todo falló) o `Partial` (mixto).
+
+Tests: multi-dominio atribuye un evento por host; single-dominio como
+regression guard; outcomes mixtos por dominio (`Partial` + `Error`).
+
+---
+
+## 3. Nota sobre la evidencia perdida
+
+El archivo referenciado originalmente por la issue #696 no estaba commiteado.
+Esta reconstrucción cierra esa brecha de trazabilidad. Cualquier cita futura
+debe referirse a este archivo como **reconstrucción**, no como el reporte
+original de la auditoría.


### PR DESCRIPTION
Closes #696

## Summary

Cierra los dos hallazgos menores de la auditoría MCP v2.0.0 (issue #696).

### 1. RIESGO-MCP-EXPORT-001 — write-anywhere → Root of Trust

`output_dir` absoluto era aceptado en cualquier ruta donde el proceso pudiera escribir (diseño #600). Ahora:

- `McpState.allowed_export_roots` — **fail-closed**: sin roots configurados, los `output_dir` absolutos se rechazan.
- `validate_export_dir` con normalización léxica: ni `..` ni hermanos por prefijo de string (`/tmp/rootX` vs root `/tmp/root`) escapan del root.
- Cableado en `export_file`, `export_jsonl`, `export_vector` y `download_assets`.
- `--export-roots` / `WEBFANG_MCP_EXPORT_ROOTS` en ambos binarios del server.

### 2. OBS-MCP-BATCH-001 — métricas batch por dominio real

`scrape_batch` atribuía todas las métricas a `urls.first().host`. Ahora `record_batch_metrics_by_domain` agrupa `results` + `failed` por su host real y emite un `ScrapeEvent` por dominio, todos compartiendo el `root_correlation` de la operación (#501/#698 intacto).

### 3. Evidencia de auditoría

El reporte original referenciado por la issue nunca fue persistido (búsqueda exhaustiva de filesystem). Se commitea una **reconstrucción marcada como tal** en `test_lab/REPORTE_AUDITORIA_MCP_v2.0.0_2026-08-11.md` para que el historial sea coherente con la referencia de evidencia.

## Verification

- 9 tests nuevos (6 export-roots + 3 batch-metrics), suite MCP 249/250 verde — la única falla (`detect_obsidian_vault_none_when_not_a_vault`) es ambiental y preexistente en `main`.
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` limpio.
