### PR TITLE
fix(infra): gate extraction.rs tests hitting servo_arc Tree Borrows UB under Miri (#764)

### DIFF
--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -354,6 +354,19 @@ pub async fn extract_content(
 mod tests {
     use super::*;
 
+    // Miri gating policy for this module (#764, #487): 6 tests below trip the
+    // known servo_arc 0.4.3 ArcUnion Tree Borrows UB via two entry points:
+    // - valid-selector tests drop a `scraper::Selector` built in
+    //   `extract_with_selector` (same defect family as dom_inspector, #763);
+    // - `scrape_with_readability`/`extract_content` tests reach `clean_html`
+    //   (html_cleaner.rs:112) → `lol_html::rewrite_str`, whose drop glue ends
+    //   in the same `servo_arc::ArcUnion` drop (recurrence of #498, same
+    //   class as the discovery.rs gates in #486).
+    // The 3 ungated tests avoid it: body passthrough (no Selector), and the
+    // invalid-selector / whitespace-only fallbacks (parse failure happens
+    // before `selectors::SelectorList` is constructed, so nothing drops).
+    // Regular (non-Miri) runs keep full coverage.
+
     // --- extract_with_selector: pure, no network (scraper::Html from a string) ---
 
     #[test]
@@ -368,6 +381,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // servo_arc 0.4.3 Tree Borrows UB: drops parsed Selector (#487, #764)
     #[test]
     fn test_matching_selector_wraps_elements() {
         let html = "<html><body><div class=\"main\">Hello</div><aside>noise</aside></body></html>";
@@ -385,6 +399,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // servo_arc 0.4.3 Tree Borrows UB: drops parsed Selector (#487, #764)
     #[test]
     fn test_zero_matches_falls_back_without_inspector() {
         let html = "<html><body><p>content</p></body></html>";
@@ -415,6 +430,7 @@ mod tests {
 
     // --- scrape_with_readability: ephemeral mock HTTP client, no real network ---
 
+    #[cfg_attr(miri, ignore)] // servo_arc 0.4.3 Tree Borrows UB in ArcUnion drop via lol_html (#487, #764)
     #[tokio::test]
     async fn test_scrape_with_readability_produces_single_result() {
         use crate::domain::http_port::HttpResponse;
@@ -457,6 +473,7 @@ mod tests {
     /// CLI funnel success branch (#684): readability succeeds but yields
     /// sub-threshold text on a JS-shell page → typed `ExtractionFailed` with
     /// the marker Spanish reason, never Ok near-empty.
+    #[cfg_attr(miri, ignore)] // servo_arc 0.4.3 Tree Borrows UB in ArcUnion drop via lol_html (#487, #764)
     #[tokio::test]
     async fn test_extract_content_success_branch_below_threshold_errors() {
         let html = "<html><head><title>App</title></head><body>\
@@ -491,6 +508,7 @@ mod tests {
 
     /// XC-2 legit fixture: a server-rendered page with ≥50 chars of extractable
     /// text MUST still succeed — the guard never fires above the threshold.
+    #[cfg_attr(miri, ignore)] // servo_arc 0.4.3 Tree Borrows UB in ArcUnion drop via lol_html (#487, #764)
     #[tokio::test]
     async fn test_extract_content_legit_page_above_threshold_succeeds() {
         let html = "<html><head><title>Docs</title></head><body><article>\
@@ -515,6 +533,7 @@ mod tests {
     /// CE-3 no double-gate: when readability FAILS, `MIN_FALLBACK_CONTENT=100`
     /// stays the SOLE authority on the fallback branch — the 50-char guard must
     /// NOT fire there (its Spanish text would be a duplicate signal).
+    #[cfg_attr(miri, ignore)] // servo_arc 0.4.3 Tree Borrows UB in ArcUnion drop via lol_html (#487, #764)
     #[tokio::test]
     async fn test_extract_content_poor_fallback_keeps_min_fallback_authority() {
         let html = "<html><body><a href=\"/x\"></a></body></html>";


### PR DESCRIPTION
Closes #764

## Summary

Gates 6 of 9 tests in `application/extraction.rs` (landed via #730, `1fc6ee4`) that trip the known **servo_arc 0.4.3 ArcUnion Tree Borrows UB** (#487) under Miri, following the documented repo pattern (*If a third-party crate fails, isolate that test with `#[cfg(not(miri))]`*).

## Root cause

Two entry points into the same UB, both verified empirically with the exact CI MIRIFLAGS:

| Tests | Path into UB |
|---|---|
| `test_matching_selector_wraps_elements`, `test_zero_matches_falls_back_without_inspector` | `extract_with_selector` drops a parsed `scraper::Selector` (same family as dom_inspector, #763) |
| `test_scrape_with_readability_produces_single_result` + 3 `extract_content` tests | `clean_html` (`html_cleaner.rs:112`) → `lol_html::rewrite_str` → `servo_arc::ArcUnion` drop (recurrence of #498, same class as #486's discovery.rs gates) |

The 3 **ungated** tests are Miri-safe: body passthrough (no Selector), and invalid-selector / empty-HTML fallbacks (parse fails before any `SelectorList` is constructed). Verified: they pass under Miri.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/extraction.rs` | `#[cfg_attr(miri, ignore)]` on the 6 affected tests + module-level comment documenting the gating policy and both entry points |

## Evidence

- CI: run [32041377255](https://github.com/XaviCode1000/webfang/actions/runs/32041377255) and scheduled run [31983525568](https://github.com/XaviCode1000/webfang/actions/runs/31983525568) — `Miri (core)` aborts at `test_extract_content_legit_page_above_threshold_succeeds` with `Undefined Behavior ...` in `servo_arc-0.4.3/lib.rs:535 Arc::drop`.
- Local verification (exact CI flags): extraction module → **3 passed, 6 ignored, 0 failed** (6.6s); normal run **9/9 pass**; `cargo fmt` + strict clippy clean.

## Checklist

- [x] Conventional commit format
- [x] Exactly one `type:*` label
- [x] Linked issue #764
- [x] No `Co-Authored-By` trailers