### PR TITLE
fix(cli): hallazgos menores auditoría CLI v2.0.0 (#695)

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -352,6 +352,12 @@ async fn __main() -> CliExit {
         return exit;
     }
 
+    // 6d. Elastic sink preflight (#695): --elastic without persistence nor
+    // --output-vectors would wire no sink and silently no-op — exit 78.
+    if let Err(exit) = preflight::check_elastic_sink(&opts) {
+        return exit;
+    }
+
     // 7. Initialize logging (stderr-only, respects quiet + NO_COLOR)
     let no_color = is_no_color();
     let log_level = resolve_log_level(opts.verbosity);

--- a/crates/webfang_core/src/application/container.rs
+++ b/crates/webfang_core/src/application/container.rs
@@ -455,6 +455,7 @@ impl Container {
         if opts.elastic.enabled {
             let pool = sqlite_persistence::create_pool(&config.db_path, config.db_pool_size)?;
             sqlite_persistence::setup_schema(&pool).await?;
+            tracing::info!(db_path = %config.db_path.display(), "elastic_sqlite_sink_wired");
             repos.push(Arc::new(SqliteVectorRepository::new(pool)));
         }
 

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -434,6 +434,14 @@ async fn prepare_phase(opts: &CrawlOptions) -> Result<PrepareResult, CliExit> {
         // `discover_urls_for_tui` path did one fetch and silently ignored depth.
         let discovered_urls = if opts.crawl.use_sitemap {
             match discover_urls(&crawler_config, opts).await {
+                // "Site has no sitemap" is a terminal discovery state, not
+                // an infrastructure failure (#695): exit 2 lets automation
+                // distinguish it from a real network outage (exit 69).
+                Err(crate::error::ScraperError::SitemapNotFound(_)) => {
+                    return Err(CliExit::EmptyDiscovery(
+                        "No URLs discovered: sitemap not found".into(),
+                    ));
+                },
                 Err(e) => {
                     return Err(CliExit::NetworkError(format!("URL discovery failed: {e}")));
                 },

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -179,6 +179,40 @@ fn check_js_dependencies_with(candidates: &[&str], opts: &CrawlOptions) -> Resul
     ))
 }
 
+/// Preflight: `--elastic` must have at least one wirable vector sink (#695).
+///
+/// `--elastic` and `--output-vectors` are orthogonal vector destinations
+/// (#636): the SQLite sink only exists under the `persistence` feature,
+/// while the JSONL stream sink is available in every build. Without
+/// `persistence` AND without `--output-vectors`, `--elastic` would wire no
+/// sink at all and the run would silently report success with no artifact.
+///
+/// Fail fast instead: an explicit request the binary cannot honor is a
+/// configuration error (exit 78), never a silent no-op.
+///
+/// # Errors
+///
+/// Returns [`crate::CliExit::ConfigError`] (exit 78) when `--elastic` is
+/// enabled, no `--output-vectors` path was given, and the binary was built
+/// without the `persistence` feature.
+pub fn check_elastic_sink(opts: &CrawlOptions) -> Result<(), CliExit> {
+    if !opts.elastic.enabled {
+        return Ok(());
+    }
+    if opts.elastic.output_vectors.is_some() {
+        return Ok(());
+    }
+    if cfg!(feature = "persistence") {
+        return Ok(());
+    }
+    Err(CliExit::ConfigError(
+        "--elastic requiere un destino de vectores: este binario fue compilado sin la \
+             feature `persistence` (sink SQLite); use --output-vectors <ruta> o un binario \
+             compilado con persistencia"
+            .into(),
+    ))
+}
+
 /// Spawn `<binary> --version` once and report its exit status.
 ///
 /// A missing or non-executable binary surfaces as an `io::Error`, which the
@@ -790,5 +824,57 @@ mod tests {
             ),
             other => panic!("expected ConfigError, got: {other:?}"),
         }
+    }
+
+    // ========================================================================
+    // #695 — --elastic sink availability preflight
+    // ========================================================================
+
+    /// `--elastic` disabled: no sink is required, check passes.
+    #[test]
+    fn elastic_disabled_ok() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.enabled = false;
+        assert!(check_elastic_sink(&opts).is_ok());
+    }
+
+    /// `--elastic` + `--output-vectors`: the JSONL stream sink exists in
+    /// every build, so the check passes regardless of `persistence`.
+    #[test]
+    fn elastic_with_output_vectors_ok() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.enabled = true;
+        opts.elastic.output_vectors = Some("vectors.jsonl".into());
+        assert!(check_elastic_sink(&opts).is_ok());
+    }
+
+    /// `--elastic` alone without the `persistence` feature: no wirable
+    /// sink — must fail fast with a config error naming the flag.
+    #[cfg(not(feature = "persistence"))]
+    #[test]
+    fn elastic_without_persistence_errors() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.enabled = true;
+        opts.elastic.output_vectors = None;
+        let err =
+            check_elastic_sink(&opts).expect_err("no sink available without persistence must fail");
+        match err {
+            CliExit::ConfigError(msg) => assert!(
+                msg.contains("--elastic"),
+                "config error must name the flag, got: {msg}"
+            ),
+            other => panic!("expected ConfigError, got: {other:?}"),
+        }
+    }
+
+    /// `--elastic` alone with the `persistence` feature: the SQLite sink
+    /// is wirable, check passes.
+    #[cfg(feature = "persistence")]
+    #[test]
+    fn elastic_with_persistence_ok() {
+        let mut opts = CrawlOptions::default();
+        opts.elastic.enabled = true;
+        opts.elastic.output_vectors = None;
+        assert!(check_elastic_sink(&opts).is_ok());
     }
 }

