### PR TITLE
fix(mcp): align detect_spa with the scrape extraction chain

### DIFF
--- a/crates/webfang_core/src/application/spa_detection.rs
+++ b/crates/webfang_core/src/application/spa_detection.rs
@@ -70,6 +70,50 @@ pub fn detect_spa_content(
     })
 }
 
+/// Predict whether a scrape of `raw_html` will satisfy the minimum-content
+/// guard, by running the same cleaning and extraction chain the real scrape
+/// uses (#760).
+///
+/// This is the prediction oracle for the MCP `detect_spa` tool: its verdict
+/// must anticipate the scrape's own verdict so the tool never claims
+/// "sufficient content" for a page the scrape is about to reject. It
+/// replicates the exact chain of the default MCP funnel
+/// (`build_scraped_content`):
+///
+/// 1. [`crate::infrastructure::converter::html_cleaner::clean_html`] on the raw
+///    HTML — removes `<noscript>`/`<header>`/`<footer>`/hidden nodes, the very
+///    text that made the old raw-HTML-only detector answer "sufficient content"
+///    while the scrape extracted almost nothing.
+/// 2. Readability on the cleaned HTML; on failure the two-step fallback:
+///    [`crate::infrastructure::scraper::fallback::extract_text`] (htmd) and a
+///    second [`crate::infrastructure::converter::html_cleaner::clean_html`]
+///    pass over the extracted text — byte-for-byte the funnel's own fallback.
+/// 3. [`detect_spa_content`] on the resulting text, with the ORIGINAL raw HTML
+///    for marker inspection (same inputs the guard receives).
+///
+/// # Parity limits
+///
+/// Prediction is only valid for the DEFAULT pipeline: a non-`body` CSS
+/// selector or adaptive selector repair configured on the real scrape are not
+/// modelled here.
+///
+/// # Performance
+///
+/// Runs a full clean + extraction (Readability or htmd + double clean), so it
+/// costs roughly one extraction pass. Acceptable for a diagnostic tool that
+/// runs before the scrape, in place of a wrong cheap signal.
+pub fn predict_spa_status(url: &str, raw_html: &str) -> Option<SpaDetectionResult> {
+    use crate::infrastructure::converter::html_cleaner::clean_html;
+    use crate::infrastructure::scraper::{fallback, readability};
+
+    let cleaned_html = clean_html(raw_html);
+    let extracted_text = match readability::parse(&cleaned_html, Some(url)) {
+        Ok(article) => article.text_content,
+        Err(_) => clean_html(&fallback::extract_text(&cleaned_html)),
+    };
+    detect_spa_content(url, &extracted_text, raw_html)
+}
+
 /// Shared minimum-content guard for BOTH extraction funnels (#706).
 ///
 /// Applies [`detect_spa_content`] to the freshly extracted content and fails
