### PR TITLE
fix(infra): gate Miri-hostile tests killing infra-fast/slow jobs (issue #751)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,11 +565,17 @@ jobs:
   # ============================================================================
   # MIRI INFRA-SLOW: crawler/obsidian/export/http/network/converter + pure-Rust
   # downloader submodules. 60 min timeout for the same reason as infra-fast.
-  # wikilinks/syntax_highlight explicitly skipped — FFI-heavy, can't execute
-  # under Miri. downloader: only pure-Rust submodules (cookie_bridge/spa_detector)
+  # syntax_highlight is excluded at source via #[cfg(all(test, not(miri)))];
+  # wikilinks (pure pulldown_cmark, no FFI) runs and passes under Miri. The
+  # trailing `--skip wikilinks`/`--skip syntax_highlight` flags are inert
+  # (parsed after the `--` positional filters) — kept as documentation.
+  # downloader: only pure-Rust submodules (cookie_bridge/spa_detector)
   # — FFI (wreq, obscura, chromiumoxide) and sysinfo-dependent (hybrid_router,
   # resource_governor) excluded via --skip / #[cfg(not(miri))] (#515).
   # resource_governor is covered by TSan (sanitizers.yml), where sysconf works.
+  # Budget (#751): memory_manager's test_handle_disk_swapping_with_swap is
+  # #[cfg_attr(miri, ignore)] — it alone burned ~27 min wall, leaving the rest
+  # of this job at ~30–33 min of the 60 min timeout (knife-edge resolved).
   # ============================================================================
   miri-infra-slow:
     name: Miri (infra-slow)

--- a/crates/webfang_core/src/infrastructure/crawler/memory_manager.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/memory_manager.rs
@@ -185,6 +185,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)] // 15,000-URL disk write takes ~27m wall under Miri (#751, run 31983525568: 01:07→01:35)
     #[test]
     fn test_handle_disk_swapping_with_swap() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/webfang_core/src/infrastructure/scraper/dom_inspector.rs
+++ b/crates/webfang_core/src/infrastructure/scraper/dom_inspector.rs
@@ -248,6 +248,19 @@ mod tests {
         let suggestions = inspector.suggest(&document, ".nonexistent");
         assert!(suggestions.is_empty());
     }
+}
+
+// DefaultDomInspector tests construct and drop `scraper::Selector` values (via
+// `Selector::parse` in `collect_candidates`/`inspect`/`suggest`). Dropping a
+// selector trips a Tree Borrows UB inside servo_arc's `ArcUnion`
+// (`servo_arc` 0.4.3 lib.rs:535, `Arc::drop`) — the same defect that gated
+// readability/author_extractor (5a2adc2, #515) — and large DOMs
+// (`builder_methods`, 600 divs) spin indefinitely under the interpreter. In CI
+// this module hung the whole infra-fast job until the 60m timeout (#751, run
+// 31983525568: 31 tests never completed). Regular (non-Miri) runs keep coverage.
+#[cfg(all(test, not(miri)))]
+mod default_dom_inspector_tests {
+    use super::*;
 
     // --- DefaultDomInspector::inspect tests ---
 


### PR DESCRIPTION
Closes #751

## Summary

Root-caused and fixed the scheduled Miri jobs that die at the 60-minute timeout (ci.yml, runs 31983525568 and 31346782163). Two distinct culprits, one PR — both verified locally under the **exact CI MIRIFLAGS**.

## Root cause

**infra-fast hang** — last completed test was `output::frontmatter`; everything after it alphabetically (`scraper::dom_inspector` → `fallback` → `stream` → `user_agent`, 31 tests) never finished. `dom_inspector`'s `DefaultDomInspector` tests construct and drop `scraper::Selector` values, which trips **Tree Borrows UB in servo_arc 0.4.3** (`ArcUnion`, `Arc::drop`, lib.rs:535) and large DOMs (`builder_methods`, 600 divs) **spin indefinitely** under the interpreter. Same defect family that gated readability/author_extractor (5a2adc2, #515) — dom_inspector just missed the gate.

**infra-slow knife-edge** — `test_handle_disk_swapping_with_swap` (15,000-URL disk write) alone burned **~27 min wall** under Miri (01:07→01:35), leaving the job on a ~59-min budget against a 60-min timeout.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/infrastructure/scraper/dom_inspector.rs` | Split tests: keep 2 NoOpInspector tests (Miri-safe, no Selector), gate 14 DefaultDomInspector tests behind `#[cfg(all(test, not(miri)))]` |
| `crates/webfang_core/src/infrastructure/crawler/memory_manager.rs` | `#[cfg_attr(miri, ignore)]` on the 27-min disk-write test |
| `.github/workflows/ci.yml` | Correct misleading comment: wikilinks is pure pulldown_cmark (passes Miri), syntax_highlight is source-gated, trailing `--skip` flags are inert |

## Evidence

- Minimal repro: `cargo +nightly miri test` on `scraper 0.27` aborts with `Undefined Behavior ... servo_arc-0.4.3/lib.rs:535 Arc::drop`; reproduces the same on `dom_inspector` in-repo.
- After fix, the **full infra-fast filter** passes cleanly: **91 passed, 17 ignored, 0 failed in 326s** (vs. killed at 87/118 in CI).
- `memory_manager::` under Miri: 3 passed, 2 ignored in 48s (was ~27 min).
- No-op and all other tests unaffected: regular run 35/35 green; `cargo check`/`clippy`/`fmt` clean.

## Test Plan

- [x] `cargo check --lib --tests` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` — clean
- [x] `cargo fmt` — clean
- [x] `cargo nextest run --lib dom_inspector memory_manager` — 35/35 pass
- [x] Full infra-fast Miri filter with exact CI flags — no hang, all pass
- [x] memory_manager under Miri — swap test ignored, ~27 min reclaimed

## Checklist

- [x] Conventional commit format
- [x] Exactly one `type:*` label
- [x] Linked issue #751
- [x] No `Co-Authored-By` trailers