### PR TITLE
fix(ci): gate Chrome preflight spawn tests from Miri (#775)

### DIFF
--- a/crates/webfang_core/src/cli/preflight.rs
+++ b/crates/webfang_core/src/cli/preflight.rs
@@ -858,6 +858,10 @@ mod tests {
 
     /// `Full` strategy with a present, exit-0 binary (`true` exists in CI)
     /// passes the preflight check.
+    // Miri cannot emulate posix_spawn (Command::status), so both tests that
+    // actually probe a candidate binary are skipped there (#775). The
+    // short-circuit tests (static/hybrid/feature-gate) above stay active.
+    #[cfg_attr(miri, ignore)] // Command::spawn → posix_spawnattr_init unsupported by Miri (#775)
     #[test]
     fn full_strategy_ok_when_binary_reports_version() {
         let mut opts = CrawlOptions::default();
@@ -870,6 +874,7 @@ mod tests {
 
     /// `Full` strategy with no working candidate yields a config error whose
     /// message names Chrome (user-facing, Spanish).
+    #[cfg_attr(miri, ignore)] // Command::spawn → posix_spawnattr_init unsupported by Miri (#775)
     #[test]
     fn full_strategy_errors_when_no_binary_found() {
         let mut opts = CrawlOptions::default();


### PR DESCRIPTION
Closes #775

## Summary

Gates the two Chrome-preflight tests that probe a candidate binary via `Command::status` — Miri cannot emulate `posix_spawn` and aborts the whole `Miri (core)` job on `posix_spawnattr_init`.

Root cause class introduced by #758/#771 (commit `5af6fed`): both `feature` branches already carried it and hit the gate first (runs 32067328394, 32076971848).

## Evidence

Both manual runs identical: 3 other Miri jobs green, core aborts at `cli::preflight` right after `elastic_without_persistence_errors`:

\[error\] unsupported operation: can't call foreign function `posix_spawnattr_init` on OS `linux`  — \[note\] this is on thread `cli::preflight:`

- Run 32067328394 backtrace names `full_strategy_errors_when_no_binary_found`; 434 ok + 13 ignored, 0 UB, 0 FAIL before the abort — the suite is clean except for these two spawn tests.

## Changes

\[file\] crates/webfang_core/src/cli/preflight.rs — \[cfg_attr(miri, ignore)\] on `full_strategy_ok_when_binary_reports_version` (spawns `true --version`) and `full_strategy_errors_when_no_binary_found` (spawns nonexistent binary; ENOENT still calls posix_spawn), + explanatory comment.

The three short-circuit tests (`static_strategy_ok_without_spawn`, `hybrid_strategy_ok_without_chromium_feature`, `full_strategy_errors_without_chromium_feature`) never reach `Command::new` and stay active under Miri.

## Verification

- Normal run: preflight 13/13 pass
- Miri (exact CI MIRIFLAGS): `cli::preflight::` → 11 passed, 2 ignored, 0 failed
- clippy strict + fmt clean

## Checklist

- [x] Conventional commit format
- [x] Exactly one `type:*` label
- [x] Linked issue #775
- [x] No `Co-Authored-By` trailers