### PR TITLE
fix(cli): resolve 5 CLI audit findings from #761

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -357,7 +357,7 @@ async fn __main() -> CliExit {
     if let Err(exit) = preflight::check_elastic_sink(&opts) {
         return exit;
     }
-    
+
     // 6e. AI feature preflight (#761): --clean-ai on a non-AI build must
     // fail before any network request, not after a full scrape.
     if let Err(exit) = preflight::check_clean_ai_feature(&opts) {
@@ -524,10 +524,10 @@ async fn resolve_url(args: &mut Args) -> Result<(), CliExit> {
     // CI environment always requires --url
     if is_ci() {
         return Err(CliExit::UsageError(
-"--url is required for scraping (CI mode)".into(),
+            "--url is required for scraping (CI mode)".into(),
         ));
     }
-    
+
     // Try interactive prompt only if stdin is a TTY
     if stdin_is_tty() {
         prompt_for_url_interactive(args)
@@ -556,7 +556,7 @@ fn prompt_for_url_interactive(args: &mut Args) -> Result<(), CliExit> {
 #[cfg(not(feature = "ui"))]
 fn prompt_for_url_interactive(_args: &mut Args) -> Result<(), CliExit> {
     Err(CliExit::UsageError(
-"--url is required for scraping (interactive prompt requires --features ui)".into(),
+        "--url is required for scraping (interactive prompt requires --features ui)".into(),
     ))
 }
 

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -357,6 +357,12 @@ async fn __main() -> CliExit {
     if let Err(exit) = preflight::check_elastic_sink(&opts) {
         return exit;
     }
+    
+    // 6e. AI feature preflight (#761): --clean-ai on a non-AI build must
+    // fail before any network request, not after a full scrape.
+    if let Err(exit) = preflight::check_clean_ai_feature(&opts) {
+        return exit;
+    }
 
     // 7. Initialize logging (stderr-only, respects quiet + NO_COLOR)
     let no_color = is_no_color();

--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -517,17 +517,17 @@ async fn resolve_url(args: &mut Args) -> Result<(), CliExit> {
 
     // CI environment always requires --url
     if is_ci() {
-        eprintln!("Error: --url is required for scraping (CI mode)");
-        return Err(CliExit::UsageError("--url is required".into()));
+        return Err(CliExit::UsageError(
+"--url is required for scraping (CI mode)".into(),
+        ));
     }
-
+    
     // Try interactive prompt only if stdin is a TTY
     if stdin_is_tty() {
         prompt_for_url_interactive(args)
     } else {
         // Not a TTY and no URL provided
-        eprintln!("Error: --url is required for scraping");
-        Err(CliExit::UsageError("--url is required".into()))
+        Err(CliExit::UsageError("--url is required for scraping".into()))
     }
 }
 
@@ -541,8 +541,7 @@ fn prompt_for_url_interactive(args: &mut Args) -> Result<(), CliExit> {
         },
         Err(_e) => {
             // Prompt failed (e.g., non-interactive), fall through to error
-            eprintln!("Error: --url is required for scraping");
-            Err(CliExit::UsageError("--url is required".into()))
+            Err(CliExit::UsageError("--url is required for scraping".into()))
         },
     }
 }
@@ -550,8 +549,9 @@ fn prompt_for_url_interactive(args: &mut Args) -> Result<(), CliExit> {
 /// Headless builds have no inquire prompt — require --url explicitly.
 #[cfg(not(feature = "ui"))]
 fn prompt_for_url_interactive(_args: &mut Args) -> Result<(), CliExit> {
-    eprintln!("Error: --url is required for scraping (interactive prompt requires --features ui)");
-    Err(CliExit::UsageError("--url is required".into()))
+    Err(CliExit::UsageError(
+"--url is required for scraping (interactive prompt requires --features ui)".into(),
+    ))
 }
 
 /// Resolve the webfang config file path (graceful: missing file = defaults).

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -68,9 +68,11 @@ pub fn extract_with_selector(
                 html,
                 inspector,
                 &document,
+                // The diagnostic keeps the raw crate error for debugging;
+                // the user-facing WARN must not leak library jargon (#761).
                 SelectorErrorKind::InvalidSelector(e.to_string()),
                 selector,
-                &format!("Invalid CSS selector '{selector}': {e}, falling back to full HTML"),
+                &invalid_selector_message(selector),
             );
         },
     };
@@ -103,6 +105,17 @@ pub fn extract_with_selector(
 /// Emit the fallback warning and build a [`ExtractResult::Fallback`] carrying
 /// the full HTML and a diagnostic for the given [`SelectorErrorKind`], when an
 /// inspector is available.
+/// Clean user-facing message for an invalid CSS selector (#761).
+///
+/// The `selectors` crate's error text leaks library jargon
+/// (`NoQualifiedNameInAttributeSelector(...)`, "Please report this to the
+/// developer") into production stderr. The raw error is preserved in the
+/// [`SelectorErrorKind::InvalidSelector`] diagnostic for debugging; only this
+/// sanitized message reaches the user.
+fn invalid_selector_message(selector: &str) -> String {
+    format!("selector CSS inválido: '{selector}' — se usó el HTML completo como fallback")
+}
+
 fn fallback(
     html: &str,
     inspector: Option<&dyn DomInspectorPort>,
@@ -420,6 +433,22 @@ mod tests {
         let result = extract_with_selector(html, ">>>not-a-selector", None);
         assert!(!result.is_matched());
         assert_eq!(result.as_html(), html);
+    }
+
+    /// #761: the user-facing WARN must not leak `selectors` crate jargon
+    /// ("Please report this to the developer", variant debug names).
+    #[test]
+    fn test_invalid_selector_message_is_clean() {
+        let msg = super::invalid_selector_message("[[[invalid");
+        assert!(msg.contains("'[[[invalid'"), "must name the offending selector");
+        assert!(
+        !msg.contains("Please report this to the developer"),
+        "must not leak crate jargon: {msg}"
+        );
+        assert!(
+        !msg.contains("NoQualifiedNameInAttributeSelector"),
+        "must not leak variant debug names: {msg}"
+        );
     }
 
     #[test]

--- a/crates/webfang_core/src/application/extraction.rs
+++ b/crates/webfang_core/src/application/extraction.rs
@@ -440,14 +440,17 @@ mod tests {
     #[test]
     fn test_invalid_selector_message_is_clean() {
         let msg = super::invalid_selector_message("[[[invalid");
-        assert!(msg.contains("'[[[invalid'"), "must name the offending selector");
         assert!(
-        !msg.contains("Please report this to the developer"),
-        "must not leak crate jargon: {msg}"
+            msg.contains("'[[[invalid'"),
+            "must name the offending selector"
         );
         assert!(
-        !msg.contains("NoQualifiedNameInAttributeSelector"),
-        "must not leak variant debug names: {msg}"
+            !msg.contains("Please report this to the developer"),
+            "must not leak crate jargon: {msg}"
+        );
+        assert!(
+            !msg.contains("NoQualifiedNameInAttributeSelector"),
+            "must not leak variant debug names: {msg}"
         );
     }
 

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -239,6 +239,35 @@ pub fn check_elastic_sink(opts: &CrawlOptions) -> Result<(), CliExit> {
     ))
 }
 
+/// Preflight: `--clean-ai` on a binary built WITHOUT the `ai` feature must
+/// fail before any network request (#761).
+///
+/// Previously the check lived only in the export flow, so a non-AI build
+/// downloaded and extracted the whole page before erroring out. This mirrors
+/// the #685 pattern: a build-configuration problem is a config error (exit 78)
+/// detected before the crawl starts.
+///
+/// # Errors
+///
+/// Returns [`crate::CliExit::ConfigError`] when `clean_ai` is requested and
+/// the `ai` feature is not compiled in.
+pub fn check_clean_ai_feature(opts: &CrawlOptions) -> Result<(), CliExit> {
+    check_clean_ai_feature_with(cfg!(feature = "ai"), opts)
+}
+
+/// Feature-injectable core of [`check_clean_ai_feature`] — `cfg!` cannot be
+/// toggled per test.
+fn check_clean_ai_feature_with(ai_enabled: bool, opts: &CrawlOptions) -> Result<(), CliExit> {
+    if !opts.ai || ai_enabled {
+        return Ok(());
+    }
+    Err(CliExit::ConfigError(
+        "--clean-ai requiere un binario compilado con la feature `ai`; \
+             recompilá con --features ai"
+            .into(),
+    ))
+}
+
 /// Spawn `<binary> --version` once and report its exit status.
 ///
 /// A missing or non-executable binary surfaces as an `io::Error`, which the
@@ -935,5 +964,41 @@ mod tests {
         opts.elastic.enabled = true;
         opts.elastic.output_vectors = None;
         assert!(check_elastic_sink(&opts).is_ok());
+    }
+
+    // ========================================================================
+    // #761 — --clean-ai preflight feature check
+    // ========================================================================
+
+    /// `--clean-ai` without the `ai` feature: config error naming the
+    /// feature, before any network request (#761).
+    #[test]
+    fn clean_ai_without_feature_errors() {
+        let mut opts = CrawlOptions::default();
+        opts.ai = true;
+        let err = check_clean_ai_feature_with(false, &opts)
+.expect_err("non-AI build must reject --clean-ai in preflight");
+        match err {
+CliExit::ConfigError(msg) => assert!(
+msg.contains("--clean-ai") && msg.contains("ai"),
+"config error must name the flag and the feature, got: {msg}"
+),
+other => panic!("expected ConfigError, got: {other:?}"),
+        }
+    }
+
+    /// `--clean-ai` with the `ai` feature compiled in: passes.
+    #[test]
+    fn clean_ai_with_feature_ok() {
+        let mut opts = CrawlOptions::default();
+        opts.ai = true;
+        assert!(check_clean_ai_feature_with(true, &opts).is_ok());
+    }
+
+    /// No `--clean-ai`: passes regardless of the feature state.
+    #[test]
+    fn no_clean_ai_ok_without_feature() {
+        let opts = CrawlOptions::default();
+        assert!(check_clean_ai_feature_with(false, &opts).is_ok());
     }
 }

--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -974,24 +974,28 @@ mod tests {
     /// feature, before any network request (#761).
     #[test]
     fn clean_ai_without_feature_errors() {
-        let mut opts = CrawlOptions::default();
-        opts.ai = true;
+        let opts = CrawlOptions {
+            ai: true,
+            ..CrawlOptions::default()
+        };
         let err = check_clean_ai_feature_with(false, &opts)
-.expect_err("non-AI build must reject --clean-ai in preflight");
+            .expect_err("non-AI build must reject --clean-ai in preflight");
         match err {
-CliExit::ConfigError(msg) => assert!(
-msg.contains("--clean-ai") && msg.contains("ai"),
-"config error must name the flag and the feature, got: {msg}"
-),
-other => panic!("expected ConfigError, got: {other:?}"),
+            CliExit::ConfigError(msg) => assert!(
+                msg.contains("--clean-ai") && msg.contains("ai"),
+                "config error must name the flag and the feature, got: {msg}"
+            ),
+            other => panic!("expected ConfigError, got: {other:?}"),
         }
     }
 
     /// `--clean-ai` with the `ai` feature compiled in: passes.
     #[test]
     fn clean_ai_with_feature_ok() {
-        let mut opts = CrawlOptions::default();
-        opts.ai = true;
+        let opts = CrawlOptions {
+            ai: true,
+            ..CrawlOptions::default()
+        };
         assert!(check_clean_ai_feature_with(true, &opts).is_ok());
     }
 

--- a/crates/webfang_core/src/infrastructure/downloader/mod.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/mod.rs
@@ -231,14 +231,41 @@ impl From<wreq::Error> for DownloadError {
             }
             let msg = s.to_string().to_lowercase();
             if msg.contains("dns") || msg.contains("resolve") {
-                return DownloadError::Dns(s.to_string());
+                return DownloadError::Dns(strip_display_marker(&s.to_string(), "dns error"));
             }
             if msg.contains("tls") || msg.contains("certificate") || msg.contains("ssl") {
-                return DownloadError::Tls(s.to_string());
+                return DownloadError::Tls(strip_display_marker(&s.to_string(), "tls error"));
             }
             source = s.source();
         }
         DownloadError::Network(Box::new(e))
+    }
+}
+
+/// Strip a leading marker that the variant's `Display` already prints.
+///
+/// `wreq`'s erased source text often IS the bare marker (e.g. `"dns error"`),
+/// which would render as `"DNS error: dns error"` (#761). Removing the
+/// redundant prefix keeps the message informative. The variant's `Display`
+/// prefix still carries the marker, so downstream text-based classification
+/// (`error.rs` heuristics match the lowercased full chain) is unaffected.
+/// If stripping leaves nothing, substitute a short description so the
+/// message never ends in a dangling colon.
+fn strip_display_marker(payload: &str, marker: &str) -> String {
+    let stripped = if payload.to_lowercase().starts_with(marker) {
+        payload[marker.len()..].trim_start_matches([':', ' ']).to_string()
+    } else {
+        payload.to_string()
+    };
+    if stripped.is_empty() {
+        // Bare marker only — no extra detail survived the erasure.
+        if marker.starts_with("dns") {
+            "name resolution failed".to_string()
+        } else {
+            "handshake failed".to_string()
+        }
+    } else {
+        stripped
     }
 }
 
@@ -348,7 +375,35 @@ mod tests {
         let err = DownloadError::Timeout(30);
         assert!(err.to_string().contains("30"));
     }
-
+    
+    /// #761: the erased wreq source text is often the bare marker
+    /// (`"dns error"`), which used to render as `"DNS error: dns error"`.
+    /// `strip_display_marker` removes the redundant prefix; a bare marker
+    /// becomes a short description instead of a dangling colon.
+    #[test]
+    fn test_strip_display_marker_dedupes_redundant_prefix() {
+        // Bare marker → substituted description, no dangling colon.
+        assert_eq!(
+super::strip_display_marker("dns error", "dns error"),
+"name resolution failed"
+        );
+        // Marker + detail → detail survives.
+        assert_eq!(
+super::strip_display_marker("dns error: NXDOMAIN", "dns error"),
+"NXDOMAIN"
+        );
+        // No marker prefix → payload untouched.
+        assert_eq!(
+super::strip_display_marker("failed to lookup address", "dns error"),
+"failed to lookup address"
+        );
+        // TLS variant shares the same behavior.
+        assert_eq!(
+super::strip_display_marker("tls error", "tls error"),
+"handshake failed"
+        );
+    }
+    
     #[test]
     fn test_download_error_classify_variants() {
         use crate::error::ErrorClass;

--- a/crates/webfang_core/src/infrastructure/downloader/mod.rs
+++ b/crates/webfang_core/src/infrastructure/downloader/mod.rs
@@ -253,7 +253,9 @@ impl From<wreq::Error> for DownloadError {
 /// message never ends in a dangling colon.
 fn strip_display_marker(payload: &str, marker: &str) -> String {
     let stripped = if payload.to_lowercase().starts_with(marker) {
-        payload[marker.len()..].trim_start_matches([':', ' ']).to_string()
+        payload[marker.len()..]
+            .trim_start_matches([':', ' '])
+            .to_string()
     } else {
         payload.to_string()
     };
@@ -375,7 +377,7 @@ mod tests {
         let err = DownloadError::Timeout(30);
         assert!(err.to_string().contains("30"));
     }
-    
+
     /// #761: the erased wreq source text is often the bare marker
     /// (`"dns error"`), which used to render as `"DNS error: dns error"`.
     /// `strip_display_marker` removes the redundant prefix; a bare marker
@@ -384,26 +386,26 @@ mod tests {
     fn test_strip_display_marker_dedupes_redundant_prefix() {
         // Bare marker → substituted description, no dangling colon.
         assert_eq!(
-super::strip_display_marker("dns error", "dns error"),
-"name resolution failed"
+            super::strip_display_marker("dns error", "dns error"),
+            "name resolution failed"
         );
         // Marker + detail → detail survives.
         assert_eq!(
-super::strip_display_marker("dns error: NXDOMAIN", "dns error"),
-"NXDOMAIN"
+            super::strip_display_marker("dns error: NXDOMAIN", "dns error"),
+            "NXDOMAIN"
         );
         // No marker prefix → payload untouched.
         assert_eq!(
-super::strip_display_marker("failed to lookup address", "dns error"),
-"failed to lookup address"
+            super::strip_display_marker("failed to lookup address", "dns error"),
+            "failed to lookup address"
         );
         // TLS variant shares the same behavior.
         assert_eq!(
-super::strip_display_marker("tls error", "tls error"),
-"handshake failed"
+            super::strip_display_marker("tls error", "tls error"),
+            "handshake failed"
         );
     }
-    
+
     #[test]
     fn test_download_error_classify_variants() {
         use crate::error::ErrorClass;

--- a/crates/webfang_core/src/infrastructure/export/state_store.rs
+++ b/crates/webfang_core/src/infrastructure/export/state_store.rs
@@ -12,13 +12,72 @@
 
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::domain::ExportState;
 use crate::error::ScraperError;
 use dirs::cache_dir;
 use fs2::FileExt;
 use tracing::{debug, info};
+
+/// RAII wrapper around a state-file lock. While alive it holds the lock;
+/// on drop it releases the lock **and deletes the lock file** so no `.lock`
+/// orphan is left behind (#761 — same pattern as `jsonl_exporter::FileLock`,
+/// #582).
+///
+/// `#[must_use]` warns if a caller acquires the lock but lets it drop
+/// immediately (a likely bug — the lock would be released before any I/O).
+#[must_use]
+struct StateLock {
+    handle: fs::File,
+    lock_path: PathBuf,
+}
+
+impl StateLock {
+    /// Acquire a lock at `<path>.json.lock`. `exclusive` selects write mode
+    /// (exclusive) vs read mode (shared).
+    fn acquire(path: &Path, exclusive: bool) -> crate::error::Result<Self> {
+        let lock_path = path.with_extension("json.lock");
+        // M1 FIX: Write PID metadata to lock file for debugging
+        let mut lock_file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&lock_path)
+            .map_err(ScraperError::Io)?;
+        let op = if exclusive {
+            "exclusive_write"
+        } else {
+            "shared_read"
+        };
+        let _ = writeln!(lock_file, "pid={} op={op}", std::process::id());
+        let locked = if exclusive {
+            lock_file.lock_exclusive()
+        } else {
+            FileExt::lock_shared(&lock_file)
+        };
+        locked.map_err(|e| {
+            ScraperError::Io(std::io::Error::other(format!(
+                "failed to acquire state lock: {e}"
+            )))
+        })?;
+        Ok(Self {
+            handle: lock_file,
+            lock_path,
+        })
+    }
+}
+
+impl Drop for StateLock {
+    fn drop(&mut self) {
+        // Release the OS-level lock, then delete the lock file. Both
+        // best-effort: a failure here must not mask the real result (#761).
+        // Fully qualified syntax: avoids unstable_name_collisions with future
+        // std::fs::File::unlock (rust-lang/rust#48919).
+        let _ = FileExt::unlock(&self.handle);
+        let _ = fs::remove_file(&self.lock_path);
+    }
+}
 
 /// StateStore manages persistence of export state for a specific domain
 ///
@@ -126,23 +185,9 @@ impl StateStore {
             return Err(ScraperError::Io(err));
         }
 
-        // Acquire shared lock to prevent reading during concurrent write
-        let lock_path = path.with_extension("json.lock");
-        // M1 FIX: Write PID metadata to lock file for debugging
-        let mut lock_file = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&lock_path)
-            .map_err(ScraperError::Io)?;
-        let _ = writeln!(lock_file, "pid={} op=shared_read", std::process::id());
-        #[allow(clippy::io_other_error)]
-        fs2::FileExt::lock_shared(&lock_file).map_err(|e| {
-            ScraperError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("failed to acquire state read lock: {e}"),
-            ))
-        })?;
+        // Acquire shared lock to prevent reading during concurrent write.
+        // The guard releases the lock AND removes the lock file on drop (#761).
+        let _lock = StateLock::acquire(&path, false)?;
 
         // Read and parse JSON file
         let content = fs::read_to_string(&path).map_err(ScraperError::Io)?; // IO error when reading file
@@ -156,7 +201,6 @@ impl StateStore {
             state.processed_urls.len()
         );
 
-        // Lock released automatically on drop
         Ok(state)
     }
 
@@ -193,23 +237,9 @@ impl StateStore {
             fs::create_dir_all(parent).map_err(ScraperError::Io)?; // IO error when creating directories
         }
 
-        // Acquire exclusive file lock to prevent concurrent writes
-        let lock_path = path.with_extension("json.lock");
-        // M1 FIX: Write PID metadata to lock file for debugging
-        let mut lock_file = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&lock_path)
-            .map_err(ScraperError::Io)?;
-        let _ = writeln!(lock_file, "pid={} op=exclusive_write", std::process::id());
-        #[allow(clippy::io_other_error)]
-        lock_file.lock_exclusive().map_err(|e| {
-            ScraperError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("failed to acquire state lock: {e}"),
-            ))
-        })?;
+        // Acquire exclusive file lock to prevent concurrent writes.
+        // The guard releases the lock AND removes the lock file on drop (#761).
+        let _lock = StateLock::acquire(&path, true)?;
 
         // Serialize to JSON
         let json = serde_json::to_string_pretty(state).map_err(ScraperError::Serialization)?; // Serialization error
