### PR TITLE
fix(cli): compile adaptive-selectors test arity + add CI coverage (#737)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,11 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - name: Feature matrix check
         run: cargo hack check --each-feature --workspace --no-dev-deps
+      # `cargo hack check` never compiles test targets (and `--no-dev-deps` drops
+      # dev-dependencies), so feature-gated test arity breaks slip past the
+      # matrix. Compile the test targets for the combo that exposed the gap (#737).
+      - name: Feature-gated test targets compile (adaptive-selectors)
+        run: cargo check -p webfang_core --no-default-features --features adaptive-selectors --tests
 
   # ============================================================================
   # MCP SMOKE: After full tests pass

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -1875,6 +1875,17 @@ mod tests {
         let mut opts = CrawlOptions::default();
         opts.elastic.output_vectors = Some("vectors.jsonl".to_string());
 
+        // The cfg-gated `adaptive_engine` parameter makes the arity depend on
+        // the feature combo — dispatch the call exactly like `build_and_run`
+        // does in webfang_cli/src/main.rs.
+        #[cfg(feature = "adaptive-selectors")]
+        let exit = run(
+            opts,
+            None,
+            crate::application::container::VaultAiPorts::default(),
+        )
+        .await;
+        #[cfg(not(feature = "adaptive-selectors"))]
         let exit = run(opts, crate::application::container::VaultAiPorts::default()).await;
 
         assert!(


### PR DESCRIPTION
Closes #737

## Summary

`webfang_core` test targets don't compile with `--no-default-features --features adaptive-selectors` (without `ai`): ```run()``` takes the cfg-gated `adaptive_engine` parameter in that combo (arity 3), but `run_returns_config_error_when_output_vectors_without_ai` (`cfg(not(ai))`) hardcoded a 2-arg call → E0061. The issue body said 4-vs-2; post-#730 main is 3-vs-2 in this combo (comment on the issue).

CI never caught it: the `feature-matrix` job runs `cargo hack check --each-feature --workspace --no-dev-deps`, which never compiles test targets.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/cli/orchestrator.rs` | Test dispatches the `run()` call by `adaptive-selectors` cfg — same pattern the sibling `run_returns_data_error_when_output_vectors_without_clean_ai` already uses |
| `.github/workflows/ci.yml` | New `feature-matrix` step: `cargo check -p webfang_core --no-default-features --features adaptive-selectors --tests` — compiles exactly the uncovered test-target combo |

No production code changed.

## Acceptance

- [x] `cargo check -p webfang_core --no-default-features --features adaptive-selectors --tests` compiles (was the failing repro)
- [x] `cargo nextest run -p webfang_core --no-default-features --features adaptive-selectors` — the changed test passes; the 36-test orchestrator module is all green
- [x] CI matrix step added for the missing combination
- [x] `--all-features` compilation + strict clippy ratchets + fmt clean

## Notes

Running the full nextest suite under that feature combo surfaces 112 pre-existing environmental failures (reproduced identically with default features, so unrelated to this change): 109 binary-harness tests fail because `webfang_path()` hardcodes `<worktree>/target/debug/webfang` while this machine sets `CARGO_TARGET_DIR` to a shared dir; 3 `vault_detector` tests fail on machines with a real Obsidian vault (`/home/xavi/Documents/obsidian`) — that second cluster is exactly issue #726. Both tracked separately; not addressed here.