### PR TITLE
fix(infra): make Obsidian vault detection hermetic (injectable registry path) (#726)

### DIFF
--- a/crates/webfang_core/src/infrastructure/obsidian/mod.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/mod.rs
@@ -18,5 +18,7 @@ pub use metadata::{
 pub use uri::{
     build_obsidian_uri, extract_vault_name, open_in_obsidian, open_note, DispatchStatus,
 };
-pub use vault_detector::{detect_vault, detect_vault_with_root, is_valid_vault};
+pub use vault_detector::{
+    detect_vault, detect_vault_hermetic, detect_vault_with_root, is_valid_vault,
+};
 pub use vault_reader::{read_vault_notes, VaultNote};

--- a/crates/webfang_core/src/infrastructure/obsidian/vault_detector.rs
+++ b/crates/webfang_core/src/infrastructure/obsidian/vault_detector.rs
@@ -36,8 +36,9 @@ pub fn detect_vault(
 /// Detect an Obsidian vault with an injectable scan root for hermetic testing.
 ///
 /// Behaves identically to [`detect_vault`] except that priority-5 auto-scan
-/// uses `root` instead of the process cwd / home directory. Pass `None` for
-/// `root` to get the default production behavior.
+/// is rooted at `root` instead of the process cwd / home directory. The
+/// priority-4 Obsidian registry is still resolved from the real per-platform
+/// location; use [`detect_vault_hermetic`] to inject a test registry as well.
 ///
 /// # Arguments
 /// - `root` — Optional root directory for the auto-scan (replaces cwd/home)
@@ -46,6 +47,33 @@ pub fn detect_vault(
 /// - `config_path` — Optional vault path from config file
 pub fn detect_vault_with_root(
     root: Option<&Path>,
+    cli_path: Option<&Path>,
+    env_var: Option<&str>,
+    config_path: Option<&str>,
+) -> Option<PathBuf> {
+    detect_vault_hermetic(root, None, cli_path, env_var, config_path)
+}
+
+/// Detect an Obsidian vault with every filesystem dependency injectable.
+///
+/// Hermetic variant of [`detect_vault`] for tests: both the priority-4
+/// Obsidian registry file and the priority-5 auto-scan root are injectable,
+/// so detection never reads the host machine's real registry
+/// (`obsidian.json`).
+///
+/// # Arguments
+/// - `root` — Optional root directory for the priority-5 auto-scan
+///   (replaces cwd/home)
+/// - `registry_path` — Optional path to the priority-4 registry file
+///   (replaces the per-platform location; a missing file behaves exactly
+///   like a host without Obsidian installed)
+/// - `cli_path` — Optional explicit vault path from CLI
+/// - `env_var` — Optional environment variable name to check (default: "OBSIDIAN_VAULT")
+/// - `config_path` — Optional vault path from config file
+#[must_use]
+pub fn detect_vault_hermetic(
+    root: Option<&Path>,
+    registry_path: Option<&Path>,
     cli_path: Option<&Path>,
     env_var: Option<&str>,
     config_path: Option<&str>,
@@ -66,8 +94,8 @@ pub fn detect_vault_with_root(
         return Some(path);
     }
 
-    // Priority 4: Official Obsidian registry
-    if let Some(path) = detect_from_registry() {
+    // Priority 4: Official Obsidian registry (injected or platform path)
+    if let Some(path) = detect_from_registry(registry_path) {
         return Some(path);
     }
 
@@ -117,8 +145,11 @@ fn detect_from_config(config_path: Option<&str>) -> Option<PathBuf> {
 }
 
 /// Priority 4: detect from the official Obsidian registry.
-fn detect_from_registry() -> Option<PathBuf> {
-    let path = get_vault_from_registry()?;
+///
+/// Reads the registry at `registry_path` when injected (`Some`), otherwise
+/// falls back to the per-platform location resolved by [`get_registry_path`].
+fn detect_from_registry(registry_path: Option<&Path>) -> Option<PathBuf> {
+    let path = get_vault_from_registry(registry_path)?;
     tracing::debug!("Vault detected from Obsidian registry: {}", path.display());
     Some(path)
 }
@@ -218,8 +249,15 @@ fn get_registry_path() -> Option<PathBuf> {
 ///
 /// The registry contains a map of vault IDs to vault metadata. Returns the vault
 /// with the most recent `ts` timestamp (last opened).
-fn get_vault_from_registry() -> Option<PathBuf> {
-    let registry_path = get_registry_path()?;
+///
+/// Reads `registry_path` verbatim when injected (`Some`) — used for hermetic
+/// tests — or falls back to the per-platform location from
+/// [`get_registry_path`] when `None`.
+fn get_vault_from_registry(registry_path: Option<&Path>) -> Option<PathBuf> {
+    let registry_path = match registry_path {
+        Some(path) => path.to_path_buf(),
+        None => get_registry_path()?,
+    };
 
     if !registry_path.is_file() {
         return missing_registry(&registry_path);
@@ -308,6 +346,34 @@ mod tests {
     use super::*;
     use std::fs;
 
+    /// Create a valid Obsidian vault (dir with a `.obsidian/` marker) under `root`.
+    fn make_vault(root: &Path, name: &str) -> PathBuf {
+        let vault = root.join(name);
+        fs::create_dir_all(vault.join(".obsidian")).unwrap();
+        vault
+    }
+
+    /// Deterministic "missing registry" fixture: a path inside `tmp` that does not exist.
+    fn missing_registry_path(tmp: &Path) -> PathBuf {
+        tmp.join("nonexistent_obsidian.json")
+    }
+
+    /// Write a registry JSON file `{"vaults": {id: {"ts": .., "path": ".."}}}`.
+    fn write_registry(registry_path: &Path, entries: &[(&str, i64, &Path)]) {
+        let mut vaults = serde_json::Map::new();
+        for (id, ts, path) in entries {
+            let mut data = serde_json::Map::new();
+            data.insert("ts".to_string(), serde_json::json!(*ts));
+            data.insert(
+                "path".to_string(),
+                serde_json::json!(path.to_str().unwrap()),
+            );
+            vaults.insert((*id).to_string(), serde_json::Value::Object(data));
+        }
+        let root_obj = serde_json::json!({ "vaults": serde_json::Value::Object(vaults) });
+        fs::write(registry_path, root_obj.to_string()).unwrap();
+    }
+
     #[test]
     fn test_is_valid_vault_true() {
         let tmp = tempfile::tempdir().unwrap();
@@ -354,27 +420,36 @@ mod tests {
     #[test]
     fn test_detect_vault_not_found() {
         let tmp = tempfile::tempdir().unwrap();
+        let registry = missing_registry_path(tmp.path());
         let _guard = webfang_test_utils::EnvGuard::clean(&["OBSIDIAN_VAULT"]);
-        let result = detect_vault_with_root(Some(tmp.path()), None, None, None);
+        let result = detect_vault_hermetic(Some(tmp.path()), Some(&registry), None, None, None);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_detect_vault_invalid_path() {
         let tmp = tempfile::tempdir().unwrap();
+        let registry = missing_registry_path(tmp.path());
         let non_existent = PathBuf::from("/nonexistent/path/to/vault");
         let _guard = webfang_test_utils::EnvGuard::clean(&["OBSIDIAN_VAULT"]);
-        let result = detect_vault_with_root(Some(tmp.path()), Some(&non_existent), None, None);
+        let result = detect_vault_hermetic(
+            Some(tmp.path()),
+            Some(&registry),
+            Some(&non_existent),
+            None,
+            None,
+        );
         assert!(result.is_none());
     }
 
     #[test]
     fn test_detect_vault_with_fixture() {
         let tmp = tempfile::tempdir().unwrap();
+        let registry = missing_registry_path(tmp.path());
         fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
 
         let _guard = webfang_test_utils::EnvGuard::clean(&["OBSIDIAN_VAULT"]);
-        let result = detect_vault_with_root(Some(tmp.path()), None, None, None);
+        let result = detect_vault_hermetic(Some(tmp.path()), Some(&registry), None, None, None);
         assert!(result.is_some());
         assert_eq!(result.unwrap(), tmp.path());
     }
@@ -386,6 +461,71 @@ mod tests {
 
         let result = detect_vault(None, None, Some(tmp.path().to_str().unwrap()));
         assert!(result.is_some());
+    }
+
+    // ── Priority-4 (Obsidian registry) — hermetic injection, #726 ────────
+
+    #[test]
+    fn test_registry_resolves_vault() {
+        // Root without a `.obsidian` marker: the only way the vault can be
+        // found is through the injected registry (priority 4).
+        let tmp = tempfile::tempdir().unwrap();
+        let vault_root = tempfile::tempdir().unwrap();
+        let vault = make_vault(vault_root.path(), "vault");
+
+        let registry = tmp.path().join("obsidian.json");
+        write_registry(&registry, &[("a1b2c3d4e5f6a7b8", 100, &vault)]);
+
+        let _guard = webfang_test_utils::EnvGuard::clean(&["OBSIDIAN_VAULT"]);
+        let result = detect_vault_hermetic(Some(tmp.path()), Some(&registry), None, None, None);
+        assert_eq!(result.as_deref(), Some(vault.as_path()));
+    }
+
+    #[test]
+    fn test_registry_most_recent_wins() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault_root = tempfile::tempdir().unwrap();
+        let vault_old = make_vault(vault_root.path(), "old");
+        let vault_new = make_vault(vault_root.path(), "new");
+
+        let registry = tmp.path().join("obsidian.json");
+        write_registry(
+            &registry,
+            &[
+                ("aaaaaaaaaaaaaaaa", 100, &vault_old),
+                ("bbbbbbbbbbbbbbbb", 200, &vault_new),
+            ],
+        );
+
+        let _guard = webfang_test_utils::EnvGuard::clean(&["OBSIDIAN_VAULT"]);
+        let result = detect_vault_hermetic(Some(tmp.path()), Some(&registry), None, None, None);
+        assert_eq!(result.as_deref(), Some(vault_new.as_path()));
+    }
+
+    #[test]
+    fn test_registry_missing_falls_through() {
+        // Missing registry file: priority 4 returns None (trace log) and the
+        // chain falls through to the injected priority-5 auto-scan, which
+        // finds nothing in an empty root.
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = missing_registry_path(tmp.path());
+
+        let _guard = webfang_test_utils::EnvGuard::clean(&["OBSIDIAN_VAULT"]);
+        let result = detect_vault_hermetic(Some(tmp.path()), Some(&registry), None, None, None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_registry_malformed_json_none() {
+        // Malformed registry JSON: parse fails, priority 4 returns None
+        // without panicking; auto-scan finds nothing in an empty root.
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = tmp.path().join("obsidian.json");
+        fs::write(&registry, "{ not valid json !!").unwrap();
+
+        let _guard = webfang_test_utils::EnvGuard::clean(&["OBSIDIAN_VAULT"]);
+        let result = detect_vault_hermetic(Some(tmp.path()), Some(&registry), None, None, None);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs
@@ -32,9 +32,23 @@ impl McpHandler {
             .vault_path
             .as_ref()
             .map(|p| std::path::Path::new(p.as_str()));
-        match webfang_core::infrastructure::obsidian::vault_detector::detect_vault(
-            cli_path, None, None,
-        ) {
+        // Hermetic injection (tests, #726): route detection through the
+        // injected root/registry so the host's Obsidian registry is never
+        // read. `None` (production) keeps the default detection chain.
+        let detected = if let Some((root, registry_path)) = &self.state.obsidian_hermetic {
+            webfang_core::infrastructure::obsidian::vault_detector::detect_vault_hermetic(
+                Some(root.as_path()),
+                Some(registry_path.as_path()),
+                cli_path,
+                None,
+                None,
+            )
+        } else {
+            webfang_core::infrastructure::obsidian::vault_detector::detect_vault(
+                cli_path, None, None,
+            )
+        };
+        match detected {
             Some(path) => Ok(CallToolResult::success(vec![Content::text(
                 path.display().to_string(),
             )])),
@@ -145,7 +159,13 @@ mod tests {
         let container = Container::new(crawler_config, scraper_config)
             .await
             .expect("create container");
-        let state = McpState::new(container);
+        // Hermetic vault detection (#726): detection runs against an isolated
+        // empty scan root and a non-existent registry file, so tests never
+        // touch the host's real Obsidian installation.
+        let detect_root = tmp.path().join("detect-root");
+        fs::create_dir_all(&detect_root).expect("create detect root");
+        let registry = detect_root.join("obsidian.json");
+        let state = McpState::new(container).with_obsidian_hermetic(detect_root, registry);
         (McpHandler::new(state), tmp)
     }
 

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -84,6 +84,11 @@ pub struct McpState {
     /// (fail-closed). When non-empty, an absolute `output_dir` must be
     /// lexically under one of these roots after normalization.
     pub allowed_export_roots: Arc<Vec<PathBuf>>,
+    /// Hermetic Obsidian detection overrides for tests (#726): `(scan_root,
+    /// registry_path)`. When `Some`, vault detection is injected with these
+    /// paths and never reads the host's real Obsidian registry. Production
+    /// leaves this `None` (real detection chain).
+    pub obsidian_hermetic: Option<(PathBuf, PathBuf)>,
     /// Cancellation token for graceful shutdown propagation.
     pub cancel_token: CancellationToken,
 }
@@ -137,6 +142,7 @@ impl McpState {
             robots_fetcher,
             metrics: Arc::new(Mutex::new(ScrapeMetrics::default())),
             allowed_export_roots: Arc::new(Vec::new()),
+            obsidian_hermetic: None,
             cancel_token: CancellationToken::new(),
         }
     }
@@ -186,6 +192,23 @@ impl McpState {
     #[must_use]
     pub fn with_export_roots(mut self, roots: Vec<PathBuf>) -> Self {
         self.allowed_export_roots = Arc::new(roots);
+        self
+    }
+
+    /// Inject hermetic Obsidian detection paths for tests (#726).
+    ///
+    /// When set, Obsidian vault detection runs through
+    /// [`detect_vault_hermetic`](webfang_core::infrastructure::obsidian::vault_detector::detect_vault_hermetic)
+    /// rooted at `root` with the registry read from `registry_path`, so tests
+    /// never touch the host's real Obsidian registry. Production leaves this
+    /// `None` and keeps the default detection chain.
+    #[must_use]
+    pub fn with_obsidian_hermetic(
+        mut self,
+        root: impl Into<PathBuf>,
+        registry_path: impl Into<PathBuf>,
+    ) -> Self {
+        self.obsidian_hermetic = Some((root.into(), registry_path.into()));
         self
     }
 


### PR DESCRIPTION
Closes #726

## Summary
The priority-4 branch of `detect_vault()` read the host's real Obsidian registry (`~/.config/obsidian/obsidian.json` on Linux), so 3 unit tests and 1 MCP handler test failed on any dev machine with Obsidian installed — CI only passed by accident, because the runner has no Obsidian. The priority-4 registry branch also had **zero real test coverage**.

Fix: mirror the existing priority-5 injectable-`root` pattern for priority-4 and expose a hermetic entry point.

## Changes
| File | Change |
| :--- | :--- |
| `crates/webfang_core/src/infrastructure/obsidian/vault_detector.rs` | New `detect_vault_hermetic(root, registry_path, cli_path, env_var, config_path)`; `detect_vault_with_root` / `detect_vault` signatures unchanged, now delegate; `detect_from_registry()` / `get_vault_from_registry()` thread `Option<&Path>`. 3 non-hermetic tests fixed + 4 new priority-4 tests (registry-resolves-vault, most-recent-ts-wins, missing-registry fall-through, malformed-JSON no panic). |
| `crates/webfang_core/src/infrastructure/obsidian/mod.rs` | Re-export `detect_vault_hermetic`. |
| `crates/webfang_mcp/src/mcp_server/state.rs` | New `obsidian_hermetic: Option<(PathBuf, PathBuf)>` field + `with_obsidian_hermetic(root, registry_path)` builder (mirrors `with_export_roots`). |
| `crates/webfang_mcp/src/mcp_server/handlers/obsidian.rs` | `detect_obsidian_vault` routes through `detect_vault_hermetic` when the override is set, `detect_vault` otherwise; `test_handler()` wires an isolated root + nonexistent registry. |

## Acceptance
- ✅ `cargo nextest run -p webfang_core vault_detector` → 14 passed, 0 failed (the #726 repro, now hermetic without any exclusion filter)
- ✅ `cargo nextest run -p webfang_mcp -E 'test(detect_obsidian_vault)'` → 2 passed, 0 failed
- ✅ `cargo check -p webfang_core -p webfang_mcp --all-targets`
- ✅ CI strict clippy gate: `cargo clippy -p webfang_core -p webfang_mcp --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines`
- ✅ `cargo fmt --all --check`
- ✅ `detect_vault` signature unchanged (line 28 of `vault_detector.rs`)
- ✅ New priority-4 registry branch has real coverage
- ✅ Full `webfang_core` lib: 1711 passed; full `webfang_mcp`: 259 passed

## Notes
- CI passed on main only because the runner has no Obsidian installed; this change makes the suite deterministic regardless of host.
- The MCP handler keeps exactly the same production behavior when no override is set.