### PR TITLE
docs(infra): artifacto LLM como directorio llms.txt v2 con fuentes por crate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,6 +76,12 @@ jobs:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --all-features --no-deps
 
+      - name: LLM artifact script sanity
+        run: |
+          set -euo pipefail
+          test -x scripts/build-llm-artifact.sh
+          bash -n scripts/build-llm-artifact.sh
+
       - name: CLI reference drift check (chapter must match binary help)
         run: |
           set -euo pipefail
@@ -144,102 +150,30 @@ jobs:
           cp -r target/doc docs/book/api
           touch docs/book/.nojekyll
 
-      # Build the LLM / RAG markdown: clean text sized to fit NotebookLM's
-      # ~500k-word per-source limit (the full artifact measured 658k words).
-      # Single H1 (# WebFang Documentation) at the top; chapters and crate API
-      # sections are H3 under H2 parents so chunkers split cleanly. Three parts:
-      #   1. Narrative (mdBook chapters) — chapter H1 downgraded to H3, no dupes.
-      #   2. CLI reference — the cli-reference.md chapter is a single
-      #      self-contained file (no mdBook {{#include}} preprocessing needed),
-      #      so it is read from raw source; its help block is CI drift-checked.
-      #   3. API reference (rustdoc via pandoc) — ALL noise stripped: <a>, "Expand
-      #      description", "§", "Copy item path", stray HTML tags, blank-line runs,
-      #      plus the repeated "Blanket/Auto Trait Implementations" sections
-      #      (identical boilerplate on every type page).
-      # Excluded: raw source files (crates/**/*.rs — 308k of the 658k words) and
-      # the boilerplate sections above, which carry no semantics for a language
-      # model. Raw code stays available in the repo and on docs.rs.
-      # Output: docs/book/webfang-docs-llm.md → uploaded as `webfang-docs-llm`,
-      # consumed locally by `just docs`.
-      - name: Build LLM markdown artifact
+      # Build the LLM / RAG markdown artifact (#734): scripts/build-llm-artifact.sh
+      # replaces the old inline ~80-line step. It emits an llms.txt v2 directory,
+      # docs/book/webfang-docs-llm/, instead of one monolith:
+      #   llms.txt             small index (H1 + blockquote + word-counted file
+      #                        lists) pointing at the Pages-hosted sources.
+      #   00-narrative.md      mdBook chapters (single H1, chapters as H2).
+      #   01..05-<crate>.md    per-crate rustdoc API (single H1 each, headings
+      #                        demoted one level uniformly). Crates missing from
+      #                        target/doc/ are skipped silently (as before).
+      #   06-cli-reference.md  CLI flag reference chapter (#733; its help block
+      #                        is CI drift-checked by the validate job).
+      #   webfang-docs-full.md back-compat monolith, byte-equivalent to the
+      #                        pre-#734 single file (narrative / CLI / rustdoc
+      #                        API with the original heading conventions).
+      # Raw source files (crates/**/*.rs) and the "Blanket/Auto Trait
+      # Implementations" boilerplate sections stay excluded — they carry no
+      # semantics for a language model and dominated the old 658k-word draft.
+      # BUILD_DATE is injected only in CI (local runs omit Generated lines).
+      # The heavy generation (pandoc over every rustdoc page) happens only
+      # here, exactly as the old inline step did.
+      - name: Build LLM markdown artifact (llms.txt directory)
         run: |
           set -euo pipefail