--- a/crates/webfang_core/src/infrastructure/output/frontmatter.rs
+++ b/crates/webfang_core/src/infrastructure/output/frontmatter.rs
@@ -9,8 +9,25 @@
 //! - Tags (if available, for Obsidian compatibility)
 //! - Rich metadata (word count, reading time, language, content type, status)
 
+use std::borrow::Cow;
+
 use chrono::Utc;
 use serde::Serialize;
+
+/// Collapse whitespace runs in `text` to single spaces, zero-cost when clean.
+///
+/// Readability excerpts can carry extraction artifacts such as doubled
+/// spaces ("...by  (about)", RIESGO-OBS-001). Borrowing the input when it
+/// is already clean keeps the common path allocation-free; only dirty
+/// excerpts pay for a cleaned clone.
+fn normalize_whitespace(text: &str) -> Cow<'_, str> {
+    let needs_cleanup = text.chars().any(|c| c.is_whitespace() && c != ' ') || text.contains("  ");
+    if needs_cleanup {
+        Cow::Owned(text.split_whitespace().collect::<Vec<_>>().join(" "))
+    } else {
+        Cow::Borrowed(text)
+    }
+}
 
 /// Frontmatter data structure
 #[derive(Debug, Serialize)]
@@ -98,7 +115,7 @@ pub fn generate_with_metadata(
             .map(|s| s.to_string())
             .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string()),
         author: author.map(|s| s.to_string()),
-        excerpt: excerpt.map(|s| s.to_string()),
+        excerpt: excerpt.map(|s| normalize_whitespace(s).into_owned()),
         tags: tags.to_vec(),
         word_count: rich_meta.map(|m| m.word_count),
         reading_time: rich_meta.map(|m| m.reading_time),
