### PR TITLE
fix(crawler): sitemap .gz double decompression — magic-byte-first detection (#757)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Extensible Design:** Easy to add new validation rules and error variants
 - **Memory Safety:** Pure move semantics prevent accidental clones in hot paths
 
+### 🔧 Fixed
+
+#### Sitemap double decompression (#757)
+- **Root cause:** `wreq` (built with `.gzip(true)`) auto-decompresses the transport `Content-Encoding` and strips that header, while `CompressionHandler::detect_compression` trusted the `.gz` URL extension and decompressed again — `decompression failed: Invalid gzip header` on every `.xml.gz` sitemap served with `content-encoding: gzip` (e.g. MDN: 10/10 child sitemaps failed).
+- **Fix:** magic bytes are now the sovereign truth for snifable formats (gzip `0x1f8b`, zstd frame/skippable magics). The URL extension is only a fallback hint for non-snifable formats (brotli `.br`, still fail-closed). A `.gz`/`.gzip`/`.zst` URL whose payload lacks magic bytes passes through untouched (transport already decoded, or lying extension) with a `tracing::debug!` audit trail.
+- **Coverage:** body-gzip + `content-encoding: gzip` (was broken), gzip body without header (still works), plain body behind `.gz` URL (now passes through), end-to-end wiremock regressions added to `sitemap_parser.rs` plus extended unit tests.
+
 ## [1.1.1] - 2026-07-11
 
 ### 🔧 Fixed / Observability Hardening (Blindaje de Fidelidad D1–D5)

--- a/crates/webfang_core/src/infrastructure/crawler/compression_handler.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/compression_handler.rs
@@ -2,6 +2,14 @@
 //!
 //! Multi-format compression detection and decompression for sitemap processing.
 //! Supports gzip, deflate, brotli, and zstd formats with automatic detection.
+//!
+//! Detection policy (#757): **magic bytes are the sovereign truth** for
+//! snifable formats (gzip, zstd). The URL extension is only a fallback hint
+//! for formats that cannot be sniffed (brotli). A `.gz`/`.gzip`/`.zst` URL
+//! whose payload has no magic bytes passes through untouched: either the HTTP
+//! transport (`wreq`, built with `.gzip(true)`) already decoded the
+//! `Content-Encoding` — and strips that header afterwards — or the extension
+//! was lying. Decompressing anyway would double-decode valid XML.
 
 use crate::domain::CompressionType;
 use async_compression::tokio::bufread::{BrotliDecoder, DeflateDecoder, GzipDecoder, ZstdDecoder};
@@ -44,30 +52,28 @@ impl CompressionHandler {
     }
 
     /// Detect compression format from content and URL
+    ///
+    /// Magic bytes are the sovereign truth for snifable formats (gzip, zstd):
+    /// if the payload carries them, the matching decoder is returned. The URL
+    /// extension is only a fallback hint for formats that cannot be sniffed
+    /// (brotli).
+    ///
+    /// A `.gz`/`.gzip`/`.zst` URL whose payload has no magic bytes produces an
+    /// **empty** result (pass-through): either the HTTP transport (`wreq`)
+    /// already decoded the `Content-Encoding` — it strips that header after
+    /// decoding — or the extension was lying. Decompressing anyway would
+    /// double-decode valid XML (#757).
     pub fn detect_compression(content: &[u8], url: &str) -> Vec<CompressionType> {
         let mut formats = Vec::new();
 
-        // Check URL extensions
-        if url.ends_with(".gz") || url.ends_with(".gzip") {
-            formats.push(CompressionType::Gzip);
-        }
-        if url.ends_with(".br") {
-            formats.push(CompressionType::Brotli);
-        }
-        if url.ends_with(".zst") {
-            formats.push(CompressionType::Zstd);
-        }
-
-        // Check content signatures
+        // 1. Magic bytes: sovereign truth for snifable formats.
         if content.len() >= 2 {
             // Gzip magic: 0x1f 0x8b
-            if content[0] == 0x1f && content[1] == 0x8b && !formats.contains(&CompressionType::Gzip)
-            {
+            if content[0] == 0x1f && content[1] == 0x8b {
                 formats.push(CompressionType::Gzip);
             }
             // Zstd magic: 0x28 0xb5 0x2f 0xfd or 0x37 0xa4 0x30 0xec
             if content.len() >= 4
-                && !formats.contains(&CompressionType::Zstd)
                 && ((content[0] == 0x28
                     && content[1] == 0xb5
                     && content[2] == 0x2f
@@ -79,6 +85,28 @@ impl CompressionHandler {
             {
                 formats.push(CompressionType::Zstd);
             }
+        }
+
+        // 2. Extension as hint ONLY when magic bytes did not decide.
+        let url_lower = url.to_lowercase();
+        if formats.is_empty() && url_lower.ends_with(".br") {
+            formats.push(CompressionType::Brotli);
+        } else if !formats.is_empty() {
+            tracing::debug!(
+                url = %url,
+                detected = ?formats,
+                "compression detected by magic bytes"
+            );
+        } else if url_lower.ends_with(".gz")
+            || url_lower.ends_with(".gzip")
+            || url_lower.ends_with(".zst")
+        {
+            // #757 guard: transport already decoded or lying extension —
+            // pass through untouched.
+            tracing::debug!(
+                url = %url,
+                "compression hint ignored: no magic bytes (body already decompressed by transport)"
+            );
         }
 
         formats
@@ -208,11 +236,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_detect_gzip_by_extension() {
+    fn test_detect_gzip_by_extension_is_now_hint() {
+        // #757: a `.gz` URL whose payload lacks gzip magic bytes must NOT be
+        // decompressed — transport already decoded it (or the URL lies).
         let url = "https://example.com/sitemap.xml.gz";
-        let content = b"fake gzip content";
-        let formats = CompressionHandler::detect_compression(content, url);
-        assert!(formats.contains(&CompressionType::Gzip));
+
+        // CASE C: plain content behind a .gz URL -> pass-through (empty).
+        let plain = b"<?xml version=\"1.0\"?><urlset/>";
+        let formats = CompressionHandler::detect_compression(plain, url);
+        assert!(
+            formats.is_empty(),
+            "plain content with .gz URL must pass through, got: {formats:?}"
+        );
+
+        // CASE B: real gzip magic behind a .gz URL -> still detected via magic
+        // bytes, regardless of the extension hint.
+        let gzip_content = [0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let formats = CompressionHandler::detect_compression(&gzip_content, url);
+        assert_eq!(formats, vec![CompressionType::Gzip]);
     }
 
     #[test]
@@ -221,6 +262,43 @@ mod tests {
         let content = &[0x1f, 0x8b, b'f', b'a', b'k', b'e'];
         let formats = CompressionHandler::detect_compression(content, url);
         assert!(formats.contains(&CompressionType::Gzip));
+    }
+
+    #[test]
+    fn test_detect_zstd_by_magic() {
+        // Zstd magic wins even for a misleading non-compressed URL.
+        let url = "https://example.com/data.bin";
+        let content = [0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x00];
+        let formats = CompressionHandler::detect_compression(&content, url);
+        assert_eq!(formats, vec![CompressionType::Zstd]);
+    }
+
+    #[test]
+    fn test_detect_zstd_extension_without_magic_passes_through() {
+        // #757 guard applies to .zst too: no magic bytes -> no decompression.
+        let url = "https://example.com/sitemap.xml.zst";
+        let plain = b"<urlset/>";
+        let formats = CompressionHandler::detect_compression(plain, url);
+        assert!(formats.is_empty());
+    }
+
+    #[test]
+    fn test_detect_brotli_extension_hint_when_not_snifable() {
+        // Brotli has no magic bytes; the .br extension remains the hint and
+        // stays fail-closed (decoding errors propagate).
+        let url = "https://example.com/sitemap.xml.br";
+        let content = b"brotli has no magic prefix";
+        let formats = CompressionHandler::detect_compression(content, url);
+        assert_eq!(formats, vec![CompressionType::Brotli]);
+    }
+
+    #[test]
+    fn test_detect_compression_uppercase_extension() {
+        // Extension matching is case-insensitive.
+        let url = "https://example.com/sitemap.xml.BR";
+        let content = b"payload";
+        let formats = CompressionHandler::detect_compression(content, url);
+        assert_eq!(formats, vec![CompressionType::Brotli]);
     }
 
     #[tokio::test]

--- a/crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs
+++ b/crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs
@@ -1004,6 +1004,118 @@ mod tests {
         }
     }
 
+    /// Compress `data` with gzip using the existing workspace dependency
+    /// (`async-compression` only exposes `tokio::bufread` adapters).
+    async fn gzip_compress(data: &[u8]) -> Vec<u8> {
+        use async_compression::tokio::bufread::GzipEncoder;
+        use tokio::io::{AsyncReadExt, BufReader};
+
+        let mut encoder = GzipEncoder::new(BufReader::new(std::io::Cursor::new(data)));
+        let mut out = Vec::new();
+        encoder.read_to_end(&mut out).await.unwrap();
+        out
+    }
+
+    /// #757 regression — the MDN case: a server serves an `.xml.gz` sitemap
+    /// whose body is gzip AND sets `content-encoding: gzip` for transport.
+    /// The HTTP client (`wreq` built with `.gzip(true)`) auto-decompresses the
+    /// transport layer and strips `Content-Encoding`, delivering plain XML.
+    /// Before the fix, `CompressionHandler` trusted the `.gz` extension and
+    /// decompressed again -> "decompression failed: Invalid gzip header".
+    /// After the fix, extension without magic bytes passes through.
+    #[tokio::test]
+    async fn test_sitemap_gz_with_content_encoding_header() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let port = server.address().port();
+
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://developer.mozilla.org/en-US/docs/page1</loc></url>
+            <url><loc>https://developer.mozilla.org/en-US/docs/page2</loc></url>
+        </urlset>"#;
+
+        Mock::given(path("/sitemap.xml.gz"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(gzip_compress(xml.as_bytes()).await, "application/gzip")
+                    .insert_header("content-encoding", "gzip"),
+            )
+            .mount(&server)
+            .await;
+
+        let parser = SitemapParser::new().unwrap();
+        let urls = parser
+            .parse_from_url(&format!("http://127.0.0.1:{port}/sitemap.xml.gz"))
+            .await
+            .expect("body gzip + content-encoding gzip must parse (#757)");
+        assert_eq!(urls.len(), 2);
+    }
+
+    /// #757 case (b): a gzip body behind a `.gz` URL WITHOUT a transport
+    /// `content-encoding` header. Today this works; it must keep working —
+    /// magic-byte sniffing detects gzip and the handler decompresses.
+    #[tokio::test]
+    async fn test_sitemap_gz_body_without_content_encoding() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let port = server.address().port();
+
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://example.com/page1</loc></url>
+        </urlset>"#;
+
+        Mock::given(path("/manual.xml.gz"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(gzip_compress(xml.as_bytes()).await, "application/gzip"),
+            )
+            .mount(&server)
+            .await;
+
+        let parser = SitemapParser::new().unwrap();
+        let urls = parser
+            .parse_from_url(&format!("http://127.0.0.1:{port}/manual.xml.gz"))
+            .await
+            .expect("gzip body without content-encoding must still decompress");
+        assert_eq!(urls.len(), 1);
+    }
+
+    /// #757 case (c): a plain (already-decoded) body behind a lying `.gz` URL
+    /// with no compression headers. Before the fix this failed with
+    /// "Invalid gzip header" because the extension forced decompression;
+    /// after the fix, magic-byte sniffing passes it through untouched.
+    #[tokio::test]
+    async fn test_sitemap_lying_gz_extension_with_plain_body() {
+        use wiremock::matchers::path;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let port = server.address().port();
+
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://example.com/page1</loc></url>
+        </urlset>"#;
+
+        Mock::given(path("/sitemap.xml.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(xml))
+            .mount(&server)
+            .await;
+
+        let parser = SitemapParser::new().unwrap();
+        let urls = parser
+            .parse_from_url(&format!("http://127.0.0.1:{port}/sitemap.xml.gz"))
+            .await
+            .expect("plain body behind .gz URL must pass through (#757)");
+        assert_eq!(urls.len(), 1);
+    }
+
     #[tokio::test]
     async fn test_parse_sitemap_with_namespaces() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Linked Issue

Closes #757

## PR Type

- [x] Bug fix (`type:bug`)
- [ ] New feature (`type:feature`)
- [ ] Documentation only (`type:docs`)
- [ ] Code refactoring (`type:refactor`)
- [ ] Maintenance / tooling (`type:chore`)
- [ ] Breaking change (`type:breaking-change`)

## Summary

- Sitemaps `.xml.gz` served with `Content-Encoding: gzip` failed with `decompression failed: Invalid gzip header`: wreq (`.gzip(true)`) auto-decompresses the transport layer and strips the header, while `CompressionHandler::detect_compression` trusted the `.gz` URL extension and decompressed the already-decoded XML again (MDN: 10/10 child sitemaps failed, breaking `--use-sitemap` on large sites).
- Detection is now magic-byte-first for snifable formats (gzip `0x1f8b`, zstd frame/skippable); the extension is only a fallback hint for non-snifable brotli (`.br`, stays fail-closed). A `.gz`/`.gzip`/`.zst` URL whose payload lacks magic bytes passes through untouched (transport already decoded, or lying extension), logged at `debug` for trace-file audits.
- The alternative of disabling wreq transport decompression for the sitemap client was rejected: it would drop browser-like `Accept-Encoding` headers and weaken the WAF fingerprint that is the reason wreq exists in this scraper.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/infrastructure/crawler/compression_handler.rs` | `detect_compression`: magic bytes sovereign (gzip/zstd); extension demoted to fallback hint (brotli only, case-insensitive); pass-through + `tracing::debug!` for `.gz`/`.gzip`/`.zst` without magic; module and fn doc comments document the #757 detection contract |
| `crates/webfang_core/src/infrastructure/crawler/sitemap_parser.rs` | 3 wiremock end-to-end regression tests: (a) the exact MDN case — body gzip + `content-encoding: gzip` (broken path), (b) gzip body without the header (must keep decompressing), (c) plain body behind a lying `.gz` URL (now passes through); `gzip_compress` helper using the existing workspace `async-compression` dep |
| `CHANGELOG.md` | Unreleased / Fixed entry for #757 |

No signature changes: `detect_compression(content, url)` stays associated, so both fuzz targets (`fuzz_compression_detect`, `fuzz_decompression`) compile untouched. `detect_and_decompress` keeps its fail-closed streaming `take(max)` zip-bomb guard.

## Test Plan

- [x] `cargo fmt --check` clean (fmt applied)
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run` passes (2150 passed, 0 failed — full `webfang_core` suite including root integration tests)
- [x] Manually verified the affected functionality: `webfang --url https://developer.mozilla.org --sitemap-url https://developer.mozilla.org/sitemap.xml --dry-run` → exit 0, 66,674 URLs discovered, zero decompression errors (before: all 10 child sitemaps failed)

## Contributor Checklist

- [x] Linked an approved issue (`status:approved`) with `Closes/Fixes/Resolves #N`
- [x] Branch name matches `type/description` (e.g. `fix/parser-crash`) — CI rejects others
- [x] Added exactly one `type:*` label
- [x] Conventional commit format (`type(scope): description`)
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (CHANGELOG.md)
- [x] Defensive error paths annotated with `// LCOV_EXCL_*` markers per docs/src/testing.md (issue #527) — N/A: no new unreachable defensive paths introduced