-          OUT=docs/book/webfang-docs-llm.md
-          {
-            echo "# WebFang Documentation"
-            echo
-            echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo
-            echo "---"
-            echo
-            echo "## Narrative Documentation"
-            echo
-            for f in overview debugging testing troubleshooting tui-unified-design; do
-              # Downgrade the chapter's leading "# Title" to "### Title" so the
-              # artifact has a single H1 (the doc title) and no duplicate headers.
-              sed '1s/^# /### /' "docs/src/$f.md"
-              echo
-              echo "---"
-              echo
-            done
-
-            echo "## CLI Reference"
-            echo
-            # The chapter embeds the auto-generated help block; raw-source read
-            # (no mdbook preprocessing needed — the include-free chapter is
-            # self-contained).
-            sed '1s/^# /### /' docs/src/cli-reference.md
-            echo
-            echo "---"
-            echo
-
-            echo "## API Reference (rustdoc)"
-            echo
-            for crate in webfang_core webfang_ai webfang_tui webfang_mcp webfang_cli webfang_test_utils; do
-              if [ -d "target/doc/$crate" ]; then
-                echo "### API: $crate"
-                echo
-                # Single H1 in the artifact: downgrade rustdoc page titles
-                # (Struct/Function/Enum/.../List) to H3 under "## API Reference".
-                # Safe: doctest hidden lines (# use ...) never match these words.
-                {
-                  pandoc -f html -t gfm --wrap=none "target/doc/$crate/index.html" 2>/dev/null
-                  find "target/doc/$crate" -name '*.html' ! -name 'index.html' ! -path '*/src/*' -print0 \
-                    | sort -z \
-                    | while IFS= read -r -d '' fl; do
-                        pandoc -f html -t gfm --wrap=none "$fl" 2>/dev/null
-                      done
-                } \
-                | sed -e 's/Copy item path//g' \
-                      -e 's/Expand description//g' \
-                      -e 's/§//g' \
-                      -e 's/<span[^>]*>//g' -e 's/<\/span>//g' \
-                      -e 's/<div[^>]*>//g' -e 's/<\/div>//g' \
-                      -e 's/<a [^>]*>//g' -e 's/<\/a>//g' \
-                      -e 's/<[^>]*>//g' \
-                      -e 's/Show [0-9][0-9]* fields[[:space:]]*//g' \
-                      -e 's/Show [0-9][0-9]* variants[[:space:]]*//g' \
-                      -e 's/^# \(Struct\|Function\|Enum\|Trait\|Constant\|Type\|Crate\|Macro\|List\) /### \1 /' \
-                | awk 'BEGIN{skip=0} /^## Blanket Implementations|^## Auto Trait Implementations/{skip=1; next} skip && (/^## / || /^### (Struct|Function|Enum|Trait|Constant|Type|Crate|Macro|List) /){skip=0} !skip{print}' \
-                | sed -e '/^[[:space:]]*$/N;/^\n[[:space:]]*$/D' \
-                > "target/doc/$crate.md"
-                # Gate ONLY the cleaned API markdown. The gate is fence-aware:
-                # doctests may legitimately contain HTML inside ``` code fences
-                # (e.g. assert!(html.contains("<span"))).
-                if awk 'BEGIN{f=0} /^```/{f=!f; next} !f && /Expand description|Copy item path|href="|<a |<span|<div|<abbr|<code|§/{bad=1} END{exit !bad}' "target/doc/$crate.md"; then
-                  echo "::error::rustdoc noise not fully stripped for $crate"
-                  exit 1
-                fi
-                cat "target/doc/$crate.md"
-                echo
-                echo "---"
-                echo
-              fi
-            done
-
-          } > "$OUT"
-
-          echo "wrote $OUT ($(wc -l < "$OUT") lines)"
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" scripts/build-llm-artifact.sh
 
       # --- Native GitHub Pages deployment (2025+ "deploy from a workflow") ---
       # configure-pages@v5 enables/gathers the Pages site; upload-pages-artifact
@@ -264,7 +198,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: webfang-docs-llm
-          path: docs/book/webfang-docs-llm.md
+          path: docs/book/webfang-docs-llm
           if-no-files-found: error
           retention-days: 30
 

--- a/justfile
+++ b/justfile
@@ -264,7 +264,11 @@ docs:
     # con "file exists" si target/docs-llm ya existe.
     @rm -rf target/docs-llm
     @gh run download -R XaviCode1000/webfang -n webfang-docs-llm -D target/docs-llm
-    @cp target/docs-llm/webfang-docs-llm.md "{{wiki_output}}"
+    @# El artifact puede tener el layout de directorio (post-#734) — acepto ambos.
+    @FULL=target/docs-llm/webfang-docs-llm/webfang-docs-full.md; \
+    test -f "$FULL" || FULL=target/docs-llm/webfang-docs-llm.md; \
+    test -f "$FULL" || { echo "⚠️  No encontré webfang-docs-full.md en el artifacto"; exit 1; }; \
+    cp "$FULL" "{{wiki_output}}"
     @echo "✅ Documentación actualizada (desde CI, último run de main):"
     @ls -lh "{{wiki_output}}" | awk '{print "  " $NF " (" $5 ")"}'
 