@@ -222,5 +239,48 @@ mod tests {
         assert!(!fm.contains("language"));
         assert!(!fm.contains("contentType"));
         assert!(!fm.contains("status"));
+    }
+
+    // ====================================================================
+    // #695 — excerpt whitespace normalization (RIESGO-OBS-001)
+    // ====================================================================
+
+    /// Clean excerpts are borrowed untouched (zero-cost path).
+    #[test]
+    fn normalize_whitespace_borrows_clean_text() {
+        let out = normalize_whitespace("a clean excerpt");
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, "a clean excerpt");
+    }
+
+    /// Doubled spaces (the Readability "...by  (about)" artifact) collapse
+    /// to single spaces via the owned path.
+    #[test]
+    fn normalize_whitespace_collapses_double_spaces() {
+        let out = normalize_whitespace("...by  (about)");
+        assert!(matches!(out, Cow::Owned(_)));
+        assert_eq!(out, "...by (about)");
+    }
+
+    /// Tabs and newlines collapse to single spaces too.
+    #[test]
+    fn normalize_whitespace_collapses_tabs_and_newlines() {
+        let out = normalize_whitespace("word\t\nword");
+        assert_eq!(out, "word word");
+    }
+
+    /// The frontmatter serializes the normalized excerpt.
+    #[test]
+    fn test_generate_normalizes_excerpt_whitespace() {
+        let fm = generate(
+            "Title",
+            "https://example.com",
+            Some("2024-01-15"),
+            None,
+            Some("...by  (about)"),
+            &[],
+        );
+        assert!(fm.contains("excerpt: '...by (about)'"));
+        assert!(!fm.contains("by  (about)"));
     }
 }

--- a/crates/webfang_core/tests/exit_code_integration.rs
+++ b/crates/webfang_core/tests/exit_code_integration.rs
@@ -100,6 +100,26 @@ async fn test_empty_sitemap_returns_exit_2() {
         .stderr(predicate::str::contains("No URLs discovered"));
 }
 
+/// Site without any sitemap (auto-discovery finds nothing) returns exit 2,
+/// not exit 69: "no sitemap" is a terminal discovery state, not an
+/// infrastructure failure (#695, OBS-SITEMAP-001).
+#[tokio::test]
+async fn test_missing_sitemap_returns_exit_2() {
+    let mock_server = MockServer::start().await;
+
+    // No mocks mounted: robots.txt and every sitemap candidate 404.
+    let base_url = format!("{}/", mock_server.uri());
+
+    cmd()
+        .arg("--url")
+        .arg(&base_url)
+        .arg("--use-sitemap")
+        .timeout(Duration::from_secs(30))
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("No URLs discovered"));
+}
+
 // ============================================================================
 // Tests: DOM discovery with only external links → exit 0 (seed injected)
 // ============================================================================


### PR DESCRIPTION
Closes #695

## Summary

Tres fixes de la auditoría CLI v2.0.0, un commit por hallazgo:

### 1. RIESGO-EXPORT-002 — `--elastic` sin artefacto auditable
`--elastic` sin la feature `persistence` y sin `--output-vectors` no cableaba ningún sink pero el run reportaba éxito sin artefacto (no-op silencioso). Ahora el preflight falla con exit 78 y mensaje claro. Además, cuando el sink SQLite se cablea, se loguea la ruta real del `.db` (`elastic_sqlite_sink_wired`). Nota: `--elastic --output-vectors <ruta>` sigue siendo válido sin `persistence` (destinos ortogonales, #636).

### 2. RIESGO-OBS-001 — excerpt de frontmatter con doble espacio
Normalizador `Cow<'_, str>` en `frontmatter.rs`: colapsa corridas de whitespace (`"...by  (about)"` → `"...by (about)"`). Los excerpts limpios se toman prestados sin alocar.

### 3. OBS-SITEMAP-001 — sitio sin sitemap → exit 69
`SitemapNotFound` ahora mapea a `EmptyDiscovery` (exit 2) en vez de `NetworkError` (exit 69): es un estado terminal de descubrimiento, no un fallo de infraestructura. El timeout de red sigue en 69 (test existente intacto).

## Testing
- `cargo check` + `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` + `cargo fmt --check` ✅
- Unit tests nuevos: `check_elastic_sink` (4 casos por feature) y `normalize_whitespace` (4 casos)
- `cargo nextest run --test exit_code_integration`: 5/5 PASS, incluyendo el nuevo `test_missing_sitemap_returns_exit_2`
