### PR TITLE
fix(mcp): enforce export root-of-trust gate in export_file/export_jsonl/export_vector (#756)

### DIFF
--- a/crates/webfang_mcp/src/mcp_server/handlers/export.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/export.rs
@@ -130,6 +130,24 @@ impl McpHandler {
     async fn load_results(&self) -> Result<Vec<ScrapedContent>, CallToolResult> {
         load_results_from(self.state.container.crawl_result_repository())
     }
+
+    /// Resolve and validate a caller-supplied export directory (#756).
+    ///
+    /// Applies `default` when the caller omitted the directory, then routes
+    /// the result through the server root-of-trust gate: relative paths stay
+    /// allowed, absolute paths must be under a configured export root, and
+    /// with no roots configured absolute paths are rejected (fail-closed,
+    /// same contract as `download_assets`, #696).
+    ///
+    /// # Errors
+    /// Returns `McpError::invalid_params` when the directory is absolute and
+    /// outside every configured export root (or when no roots are configured
+    /// at all).
+    fn validated_output_dir(&self, dir: Option<&str>, default: &str) -> Result<PathBuf, McpError> {
+        let dir_str = dir.unwrap_or(default);
+        self.state.validate_export_dir(Path::new(dir_str))?;
+        Ok(PathBuf::from(dir_str))
+    }
 }
 
 #[tool_router(router = tool_router_export, vis = "pub")]
@@ -146,6 +164,12 @@ impl McpHandler {
         Parameters(params): Parameters<ExportFileParams>,
     ) -> Result<CallToolResult, McpError> {
         params.validate()?;
+
+        // Root-of-trust (#756): reject a forbidden absolute `output_dir`
+        // before spending an export permit — same fail-closed gate as
+        // `download_assets` (#696). The `""` default is unreachable:
+        // `params.validate()` already rejects an empty `output_dir`.
+        let output_dir = self.validated_output_dir(Some(&params.output_dir), "")?;
 
         let _permit = acquire_semaphore!(self, export);
 
@@ -165,7 +189,6 @@ impl McpHandler {
             )
         })?;
 
-        let output_dir = PathBuf::from(&params.output_dir);
         // `filename` reaches the filesystem via `create_exporter` /
         // `resolve_export_path`; it MUST be a validated [`SanitizedFilename`]
         // so a `..` can never reach `std::fs` (issue #601). The raw string is
@@ -242,9 +265,12 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         params.validate()?;
 
+        // Root-of-trust (#756): validate the (defaulted) output directory
+        // before spending an export permit (#696 fail-closed gate).
+        let output_dir = self.validated_output_dir(params.output_dir.as_deref(), "./output")?;
+
         let _permit = acquire_semaphore!(self, export);
 
-        let output_dir = PathBuf::from(params.output_dir.as_deref().unwrap_or("./output"));
         // Validated flat filename (issue #601): the raw `Option<String>` can
         // only become a `SanitizedFilename` through exhaustive boundary
         // validation, so the join in `export_results` can never escape