@@ -232,7 +262,6 @@ impl StateStore {
             state.processed_urls.len()
         );
 
-        // Lock released automatically on drop
         Ok(())
     }
 
@@ -386,6 +415,36 @@ mod tests {
         assert_eq!(loaded_state.processed_urls.len(), 2);
         assert!(loaded_state.is_processed("https://test.com/page1"));
         assert!(loaded_state.is_processed("https://test.com/page2"));
+    }
+
+    /// #761: after save and load complete, no `.json.lock` orphan may
+    /// remain on disk — the RAII guard removes it on drop.
+    #[test]
+    fn test_lockfile_removed_after_save_and_load() {
+        let dir = tempdir().unwrap();
+        let mut cache_dir = dir.path().to_path_buf();
+        cache_dir.push("webfang/state");
+
+        let mut store = StateStore::new("lockfile.test");
+        store.cache_dir = cache_dir;
+
+        let mut state = ExportState::new("lockfile.test");
+        state.mark_processed("https://lockfile.test/page1");
+        store.save(&state).expect("save must succeed");
+
+        let lock_path = store.get_state_path().with_extension("json.lock");
+        assert!(
+            !lock_path.exists(),
+            "lockfile must be removed after save, found: {}",
+            lock_path.display()
+        );
+
+        let _ = store.load().expect("load must succeed");
+        assert!(
+            !lock_path.exists(),
+            "lockfile must be removed after load, found: {}",
+            lock_path.display()
+        );
     }
 
     #[test]