@@ -285,6 +329,79 @@ mod tests {
         assert!(
             !reason.contains("renderizado de JavaScript"),
             "no-marker variant must not claim JS requirement: {reason}"
+        );
+    }
+
+    // --- predict_spa_status: the MCP detect_spa prediction oracle (#760) ---
+
+    /// #760 regression: a JS-only shell whose `<noscript>` carries 200+ chars
+    /// must be flagged. The pre-fix `detect_spa` tool counted raw htmd text
+    /// (noscript included) and answered "sufficient content", contradicting
+    /// the scrape, which cleans first and extracts almost nothing.
+    #[cfg_attr(miri, ignore)] // clean_html → lol_html/servo_arc Tree Borrows UB (#487, #764)
+    #[test]
+    fn test_predict_js_shell_with_fat_noscript_is_flagged() {
+        let html = format!(
+            "<html><head><title>JS App</title></head><body>\
+             <div id=\"app\"></div>\
+             <noscript>{}</noscript>\
+             </body></html>",
+            "JavaScript must be enabled to view this quoting application. ".repeat(4)
+        );
+        // The pre-fix detector's input (raw htmd text) clears the 50-char
+        // threshold: the exact false negative this test pins.
+        let raw_text = crate::infrastructure::scraper::fallback::extract_text(&html);
+        assert!(
+            raw_text.chars().count() >= MIN_CONTENT_CHARS,
+            "fixture must defeat the old raw-HTML detector, got {} chars",
+            raw_text.chars().count()
+        );
+
+        let result = predict_spa_status(URL, &html)
+            .expect("the prediction oracle must flag the JS shell the scrape will reject");
+        assert!(
+            result.has_spa_markers,
+            "the app mount point in the raw HTML must be reported"
+        );
+        assert!(
+            result.char_count < MIN_CONTENT_CHARS,
+            "cleaned extraction must stay under the threshold, got {}",
+            result.char_count
+        );
+    }
+
+    /// #760: SSR pages with hydration markers but substantial text stay
+    /// unflagged — the char gate runs before marker inspection.
+    #[cfg_attr(miri, ignore)] // clean_html → lol_html/servo_arc Tree Borrows UB (#487, #764)
+    #[test]
+    fn test_predict_ssr_with_markers_keeps_substantial_content() {
+        let html = "<html><head><title>Docs</title></head><body>\
+             <script id=\"__NEXT_DATA__\" type=\"application/json\">{}</script>\
+             <article><h1>Guide</h1>\
+             <p>This is a substantially long paragraph of server-rendered \
+             article content, easily over the fifty character extraction \
+             threshold, so the prediction must stay quiet.</p>\
+             </article></body></html>";
+        assert!(
+            predict_spa_status(URL, html).is_none(),
+            "substantial SSR content must not be flagged even with hydration markers"
+        );
+    }
+
+    /// #760: when Readability cannot find an article, the oracle must follow
+    /// the funnel's own fallback (htmd + second clean) — the same verdict the
+    /// scrape's guard would reach on that branch.
+    #[cfg_attr(miri, ignore)] // clean_html → lol_html/servo_arc Tree Borrows UB (#487, #764)
+    #[test]
+    fn test_predict_readability_failure_uses_funnel_fallback() {
+        // The known Readability-failure fixture from extraction.rs (CE-3):
+        // a document without article content.
+        let html = "<html><body><a href=\"/x\"></a></body></html>";
+        let result = predict_spa_status(URL, html)
+            .expect("a document without extractable text must be flagged");
+        assert!(
+            result.char_count < MIN_CONTENT_CHARS,
+            "the fallback branch must count the cleaned htmd text"
         );
     }
 }

--- a/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
+++ b/crates/webfang_mcp/src/mcp_server/handlers/scraping.rs
@@ -615,12 +615,16 @@ impl McpHandler {
         }
     }
 
-    /// Detect if a URL requires JavaScript rendering (SPA)
+    /// Predict if a URL requires JavaScript rendering (SPA)
+    ///
+    /// Runs the same cleaning + extraction chain the default scrape uses
+    /// (`predict_spa_status`, #760), so the verdict anticipates whether the
+    /// scrape itself will fail the minimum-content guard.
     ///
     /// Respects the site's robots.txt: a disallowed URL is rejected with a
     /// `robots.txt` error before any fetch (#749, uniform with #697).
     #[tool(
-        description = "Detect if a page requires JavaScript rendering (Single Page Application). Checks for minimal content and SPA markers like <div id=\"root\"> or <div id=\"app\">."
+        description = "Predicts if a page requires JavaScript rendering (Single Page Application) by running the same cleaning and extraction pipeline as a scrape, so its verdict matches what the scrape would do. Reports insufficient-content diagnostics and SPA markers (e.g. <div id=\"root\">, <div id=\"app\">) when the default pipeline cannot extract enough text."
     )]
     #[instrument(skip(self), fields(url = %params.url))]
     // serde_json::to_string cannot fail for a serde_json::Value.