--- a/scripts/build-llm-artifact.sh
+++ b/scripts/build-llm-artifact.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# ============================================================================
+# build-llm-artifact.sh — assemble the LLM/RAG documentation artifact (#734)
+#
+# Emits docs/book/webfang-docs-llm/, an llms.txt v2 directory: llms.txt index,
+# per-source files (00-narrative, 01..05-<crate>, 06-cli-reference — one H1
+# each) and webfang-docs-full.md, the back-compat monolith (pre-#734 single
+# file, unchanged heading conventions).
+#
+# Prerequisites (validated up front — this script does NOT build them):
+#   mdbook build docs                                → docs/src chapters exist
+#   cargo doc --workspace --all-features --no-deps   → target/doc/<crate>/ HTML
+#
+# BUILD_DATE: injected by CI (docs.yml). Local runs leave it empty; only
+# llms.txt then carries a "Generated: local run" note.
+# ============================================================================
+set -euo pipefail
+
+OUT_DIR=docs/book/webfang-docs-llm
+BUILD_DATE="${BUILD_DATE:-}"
+PAGES_PREFIX="https://xavicode1000.github.io/webfang/webfang-docs-llm"
+CHAPTERS="overview debugging testing troubleshooting tui-unified-design"
+# webfang_cli is bin-only: cargo doc produces no target/doc/webfang_cli/, so
+# it is skipped by the same -d check the old inline step used.
+ALL_CRATES="webfang_core webfang_ai webfang_tui webfang_mcp webfang_cli webfang_test_utils"
+
+for f in $CHAPTERS cli-reference; do
+  if [ ! -f "docs/src/$f.md" ]; then
+    echo "ERROR: docs/src/$f.md is missing. Prerequisite: mdbook build docs" >&2
+    exit 1
+  fi
+done
+if [ ! -d target/doc/webfang_core ]; then
+  echo "ERROR: target/doc/<crate>/ HTML is missing. Prerequisite:" >&2
+  echo "       cargo doc --workspace --all-features --no-deps" >&2
+  exit 1
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+# Two metadata lines (Generated + blank) in CI, nothing locally.
+generated_line() {
+  if [ -n "$BUILD_DATE" ]; then
+    echo "Generated: $BUILD_DATE"
+    echo
+  fi
+}
+
+# Demote every heading by exactly ONE level (deepest first, no double demotion).
+demote_headings() {
+  sed -e 's/^### /#### /' -e 's/^## /### /' -e 's/^# /## /' "$1"
+}
+
+# Strip rustdoc noise — the EXACT pipeline previously inlined in docs.yml.
+# Writes target/doc/$1.md, then applies the fence-aware noise gate.
+render_api() {
+  local crate="$1"
+  {
+    pandoc -f html -t gfm --wrap=none "target/doc/$crate/index.html" 2>/dev/null
+    find "target/doc/$crate" -name '*.html' ! -name 'index.html' ! -path '*/src/*' -print0 \
+      | sort -z \
+      | while IFS= read -r -d '' fl; do
+          pandoc -f html -t gfm --wrap=none "$fl" 2>/dev/null
+        done
+  } \
+  | sed -e 's/Copy item path//g' \
+        -e 's/Expand description//g' \
+        -e 's/§//g' \
+        -e 's/<span[^>]*>//g' -e 's/<\/span>//g' \
+        -e 's/<div[^>]*>//g' -e 's/<\/div>//g' \
+        -e 's/<a [^>]*>//g' -e 's/<\/a>//g' \
+        -e 's/<[^>]*>//g' \
+        -e 's/Show [0-9][0-9]* fields[[:space:]]*//g' \
+        -e 's/Show [0-9][0-9]* variants[[:space:]]*//g' \
+        -e 's/^# \(Struct\|Function\|Enum\|Trait\|Constant\|Type\|Crate\|Macro\|List\) /### \1 /' \
+  | awk 'BEGIN{skip=0} /^## Blanket Implementations|^## Auto Trait Implementations/{skip=1; next} skip && (/^## / || /^### (Struct|Function|Enum|Trait|Constant|Type|Crate|Macro|List) /){skip=0} !skip{print}' \
+  | sed -e '/^[[:space:]]*$/N;/^\n[[:space:]]*$/D' \
+  > "target/doc/$crate.md"
+  # Gate is fence-aware: doctests may legitimately contain HTML inside ``` fences.
+  if awk 'BEGIN{f=0} /^```/{f=!f; next} !f && /Expand description|Copy item path|href="|<a |<span|<div|<abbr|<code|§/{bad=1} END{exit !bad}' "target/doc/$crate.md"; then
+    echo "::error::rustdoc noise not fully stripped for $crate"
+    exit 1
+  fi
+}
+
+# mdBook chapters with their leading H1 downgraded to $1 (body untouched).
+emit_chapters() {
+  local level="$1" f
+  for f in $CHAPTERS; do
+    sed "1s/^# /$level /" "docs/src/$f.md"
+    echo
+    echo "---"
+    echo
+  done
+}
+
+per_source_file() {
+  case "$1" in
+    webfang_core) echo "01-webfang_core.md" ;;
+    webfang_ai) echo "02-webfang_ai.md" ;;
+    webfang_tui) echo "03-webfang_tui.md" ;;
+    webfang_mcp) echo "04-webfang_mcp.md" ;;
+    webfang_test_utils) echo "05-webfang_test_utils.md" ;;
+    *) echo "" ;;
+  esac
+}
+
+crate_description() {
+  case "$1" in
+    webfang_core) echo "core domain/application/infrastructure API" ;;
+    webfang_ai) echo "ONNX embeddings and semantic cleaning API" ;;
+    webfang_tui) echo "ratatui TUI selector API" ;;
+    webfang_mcp) echo "MCP server (35 tools) API" ;;
+    webfang_test_utils) echo "shared test utilities API" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Phase 1: render + noise-gate every crate API (as the old inline step did).
+for crate in $ALL_CRATES; do
+  [ -d "target/doc/$crate" ] || continue
+  render_api "$crate"
+done
+
+# Phase 2: per-source files (single H1 each).
+{
+  echo "# WebFang Narrative Documentation"
+  generated_line
+  echo "---"
+  echo
+  emit_chapters "##"
+} > "$OUT_DIR/00-narrative.md"
+
+for crate in $ALL_CRATES; do
+  out_file=$(per_source_file "$crate")
+  [ -n "$out_file" ] && [ -d "target/doc/$crate" ] || continue
+  {
+    echo "# $crate API Reference"
+    generated_line
+    echo "---"
+    echo
+    demote_headings "target/doc/$crate.md"
+    echo
+  } > "$OUT_DIR/$out_file"
+done
+
+{
+  echo "# WebFang CLI Reference"
+  generated_line
+  echo "---"
+  echo
+  sed '1s/^# /## /' docs/src/cli-reference.md
+} > "$OUT_DIR/06-cli-reference.md"
+
+# Phase 3: back-compat monolith (byte-equivalent to the pre-#734 output).
+{
+  echo "# WebFang Documentation"
+  echo
+  generated_line
+  echo "---"
+  echo
+  echo "## Narrative Documentation"
+  echo
+  emit_chapters "###"
+  echo "## CLI Reference"
+  echo
+  sed '1s/^# /### /' docs/src/cli-reference.md
+  echo
+  echo "---"
+  echo
+  echo "## API Reference (rustdoc)"
+  echo
+  for crate in $ALL_CRATES; do
+    if [ -d "target/doc/$crate" ]; then
+      echo "### API: $crate"
+      echo
+      cat "target/doc/$crate.md"
+      echo
+      echo "---"
+      echo
+    fi
+  done
+} > "$OUT_DIR/webfang-docs-full.md"
+
+# Phase 4: llms.txt (v2 index).
+{
+  echo "# WebFang"
+  echo
+  echo "> Production-ready web scraper: Clean Architecture, TUI selector, AI semantic cleaning, sitemap-based crawling. This directory bundles LLM/RAG-oriented documentation sources generated in CI."
+  echo
+  if [ -n "$BUILD_DATE" ]; then
+    echo "Generated: $BUILD_DATE"
+  else
+    echo "Generated: local run (set BUILD_DATE in CI)"
+  fi
+  echo
+  echo "Complete reference:"
+  echo
+  echo "- [webfang-docs-full.md]($PAGES_PREFIX/webfang-docs-full.md): everything on this page, one file — narrative + CLI + all crate APIs (~$(wc -w < "$OUT_DIR/webfang-docs-full.md") words)"
+  echo
+  echo "Focused sources:"
+  echo
+  echo "- [00-narrative.md]($PAGES_PREFIX/00-narrative.md): guides — debugging/tracing, testing, troubleshooting, TUI design ($(wc -w < "$OUT_DIR/00-narrative.md") words)"
+  for crate in $ALL_CRATES; do
+    out_file=$(per_source_file "$crate")
+    [ -n "$out_file" ] && [ -f "$OUT_DIR/$out_file" ] || continue
+    echo "- [$out_file]($PAGES_PREFIX/$out_file): $(crate_description "$crate") ($(wc -w < "$OUT_DIR/$out_file") words)"
+  done
+  echo
+  echo "CLI:"
+  echo
+  echo "- [06-cli-reference.md]($PAGES_PREFIX/06-cli-reference.md): complete \`webfang\` binary flag reference (--help, env vars) ($(wc -w < "$OUT_DIR/06-cli-reference.md") words)"
+  echo
+  echo "Optional:"
+  echo
+  echo "- [GitHub Pages site](https://xavicode1000.github.io/webfang/): human-oriented docs + rustdoc HTML under /api/"
+} > "$OUT_DIR/llms.txt"
+
+# Summary.
+echo
+echo "Output: $OUT_DIR"
+for f in llms.txt 00-narrative.md 01-webfang_core.md 02-webfang_ai.md 03-webfang_tui.md 04-webfang_mcp.md 05-webfang_test_utils.md 06-cli-reference.md webfang-docs-full.md; do
+  [ -f "$OUT_DIR/$f" ] || continue
+  echo "$f $(wc -w < "$OUT_DIR/$f") words"
+done


