### PR TITLE
fix(cli): just docs — wiki_output portable + resolución artifacto aplanado

### DIFF
--- a/justfile
+++ b/justfile
@@ -250,7 +250,7 @@ test-ci-quick:
 # -- Documentación --
 
 # Ruta del wiki combinado (Obsidian vault)
-wiki_output := "/home/xavi/Documentos/obsidian/webfang/wiki.md"
+wiki_output := home_dir() / "Documentos" / "obsidian" / "webfang" / "wiki.md"
 
 # Descarga la documentación combinada (narrativa + API rustdoc) generada en CI.
 # Todo el cómputo pesado (mdBook build/test/linkcheck + cargo doc + pandoc)
@@ -265,7 +265,8 @@ docs:
     @rm -rf target/docs-llm
     @gh run download -R XaviCode1000/webfang -n webfang-docs-llm -D target/docs-llm
     @# El artifact puede tener el layout de directorio (post-#734) — acepto ambos.
-    @FULL=target/docs-llm/webfang-docs-llm/webfang-docs-full.md; \
+    @FULL=target/docs-llm/webfang-docs-full.md; \
+    test -f "$FULL" || FULL=target/docs-llm/webfang-docs-llm/webfang-docs-full.md; \
     test -f "$FULL" || FULL=target/docs-llm/webfang-docs-llm.md; \
     test -f "$FULL" || { echo "⚠️  No encontré webfang-docs-full.md en el artifacto"; exit 1; }; \
     cp "$FULL" "{{wiki_output}}"


### PR DESCRIPTION
Closes #743

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `just docs` roto por dos defectos: (1) `wiki_output` hardcodeado con path absoluto (originalmente `/var/home/...` de otro host — `mkdir -p` fallaba con Permiso denegado y abortaba antes de descargar), (2) la cadena de resolución esperaba el artifacto con el subdirectorio `webfang-docs-llm/` intermedio, pero `gh run download -D` **aplana** los archivos directo en el destino → "No encontré webfang-docs-full.md" con el archivo ya descargado.
- Fix: `wiki_output` con `home_dir()` (built-in de just, portable entre hosts) y cadena de resolución flattened-first: ruta aplanada → anidada → legacy de archivo único.
- **Resolución de conflicto con #742** (mergeado a main durante este PR): #742 movió el destino al vault de Obsidian (`~/Documentos/obsidian/webfang/wiki.md`). Se mantiene ese destino (main ya eligió la dirección); este PR solo lo hace portable con `home_dir()` + agrega la resolución aplanada del artifacto.

## Changes

| File | Change |
|------|--------|
| `justfile` | `wiki_output := home_dir() / "Documentos" / "obsidian" / "webfang" / "wiki.md"`; orden de la cadena `test -f` flattened-first |

## Test Plan

- [x] `just docs` rebaseado sobre main (post-#742): descarga del artifacto real del último deploy y produce `~/Documentos/obsidian/webfang/wiki.md` (1,2M)
- [x] Revisado el diff final contra main: solo justfile, +3/-2, sin markers de conflicto