### PR TITLE
fix(infra): gate sitemap_discovery tests under Miri, force nightly in sanitizers miri job

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   miri:
     runs-on: ubuntu-latest
+    env:
+      # rust-toolchain.toml pins 1.88.0 and would override nightly for
+      # `cargo miri` (miri is nightly-only). RUSTUP_TOOLCHAIN (env var) has
+      # higher precedence than rust-toolchain.toml (mirrors ci.yml, #750).
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
+++ b/crates/webfang_core/src/application/crawler/sitemap_discovery.rs
@@ -529,7 +529,11 @@ async fn probe_subpath_sitemaps(base: &Url, client: &wreq::Client) -> Option<Str
     probe_sitemap_paths(base, client, &refs).await
 }
 
-#[cfg(test)]
+// All tests in this module build a wreq::Client (test_client()), which
+// depends on boring-sys2 (BoringSSL → TLS_method FFI). Miri cannot execute
+// C FFI — gate the whole module instead of patching test by test, keeping
+// Miri focused on UB in pure Rust logic (same pattern as readability).
+#[cfg(all(test, not(miri)))]
 mod tests {
     use super::*;
     use wiremock::matchers::{method, path};


### PR DESCRIPTION
Closes #750

## Summary
- `sitemap_discovery::tests` builds a `wreq::Client` (boring-sys2 → BoringSSL `TLS_method` FFI), which Miri cannot execute — the Monday Miri (core) job has died on it every run since #660 landed (run #31983525568). Module-level `#[cfg(all(test, not(miri)))]` gate, matching the `readability.rs` / `http_client/client.rs` pattern.
- `sanitizers.yml` miri job was missing the `RUSTUP_TOOLCHAIN: nightly` env that `ci.yml` has had since db13fd4 — `rust-toolchain.toml` (1.88.0, no miri component) won over the nightly rustup override and `cargo miri setup` failed on all 3 runs since the job's creation (run #31991748613).
- Run #31983525568's third failure (Miri infra-fast/slow timeout) is tracked separately in #751.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/crawler/sitemap_discovery.rs` | Gate entire test module with `#[cfg(all(test, not(miri)))]` + explanatory comment |
| `.github/workflows/sanitizers.yml` | Add job-level `env: RUSTUP_TOOLCHAIN: nightly` to the miri job (mirrors ci.yml 480-486) |

## Test Plan
- [x] `cargo check -p webfang_core` clean
- [x] `cargo nextest run -p webfang_core sitemap_discovery` — 5/5 PASS (gate invisible to regular CI)
- [x] Strict clippy gate (`--all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines`) — zero warnings
- [x] YAML parses; asserted `jobs.miri.env.RUSTUP_TOOLCHAIN == "nightly"`
- [x] `git diff --stat main...HEAD` — only the 2 intended files (10 insertions, 1 deletion)

## Checklist
- [x] Linked issue (#750)
- [x] Exactly one `type:*` label (`type:bug`)
- [x] Conventional branch name (`fix/miri-red`)
- [x] Conventional commit, no Co-Authored-By
- [x] No user-facing error strings (no Spanish-message changes needed)
- [x] Verified worktree: branch `fix/miri-red` matches directory name; no checkout/switch/stash used