### PR DESCRIPTION
Closes #734

## PR Type

- [x] Documentation only (`type:docs`)

## Summary

- El artifacto `webfang-docs-llm` pasa de monolito único a un **directorio formato llms.txt v2**: índice `llms.txt` (con word counts y links absolutos al sitio Pages) + 6 fuentes focalizadas por crate/capítulo + monolito `webfang-docs-full.md` idéntico al actual (back-compat con `just docs`).
- La generación se extrae del inline de ~80 líneas del workflow a `scripts/build-llm-artifact.sh` (idempotente, testeable local, con mensajes de error que nombran el prerequisito faltante). El pipeline pandoc/sed/awk de limpieza se copia verbatim, con su gate de ruido intacto.
- `just docs` se hace robusto a ambos layouts del artifacto (dir nuevo / archivo legacy) y mantiene su contrato: un único markdown en `wiki_output`.

## Changes

| File | Change |
|------|--------|
| `scripts/build-llm-artifact.sh` | Nuevo: genera el directorio llms.txt (226 líneas) |
| `.github/workflows/docs.yml` | El deploy job llama al script con `BUILD_DATE`; upload apunta al directorio; validate gana sanity-check ligero del script |
| `justfile` | Recipe `docs` resuelve ambos layouts del artifacto |

## Layout resultante