@@ -669,10 +673,12 @@ impl McpHandler {
                     &root_correlation,
                 );
                 let html = resp.body;
-                let text = webfang_core::infrastructure::scraper::fallback::extract_text(&html);
-                match webfang_core::application::scraper_service::detect_spa_content(
+                // #760: run the same cleaning + extraction chain the scrape's
+                // minimum-content guard consumes, so the tool's verdict
+                // anticipates the scrape's (the old raw-htmd path counted
+                // <noscript>/header/footer text the real pipeline discards).
+                match webfang_core::application::spa_detection::predict_spa_status(
                     url.as_str(),
-                    &text,
                     &html,
                 ) {
                     Some(info) => {

--- a/crates/webfang_mcp/tests/scraping_coverage_test.rs
+++ b/crates/webfang_mcp/tests/scraping_coverage_test.rs
@@ -3,7 +3,8 @@
 //! End-to-end tests for scraping tools not covered by the existing suite:
 //! - `scrape_url`: invalid-URL invalid-params (-32602) + HTTP error path
 //! - `discover_urls`: real link extraction (internal + external)
-//! - `detect_spa`: SPA-marker detection vs. sufficient-content pass
+//! - `detect_spa`: SPA-marker detection vs. sufficient-content pass vs.
+//!   scrape-verdict parity on a JS shell (#760)
 //! - `scrape_batch`: partial results when some URLs fail
 //! - `crawl_site`: BFS with max_depth=0 (seed only) and max_depth=1 (follows
 //!   internal links)
@@ -499,6 +500,82 @@ async fn test_detect_spa_sufficient_content_not_spa() {
         tool_text(&result)
     );
     assert_eq!(tool_text(&result), "not an SPA - sufficient content found");
+}
+
+/// #760 parity: one JS-shell fixture (app mount point + a long `<noscript>`
+/// block that defeated the pre-fix detector — raw htmd counted the noscript
+/// text, clean-based extraction does not) must produce IDENTICAL verdicts on
+/// both surfaces: `detect_spa` reports an SPA (JSON, markers true) and
+/// `scrape_url` fails honestly with the JavaScript-rendering error. The tool
+/// signal now PREDICTS the scrape's behavior instead of contradicting it.
+#[tokio::test]
+async fn test_detect_spa_predicts_scrape_verdict_on_js_shell() {
+    let mock = MockServer::start().await;
+    // Shell whose only text lives inside <noscript>: enough (200+ chars) to
+    // clear MIN_CONTENT_CHARS on the old raw-htmd detector, near-zero once the
+    // real pipeline's cleaning runs.
+    let html = format!(
+        "<!DOCTYPE html><html><head><title>JS App</title></head><body>\
+         <div id=\"app\"></div>\
+         <noscript>{}</noscript>\
+         </body></html>",
+        "JavaScript must be enabled to view this quoting application. ".repeat(4)
+    );
+    mount_page_200(&mock, "/", &html).await;
+
+    let (base_url, _handle) = start_test_server().await;
+    let client = Client::new();
+    let session_id = init_session(&client, &base_url).await;
+
+    // 1. detect_spa must predict the SPA verdict (JSON with markers), not the
+    //    pre-fix "not an SPA - sufficient content found" literal.
+    let result =
+        call_single_url_tool_result(&client, &base_url, &session_id, "detect_spa", &mock.uri())
+            .await;
+    assert!(
+        !is_tool_error(&result),
+        "detect_spa should succeed: {}",
+        tool_text(&result)
+    );
+    let text = tool_text(&result);
+    assert_ne!(
+        text, "not an SPA - sufficient content found",
+        "the tool must no longer contradict the scrape on a JS shell"
+    );
+    let parsed: Value = serde_json::from_str(&text).expect("SPA result must be valid JSON");
+    assert_eq!(
+        parsed.get("has_spa_markers").and_then(|v| v.as_bool()),
+        Some(true),
+        "the app mount point must be reported: {parsed}"
+    );
+    let char_count = parsed
+        .get("char_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(u64::MAX);
+    assert!(
+        char_count < 50,
+        "extracted content after cleaning must be below the threshold: {parsed}"
+    );
+
+    // 2. scrape_url on the SAME fixture must fail with the JS-rendering
+    //    verdict the tool just predicted.
+    let scrape_result =
+        call_single_url_tool_result(&client, &base_url, &session_id, "scrape_url", &mock.uri())
+            .await;
+    assert!(
+        is_tool_error(&scrape_result),
+        "the scrape must fail the minimum-content guard the tool predicted: {}",
+        tool_text(&scrape_result)
+    );
+    assert!(
+        tool_text(&scrape_result).contains("renderizado de JavaScript"),
+        "the scrape error must name the JS cause: {}",
+        tool_text(&scrape_result)
+    );
+
+    // Snapshot (XC-2): redact the wiremock port for determinism.
+    let redacted = text.replace(&mock.uri(), "http://127.0.0.1:<PORT>");
+    insta::assert_snapshot!("detect_spa_js_shell_predicts_scrape", redacted);
 }
 
 // ============================================================================

--- a/crates/webfang_mcp/tests/snapshots/scraping_coverage_test__detect_spa_js_shell_predicts_scrape.snap
+++ b/crates/webfang_mcp/tests/snapshots/scraping_coverage_test__detect_spa_js_shell_predicts_scrape.snap
@@ -1,0 +1,9 @@
+---
+source: crates/webfang_mcp/tests/scraping_coverage_test.rs
+expression: redacted
+---
+{
+  "char_count": 6,
+  "has_spa_markers": true,
+  "url": "http://127.0.0.1:<PORT>/"
+}


### PR DESCRIPTION
## Linked Issue

Closes #760

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- The MCP `detect_spa` tool and the CLI scrape disagreed on the same JS-only page (audit 2026-08-17, `quotes.toscrape.com/js/`): the scrape failed with "requiere renderizado de JavaScript" while the tool answered "not an SPA - sufficient content found".
- Root cause: the tool counted raw `htmd` text over UNCLEANED HTML, so `<noscript>`/`<header>`/`<footer>` text cleared the 50-char threshold while the real pipeline (clean_html → readability/fallback → guard) discards it and extracts almost nothing.
- Fix: new `predict_spa_status` in `application::spa_detection` runs the exact `build_scraped_content` chain (clean → readability/fallback + re-clean) and the handler consumes it — the tool signal now **predicts** the scrape's verdict.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/spa_detection.rs` | New `predict_spa_status(url, raw_html)` — same extraction chain as the MCP funnel, markers on raw HTML; unit tests for fat-noscript shell, SSR markers, fallback parity |
| `crates/webfang_mcp/src/mcp_server/handlers/scraping.rs` | `detect_spa` handler switched to the predictor; SSRF/robots/semaphore/identity untouched; tool description documents the prediction semantics |
| `crates/webfang_mcp/tests/scraping_coverage_test.rs` | Parity integration test: one JS-shell fixture yields identical verdicts on `detect_spa` (JSON, markers) and `scrape_url` (honest JS-rendering error) + snapshot |
| `crates/webfang_mcp/tests/snapshots/…predicts_scrape.snap` | New snapshot (port-redacted) |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean (exact CI gate)
- [x] `cargo nextest run` passes (full workspace; unrelated `cli_binary_test`/`exit_code_integration` binary-respawn flakes observed locally were proven to be shared-target-dir contention with a concurrent sibling session, fixed on rebuild)
- [x] `test_detect_spa_predicts_scrape_verdict_on_js_shell` asserts both tools agree on the same wiremock fixture

## Contributor Checklist

- [x] Linked an approved issue with `Closes #760`
- [x] Branch name matches `fix/mcp-detect-spa`
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format
- [x] No AI attribution trailers
- [x] Behavior change documented in tool description + function docs