### PR TITLE
fix(ci): raise Miri (core) timeout from 30 to 60 min (#766)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,7 +480,13 @@ jobs:
   miri:
     name: Miri (${{ matrix.group }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 60 min, same as infra-fast/infra-slow (#766). The old 30-min budget was
+    # set when Miri (core) aborted in ~20 min on servo_arc UB; once that UB
+    # was gated (#765), core started interpreting its full 691-test universe
+    # and ran out the wall exactly at 30:00 with 422 tests completed and no
+    # UB/FAIL anywhere (run 32049909561, 2026-08-17). 60 min leaves ~25 min
+    # of headroom past the observed full-suite pace.
+    timeout-minutes: 60
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     env:
       # rust-toolchain.toml pins 1.88.0 and would override the nightly toolchain


### PR DESCRIPTION
Closes #766

## Summary

Raises the matrix `miri` job (core/domain) timeout from 30 to 60 minutes, matching `miri-infra-fast` and `miri-infra-slow`. The 30-min budget is a leftover from when `Miri (core)` aborted after ~20 min on servo_arc UB — that UB is now gated (#764/#765) and the job genuinely needs the headroom to interpret its full test suite.

## Evidence

Run [32049909561](https://github.com/XaviCode1000/webfang/actions/runs/32049909561) (post-#765):

- Test step cancelled at **exactly 30:00** (17:21:08 → 17:51:06) — the job timeout, not UB.
- `running 691 tests`; at kill: **422 completed (409 ok + 13 ignored), 0 failed, 0 UB**.
- Progress reached `cli::orchestrator::` — `adapters::` and `application::` fully traversed; `config::`/`di::`/`error::` remained (~minutes of trivial tests).
- Observed pace projects to ~35 min for the full 691; 60 min leaves ~25 min headroom.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `miri` matrix job: `timeout-minutes: 30` → `60` + comment documenting why |

## Checklist

- [x] Conventional commit format
- [x] Exactly one `type:*` label
- [x] Linked issue #766
- [x] No `Co-Authored-By` trailers