```
docs/book/webfang-docs-llm/
├── llms.txt                  (131 palabras — índice v2)
├── 00-narrative.md           (3.1k)
├── 01-webfang_core.md        (81k)  … 05-webfang_test_utils.md
├── 06-cli-reference.md       (1.5k, de #733)
└── webfang-docs-full.md      (115.9k — compatibilidad)
```

Nota: `webfang_cli` no tiene fuente propia por ser bin-only (capturado vía help del binario en #733). Los conteos de H1 "extra" en narrative/full son comentarios `# ` dentro de code fences (pre-existentes en los capítulos mdBook; los parsers los ven como código, no como headings).

## Test Plan

- [x] `bash -n` + ejecutable; ejecución local end-to-end produce los 9 archivos con la tabla de word counts
- [x] Regression: el monolito nuevo es **byte-idéntico** al inline anterior (diff contra el bloque extraído del commit base), salvo la línea `Generated:` que solo existe en CI
- [x] `BUILD_DATE` se propaga a todos los archivos en CI y no deja residuos en runs locales
- [x] Error paths: capítulos faltantes / rustdoc ausente fallan con mensaje explícito y exit 1
- [x] `mdbook build` + YAML parse + `cargo fmt --check` limpios; rebaseado sin conflictos sobre main post-#733