--- a/crates/webfang_core/tests/exit_code_integration.rs
+++ b/crates/webfang_core/tests/exit_code_integration.rs
@@ -290,9 +290,11 @@ async fn test_clean_ai_without_feature_fails_before_fetch() {
     // If the CLI fetches anything, this mock would record it — the assertion
     // below proves the preflight fired before any request left the process.
     Mock::given(method("GET"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(
-            "<html><body><p>content that must never be fetched</p></body></html>",
-        ))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(
+                "<html><body><p>content that must never be fetched</p></body></html>",
+            ),
+        )
         .mount(&mock_server)
         .await;
 

--- a/crates/webfang_core/tests/exit_code_integration.rs
+++ b/crates/webfang_core/tests/exit_code_integration.rs
@@ -274,3 +274,43 @@ async fn test_valid_sitemap_returns_exit_0() {
         .assert()
         .code(0);
 }
+
+// ============================================================================
+// Tests: --clean-ai preflight on non-AI builds (#761)
+// ============================================================================
+
+/// `--clean-ai` on a binary built without the `ai` feature must fail in
+/// preflight with exit 78 BEFORE any network request — previously the CLI
+/// scraped the whole page and only failed at export time (#761).
+#[cfg(not(feature = "ai"))]
+#[tokio::test]
+async fn test_clean_ai_without_feature_fails_before_fetch() {
+    let mock_server = MockServer::start().await;
+
+    // If the CLI fetches anything, this mock would record it — the assertion
+    // below proves the preflight fired before any request left the process.
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><body><p>content that must never be fetched</p></body></html>",
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let base_url = format!("{}/", mock_server.uri());
+
+    cmd()
+        .arg("--url")
+        .arg(&base_url)
+        .arg("--clean-ai")
+        .timeout(Duration::from_secs(30))
+        .assert()
+        .code(78)
+        .stderr(predicate::str::contains("--clean-ai"));
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert!(
+        requests.is_empty(),
+        "preflight must fail before any network request, got {} requests",
+        requests.len()
+    );
+}

--- a/crates/webfang_core/tests/snapshots/cli_binary_test__test_dry_run_flag_accepted.snap
+++ b/crates/webfang_core/tests/snapshots/cli_binary_test__test_dry_run_flag_accepted.snap
@@ -3,4 +3,3 @@ source: crates/webfang_core/../../tests/cli_binary_test.rs
 expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stderr)"
 ---
 Error: --url is required for scraping
