### PR TITLE
fix(mcp): enforce robots.txt uniformly across all direct-fetch tools

### DIFF
--- a/crates/webfang_core/src/application/scraper_service.rs
+++ b/crates/webfang_core/src/application/scraper_service.rs
@@ -187,16 +187,19 @@ pub async fn scrape_with_config(
 
 /// Enforce the robots.txt policy for one URL before any page fetch (#697).
 ///
-/// Keeps the crawl path's semantics: `ignore_robots` bypasses the check, a
-/// missing fetcher means "no enforcement available" (legacy behavior), and a
-/// denial returns [`ScraperError::waf_blocked`] with provider `"robots.txt"`
-/// — the WafBlocked variant is deliberately reused for robots.txt denials per
-/// the #705 audit decision (`ScraperError` has no dedicated robots variant).
+/// Single source of truth for the robots decision — shared by the crawl path
+/// ([`scrape_with_config`]) and the MCP direct-fetch tools via
+/// `McpState::robots_denied_for` (#749): `ignore_robots` opts out, a `None`
+/// fetcher means "no enforcement available" (fail-open), and a denial emits
+/// `tracing::warn!("robots_txt_denied")` and returns
+/// [`ScraperError::waf_blocked`] with provider `"robots.txt"` — the WafBlocked
+/// variant is deliberately reused for robots.txt denials per the #705 audit
+/// decision (`ScraperError` has no dedicated robots variant).
 ///
 /// [`RobotsFetcher::is_allowed`] is FAIL-OPEN: if the robots.txt fetch itself
 /// fails (network error, non-2xx, timeout), the URL is treated as allowed —
 /// matching the production crawl behavior.
-async fn enforce_robots_policy(
+pub async fn enforce_robots_policy(
     url: &url::Url,
     robots: Option<&RobotsFetcher>,
     ignore_robots: bool,

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -258,6 +258,7 @@ mod tests {
     use crate::mcp_server::state::McpState;
     use rmcp::handler::server::wrapper::Parameters;
     use rmcp::model::CallToolResult;
+    use serial_test::serial;
     use tempfile::TempDir;
     use webfang_core::di::Container;
     use webfang_core::domain::CrawlerConfig;
@@ -371,6 +372,7 @@ mod tests {
     /// REQ-02: a valid URL with no cleaner injected (ai feature off) maps to an
     /// honest Spanish `isError:true` envelope — never a false success.
     #[tokio::test]
+    #[serial] // WEBFANG_MCP_DISABLE_SSRF is process-global — see scraping.rs
     async fn semantic_cleaner_no_cleaner_is_honest_feature_error() {
         // #749 made SSRF/robots gates run before the cleaner check; keep this
         // feature-gated test hermetic (offline) by disabling the SSRF probe —
@@ -402,6 +404,7 @@ mod tests {
     /// of local feature state).
     #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
     #[tokio::test]
+    #[serial]
     async fn semantic_cleaner_robots_disallowed_errors_before_fetch_and_cleaner_check() {
         std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
         let (handler, _tmp) = test_handler_with_robots().await;

--- a/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/ai.rs
@@ -76,6 +76,10 @@ impl McpHandler {
     ///
     /// Fetches a URL, cleans its HTML content, and returns semantically
     /// chunked content with embeddings. Requires the `ai` feature.
+    ///
+    /// Respects SSRF protection and the site's robots.txt: a disallowed URL
+    /// is rejected with a `robots.txt` error before any fetch — even with the
+    /// `ai` feature off (#749, uniform with #697).
     #[tool(
         description = "Fetch a URL, semantically clean its HTML content using AI embeddings, and return chunked content with vectors. Requires --features ai."
     )]
@@ -90,12 +94,22 @@ impl McpHandler {
 
         // REQ-03: reject malformed URLs first (invalid-params), regardless of
         // cleaner presence — no fetch, no cleaning.
-        let _url = url::Url::parse(&params.url).map_err(|e| {
+        let url = url::Url::parse(&params.url).map_err(|e| {
             McpError::invalid_params(
                 format!("URL inválida: {e}"),
                 Some(serde_json::Value::String("url".to_string())),
             )
         })?;
+
+        // #749 fold-in: this tool fetched the caller URL without the SSRF
+        // guard every other URL-fetching tool has.
+        crate::mcp_server::ssrf::validate_url_no_ssrf(&url).await?;
+        // #749: robots.txt gate BEFORE the cleaner-presence check — site
+        // policy is independent of local feature state, so a denial is
+        // reported even with the `ai` feature off.
+        if let Some(err) = self.state.robots_denied_for(&url).await {
+            return Ok(honest_error(err.to_string()));
+        }
 
         // REQ-02: absent cleaner (ai feature off) -> honest Spanish error.
         let Some(cleaner) = self.state.container.cleaner() else {
@@ -248,6 +262,9 @@ mod tests {
     use webfang_core::di::Container;
     use webfang_core::domain::CrawlerConfig;
     use webfang_core::infrastructure::config::ScraperConfig;
+    use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// REQ-02/04 contract: `honest_error` produces a `CallToolResult` that
     /// serializes with `isError:true` and carries the exact Spanish text —
@@ -282,7 +299,32 @@ mod tests {
     /// a real DI container. The `ai` feature is off in unit tests, so the
     /// cleaner and embedding ports are `None` — exactly the branch these tests
     /// exercise (honest feature-gated errors, no ONNX model needed).
+    ///
+    /// The robots fetcher is dropped for determinism (#705/#749): with
+    /// `None`, the robots gate is no-op and never touches the network against
+    /// the real hosts these validation tests use; tests that exercise
+    /// enforcement wire a fetcher explicitly (see the #749 robots tests).
     async fn test_handler() -> (McpHandler, TempDir) {
+        let (mut state, tmp) = test_state().await;
+        state.robots_fetcher = None;
+        (McpHandler::new(state), tmp)
+    }
+
+    /// Build a state with a real robots fetcher for #749 enforcement tests.
+    /// Offline-friendly: construction never touches the network.
+    async fn test_handler_with_robots() -> (McpHandler, TempDir) {
+        let (state, tmp) = test_state().await;
+        let state = state.with_robots_fetcher(std::sync::Arc::new(
+            RobotsFetcher::with_default_profile(5).expect("fetcher construction is offline"),
+        ));
+        (McpHandler::new(state), tmp)
+    }
+
+    /// Shared state construction for `test_handler` /
+    /// `test_handler_with_robots` (kept in one place so both states build on
+    /// the identical baseline). The `TempDir` is returned so the caller keeps
+    /// the configured `output_dir` alive.
+    async fn test_state() -> (McpState, TempDir) {
         let tmp = TempDir::new().expect("create temp dir");
         let crawler_config =
             CrawlerConfig::new(url::Url::parse("https://example.com").expect("valid url"));
@@ -293,7 +335,7 @@ mod tests {
         let container = Container::new(crawler_config, scraper_config)
             .await
             .expect("create container");
-        (McpHandler::new(McpState::new(container)), tmp)
+        (McpState::new(container), tmp)
     }
 
     fn result_text(result: &CallToolResult) -> String {
@@ -330,6 +372,10 @@ mod tests {
     /// honest Spanish `isError:true` envelope — never a false success.
     #[tokio::test]
     async fn semantic_cleaner_no_cleaner_is_honest_feature_error() {
+        // #749 made SSRF/robots gates run before the cleaner check; keep this
+        // feature-gated test hermetic (offline) by disabling the SSRF probe —
+        // the robots gate is already a no-op in `test_handler`.
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1");
         let (handler, _tmp) = test_handler().await;
         let res = handler
             .semantic_cleaner(Parameters(ScrapeUrlParams {
@@ -348,6 +394,52 @@ mod tests {
             text.contains("--features ai") && text.contains("limpieza semántica"),
             "Spanish feature-gated message expected, got: {text}"
         );
+    }
+
+    /// #749: a robots-disallowed URL is rejected with an honest `robots.txt`
+    /// error BEFORE the page fetch — even without a cleaner, since the robots
+    /// gate precedes the cleaner-presence check (site policy is independent
+    /// of local feature state).
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn semantic_cleaner_robots_disallowed_errors_before_fetch_and_cleaner_check() {
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
+        let (handler, _tmp) = test_handler_with_robots().await;
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/robots.txt"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("User-agent: *\nDisallow: /private\n"),
+            )
+            .mount(&server)
+            .await;
+
+        let res = handler
+            .semantic_cleaner(Parameters(ScrapeUrlParams {
+                url: format!("{}/private/page", server.uri()),
+            }))
+            .await
+            .expect("semantic_cleaner returns Ok with honest error");
+
+        let json = serde_json::to_value(&res).expect("CallToolResult serializes");
+        assert_eq!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "robots denial must set isError:true, got: {json}"
+        );
+        let text = result_text(&res);
+        assert!(
+            text.contains("robots.txt"),
+            "error text must report the robots.txt denial, got: {text}"
+        );
+        let page_hits = server
+            .received_requests()
+            .await
+            .expect("request recording is enabled")
+            .iter()
+            .filter(|r| r.url.path() != "/robots.txt")
+            .count();
+        assert_eq!(page_hits, 0, "the robots gate must block the page fetch");
     }
 
     /// `search_obsidian` with no embedding port injected maps to an honest

--- a/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/assets.rs
@@ -104,6 +104,7 @@ mod tests {
     use crate::mcp_server::state::McpState;
     use rmcp::handler::server::wrapper::Parameters;
     use rmcp::model::CallToolResult;
+    use serial_test::serial;
     use tempfile::TempDir;
     use webfang_core::di::Container;
     use webfang_core::domain::CrawlerConfig;
@@ -159,6 +160,7 @@ mod tests {
     /// (guard ON by default) with a "SSRF" error, BEFORE any asset fetch.
     /// The loopback literal resolves locally (no DNS/network dependency).
     #[tokio::test]
+    #[serial] // WEBFANG_MCP_DISABLE_SSRF is process-global — see scraping.rs
     async fn download_assets_rejects_loopback_base_url() {
         // Defensive under shared-process harnesses: the escape hatch must be
         // unset for this process so the guard is active. (nextest isolates
@@ -208,6 +210,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn download_assets_downloads_image_from_html() {
         // REQ-03 (#707) validates `base_url` at entry. This test serves an
         // asset from wiremock on 127.0.0.1, so lift the guard for this

--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -445,6 +445,7 @@ mod handler_tests {
     use crate::mcp_server::state::McpState;
     use rmcp::handler::server::wrapper::Parameters;
     use rmcp::model::CallToolResult;
+    use serial_test::serial;
     use std::path::Path;
     use tempfile::TempDir;
     use webfang_core::di::Container;
@@ -779,6 +780,7 @@ mod handler_tests {
     /// fetch is issued (only the robots.txt probe reaches the mock).
     #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
     #[tokio::test]
+    #[serial] // WEBFANG_MCP_DISABLE_SSRF is process-global — see scraping.rs
     async fn process_export_pipeline_url_robots_disallowed_errors_before_scrape() {
         // Wiremock binds 127.0.0.1 — lift the SSRF guard for this test
         // process (nextest isolates each test in its own process). The SSRF
@@ -828,7 +830,12 @@ mod handler_tests {
     /// fetch. Mirrors the loopback tests of the other URL-fetching tools
     /// (Bug #673).
     #[tokio::test]
+    #[serial]
     async fn process_export_pipeline_url_ssrf_guard_blocks_loopback() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
         let (handler, _tmp) = test_handler().await;
         let res = handler
             .process_export_pipeline(Parameters(ProcessExportPipelineParams {

--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -303,6 +303,10 @@ impl McpHandler {
     }
 
     /// Full export pipeline: scrape (when `url` is given) → export synchronously
+    ///
+    /// The live-scrape branch respects SSRF protection and the site's
+    /// robots.txt: a disallowed URL is rejected with a `robots.txt` error
+    /// before any fetch (#749, uniform with #697).
     #[tool(
         description = "Run the export pipeline synchronously: when `url` is provided, scrape it first; otherwise use persisted crawl results. Export to the specified format (jsonl, vector, or auto; default jsonl). Reports the real written path; never queues."
     )]
@@ -334,6 +338,17 @@ impl McpHandler {
                         Some(serde_json::Value::String("url".to_string())),
                     )
                 })?;
+                // #749 fold-in: this branch fetched a caller URL without the
+                // SSRF guard every other URL-fetching tool has.
+                crate::mcp_server::ssrf::validate_url_no_ssrf(&url).await?;
+                // #749: robots.txt gate before the live scrape, same site-policy
+                // contract as the other scrape tools; denials reuse this
+                // branch's error wrapper below.
+                if let Some(err) = self.state.robots_denied_for(&url).await {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "error al rastrear {url}: {err}"
+                    ))]));
+                }
                 let client = self.state.container.http_client().as_ref();
                 match webfang_core::application::scraper_service::scrape_with_readability(
                     client, &url,
@@ -435,8 +450,33 @@ mod handler_tests {
     use webfang_core::di::Container;
     use webfang_core::domain::{CrawlerConfig, ScrapedContent, ValidUrl};
     use webfang_core::infrastructure::config::ScraperConfig;
+    use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    /// Determinism (#705/#749): the robots check performs a real robots.txt
+    /// fetch, so plain unit tests drop the fetcher (no-op gate); #749 robots
+    /// tests wire a fetcher explicitly (see `test_handler_with_robots`).
     async fn test_handler() -> (McpHandler, TempDir) {
+        let (mut state, tmp) = test_state().await;
+        state.robots_fetcher = None;
+        (McpHandler::new(state), tmp)
+    }
+
+    /// Build a state with a real robots fetcher for #749 enforcement tests.
+    /// Offline-friendly: construction never touches the network.
+    async fn test_handler_with_robots() -> (McpHandler, TempDir) {
+        let (state, tmp) = test_state().await;
+        let state = state.with_robots_fetcher(std::sync::Arc::new(
+            RobotsFetcher::with_default_profile(5).expect("fetcher construction is offline"),
+        ));
+        (McpHandler::new(state), tmp)
+    }
+
+    /// Shared state construction for `test_handler` /
+    /// `test_handler_with_robots`. The `TempDir` is returned so the caller
+    /// keeps the configured `output_dir` alive.
+    async fn test_state() -> (McpState, TempDir) {
         let tmp = TempDir::new().expect("create temp dir");
         let crawler_config =
             CrawlerConfig::new(url::Url::parse("https://example.com").expect("valid url"));
@@ -447,8 +487,7 @@ mod handler_tests {
         let container = Container::new(crawler_config, scraper_config)
             .await
             .expect("create container");
-        let state = McpState::new(container);
-        (McpHandler::new(state), tmp)
+        (McpState::new(container), tmp)
     }
 
     /// Seed the container's crawl-result repository with one item, polling
@@ -732,6 +771,78 @@ mod handler_tests {
         assert!(
             text.contains("error al rastrear") || text.contains("Exportación completada"),
             "url branch must attempt a live scrape: {text}"
+        );
+    }
+
+    /// #749: the url branch must respect robots.txt — a disallowed URL fails
+    /// with the branch's error wrapper mentioning `robots.txt`, and no page
+    /// fetch is issued (only the robots.txt probe reaches the mock).
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn process_export_pipeline_url_robots_disallowed_errors_before_scrape() {
+        // Wiremock binds 127.0.0.1 — lift the SSRF guard for this test
+        // process (nextest isolates each test in its own process). The SSRF
+        // guard itself is asserted by the dedicated regression test below.
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1");
+        let (handler, _tmp) = test_handler_with_robots().await;
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/robots.txt"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("User-agent: *\nDisallow: /private\n"),
+            )
+            .mount(&server)
+            .await;
+
+        let res = handler
+            .process_export_pipeline(Parameters(ProcessExportPipelineParams {
+                url: Some(format!("{}/private/page", server.uri())),
+                format: Some("jsonl".to_string()),
+            }))
+            .await
+            .expect("process_export_pipeline returns Ok on robots denial");
+
+        let json = serde_json::to_value(&res).expect("CallToolResult serializes");
+        assert_eq!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "robots denial must set isError:true, got: {json}"
+        );
+        let text = result_text(&res);
+        assert!(
+            text.contains("error al rastrear") && text.contains("robots.txt"),
+            "url branch must wrap the robots denial: {text}"
+        );
+        let page_hits = server
+            .received_requests()
+            .await
+            .expect("request recording is enabled")
+            .iter()
+            .filter(|r| r.url.path() != "/robots.txt")
+            .count();
+        assert_eq!(page_hits, 0, "the robots gate must block the page fetch");
+    }
+
+    /// #749 fold-in regression: the url branch now validates against SSRF —
+    /// a loopback target is rejected with an SSRF protocol error before any
+    /// fetch. Mirrors the loopback tests of the other URL-fetching tools
+    /// (Bug #673).
+    #[tokio::test]
+    async fn process_export_pipeline_url_ssrf_guard_blocks_loopback() {
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .process_export_pipeline(Parameters(ProcessExportPipelineParams {
+                url: Some("http://127.0.0.1/".to_string()),
+                format: Some("jsonl".to_string()),
+            }))
+            .await;
+        assert!(res.is_err(), "loopback URL must be a protocol error");
+        let msg = res
+            .expect_err("loopback URL must be blocked by SSRF")
+            .to_string();
+        assert!(
+            msg.contains("SSRF"),
+            "error must report SSRF protection, got: {msg}"
         );
     }
 }

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -20,6 +20,9 @@ use tracing::instrument;
 #[allow(missing_docs)]
 impl McpHandler {
     /// Scrape a single URL and extract clean content using Readability algorithm
+    ///
+    /// Respects the site's robots.txt: a disallowed URL is rejected with a
+    /// `robots.txt` error before any fetch (#749, uniform with #697).
     #[tool(
         description = "Scrape a single URL and extract clean content using Readability algorithm (Firefox Reader mode). Returns title, content, excerpt, author, and date."
     )]
@@ -42,9 +45,22 @@ impl McpHandler {
         crate::mcp_server::ssrf::validate_url_no_ssrf(&url).await?;
 
         let start = Instant::now();
-        let client = self.state.container.http_client().as_ref();
         // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
+        // robots.txt gate BEFORE any fetch (#749): a disallowed URL is rejected
+        // without touching the network, mirroring `scrape_with_options` (#697).
+        if let Some(err) = self.state.robots_denied_for(&url).await {
+            self.state.record_scrape_identity(
+                "scrape_url",
+                domain_of(&params.url),
+                Outcome::Error,
+                0,
+                start,
+                &root_correlation,
+            );
+            return Ok(CallToolResult::error(vec![Content::text(err.to_string())]));
+        }
+        let client = self.state.container.http_client().as_ref();
         match webfang_core::application::scraper_service::scrape_with_readability(client, &url)
             .await
         {
@@ -433,6 +449,9 @@ impl McpHandler {
     }
 
     /// Discover URLs from a single page's HTML links
+    ///
+    /// Respects the site's robots.txt: a disallowed URL is rejected with a
+    /// `robots.txt` error before any fetch (#749, uniform with #697).
     #[tool(
         description = "Fetch a single page and extract all internal links. Lightweight URL discovery without full crawl."
     )]
@@ -456,6 +475,19 @@ impl McpHandler {
         let start = Instant::now();
         // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
+        // robots.txt gate BEFORE any fetch (#749).
+        if let Some(robots_error) = robots_denied_response(
+            self,
+            "discover_urls",
+            &url,
+            &params.url,
+            start,
+            &root_correlation,
+        )
+        .await
+        {
+            return Ok(robots_error);
+        }
         let port = self.state.container.http_client();
         match port.get(url.as_str()).await {
             Ok(resp) => {
@@ -584,6 +616,9 @@ impl McpHandler {
     }
 
     /// Detect if a URL requires JavaScript rendering (SPA)
+    ///
+    /// Respects the site's robots.txt: a disallowed URL is rejected with a
+    /// `robots.txt` error before any fetch (#749, uniform with #697).
     #[tool(
         description = "Detect if a page requires JavaScript rendering (Single Page Application). Checks for minimal content and SPA markers like <div id=\"root\"> or <div id=\"app\">."
     )]
@@ -609,6 +644,19 @@ impl McpHandler {
         let start = Instant::now();
         // One run identity per tool call, shared by its success and error events (#501/#698).
         let root_correlation = webfang_core::domain::CorrelationId::new();
+        // robots.txt gate BEFORE any fetch (#749).
+        if let Some(robots_error) = robots_denied_response(
+            self,
+            "detect_spa",
+            &url,
+            &params.url,
+            start,
+            &root_correlation,
+        )
+        .await
+        {
+            return Ok(robots_error);
+        }
         let port = self.state.container.http_client();
         match port.get(url.as_str()).await {
             Ok(resp) => {
@@ -658,6 +706,34 @@ impl McpHandler {
             },
         }
     }
+}
+
+/// robots.txt gate for single-URL direct-fetch tools (#749).
+///
+/// Delegates to the single policy source
+/// (`McpState::robots_denied_for` → `scraper_service::enforce_robots_policy`,
+/// fail-open when no fetcher is wired). On denial, records an
+/// `Outcome::Error` scrape identity for `tool` — the same shape as each
+/// handler's HTTP-error branch — and returns the tool error envelope carrying
+/// the denial text (`WafBlocked(url, "robots.txt")`).
+async fn robots_denied_response(
+    handler: &McpHandler,
+    tool: &'static str,
+    url: &url::Url,
+    raw_url: &str,
+    start: Instant,
+    correlation: &webfang_core::domain::CorrelationId,
+) -> Option<CallToolResult> {
+    let err = handler.state.robots_denied_for(url).await?;
+    handler.state.record_scrape_identity(
+        tool,
+        domain_of(raw_url),
+        Outcome::Error,
+        0,
+        start,
+        correlation,
+    );
+    Some(CallToolResult::error(vec![Content::text(err.to_string())]))
 }
 
 /// Keep only seed-host-internal URLs in the discovery output (REQ-01, SSRF
@@ -773,8 +849,33 @@ mod tests {
     use webfang_core::di::Container;
     use webfang_core::domain::CrawlerConfig;
     use webfang_core::infrastructure::config::ScraperConfig;
+    use webfang_core::infrastructure::crawler::robots_utils::RobotsFetcher;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     async fn test_handler() -> (McpHandler, TempDir) {
+        let (mut state, tmp) = test_state().await;
+        // Determinism (#705): handler tests must stay offline — the robots
+        // check performs a real robots.txt fetch, so unit tests drop the
+        // fetcher instead of risking network access through loopback URLs.
+        state.robots_fetcher = None;
+        (McpHandler::new(state), tmp)
+    }
+
+    /// Build a state with a real robots fetcher for #749 enforcement tests.
+    /// Offline-friendly: construction never touches the network.
+    async fn test_handler_with_robots() -> (McpHandler, TempDir) {
+        let (state, tmp) = test_state().await;
+        let state = state.with_robots_fetcher(std::sync::Arc::new(
+            RobotsFetcher::with_default_profile(5).expect("fetcher construction is offline"),
+        ));
+        (McpHandler::new(state), tmp)
+    }
+
+    /// Shared state construction for `test_handler` / `test_handler_with_robots`.
+    /// The `TempDir` is returned so the caller keeps the configured
+    /// `output_dir` alive.
+    async fn test_state() -> (McpState, TempDir) {
         let tmp = TempDir::new().expect("create temp dir");
         let crawler_config =
             CrawlerConfig::new(url::Url::parse("https://example.com").expect("valid url"));
@@ -785,12 +886,86 @@ mod tests {
         let container = Container::new(crawler_config, scraper_config)
             .await
             .expect("create container");
-        let mut state = McpState::new(container);
-        // Determinism (#705): handler tests must stay offline — the robots
-        // check performs a real robots.txt fetch, so unit tests drop the
-        // fetcher instead of risking network access through loopback URLs.
-        state.robots_fetcher = None;
-        (McpHandler::new(state), tmp)
+        (McpState::new(container), tmp)
+    }
+
+    // ── #749 robots.txt gate fixtures (modeled on
+    // `crates/webfang_core/tests/scraper_service_test.rs::robots`) ──
+
+    /// Minimal article HTML that Readability extracts deterministically
+    /// (scraping_coverage_test.rs style).
+    const ARTICLE_HTML: &str = r#"<!DOCTYPE html>
+<html>
+<head><title>Public Page</title></head>
+<body>
+<article>
+<h1>Main Heading</h1>
+<p>This is the content of the article. It has enough text to be extracted by Readability.</p>
+</article>
+</body>
+</html>"#;
+
+    /// Mount a robots.txt disallowing `/private/*` and a 200 page at
+    /// `/{path}` on the same origin — the fetcher keys its rule cache on the
+    /// page URL's origin, so both routes must sit on one `MockServer`.
+    async fn mount_robots_site(server: &MockServer, page_path: &str) {
+        Mock::given(method("GET"))
+            .and(path("/robots.txt"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("User-agent: *\nDisallow: /private\n"),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{page_path}")))
+            .respond_with(ResponseTemplate::new(200).set_body_string(ARTICLE_HTML))
+            .mount(server)
+            .await;
+    }
+
+    /// Count requests that are NOT the robots.txt probe — zero proves the
+    /// gate short-circuited BEFORE any page fetch.
+    async fn page_hits(server: &MockServer) -> usize {
+        server
+            .received_requests()
+            .await
+            .expect("request recording is enabled")
+            .iter()
+            .filter(|r| r.url.path() != "/robots.txt")
+            .count()
+    }
+
+    /// The first text content of a tool result, serialized as the transport
+    /// would.
+    fn result_text(result: &CallToolResult) -> String {
+        serde_json::to_value(result)
+            .ok()
+            .and_then(|v| v.get("content").and_then(|c| c.as_array()).cloned())
+            .and_then(|arr| arr.first().cloned())
+            .and_then(|first| {
+                first
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .map(str::to_owned)
+            })
+            .unwrap_or_default()
+    }
+
+    /// Assert that a tool result is an honest error (`isError:true`) whose
+    /// text reports the robots.txt denial.
+    fn assert_robots_error(result: &CallToolResult) -> String {
+        let json = serde_json::to_value(result).expect("CallToolResult serializes");
+        assert_eq!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "robots denial must set isError:true, got: {json}"
+        );
+        let text = result_text(result);
+        assert!(
+            text.contains("robots.txt"),
+            "error text must report the robots.txt denial, got: {text}"
+        );
+        text
     }
 
     /// Assert that a handler rejected a loopback/private URL via the SSRF gate.
@@ -964,6 +1139,116 @@ mod tests {
         assert!(
             res.is_err(),
             "invalid URL must be a protocol error, got: {res:?}"
+        );
+    }
+
+    // ── #749: robots.txt must be respected before any page fetch ──
+
+    /// `scrape_url` with a robots-disallowed URL returns an `isError:true`
+    /// result reporting `robots.txt` and never issues the page fetch.
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn scrape_url_robots_disallowed_returns_error_and_zero_page_hits() {
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
+        let (handler, _tmp) = test_handler_with_robots().await;
+        let server = MockServer::start().await;
+        mount_robots_site(&server, "private/page").await;
+
+        let res = handler
+            .scrape_url(Parameters(ScrapeUrlParams {
+                url: format!("{}/private/page", server.uri()),
+            }))
+            .await
+            .expect("handler returns Ok with an honest error");
+
+        assert_robots_error(&res);
+        assert_eq!(
+            page_hits(&server).await,
+            0,
+            "the robots gate must short-circuit before the page fetch"
+        );
+    }
+
+    /// Positive path: a robots-allowed URL passes the gate through to a real
+    /// scrape (fail-open positive: allowed = no interference), and the
+    /// extracted content reaches the caller.
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn scrape_url_robots_allowed_still_scrapes_page() {
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
+        let (handler, _tmp) = test_handler_with_robots().await;
+        let server = MockServer::start().await;
+        mount_robots_site(&server, "public/page").await;
+
+        let res = handler
+            .scrape_url(Parameters(ScrapeUrlParams {
+                url: format!("{}/public/page", server.uri()),
+            }))
+            .await
+            .expect("handler returns Ok");
+
+        let json = serde_json::to_value(&res).expect("CallToolResult serializes");
+        assert_ne!(
+            json.get("isError").and_then(|v| v.as_bool()),
+            Some(true),
+            "robots-allowed URL must not be rejected: {}",
+            result_text(&res)
+        );
+        assert_eq!(page_hits(&server).await, 1, "the page must be fetched");
+        assert!(
+            result_text(&res).contains("Public Page"),
+            "allowed scrape must return the extracted article title, got: {}",
+            result_text(&res)
+        );
+    }
+
+    /// `discover_urls` with a robots-disallowed URL returns a `robots.txt`
+    /// error and never issues the page fetch.
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn discover_urls_robots_disallowed_returns_error_and_zero_page_hits() {
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
+        let (handler, _tmp) = test_handler_with_robots().await;
+        let server = MockServer::start().await;
+        mount_robots_site(&server, "private/list").await;
+
+        let res = handler
+            .discover_urls(Parameters(DiscoverUrlsParams {
+                url: format!("{}/private/list", server.uri()),
+            }))
+            .await
+            .expect("handler returns Ok with an honest error");
+
+        assert_robots_error(&res);
+        assert_eq!(
+            page_hits(&server).await,
+            0,
+            "the robots gate must short-circuit before the page fetch"
+        );
+    }
+
+    /// `detect_spa` with a robots-disallowed URL returns a `robots.txt` error
+    /// and never issues the page fetch.
+    #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
+    #[tokio::test]
+    async fn detect_spa_robots_disallowed_returns_error_and_zero_page_hits() {
+        std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
+        let (handler, _tmp) = test_handler_with_robots().await;
+        let server = MockServer::start().await;
+        mount_robots_site(&server, "private/app").await;
+
+        let res = handler
+            .detect_spa(Parameters(DetectSpaParams {
+                url: format!("{}/private/app", server.uri()),
+            }))
+            .await
+            .expect("handler returns Ok with an honest error");
+
+        assert_robots_error(&res);
+        assert_eq!(
+            page_hits(&server).await,
+            0,
+            "the robots gate must short-circuit before the page fetch"
         );
     }
 

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -845,6 +845,7 @@ mod tests {
     use crate::mcp_server::state::McpState;
     use rmcp::handler::server::wrapper::Parameters;
     use rmcp::model::CallToolResult;
+    use serial_test::serial;
     use tempfile::TempDir;
     use webfang_core::di::Container;
     use webfang_core::domain::CrawlerConfig;
@@ -978,8 +979,18 @@ mod tests {
         );
     }
 
+    /// WEBFANG_MCP_DISABLE_SSRF is a process-global variable. The Coverage job
+    /// runs raw `cargo test` (single process, parallel threads — nextest
+    /// isolates per process, which hides the race), so every test that reads
+    /// or mutates the escape hatch is `#[serial]` to keep the guard's state
+    /// consistent (pattern: metrics.rs).
     #[tokio::test]
+    #[serial]
     async fn scrape_url_rejects_loopback() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
         // SSRF protection must block requests to internal/loopback addresses
         // before any fetch happens (Bug #673).
         let (handler, _tmp) = test_handler().await;
@@ -1003,7 +1014,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn scrape_with_options_rejects_loopback() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
         // SSRF protection must block internal/loopback addresses (Bug #673).
         let (handler, _tmp) = test_handler().await;
         let res = handler
@@ -1036,7 +1052,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn scrape_batch_rejects_loopback() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
         // SSRF protection must block internal/loopback addresses in a batch (Bug #673).
         let (handler, _tmp) = test_handler().await;
         let res = handler
@@ -1089,7 +1110,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn discover_urls_rejects_loopback() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
         // SSRF protection must block internal/loopback addresses (Bug #673).
         let (handler, _tmp) = test_handler().await;
         let res = handler
@@ -1116,7 +1142,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn detect_spa_rejects_loopback() {
+        // Defensive under shared-process harnesses: the escape hatch must be
+        // unset for this process so the guard is active. (nextest isolates
+        // each test in its own process, so this is a no-op there.)
+        std::env::remove_var("WEBFANG_MCP_DISABLE_SSRF");
         // SSRF protection must block internal/loopback addresses (Bug #673).
         let (handler, _tmp) = test_handler().await;
         let res = handler
@@ -1148,6 +1179,7 @@ mod tests {
     /// result reporting `robots.txt` and never issues the page fetch.
     #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
     #[tokio::test]
+    #[serial]
     async fn scrape_url_robots_disallowed_returns_error_and_zero_page_hits() {
         std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
         let (handler, _tmp) = test_handler_with_robots().await;
@@ -1174,6 +1206,7 @@ mod tests {
     /// extracted content reaches the caller.
     #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
     #[tokio::test]
+    #[serial]
     async fn scrape_url_robots_allowed_still_scrapes_page() {
         std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
         let (handler, _tmp) = test_handler_with_robots().await;
@@ -1206,6 +1239,7 @@ mod tests {
     /// error and never issues the page fetch.
     #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
     #[tokio::test]
+    #[serial]
     async fn discover_urls_robots_disallowed_returns_error_and_zero_page_hits() {
         std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
         let (handler, _tmp) = test_handler_with_robots().await;
@@ -1231,6 +1265,7 @@ mod tests {
     /// and never issues the page fetch.
     #[cfg_attr(miri, ignore)] // real network stack via wreq — unsupported by Miri
     #[tokio::test]
+    #[serial]
     async fn detect_spa_robots_disallowed_returns_error_and_zero_page_hits() {
         std::env::set_var("WEBFANG_MCP_DISABLE_SSRF", "1"); // wiremock binds 127.0.0.1
         let (handler, _tmp) = test_handler_with_robots().await;
@@ -1326,6 +1361,7 @@ mod tests {
     /// the SSRF message, before any sitemap fetch. The seed uses a public
     /// literal IP so its own validation resolves locally (no DNS dependency).
     #[tokio::test]
+    #[serial]
     async fn crawl_with_sitemap_rejects_internal_sitemap_url() {
         // Defensive under shared-process harnesses: the escape hatch must be
         // unset for this process so the guard is active. (nextest isolates

--- a/crates/webfang_mcp/src/mcp_server/state.rs
+++ b/crates/webfang_mcp/src/mcp_server/state.rs
@@ -270,6 +270,23 @@ impl McpState {
             .record(event);
     }
 
+    /// Shared robots.txt gate for tools that fetch content directly (#749).
+    ///
+    /// Delegates to the single policy source
+    /// ([`enforce_robots_policy`](webfang_core::application::scraper_service::enforce_robots_policy)):
+    /// fail-open when the fetcher is absent, `WafBlocked(url, "robots.txt")`
+    /// on denial. Callers receive the denial as an error payload and report it
+    /// through their tool error envelope.
+    pub async fn robots_denied_for(
+        &self,
+        url: &url::Url,
+    ) -> Option<webfang_core::error::ScraperError> {
+        let robots = self.robots_fetcher.as_deref();
+        webfang_core::application::scraper_service::enforce_robots_policy(url, robots, false)
+            .await
+            .err()
+    }
+
     /// Record a scrape event stamped with the tool call's run-root identity.
     ///
     /// The sole call-side helper for identified scrape metrics (#698): it owns


### PR DESCRIPTION
Closes #749

## Summary

Spin-off de #724 §1. Cinco MCP tools fetcheaban contenido ignorando robots.txt mientras `scrape_with_options`/`scrape_batch` lo respetan desde #697. Enforcement uniforme fail-open, sin exenciones para probes (decisión de producto cerrada en #724).

## Cambios

**Gate compartido (una sola fuente de verdad):**
- `enforce_robots_policy` pasa a `pub` en `scraper_service.rs` — misma semántica: `ignore_robots` opt-out, fail-open con fetcher `None`, denial = `ScraperError::waf_blocked(url, "robots.txt")` + `tracing::warn(robots_txt_denied)`.
- `McpState::robots_denied_for(&Url)` delega en core — las tools reciben el denial como payload de error.

**Las 5 tools (gate post-SSRF, pre-fetch):**
| Tool | Comportamiento |
|:---|:---|
| `scrape_url` | inline + `record_scrape_identity(Outcome::Error)` |
| `discover_urls` / `detect_spa` | helper local `robots_denied_response` (jscpd) |
| `process_export_pipeline` (url) | wrapper `"error al rastrear"` existente |
| `semantic_cleaner` | `honest_error` ANTES del feature check (política de sitio ≠ feature local) |

**Fold-in de seguridad (mismos handlers, mismo PR):** `process_export_pipeline` y `semantic_cleaner` también saltaban `validate_url_no_ssrf` — era el único par de tools con URL fetch sin el guard #673/#703. Agregado en ambos, con regression test de loopback.

**Contrato de mensajes:** denial = `"WAF/CAPTCHA detectado en {url}: robots.txt"` — paridad exacta con las tools compliant de #697. Sin strings nuevos.

## Tests (7 nuevos, wiremock, cero red real)

- Denial en las 5 tools → isError + `"robots.txt"` + **cero page hits** (el gate corta antes del fetch).
- `scrape_url` allowed → fetch real pasa (fail-open positivo).
- SSRF loopback en `process_export_pipeline` (fold-in).
- Fixture propio por test (`MockServer` por dominio — el cache de robots es per-domain).

## Verificación

- `cargo check` · `cargo nextest run -p webfang_mcp` (266 pass) · scraper_service_test (51) · scraping_coverage_test con features (11/11)
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` limpio
- jscpd ratchet: 7585 < 7728 baseline