@@ -279,9 +305,12 @@ impl McpHandler {
     ) -> Result<CallToolResult, McpError> {
         params.validate()?;
 
+        // Root-of-trust (#756): validate the (defaulted) output directory
+        // before spending an export permit (#696 fail-closed gate).
+        let output_dir = self.validated_output_dir(params.output_dir.as_deref(), "./output")?;
+
         let _permit = acquire_semaphore!(self, export);
 
-        let output_dir = PathBuf::from(params.output_dir.as_deref().unwrap_or("./output"));
         // Validated flat filename (issue #601): see `export_jsonl` above.
         let filename = SanitizedFilename::try_from(params.filename.as_deref().unwrap_or("export"))
             .map_err(|_| {
@@ -564,10 +593,12 @@ mod handler_tests {
 
     #[tokio::test]
     async fn export_file_invalid_format_is_invalid_params() {
-        let (handler, tmp) = test_handler().await;
+        let (handler, _tmp) = test_handler().await;
+        // #756: relative output_dir so the new root-of-trust gate passes and
+        // the test still exercises the format parse error, not the gate.
         let res = handler
             .export_file(Parameters(ExportFileParams {
-                output_dir: tmp.path().to_string_lossy().to_string(),
+                output_dir: "test-output/export-bad-format".to_string(),
                 filename: "doc".to_string(),
                 format: "bogus".to_string(),
                 content: "hello".to_string(),
@@ -620,12 +651,14 @@ mod handler_tests {
 
     #[tokio::test]
     async fn export_file_rejects_unknown_format_with_clear_message() {
-        let (handler, tmp) = test_handler().await;
+        let (handler, _tmp) = test_handler().await;
         // Bug #4 regression: format="md" (unsupported) must return
         // invalid_params with a message listing supported formats (issue #590).
+        // #756: relative output_dir so the new root-of-trust gate passes and
+        // the test still exercises the format rejection, not the gate.
         let res = handler
             .export_file(Parameters(ExportFileParams {
-                output_dir: tmp.path().to_string_lossy().to_string(),
+                output_dir: "test-output/export-unknown-format".to_string(),
                 filename: "doc".to_string(),
                 format: "md".to_string(),
                 content: "hello".to_string(),
@@ -661,6 +694,94 @@ mod handler_tests {
             "export file must be written"
         );
         let _ = std::fs::remove_dir_all(out_dir);
+    }
+
+    /// #756: `export_file` writes caller content to any `output_dir`, so an
+    /// absolute `output_dir` with no export roots configured must be rejected
+    /// at the protocol level (fail-closed root-of-trust gate, #696).
+    #[tokio::test]
+    async fn export_file_rejects_absolute_output_dir_without_roots() {
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .export_file(Parameters(ExportFileParams {
+                output_dir: "/tmp/webfang-mcp-exploit".to_string(),
+                filename: "doc".to_string(),
+                format: "jsonl".to_string(),
+                content: "hello".to_string(),
+            }))
+            .await;
+        let err = res.expect_err("absolute output_dir without roots must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("requires server-configured export roots"),
+            "error must name the missing export roots, got: {msg}"
+        );
+    }
+
+    /// #756: same root-of-trust gate for `export_jsonl`. The gate runs before
+    /// `load_results`, so the rejection holds even with an empty repository.
+    #[tokio::test]
+    async fn export_jsonl_rejects_absolute_output_dir_without_roots() {
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .export_jsonl(Parameters(ExportJsonlParams {
+                output_dir: Some("/tmp/webfang-mcp-exploit".to_string()),
+                filename: Some("out".to_string()),
+            }))
+            .await;
+        let err = res.expect_err("absolute output_dir without roots must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("requires server-configured export roots"),
+            "error must name the missing export roots, got: {msg}"
+        );
+    }
+
+    /// #756: same root-of-trust gate for `export_vector`.
+    #[tokio::test]
+    async fn export_vector_rejects_absolute_output_dir_without_roots() {
+        let (handler, _tmp) = test_handler().await;
+        let res = handler
+            .export_vector(Parameters(ExportVectorParams {
+                output_dir: Some("/tmp/webfang-mcp-exploit".to_string()),
+                filename: Some("vec".to_string()),
+            }))
+            .await;
+        let err = res.expect_err("absolute output_dir without roots must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("requires server-configured export roots"),
+            "error must name the missing export roots, got: {msg}"
+        );
+    }
+
+    /// #756: an absolute `output_dir` under a configured export root is
+    /// accepted — the gate is fail-closed for paths OUTSIDE every root, not
+    /// a blanket absolute-path ban (issue #600 compatibility).
+    #[tokio::test]
+    async fn export_jsonl_accepts_absolute_output_dir_inside_root() {
+        let (state, tmp) = test_state().await;
+        let root = tmp.path().to_path_buf();
+        let state = state.with_export_roots(vec![root.clone()]);
+        let handler = McpHandler::new(state);
+        seed_one(&handler).await;
+
+        let res = handler
+            .export_jsonl(Parameters(ExportJsonlParams {
+                output_dir: Some(root.to_string_lossy().to_string()),
+                filename: Some("allowed".to_string()),
+            }))
+            .await
+            .expect("export_jsonl returns Ok for absolute output_dir inside root");
+        let text = result_text(&res);
+        assert!(
+            text.contains("Exportación completada"),
+            "seeded export under a configured root must report completion: {text}"
+        );
+        assert!(
+            root.join("allowed.jsonl").exists(),
+            "export must be written under the configured root"
+        );
     }
 
     #[tokio::test]

--- a/crates/webfang_mcp/src/mcp_server/params.rs
+++ b/crates/webfang_mcp/src/mcp_server/params.rs
@@ -428,9 +428,10 @@ pub struct ExportFileParams {
 impl ExportFileParams {
     /// # Errors
     /// Returns `McpError::invalid_params` if `output_dir` is not a safe path
-    /// (absolute paths allowed — issue #600), `filename` is empty or too long,
-    /// `format` is not one of the allowed formats, or `content` exceeds the
-    /// maximum blob size.
+    /// (absolute paths allowed here — issue #600 — but the handler enforces
+    /// the server export-root gate before any write, #756), `filename` is
+    /// empty or too long, `format` is not one of the allowed formats, or
+    /// `content` exceeds the maximum blob size.
     pub fn validate(&self) -> Result<(), McpError> {
         require_safe_path_allow_absolute("output_dir", &self.output_dir)?;
         require_safe_filename("filename", &self.filename)?;
@@ -619,9 +620,10 @@ pub(crate) struct ExportJsonlParams {
 impl ExportJsonlParams {
     /// # Errors
     /// Returns `McpError::invalid_params` if `output_dir` (when present) is
-    /// not a safe path (absolute paths allowed — issue #600) or `filename`
-    /// (when present) is not a single flat component (no `..`, `/`, or
-    /// subdirectory — issue #601).
+    /// not a safe path (absolute paths allowed here — issue #600 — but the
+    /// handler enforces the server export-root gate before any write, #756)
+    /// or `filename` (when present) is not a single flat component (no `..`,
+    /// `/`, or subdirectory — issue #601).
     pub fn validate(&self) -> Result<(), McpError> {
         if let Some(d) = &self.output_dir {
             require_safe_path_allow_absolute("output_dir", d)?;
@@ -645,9 +647,10 @@ pub(crate) struct ExportVectorParams {
 impl ExportVectorParams {
     /// # Errors
     /// Returns `McpError::invalid_params` if `output_dir` (when present) is
-    /// not a safe path (absolute paths allowed — issue #600) or `filename`
-    /// (when present) is not a single flat component (no `..`, `/`, or
-    /// subdirectory — issue #601).
+    /// not a safe path (absolute paths allowed here — issue #600 — but the
+    /// handler enforces the server export-root gate before any write, #756)
+    /// or `filename` (when present) is not a single flat component (no `..`,
+    /// `/`, or subdirectory — issue #601).
     pub fn validate(&self) -> Result<(), McpError> {
         if let Some(d) = &self.output_dir {
             require_safe_path_allow_absolute("output_dir", d)?;

--- a/crates/webfang_mcp/tests/mcp_params_validation_test.rs
+++ b/crates/webfang_mcp/tests/mcp_params_validation_test.rs
@@ -128,7 +128,8 @@ fn require_safe_path_rejects_oversize() {
 // `vault_path` params (issue #600) is covered by the internal `params::tests`
 // module in `src/mcp_server/params.rs`, and `export_file` (the only `pub`
 // struct of this shape) is covered end-to-end by
-// `params_rejection_test.rs::export_file_accepts_absolute_output_dir`. The
+// `params_rejection_test.rs::export_file_rejects_absolute_output_dir_without_roots`
+// (the #756 fail-closed root-of-trust gate complements #600). The
 // `require_safe_path_allow_absolute_*` tests above cover the shared helper.
 
 // ===========================================================================

--- a/crates/webfang_mcp/tests/params_rejection_test.rs
+++ b/crates/webfang_mcp/tests/params_rejection_test.rs
@@ -388,13 +388,17 @@ async fn export_file_rejects_output_dir_traversal() {
     );
 }
 
-/// `export_file` accepts an absolute `output_dir` (issue #600 fix).
+/// `export_file` rejects an absolute `output_dir` when no export roots are
+/// configured (#756, completing #696).
 ///
-/// Before the fix `require_safe_path` forced relative-only paths and a
-/// user-supplied absolute directory yielded a hard `-32602`. Absolute paths
-/// are now accepted (traversal is still rejected elsewhere).
+/// Issue #600 relaxed the syntactic validator so absolute paths reach the
+/// handler, but the root-of-trust gate (#696) was only wired into
+/// `download_assets` — this tool happily wrote to any absolute directory
+/// (RIESGO-MCP-EXPORT-001). The handler now enforces the fail-closed gate:
+/// with no `--export-roots` configured, an absolute `output_dir` is a
+/// protocol-level `-32602`.
 #[tokio::test]
-async fn export_file_accepts_absolute_output_dir() {
+async fn export_file_rejects_absolute_output_dir_without_roots() {
     let (base_url, _handle) = start_test_server().await;
     let client = Client::new();
     let session_id = init_session(&client, &base_url).await;
@@ -415,13 +419,63 @@ async fn export_file_accepts_absolute_output_dir() {
 
     assert_eq!(
         error_code(&resp),
-        None,
-        "absolute output_dir must NOT be rejected with -32602, got: {resp}"
+        Some(JSONRPC_INVALID_PARAMS),
+        "absolute output_dir without configured export roots must be rejected with -32602, got: {resp}"
     );
-    let result = resp.get("result").unwrap_or(&Value::Null);
-    assert!(
-        !is_tool_error(result),
-        "absolute output_dir export must succeed, got: {resp}"
+}
+
+/// #756: the runtime probe the issue called for on `export_jsonl` — the
+/// root-of-trust gate runs BEFORE `load_results`, so an absolute `output_dir`
+/// on a server without seeds/export roots yields the gate's `-32602`, not the
+/// operational "no hay resultados disponibles" error.
+#[tokio::test]
+async fn export_jsonl_rejects_absolute_output_dir_without_roots() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_jsonl",
+        json!({
+            "output_dir": "/tmp/webfang-export",
+            "filename": "out"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "absolute output_dir without configured export roots must be rejected with -32602, got: {resp}"
+    );
+}
+
+/// #756: same runtime proof for `export_vector` (see `export_jsonl` above).
+#[tokio::test]
+async fn export_vector_rejects_absolute_output_dir_without_roots() {
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    let resp = call_tool(
+        &client,
+        &base_url,
+        &session_id,
+        "export_vector",
+        json!({
+            "output_dir": "/tmp/webfang-export",
+            "filename": "out"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        error_code(&resp),
+        Some(JSONRPC_INVALID_PARAMS),
+        "absolute output_dir without configured export roots must be rejected with -32602, got: {resp}"
     );
 }
 


### PR DESCRIPTION
Closes #756

## Summary

The #696 root-of-trust fix wired `McpState::validate_export_dir` into **only** `download_assets`. `export_file`, `export_jsonl` and `export_vector` kept converting caller-supplied `output_dir` straight into filesystem writes without checking absolute paths against `--export-roots` — the RIESGO-MCP-EXPORT-001 write-anywhere primitive stayed alive.

## Changes

- **`McpHandler::validated_output_dir`** helper (free `impl` block, never registered as a tool) that applies the defaulted directory and routes it through the existing fail-closed gate (#696).
- Wired into the three export tools **before** `acquire_semaphore!` so a forbidden path never spends a concurrency permit; protocol-level `-32602` rejection, identical to `download_assets`.
- `process_export_pipeline` stays out of scope: it exports to the operator's container config, not a caller-supplied path.
- **7 new regression tests**: 4 unit (reject absolute without roots ×3 tools; accept absolute under configured root with seed) + 3 end-to-end HTTP probes proving the gate fires before `load_results` (the verification the issue couldn't run).
- Inverted the obsolete #600 expectation test (`export_file_accepts_absolute_output_dir` → `..._rejects_absolute_output_dir_without_roots`) and migrated two format-validation tests to relative dirs so they keep testing format errors.

## Verified

- `cargo nextest run -p webfang_mcp`: 270 passed
- `cargo nextest run -p webfang_mcp --features mcp --test params_rejection_test`: 23 passed
- `cargo nextest run -p webfang_mcp --features mcp,ai` (behavioral + export coverage + download assets + params validation): 75 passed, 5 pre-existing AI-skipped
- `cargo check --workspace --all-targets`, CI-exact clippy gate, `cargo fmt --check`: clean

Full audit log (3-round NotebookLM senior-review bitácora) in the issue comment: https://github.com/XaviCode1000/webfang/issues/756#issuecomment-5319075643

Note: deliberate fail-closed breaking change — servers without `--export-roots` now reject absolute `output_dir` on these three tools (use relative paths or configure `--export-roots`).