-Error: --url is required

--- a/crates/webfang_core/tests/snapshots/cli_binary_test__test_no_url_shows_error.snap
+++ b/crates/webfang_core/tests/snapshots/cli_binary_test__test_no_url_shows_error.snap
@@ -3,4 +3,3 @@ source: crates/webfang_core/../../tests/cli_binary_test.rs
 expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stderr)"
 ---
 Error: --url is required for scraping
-Error: --url is required

--- a/crates/webfang_core/tests/snapshots/cli_binary_test__test_quiet_flag_accepted.snap
+++ b/crates/webfang_core/tests/snapshots/cli_binary_test__test_quiet_flag_accepted.snap
@@ -3,4 +3,3 @@ source: crates/webfang_core/../../tests/cli_binary_test.rs
 expression: "redact_nondeterministic(Path::new(\"__no_temp__\"), &stderr)"
 ---
 Error: --url is required for scraping
-Error: --url is required


### PR DESCRIPTION
Closes #761

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- Fixes all 5 findings from the CLI audit in #761: duplicate `--url` error output, redundant DNS error text, raw selector-crate jargon in WARN, late `--clean-ai` feature failure, and residual `.json.lock` files.
- Deletion-heavy: removes 4 duplicate `eprintln!` calls, dedupes error prefixes, moves one check to preflight, adds one RAII lock guard.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_cli/src/main.rs` | Removed 4 duplicate `eprintln!` before `CliExit::UsageError`; context (CI mode, headless) now travels in the error message itself |
| `crates/webfang_core/src/infrastructure/downloader/mod.rs` | `strip_display_marker` dedupes `DNS error: dns error` / `TLS error: tls error` when the source already carries the marker |
| `crates/webfang_core/src/application/extraction.rs` | Invalid-selector WARN no longer leaks raw `selectors` crate jargon; raw detail stays in the internal diagnostic |
| `crates/webfang_core/src/cli/preflight.rs` | `check_clean_ai_feature` fails `--clean-ai` without the `ai` feature in preflight (exit 78), before any request — same pattern as #685 |
| `crates/webfang_core/src/infrastructure/export/state_store.rs` | RAII `StateLock` guard releases the lock AND deletes `.json.lock` on drop (same pattern as `jsonl_exporter` #582) |
| `crates/webfang_core/tests/snapshots/*.snap` | Updated 2 snapshots that pinned the duplicate-error bug |

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run` passes (169/169 affected-module tests, 13/13 CLI behavioral tests)
- [x] Manually verified: `webfang` with no args prints the error exactly once; `--clean-ai` without the feature exits 78 with zero network requests

## Named tests proving each closure

| Finding | Test |
|---------|------|
| #1 duplicate `--url` error | `test_no_url_shows_error` + updated snapshots |
| #2 redundant DNS text | `test_strip_display_marker_dedupes_redundant_prefix` |
| #3 selector jargon | `test_invalid_selector_message_is_clean` |
| #4 late `--clean-ai` | `test_clean_ai_without_feature_fails_before_fetch` (asserts 0 mock requests) |
| #5 residual lockfile | `test_lockfile_removed_after_save_and_load` |

## Contributor Checklist

- [x] Linked an approved issue with `Closes #761`
- [x] Branch name matches `type/description`
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` / AI attribution trailers
- [x] Docs updated if behavior changed (N/A — no behavior change, only error-message hygiene and preflight timing)
- [x] Defensive error paths annotated per docs/src/testing.md (N/A — no new defensive paths)