### PR TITLE
fix(exporter): Obsidian: --vault redirige output + reparar artefacto byline vacío (#762)

### DIFF
--- a/crates/webfang_cli/src/main.rs
+++ b/crates/webfang_cli/src/main.rs
@@ -364,6 +364,12 @@ async fn __main() -> CliExit {
         return exit;
     }
 
+    // 6f. Obsidian vault/output conflict preflight (#762): an explicit
+    // --vault redirect cannot coexist with a custom non-default -o/WEBFANG_OUTPUT.
+    if let Err(exit) = webfang_core::cli::commands::validate_vault_output_conflict(&opts) {
+        return exit;
+    }
+
     // 7. Initialize logging (stderr-only, respects quiet + NO_COLOR)
     let no_color = is_no_color();
     let log_level = resolve_log_level(opts.verbosity);

--- a/crates/webfang_core/src/application/crawl_options.rs
+++ b/crates/webfang_core/src/application/crawl_options.rs
@@ -197,6 +197,14 @@ pub struct ExportOptions {
     pub quiet: bool,
     /// Path to Obsidian vault (auto-detects if not provided).
     pub obsidian_vault: Option<PathBuf>,
+    /// Whether `--vault` was passed explicitly on the CLI (#762).
+    ///
+    /// Captured at parse time (`From<Args>`, from `args.obsidian.vault.is_some()`)
+    /// because `apply_config_defaults` and autodetection can fill
+    /// `obsidian_vault` afterwards — once merged, `Some(_)` alone can no
+    /// longer distinguish an explicit flag from a config-filled value.
+    /// Only an explicit flag redirects output to the vault.
+    pub vault_is_explicit: bool,
     /// Add rich metadata to frontmatter.
     pub obsidian_rich_metadata: bool,
     /// Tags to include in YAML frontmatter.
@@ -289,6 +297,7 @@ impl Default for ExportOptions {
             dry_run: false,
             quiet: false,
             obsidian_vault: None,
+            vault_is_explicit: false,
             obsidian_rich_metadata: false,
             obsidian_tags: Vec::new(),
             obsidian_wiki_links: false,
@@ -405,6 +414,7 @@ mod tests {
         assert!(!export.dry_run);
         assert!(!export.quiet);
         assert!(export.obsidian_vault.is_none());
+        assert!(!export.vault_is_explicit);
         assert!(!export.obsidian_rich_metadata);
         assert!(export.obsidian_tags.is_empty());
         assert!(!export.obsidian_wiki_links);

--- a/crates/webfang_core/src/cli/args/mod.rs
+++ b/crates/webfang_core/src/cli/args/mod.rs
@@ -151,20 +151,10 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
             CrawlLimits, ExportOptions, IngestionTuning, NetworkOptions,
         };
 
-        // `From::from` returns `Self`, so the parse error cannot be propagated;
-        // CLI validation guarantees the URL is valid before this point.
-        #[allow(clippy::expect_used)]
-        let url = url::Url::parse(args.crawler.url.as_deref().unwrap_or("https://example.com"))
-            .expect("URL must be valid — CLI validation ensures this");
+        let url = url_from_args(&args);
 
         let overrides = args.elastic_overrides();
         let ai_config = build_ai_config(&args);
-        // #762: capture --vault EXPLICITNESS at parse time. The vault path may
-        // later be filled by config.toml (`apply_config_defaults`) or
-        // autodetection, and after that merge `obsidian_vault.is_some()` can
-        // no longer distinguish an explicit CLI flag from a config-filled
-        // value — only the explicit flag redirects output to the vault.
-        let vault_is_explicit = args.obsidian.vault.is_some();
 
         Self {
             url,
@@ -232,8 +222,10 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
                 output_dir: args.export.output,
                 dry_run: args.crawler.dry_run,
                 quiet: args.crawler.quiet,
+                // #762: capture --vault EXPLICITNESS at parse time (config
+                // merge + autodetection can fill `obsidian_vault` later).
+                vault_is_explicit: args.obsidian.vault.is_some(),
                 obsidian_vault: args.obsidian.vault,
-                vault_is_explicit,
                 obsidian_rich_metadata: args.obsidian.obsidian_rich_metadata,
                 obsidian_tags: args.obsidian.obsidian_tags.unwrap_or_default(),
                 obsidian_wiki_links: args.obsidian.obsidian_wiki_links,
@@ -260,6 +252,18 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
             ai_config,
         }
     }
+}
+
+/// Parse the CLI URL into a [`url::Url`] for the `From<Args> -> CrawlOptions`
+/// conversion.
+///
+/// `From::from` returns `Self`, so a parse failure cannot be propagated;
+/// CLI validation guarantees the URL is valid before this point, so the
+/// `expect` documents a true invariant.
+#[allow(clippy::expect_used)]
+fn url_from_args(args: &Args) -> url::Url {
+    url::Url::parse(args.crawler.url.as_deref().unwrap_or("https://example.com"))
+        .expect("URL must be valid — CLI validation ensures this")
 }
 
 #[cfg(feature = "ai")]

--- a/crates/webfang_core/src/cli/args/mod.rs
+++ b/crates/webfang_core/src/cli/args/mod.rs
@@ -159,6 +159,12 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
 
         let overrides = args.elastic_overrides();
         let ai_config = build_ai_config(&args);
+        // #762: capture --vault EXPLICITNESS at parse time. The vault path may
+        // later be filled by config.toml (`apply_config_defaults`) or
+        // autodetection, and after that merge `obsidian_vault.is_some()` can
+        // no longer distinguish an explicit CLI flag from a config-filled
+        // value — only the explicit flag redirects output to the vault.
+        let vault_is_explicit = args.obsidian.vault.is_some();
 
         Self {
             url,
@@ -227,6 +233,7 @@ impl From<Args> for crate::application::crawl_options::CrawlOptions {
                 dry_run: args.crawler.dry_run,
                 quiet: args.crawler.quiet,
                 obsidian_vault: args.obsidian.vault,
+                vault_is_explicit,
                 obsidian_rich_metadata: args.obsidian.obsidian_rich_metadata,
                 obsidian_tags: args.obsidian.obsidian_tags.unwrap_or_default(),
                 obsidian_wiki_links: args.obsidian.obsidian_wiki_links,

--- a/crates/webfang_core/src/cli/args/obsidian.rs
+++ b/crates/webfang_core/src/cli/args/obsidian.rs
@@ -22,7 +22,12 @@ pub struct ObsidianArgs {
     #[clap(next_help_heading = "Obsidian")]
     pub obsidian_relative_assets: bool,
 
-    /// Path to Obsidian vault (auto-detects if not provided)
+    /// Path to Obsidian vault (auto-detects if not provided).
+    ///
+    /// When provided explicitly, the vault becomes the output base: Markdown,
+    /// downloaded assets and the RAG export are written inside it — no need
+    /// to duplicate the path in `-o` (which then must stay at its default).
+    /// Auto-detected or config-file vaults do NOT redirect output (#762).
     #[arg(long, env = "WEBFANG_OBSIDIAN_VAULT")]
     #[clap(next_help_heading = "Obsidian")]
     pub vault: Option<std::path::PathBuf>,

--- a/crates/webfang_core/src/cli/commands.rs
+++ b/crates/webfang_core/src/cli/commands.rs
@@ -132,3 +132,83 @@ fn warn_headless_vault_mismatch(vault_path: &Option<PathBuf>, opts: &CrawlOption
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== #762 — validate_vault_output_conflict tests =====
+
+    /// Canonical conflict trigger: explicit `--vault` plus a non-default `-o`,
+    /// without `--quick-save`.
+    fn explicit_vault_with_custom_output() -> CrawlOptions {
+        let mut opts = CrawlOptions::default();
+        opts.export.obsidian_vault = Some(PathBuf::from("/tmp/vault"));
+        opts.export.vault_is_explicit = true;
+        opts.export.output_dir = PathBuf::from("/tmp/custom");
+        opts
+    }
+
+    /// Explicit `--vault` + custom `-o` is a contradiction (#762): the vault
+    /// IS the output base, so a second custom base has no meaning. The
+    /// preflight must reject it with a usage error naming the flag.
+    #[test]
+    fn conflict_rejects_explicit_vault_with_custom_output() {
+        let opts = explicit_vault_with_custom_output();
+
+        match validate_vault_output_conflict(&opts) {
+            Err(CliExit::UsageError(msg)) => {
+                assert!(
+                    msg.contains("--vault"),
+                    "usage error must name the --vault flag: {msg}"
+                );
+                assert!(
+                    msg.contains("no pueden combinarse"),
+                    "usage error must state the contradiction in Spanish: {msg}"
+                );
+            },
+            other => panic!("expected CliExit::UsageError, got {other:?}"),
+        }
+    }
+
+    /// `--quick-save` is exempt (#638 contract): markdown goes to the vault
+    /// `_inbox` while `-o` keeps the RAG export — a documented split, not a
+    /// conflict.
+    #[test]
+    fn quick_save_is_exempt_from_vault_output_conflict() {
+        let mut opts = explicit_vault_with_custom_output();
+        opts.export.quick_save = true;
+
+        assert!(
+            validate_vault_output_conflict(&opts).is_ok(),
+            "--quick-save must remain compatible with --vault + -o"
+        );
+    }
+
+    /// Leaving `-o` at clap's `"output"` default means "--vault <path> only":
+    /// the vault redirects everything, which is exactly the valid invocation.
+    #[test]
+    fn explicit_vault_with_default_output_is_allowed() {
+        let mut opts = explicit_vault_with_custom_output();
+        opts.export.output_dir = PathBuf::from("output");
+
+        assert!(
+            validate_vault_output_conflict(&opts).is_ok(),
+            "default -o must not trigger the conflict"
+        );
+    }
+
+    /// A vault filled from `config.toml` (`vault_is_explicit = false`) does
+    /// NOT redirect output, so a custom `-o` alongside it keeps its historical
+    /// meaning and must never conflict.
+    #[test]
+    fn config_filled_vault_does_not_conflict_with_custom_output() {
+        let mut opts = explicit_vault_with_custom_output();
+        opts.export.vault_is_explicit = false;
+
+        assert!(
+            validate_vault_output_conflict(&opts).is_ok(),
+            "config-filled vault must not conflict with custom -o"
+        );
+    }
+}

--- a/crates/webfang_core/src/cli/commands.rs
+++ b/crates/webfang_core/src/cli/commands.rs
@@ -72,6 +72,36 @@ fn validate_explicit_vault(opts: &CrawlOptions) -> Result<(), CliExit> {
     Ok(())
 }
 
+/// Reject an explicit `--vault` combined with an explicit non-default output
+/// directory (#762).
+///
+/// Since #762 an explicit `--vault` flag IS the output base: Markdown,
+/// assets and the RAG export all land inside the vault. Passing a custom
+/// `-o`/`WEBFANG_OUTPUT` alongside it is a contradiction — the binary would
+/// not know which base wins. Fail fast with a usage error that names the two
+/// valid invocations.
+///
+/// `--quick-save` is exempt on purpose: it keeps its historical contract
+/// (#638) where the vault receives `_inbox` content while `-o` stays the RAG
+/// export destination — an intentional, documented split, not a conflict.
+///
+/// `output_dir` only ever comes from the CLI or `WEBFANG_OUTPUT` (the config
+/// file never sets it), so comparing against clap's `"output"` default is a
+/// reliable explicitness probe.
+pub fn validate_vault_output_conflict(opts: &CrawlOptions) -> Result<(), CliExit> {
+    if opts.export.vault_is_explicit
+        && !opts.export.quick_save
+        && opts.export.output_dir != std::path::Path::new("output")
+    {
+        return Err(CliExit::UsageError(format!(
+            "--vault y un directorio de output personalizado ({}) no pueden combinarse: \
+             usá --vault <path> solo (redirige todo el output al vault) o -o <dir> sin --vault",
+            opts.export.output_dir.display()
+        )));
+    }
+    Ok(())
+}
+
 /// Detect the vault path via explicit flag, config default, or cascade.
 fn detect_vault_path(opts: &CrawlOptions, config_defaults: &ConfigDefaults) -> Option<PathBuf> {
     detect_vault(

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -279,14 +279,46 @@ fn resume_nothing_pending(
 /// asset paths escape the vault and images stop rendering. The Downloader is a
 /// slave of the config — the orchestrator is responsible for converging the
 /// two persistence roots before handing them to the crawl/export engines.
+///
+/// An EXPLICIT `--vault` flag (captured as `vault_is_explicit` at parse time,
+/// #762) extends the same invariant: the vault becomes the output base so
+/// Markdown, assets and the RAG export all land inside it without the user
+/// duplicating the path in `-o`. Vaults filled from `config.toml` or
+/// autodetection do NOT redirect — that is why explicitness is tracked
+/// separately from `obsidian_vault.is_some()`.
+///
+/// If `obsidian_vault` is somehow `None` at use time (should be unreachable
+/// after preflight validation), fall back to `output_dir` — never panic.
 fn resolve_persistence_root(opts: &CrawlOptions) -> std::path::PathBuf {
-    if opts.export.quick_save {
+    if opts.export.quick_save || opts.export.vault_is_explicit {
         opts.export
             .obsidian_vault
             .clone()
             .unwrap_or_else(|| opts.export.output_dir.clone())
     } else {
         opts.export.output_dir.clone()
+    }
+}
+
+/// Resolve the directory for the RAG pipeline export (`export.jsonl` /
+/// `export.json`).
+///
+/// The persistence root ([`resolve_persistence_root`]) owns where Markdown
+/// and assets are written; this helper exists so every sink of
+/// `opts.export.output_dir` converges on ONE resolution path instead of each
+/// call site re-deriving its own base (#762). The two diverge by design:
+///
+/// - `--quick-save` routes Markdown into `<persistence root>/_inbox` while
+///   the RAG export keeps its historical `-o` destination (unchanged by
+///   #762).
+/// - Explicit `--vault` without `--quick-save` also redirects the RAG export
+///   into the vault root, so a single `--vault` flag makes the vault
+///   self-contained.
+fn resolve_export_dir(opts: &CrawlOptions) -> std::path::PathBuf {
+    if opts.export.quick_save {
+        opts.export.output_dir.clone()
+    } else {
+        resolve_persistence_root(opts)
     }
 }
 
@@ -306,7 +338,7 @@ async fn export_phase(
         );
     }
 
-    let output_dir = opts.export.output_dir.clone();
+    let output_dir = resolve_export_dir(opts);
 
     let obsidian_options = ObsidianOptions {
         wiki_links: opts.export.obsidian_wiki_links,
@@ -848,10 +880,13 @@ async fn flush_batch_sink(sink: &BoundedFileSink) -> Result<(), CliExit> {
 
 /// Create the disk-backed capture sink for a batch run.
 ///
-/// The spool lives under the output directory so it shares the run's storage
-/// budget and is cleaned up by [`discard_batch_spool`] once extraction is done.
+/// The spool lives under the run's persistence root so it shares the run's
+/// storage budget (and lands inside the vault when `--quick-save` or an
+/// explicit `--vault` redirects the base, #638/#762) and is cleaned up by
+/// [`discard_batch_spool`] once extraction is done.
 async fn build_batch_sink(opts: &CrawlOptions) -> Result<BoundedFileSink, CliExit> {
-    let spool_path = opts.export.output_dir.join(".webfang-batch-capture.jsonl");
+    let spool_path =
+        resolve_persistence_root(opts).join(".webfang-batch-capture.jsonl");
     // One buffered page per concurrent crawl, plus headroom, keeps the writer
     // from becoming the bottleneck without unbounding memory.
     let buffer = opts
@@ -956,7 +991,7 @@ async fn extract_batch_content(
     CliExit,
 > {
     let scraper_config = ScraperConfig::default()
-        .with_output_dir(opts.export.output_dir.clone())
+        .with_output_dir(resolve_persistence_root(opts))
         .with_selector(opts.crawl.selector.clone())
         .with_ignore_waf(opts.crawl.ignore_waf);
 
@@ -1170,7 +1205,8 @@ fn parse_asset_h2_profile(s: &str) -> wreq_util::Profile {
 mod tests {
     use super::{
         batch_exit_code, build_batch_crawler_config, build_elastic_ingestion, format_failure,
-        parse_asset_h2_profile, plan_urls, report_phase,
+        parse_asset_h2_profile, plan_urls, report_phase, resolve_export_dir,
+        resolve_persistence_root,
     };
     use crate::application::crawl_options::CrawlOptions;
     use crate::cli::error::CliExit;
@@ -1831,6 +1867,85 @@ mod tests {
             matches!(exit, CliExit::UsageError(_)),
             "Expected UsageError when output_dir is '-', got: {exit:?}"
         );
+    }
+
+    // ===== #762 — persistence root / export dir convergence =====
+
+    /// No vault: both roots default to `-o`.
+    #[test]
+    fn persistence_root_defaults_to_output_dir() {
+        let mut opts = CrawlOptions::default();
+        opts.export.output_dir = std::path::PathBuf::from("/tmp/out");
+
+        assert_eq!(
+            resolve_persistence_root(&opts),
+            std::path::PathBuf::from("/tmp/out")
+        );
+        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
+    }
+
+    /// quick_save: Markdown+assets root is the vault, RAG export keeps `-o`.
+    #[test]
+    fn quick_save_roots_to_vault_keeps_export_in_output_dir() {
+        let mut opts = CrawlOptions::default();
+        opts.export.output_dir = std::path::PathBuf::from("/tmp/out");
+        opts.export.obsidian_vault = Some(std::path::PathBuf::from("/tmp/vault"));
+        opts.export.quick_save = true;
+
+        assert_eq!(
+            resolve_persistence_root(&opts),
+            std::path::PathBuf::from("/tmp/vault")
+        );
+        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
+    }
+
+    /// Explicit --vault (no quick_save): both roots redirect to the vault (#762).
+    #[test]
+    fn explicit_vault_redirects_both_roots_to_vault() {
+        let mut opts = CrawlOptions::default();
+        opts.export.output_dir = std::path::PathBuf::from("/tmp/out");
+        opts.export.obsidian_vault = Some(std::path::PathBuf::from("/tmp/vault"));
+        opts.export.vault_is_explicit = true;
+
+        assert_eq!(
+            resolve_persistence_root(&opts),
+            std::path::PathBuf::from("/tmp/vault")
+        );
+        assert_eq!(
+            resolve_export_dir(&opts),
+            std::path::PathBuf::from("/tmp/vault")
+        );
+    }
+
+    /// Config-filled vault without explicit flag: NO redirect (#762 — only
+    /// the explicit CLI flag changes the output base).
+    #[test]
+    fn config_filled_vault_does_not_redirect() {
+        let mut opts = CrawlOptions::default();
+        opts.export.output_dir = std::path::PathBuf::from("/tmp/out");
+        opts.export.obsidian_vault = Some(std::path::PathBuf::from("/tmp/vault"));
+        opts.export.vault_is_explicit = false;
+
+        assert_eq!(
+            resolve_persistence_root(&opts),
+            std::path::PathBuf::from("/tmp/out")
+        );
+        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
+    }
+
+    /// Explicit flag with a missing vault falls back to `-o` — never panics.
+    #[test]
+    fn explicit_vault_without_path_falls_back_to_output_dir() {
+        let mut opts = CrawlOptions::default();
+        opts.export.output_dir = std::path::PathBuf::from("/tmp/out");
+        opts.export.obsidian_vault = None;
+        opts.export.vault_is_explicit = true;
+
+        assert_eq!(
+            resolve_persistence_root(&opts),
+            std::path::PathBuf::from("/tmp/out")
+        );
+        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
     }
 
     // ===== Asset pattern decoupling tests (#639) =====

--- a/crates/webfang_core/src/cli/orchestrator.rs
+++ b/crates/webfang_core/src/cli/orchestrator.rs
@@ -885,8 +885,7 @@ async fn flush_batch_sink(sink: &BoundedFileSink) -> Result<(), CliExit> {
 /// explicit `--vault` redirects the base, #638/#762) and is cleaned up by
 /// [`discard_batch_spool`] once extraction is done.
 async fn build_batch_sink(opts: &CrawlOptions) -> Result<BoundedFileSink, CliExit> {
-    let spool_path =
-        resolve_persistence_root(opts).join(".webfang-batch-capture.jsonl");
+    let spool_path = resolve_persistence_root(opts).join(".webfang-batch-capture.jsonl");
     // One buffered page per concurrent crawl, plus headroom, keeps the writer
     // from becoming the bottleneck without unbounding memory.
     let buffer = opts
@@ -1881,7 +1880,10 @@ mod tests {
             resolve_persistence_root(&opts),
             std::path::PathBuf::from("/tmp/out")
         );
-        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
+        assert_eq!(
+            resolve_export_dir(&opts),
+            std::path::PathBuf::from("/tmp/out")
+        );
     }
 
     /// quick_save: Markdown+assets root is the vault, RAG export keeps `-o`.
@@ -1896,7 +1898,10 @@ mod tests {
             resolve_persistence_root(&opts),
             std::path::PathBuf::from("/tmp/vault")
         );
-        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
+        assert_eq!(
+            resolve_export_dir(&opts),
+            std::path::PathBuf::from("/tmp/out")
+        );
     }
 
     /// Explicit --vault (no quick_save): both roots redirect to the vault (#762).
@@ -1930,7 +1935,10 @@ mod tests {
             resolve_persistence_root(&opts),
             std::path::PathBuf::from("/tmp/out")
         );
-        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
+        assert_eq!(
+            resolve_export_dir(&opts),
+            std::path::PathBuf::from("/tmp/out")
+        );
     }
 
     /// Explicit flag with a missing vault falls back to `-o` — never panics.
@@ -1945,7 +1953,10 @@ mod tests {
             resolve_persistence_root(&opts),
             std::path::PathBuf::from("/tmp/out")
         );
-        assert_eq!(resolve_export_dir(&opts), std::path::PathBuf::from("/tmp/out"));
+        assert_eq!(
+            resolve_export_dir(&opts),
+            std::path::PathBuf::from("/tmp/out")
+        );
     }
 
     // ===== Asset pattern decoupling tests (#639) =====

--- a/crates/webfang_core/src/infrastructure/converter/wikilinks.rs
+++ b/crates/webfang_core/src/infrastructure/converter/wikilinks.rs
@@ -4,6 +4,8 @@
 //! - `[text](https://same-domain.com/page)` → `[[page-slug|text]]`
 //! - Extracts URL-safe slugs from paths
 
+use std::sync::LazyLock;
+
 use heck::ToKebabCase;
 use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 
@@ -287,13 +289,13 @@ fn reconstruct_image_link(state: &LinkState, result: &mut String) {
 
 /// Convert a same-domain link to `[[slug|text]]` wiki-link syntax.
 fn convert_to_wikilink(slug: String, state: &LinkState, result: &mut String) {
-    let link_text = extract_text_from_events(&state.text_parts);
-    let normalized_text = link_text.to_lowercase().trim().replace(' ', "-");
+    let raw_text = extract_text_from_events(&state.text_parts);
+    let link_text = resolve_alias_text(raw_text, &state.url, &slug);
 
     // Add space before wiki-link if result is not empty and doesn't already end with space
     let needs_space = !result.is_empty() && !result.ends_with(' ') && !result.ends_with('\n');
 
-    if slug == normalized_text {
+    if slug == normalized_link_text(&link_text) {
         if needs_space {
             result.push(' ');
         }
@@ -310,6 +312,87 @@ fn convert_to_wikilink(slug: String, state: &LinkState, result: &mut String) {
         result.push_str(&link_text);
         result.push_str("]]");
     }
+}
+
+/// Lowercase, trim, and join the link text with hyphens — the shape the
+/// slug comparison uses.
+fn normalized_link_text(text: &str) -> String {
+    text.to_lowercase().trim().replace(' ', "-")
+}
+
+/// Resolve the wiki-link alias (the `text` in `[[slug|text]]`) for a link
+/// that will be converted (#762).
+///
+/// A parenthetical-only label like `(about)` is a byline scar: Readability
+/// strips the author NAME node while capturing the byline, leaving the
+/// sibling `(about)` anchor behind with no identity of its own. Emitting
+/// `[[author-albert-einstein|(about)]]` loses the name that the HTML carried.
+/// Fall back to the link TARGET's last path segment, humanized
+/// (`/author/Albert-Einstein/` → `Albert Einstein`); as a last resort use
+/// the slug itself, so the alias is never a bare parenthetical. Links whose
+/// own label still carries real text are returned untouched.
+fn resolve_alias_text(raw_text: String, url: &str, slug: &str) -> String {
+    if !is_parenthetical_only(&raw_text) {
+        return raw_text;
+    }
+    let fallback = humanize_last_segment(url);
+    if fallback.is_empty() {
+        slug.to_string()
+    } else {
+        fallback
+    }
+}
+
+/// Parenthesized groups with no nested parens, e.g. `(about)` (#762).
+///
+/// Compile-time-constant pattern, so `expect` documents a true invariant
+/// (same convention as `author_extractor`'s static selectors).
+#[allow(clippy::expect_used)]
+static PARENTHETICAL_GROUP: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"\([^)]*\)")
+        // LCOV_EXCL_LINE defensive: fixed pattern, compile cannot fail
+        .expect("BUG: invalid parenthetical regex")
+});
+
+/// True when the label carries no usable identity on its own: empty, or
+/// composed solely of parenthetical groups like `(about)` — a Readability
+/// byline scar where the author name was stripped, leaving only the sibling
+/// anchor's decoration (#762).
+fn is_parenthetical_only(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.is_empty() || PARENTHETICAL_GROUP.replace_all(trimmed, " ").trim().is_empty()
+}
+
+/// Humanize the last non-empty URL path segment into a readable title:
+/// percent-decode, then turn `-`/`_` runs into spaces
+/// (`/author/Albert-Einstein/` → `Albert Einstein`).
+///
+/// This is a best-effort label for degenerate byline anchors only — a
+/// literal hyphen in a real alias is an acceptable cost for recovering
+/// the author name (#762). Returns an empty string for a bare root so the
+/// caller falls back to the slug instead of reusing the host name.
+fn humanize_last_segment(url_str: &str) -> String {
+    // Strip query + fragment first (they never carry path segments).
+    let no_query = url_str.split('?').next().unwrap_or(url_str);
+    let no_fragment = no_query.split('#').next().unwrap_or(no_query);
+    // Drop the scheme+authority when present, keeping only the path. A URL
+    // with no slash after the authority ("https://host") has no segments.
+    let path = match no_fragment.find("://") {
+        Some(idx) => {
+            let after_authority = idx + 3;
+            match no_fragment[after_authority..].find('/') {
+                Some(slash) => &no_fragment[after_authority + slash..],
+                None => "",
+            }
+        },
+        None => no_fragment,
+    };
+    let last = path.rsplit('/').find(|s| !s.is_empty()).unwrap_or("");
+    decode_and_normalize(last)
+        .replace('-', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Preserve a link that should not be converted as original markdown.
@@ -657,5 +740,56 @@ mod tests {
             result.contains("https://example.com/img.png"),
             "Image URL must survive emphasis, got: {result}"
         );
+    }
+
+    // ========================================================================
+    // #762 — empty-byline wiki-link alias fallback
+    // ========================================================================
+
+    /// A parenthetical-only label like `(about)` (Readability byline scar)
+    /// must fall back to the humanized last path segment, not ship as a
+    /// naked `(about)` alias.
+    #[test]
+    fn test_parenthetical_alias_falls_back_to_path_segment() {
+        let md = "by [(about)](https://quotes.toscrape.com/author/Albert-Einstein/)";
+        let result = convert_wiki_links(md, "quotes.toscrape.com");
+        assert!(
+            result.contains("[[author-albert-einstein|Albert Einstein]]"),
+            "alias must recover the author from the path, got: {result}"
+        );
+        assert!(
+            !result.contains("|(about)]"),
+            "naked (about) alias must not survive: {result}"
+        );
+    }
+
+    /// A label that still carries real text is NOT touched by the fallback.
+    #[test]
+    fn test_real_label_not_replaced_by_fallback() {
+        let md = "by [Albert Einstein](https://example.com/author/Albert-Einstein/)";
+        let result = convert_wiki_links(md, "example.com");
+        assert_eq!(result, "by [[author-albert-einstein|Albert Einstein]]");
+    }
+
+    /// is_parenthetical_only unit coverage.
+    #[test]
+    fn test_is_parenthetical_only_variants() {
+        assert!(is_parenthetical_only("(about)"));
+        assert!(is_parenthetical_only(""));
+        assert!(is_parenthetical_only("  (more)  "));
+        assert!(!is_parenthetical_only("Albert Einstein"));
+        assert!(!is_parenthetical_only("Read more (about)"));
+    }
+
+    /// humanize_last_segment unit coverage.
+    #[test]
+    fn test_humanize_last_segment() {
+        assert_eq!(
+            humanize_last_segment("https://example.com/author/Albert-Einstein/"),
+            "Albert Einstein"
+        );
+        assert_eq!(humanize_last_segment("/page/JK-Rowling"), "JK Rowling");
+        // A bare root carries no segment — the caller falls back to the slug.
+        assert_eq!(humanize_last_segment("https://example.com/"), "");
     }
 }

--- a/crates/webfang_core/src/infrastructure/converter/wikilinks.rs
+++ b/crates/webfang_core/src/infrastructure/converter/wikilinks.rs
@@ -360,7 +360,11 @@ static PARENTHETICAL_GROUP: LazyLock<regex::Regex> = LazyLock::new(|| {
 /// anchor's decoration (#762).
 fn is_parenthetical_only(text: &str) -> bool {
     let trimmed = text.trim();
-    trimmed.is_empty() || PARENTHETICAL_GROUP.replace_all(trimmed, " ").trim().is_empty()
+    trimmed.is_empty()
+        || PARENTHETICAL_GROUP
+            .replace_all(trimmed, " ")
+            .trim()
+            .is_empty()
 }
 
 /// Humanize the last non-empty URL path segment into a readable title:

--- a/crates/webfang_core/src/infrastructure/output/frontmatter.rs
+++ b/crates/webfang_core/src/infrastructure/output/frontmatter.rs
@@ -10,6 +10,7 @@
 //! - Rich metadata (word count, reading time, language, content type, status)
 
 use std::borrow::Cow;
+use std::sync::LazyLock;
 
 use chrono::Utc;
 use serde::Serialize;
@@ -27,6 +28,37 @@ fn normalize_whitespace(text: &str) -> Cow<'_, str> {
     } else {
         Cow::Borrowed(text)
     }
+}
+
+/// A byline fragment whose author name is missing: `by (about)`, `by (more)…`.
+///
+/// Reproduced from quotes.toscrape.com (#762): Readability captures the
+/// author NAME node (`<small itemprop="author">`) as the page byline and
+/// strips it from the body, leaving only the wrapper's `by ` prefix and the
+/// sibling `(about)` anchor behind — the excerpt then ships `… by (about)`.
+/// Compile-time-constant pattern, so `expect` documents a true invariant
+/// (same convention as the `author_extractor` static selectors).
+#[allow(clippy::expect_used)]
+static EMPTY_BYLINE_FRAGMENT: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"\bby\s+\([^)]*\)")
+        // LCOV_EXCL_LINE defensive: fixed pattern, compile cannot fail
+        .expect("BUG: invalid byline fragment regex")
+});
+
+/// Repair a residual empty-byline fragment in `excerpt` (#762).
+///
+/// When the author name could be resolved (the extractor cascade found it),
+/// the fragment is completed to `by <author>`; otherwise it is dropped —
+/// a `by` with no name is noise, not information. The removal can resurrect
+/// doubled spaces or trailing seams, so the result is re-normalized.
+fn repair_empty_byline(excerpt: &str, author: Option<&str>) -> String {
+    let repaired: Cow<'_, str> =
+        EMPTY_BYLINE_FRAGMENT.replace_all(excerpt, |_: &regex::Captures| match author {
+            Some(name) => format!("by {name}"),
+            None => String::new(),
+        });
+    // Re-normalize: dropping the fragment can leave `…  …` or trailing space.
+    normalize_whitespace(repaired.trim()).into_owned()
 }
 
 /// Frontmatter data structure
@@ -115,7 +147,7 @@ pub fn generate_with_metadata(
             .map(|s| s.to_string())
             .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string()),
         author: author.map(|s| s.to_string()),
-        excerpt: excerpt.map(|s| normalize_whitespace(s).into_owned()),
+        excerpt: excerpt.map(|s| repair_empty_byline(s, author)),
         tags: tags.to_vec(),
         word_count: rich_meta.map(|m| m.word_count),
         reading_time: rich_meta.map(|m| m.reading_time),
@@ -269,7 +301,9 @@ mod tests {
         assert_eq!(out, "word word");
     }
 
-    /// The frontmatter serializes the normalized excerpt.
+    /// The frontmatter serializes the normalized excerpt. Since #762 the
+    /// empty-byline fragment is DROPPED when no author is available (the
+    /// whitespace collapse from #695 still runs as part of the repair pass).
     #[test]
     fn test_generate_normalizes_excerpt_whitespace() {
         let fm = generate(
@@ -280,7 +314,71 @@ mod tests {
             Some("...by  (about)"),
             &[],
         );
-        assert!(fm.contains("excerpt: '...by (about)'"));
-        assert!(!fm.contains("by  (about)"));
+        assert!(fm.contains("excerpt: '...'"), "got: {fm}");
+        assert!(!fm.contains("by (about)"), "got: {fm}");
+        assert!(!fm.contains("by  (about)"), "got: {fm}");
+    }
+
+    // ====================================================================
+    // #762 — empty byline fragment repair
+    // ====================================================================
+
+    /// With a resolved author, the residual `by (about)` is completed to
+    /// `by <author>` instead of shipping an empty name slot.
+    #[test]
+    fn repair_empty_byline_completes_with_author() {
+        let repaired = repair_empty_byline(
+            "“The world… changing our thinking.” by  (about)",
+            Some("Albert Einstein"),
+        );
+        assert_eq!(
+            repaired,
+            "“The world… changing our thinking.” by Albert Einstein"
+        );
+    }
+
+    /// Without an author, the fragment is dropped entirely — a `by` with no
+    /// name is noise. The trailing seam is trimmed.
+    #[test]
+    fn repair_empty_byline_drops_without_author() {
+        let repaired = repair_empty_byline("“The world… changing our thinking.” by (about)", None);
+        assert_eq!(repaired, "“The world… changing our thinking.”");
+    }
+
+    /// Text that does not match stays untouched (after normalization pass).
+    #[test]
+    fn repair_empty_byline_leaves_clean_excerpt_alone() {
+        let repaired = repair_empty_byline("A clean excerpt without scars", Some("Someone"));
+        assert_eq!(repaired, "A clean excerpt without scars");
+    }
+
+    /// A real "by" phrase with an actual name is NOT mistaken for a scar.
+    #[test]
+    fn repair_empty_byline_keeps_real_by_phrases() {
+        let repaired = repair_empty_byline("Written by Jane Austen", Some("Jane Austen"));
+        assert_eq!(repaired, "Written by Jane Austen");
+    }
+
+    /// End-to-end: generate() emits the repaired excerpt in the YAML.
+    /// serde_yaml switches to double quotes when the string carries smart
+    /// quotes, so assert on the completed fragment itself.
+    #[test]
+    fn test_generate_repairs_byline_fragment_in_excerpt() {
+        let fm = generate(
+            "Quotes",
+            "https://quotes.toscrape.com",
+            Some("2026-08-17"),
+            Some("Albert Einstein"),
+            Some("“…changing our thinking.” by  (about)"),
+            &[],
+        );
+        assert!(
+            fm.contains("…changing our thinking.” by Albert Einstein"),
+            "excerpt must be completed with the author, got: {fm}"
+        );
+        assert!(
+            !fm.contains("by (about)") && !fm.contains("by  (about)"),
+            "the empty-byline fragment must not survive: {fm}"
+        );
     }
 }

--- a/crates/webfang_core/tests/behavioral/snapshots/behavioral__help.snap
+++ b/crates/webfang_core/tests/behavioral/snapshots/behavioral__help.snap
@@ -380,7 +380,9 @@ Options:
           [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
 
       --vault <VAULT>
-          Path to Obsidian vault (auto-detects if not provided)
+          Path to Obsidian vault (auto-detects if not provided).
+          
+          When provided explicitly, the vault becomes the output base: Markdown, downloaded assets and the RAG export are written inside it — no need to duplicate the path in `-o` (which then must stay at its default). Auto-detected or config-file vaults do NOT redirect output (#762).
           
           [env: WEBFANG_OBSIDIAN_VAULT=]
 

--- a/crates/webfang_core/tests/obsidian_byline_artifact_test.rs
+++ b/crates/webfang_core/tests/obsidian_byline_artifact_test.rs
@@ -1,0 +1,189 @@
+//! Obsidian byline-artifact regression tests (#762 slice 2).
+//!
+//! Reproduces the quotes.toscrape.com audit (2026-08-17) against the FULL
+//! binary pipeline with wiremock — no real network:
+//!
+//! - Readability (legible) captures the first author node (`<small
+//!   itemprop="author">`) as the page byline and STRIPS it from the content,
+//!   leaving the wrapper's `by ` prefix plus the sibling `(about)` anchor
+//!   behind. The excerpt therefore ships `… by (about)` (empty author slot).
+//! - The wiki-link converter then turns the surviving `(about)` anchor into
+//!   `[[author-albert-einstein|(about)]]` — a label that travels without the
+//!   name it used to accompany.
+//!
+//! #762 fix: frontmatter repairs the residual fragment (completed with the
+//! resolved author, or dropped when none), and the wiki-link alias falls back
+//! to the humanized last path segment instead of the naked `(about)`.
+
+#[path = "common/cli_harness.rs"]
+mod common;
+use common::{cmd, redact_nondeterministic};
+
+use std::path::Path;
+use walkdir::WalkDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Minimal quotes.toscrape.com page shape: repeated `.quote` blocks whose
+/// byline span wraps the author node and a sibling `(about)` anchor.
+const QUOTES_PAGE: &str = r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Quotes to Scrape</title></head>
+<body>
+<div class="row">
+<div class="col-md-8">
+<div class="quote" itemscope itemtype="http://schema.org/CreativeWork">
+    <span class="text" itemprop="text">&#8220;The world as we have created it is a process of our thinking. It cannot be changed without changing our thinking.&#8221;</span>
+    <span>by <small class="author" itemprop="author">Albert Einstein</small>
+    <a href="/author/Albert-Einstein/">(about)</a>
+    </span>
+    <div class="tags">
+        Tags:
+        <a class="tag" href="/tag/change/page/1/">change</a>
+    </div>
+</div>
+<div class="quote" itemscope itemtype="http://schema.org/CreativeWork">
+    <span class="text" itemprop="text">&#8220;It is our choices, Harry, that show what we truly are, far more than our abilities.&#8221;</span>
+    <span>by <small class="author" itemprop="author">J.K. Rowling</small>
+    <a href="/author/JK-Rowling/">(about)</a>
+    </span>
+</div>
+</div>
+</div>
+</body></html>"#;
+
+/// Snapshot helper matching `obsidian_test.rs` conventions (redact the temp
+/// dir + collapse the date field generated from `Utc::now()`).
+fn snapshot_byline_artifact(name: &str, dir: &Path, content: &str) {
+    let redacted = redact_nondeterministic(dir, content);
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(r"date: \d{4}-\d{2}-\d{2}", "date: [DATE]");
+    settings.bind(|| {
+        insta::assert_snapshot!(name, redacted);
+    });
+}
+
+fn scrape_quotes_page(server: &MockServer, out: &Path, cmd_args: &[&str]) {
+    let mut command = cmd();
+    command
+        .arg("--url")
+        .arg(server.uri())
+        .arg("--single-page")
+        .arg("--format")
+        .arg("markdown")
+        .arg("--output")
+        .arg(out)
+        .arg("--quiet");
+    for arg in cmd_args {
+        command.arg(*arg);
+    }
+    command.assert().success();
+}
+
+fn read_all_md(out: &Path) -> String {
+    let mut contents: Vec<String> = WalkDir::new(out)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "md"))
+        .filter_map(|e| std::fs::read_to_string(e.path()).ok())
+        .collect();
+    assert!(!contents.is_empty(), "expected at least one .md file");
+    contents.sort();
+    contents.join("\n---\n")
+}
+
+/// Slice 2 excerpt proof: the residual `by (about)` fragment is completed
+/// with the resolved author instead of shipping an empty author slot.
+#[tokio::test]
+async fn empty_byline_fragment_repaired_in_excerpt() {
+    let server = MockServer::start().await;
+    let out = tempfile::tempdir().expect("tempdir");
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(QUOTES_PAGE))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    scrape_quotes_page(&server, out.path(), &["--obsidian-wiki-links"]);
+
+    let content = read_all_md(out.path());
+    snapshot_byline_artifact(
+        "empty_byline_fragment_repaired_in_excerpt",
+        out.path(),
+        &content,
+    );
+
+    // Semantic invariants beyond the snapshot: the empty-slot artifact must
+    // not survive in ANY form, and the author must complete the byline.
+    assert!(
+        !content.contains("by (about)") && !content.contains("by  (about)"),
+        "empty-byline fragment must not reach the excerpt: {content}"
+    );
+    assert!(
+        content.contains("” by Albert Einstein"),
+        "excerpt must be completed with the resolved author: {content}"
+    );
+}
+
+/// Slice 2 alias proof: a parenthetical-only wiki-link label recovers the
+/// author from the link target instead of shipping a naked `(about)` alias.
+#[tokio::test]
+async fn parenthetical_alias_recovers_author_from_link_target() {
+    let server = MockServer::start().await;
+    let out = tempfile::tempdir().expect("tempdir");
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(QUOTES_PAGE))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    scrape_quotes_page(&server, out.path(), &["--obsidian-wiki-links"]);
+
+    let content = read_all_md(out.path());
+
+    assert!(
+        !content.contains("|(about)]"),
+        "naked (about) alias must not survive the conversion: {content}"
+    );
+    assert!(
+        content.contains("[[author-albert-einstein|Albert Einstein]]"),
+        "alias must recover the author name from the link target: {content}"
+    );
+}
+
+/// Control: without `--obsidian-wiki-links` the byline scar still must not
+/// leak an empty author slot into the frontmatter excerpt.
+#[tokio::test]
+async fn byline_fragment_dropped_when_author_missing() {
+    let server = MockServer::start().await;
+    let out = tempfile::tempdir().expect("tempdir");
+    // Variant WITHOUT itemprop/class author markers: the extractor cascade
+    // finds nothing, legible's byline capture leaves `by (about)`, and the
+    // frontmatter must DROP the fragment rather than emit `by` + empty slot.
+    const NO_AUTHOR_PAGE: &str = r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Scant Page</title></head>
+<body>
+<div>
+    <span class="text">Something worth quoting for this regression test.</span>
+    <span>by <small>Anonymous</small> <a href="/author/Anonymous/">(about)</a></span>
+    <p>Filler paragraph long enough so readability keeps this node and scores
+       it as the main article body instead of falling back to an error.</p>
+</div>
+</body></html>"#;
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(NO_AUTHOR_PAGE))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    scrape_quotes_page(&server, out.path(), &[]);
+
+    let content = read_all_md(out.path());
+    assert!(
+        !content.contains("by (about)"),
+        "empty-author byline fragment must be dropped: {content}"
+    );
+}

--- a/crates/webfang_core/tests/snapshots/cli_binary_test__test_help_contains_scraper.snap
+++ b/crates/webfang_core/tests/snapshots/cli_binary_test__test_help_contains_scraper.snap
@@ -380,7 +380,9 @@ Options:
           [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
 
       --vault <VAULT>
-          Path to Obsidian vault (auto-detects if not provided)
+          Path to Obsidian vault (auto-detects if not provided).
+          
+          When provided explicitly, the vault becomes the output base: Markdown, downloaded assets and the RAG export are written inside it — no need to duplicate the path in `-o` (which then must stay at its default). Auto-detected or config-file vaults do NOT redirect output (#762).
           
           [env: WEBFANG_OBSIDIAN_VAULT=]
 

--- a/crates/webfang_core/tests/snapshots/obsidian_byline_artifact_test__empty_byline_fragment_repaired_in_excerpt.snap
+++ b/crates/webfang_core/tests/snapshots/obsidian_byline_artifact_test__empty_byline_fragment_repaired_in_excerpt.snap
@@ -1,0 +1,17 @@
+---
+source: crates/webfang_core/tests/obsidian_byline_artifact_test.rs
+expression: redacted
+---
+---
+title: Quotes to Scrape
+url: http://127.0.0.1:<PORT>/
+date: [DATE]
+author: Albert Einstein
+excerpt: “The world as we have created it is a process of our thinking. It cannot be changed without changing our thinking.” by Albert Einstein
+---
+
+“The world as we have created it is a process of our thinking. It cannot be changed without changing our thinking.” by [[author-albert-einstein|Albert Einstein]]
+
+Tags: [[page-1|change]]
+
+“It is our choices, Harry, that show what we truly are, far more than our abilities.” by J.K. Rowling [[author-jk-rowling|JK Rowling]]

--- a/crates/webfang_core/tests/snapshots/vault_redirect_test__vault_with_custom_output_exits_with_usage_error.snap
+++ b/crates/webfang_core/tests/snapshots/vault_redirect_test__vault_with_custom_output_exits_with_usage_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/webfang_core/tests/vault_redirect_test.rs
+expression: "redact_nondeterministic(out.path(), &stderr)"
+---
+Error: --vault y un directorio de output personalizado (<OUT_DIR>) no pueden combinarse: usá --vault <path> solo (redirige todo el output al vault) o -o <dir> sin --vault

--- a/crates/webfang_core/tests/vault_redirect_test.rs
+++ b/crates/webfang_core/tests/vault_redirect_test.rs
@@ -1,0 +1,147 @@
+//! Explicit `--vault` redirect + preflight conflict E2E tests (#762 slice 1).
+//!
+//! Reproduces the issue-762 audit scenario hermetically with wiremock — no
+//! real network:
+//!
+//! - `webfang --url <seed> --vault <obsidian-vault>` (no `-o`, no
+//!   `--quick-save`) must treat the vault as the OUTPUT BASE: the scraped
+//!   Markdown lands INSIDE the vault and the default `./output` directory is
+//!   never created relative to the working directory.
+//! - The contradictory invocation `--vault <vault> -o <custom>` must fail the
+//!   step-6e preflight with exit 64 (sysexits EX_USAGE) and a Spanish usage
+//!   message BEFORE logging, vault validation, or any network I/O happens.
+//!
+//! Run with: `cargo nextest run --test vault_redirect_test`
+
+#[path = "common/cli_harness.rs"]
+mod common;
+use common::{cmd, redact_nondeterministic};
+
+use std::path::Path;
+use walkdir::WalkDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Minimal page: one article node with enough body text for readability to
+/// score it as the main content, and no assets — the redirect contract is
+/// proven by WHERE the Markdown file lands, not by its content (content
+/// invariants are covered by `obsidian_byline_artifact_test.rs`, slice 2).
+const MINIMAL_PAGE: &str = r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Vault Redirect</title></head>
+<body>
+<article>
+<h1>Vault Redirect Probe</h1>
+<p>Filler paragraph long enough so readability keeps this node and scores it
+as the main article body, proving the scrape pipeline ran end to end.</p>
+</article>
+</body></html>"#;
+
+/// Create a TempDir that `is_valid_vault` accepts: `validate_explicit_vault`
+/// requires a directory containing a `.obsidian/` marker dir.
+fn make_vault() -> tempfile::TempDir {
+    let vault = tempfile::tempdir().expect("create vault tempdir");
+    std::fs::create_dir_all(vault.path().join(".obsidian")).expect("create .obsidian marker dir");
+    vault
+}
+
+/// True when at least one regular file with `ext` exists under `root`.
+fn has_file_with_ext(root: &Path, ext: &str) -> bool {
+    WalkDir::new(root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .any(|e| e.path().extension().is_some_and(|x| x == ext))
+}
+
+/// The issue-762 reproduction: an explicit `--vault` flag alone (no `-o`,
+/// no `--quick-save`) makes the vault the output base — the scraped Markdown
+/// lands inside the vault and no `./output` sibling appears in cwd.
+#[tokio::test]
+async fn explicit_vault_redirects_output_into_vault() {
+    let server = MockServer::start().await;
+    let vault = make_vault();
+    let cwd = tempfile::tempdir().expect("create cwd tempdir");
+    Mock::given(method("GET"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(MINIMAL_PAGE))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    cmd()
+        .arg("--url")
+        .arg(server.uri())
+        .arg("--single-page")
+        .arg("--max-pages")
+        .arg("1")
+        .arg("--format")
+        .arg("markdown")
+        .arg("--vault")
+        .arg(vault.path())
+        .arg("--quiet")
+        .current_dir(cwd.path())
+        .assert()
+        .success();
+
+    assert!(
+        has_file_with_ext(vault.path(), "md"),
+        "expected a scraped .md INSIDE the vault at {:?}",
+        vault.path()
+    );
+    assert!(
+        !cwd.path().join("output").exists(),
+        "default ./output must never be created when --vault is explicit"
+    );
+}
+
+/// The contradictory invocation (`--vault` + custom non-default `-o`) must
+/// fail the step-6e preflight with exit 64 — `CliExit::UsageError` maps to
+/// sysexits EX_USAGE (see `EXIT_USAGE_ERROR` in `cli/error.rs`) — and name
+/// the conflict in Spanish.
+///
+/// No mock server is needed on purpose: the process exits BEFORE any network
+/// phase, so a URL that parses but is never fetched also proves the early
+/// exit (a missed preflight would try to scrape it).
+#[tokio::test]
+async fn vault_with_custom_output_exits_with_usage_error() {
+    let vault = make_vault();
+    let out = tempfile::tempdir().expect("create output tempdir");
+    let cwd = tempfile::tempdir().expect("create cwd tempdir");
+
+    let output = cmd()
+        .arg("--url")
+        .arg("https://example.com")
+        .arg("--vault")
+        .arg(vault.path())
+        .arg("-o")
+        .arg(out.path())
+        .current_dir(cwd.path())
+        .output()
+        .expect("run webfang binary");
+
+    // Asserted exit code: 64. CliExit::UsageError reports EXIT_USAGE_ERROR
+    // (sysexits EX_USAGE) via the Termination impl in cli/error.rs.
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "expected usage-error exit 64, got {:?}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The preflight exits before any filesystem side effect.
+    assert!(
+        !cwd.path().join("output").exists(),
+        "the conflict must abort before creating ./output"
+    );
+    // Semantic invariant beyond the snapshot: the contradiction itself.
+    assert!(
+        stderr.contains("no pueden combinarse"),
+        "stderr must state the --vault/-o contradiction: {stderr}"
+    );
+    insta::assert_snapshot!(
+        "vault_with_custom_output_exits_with_usage_error",
+        redact_nondeterministic(out.path(), &stderr)
+    );
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -416,7 +416,9 @@ Options:
           [env: WEBFANG_OBSIDIAN_RELATIVE_ASSETS=]
 
       --vault <VAULT>
-          Path to Obsidian vault (auto-detects if not provided)
+          Path to Obsidian vault (auto-detects if not provided).
+          
+          When provided explicitly, the vault becomes the output base: Markdown, downloaded assets and the RAG export are written inside it — no need to duplicate the path in `-o` (which then must stay at its default). Auto-detected or config-file vaults do NOT redirect output (#762).
           
           [env: WEBFANG_OBSIDIAN_VAULT=]
 


### PR DESCRIPTION
Closes #762

## PR Type
- [x] Bug fix (`type:bug`)

## Summary
- **Slice 1 — `--vault` redirige el output:** un `--vault` explícito por CLI se vuelve la base de output: Markdown, assets y el export RAG (incluido el spool de batch) van al vault sin necesidad de duplicar la ruta en `-o`. La explicitud se captura en parse time (`vault_is_explicit`) porque preflight y autodetección pueden rellenar `obsidian_vault` desde `config.toml` después — solo el flag explícito redirige, el vault del config mantiene el comportamiento histórico. Conflicto `--vault` + `-o` personalizado (no default) → UsageError preflight en español con las dos salidas ejecutables (exit 64), excepto `--quick-save` que mantiene su contrato #638. Todos los sinks de `output_dir` del orquestador convergen en `resolve_persistence_root`/`resolve_export_dir` (incluye los dos clones independientes que el issue no había inventariado: spool de batch y ScraperConfig de extract_batch_content).
- **Slice 2 — artefacto byline vacío:** reproducible en HEAD (la auditoría mostró `by  (about)` con doble espacio; `normalize_whitespace` de #695 ya colapsaba el espacio, el residuo real era el fragmento `by (about)` sin autor). Readability captura el nodo del autor como byline, lo elimina del body y deja el `by ` + el anchor `(about)\) hermano. Fix: el frontmatter repara el fragmento (completa con el autor resuelto o lo elimina si no hay autor, vía `repair_empty_byline` con re-normalización), y el converter de wikilinks reemplaza alias solo-parentéticos (`[[...|(about)]]`) por el último segmento del path humanizado (`Albert Einstein`), con fallback al slug — mecanismo distinto al declarado por el issue, reportado según evidencia de reproducción.

## Changes

| File | Change |
|------|--------|
| `crates/webfang_core/src/application/crawl_options.rs` | field `vault_is_explicit` en ExportOptions |
| `crates/webfang_core/src/cli/args/mod.rs` | captura de explicitud en parse + helper `url_from_args` (ratchet #516) |
| `crates/webfang_core/src/cli/args/obsidian.rs` | help de `--vault` documenta la redirección |
| `crates/webfang_core/src/cli/commands.rs` | `validate_vault_output_conflict` (+4 unit tests) |
| `crates/webfang_core/src/cli/orchestrator.rs` | `resolve_persistence_root`/`resolve_export_dir` convergen todos los sinks (+5 unit tests) |
| `crates/webfang_cli/src/main.rs` | wiring preflight paso 6e |
| `crates/webfang_core/src/infrastructure/output/frontmatter.rs` | `repair_empty_byline` (+5 unit tests) |
| `crates/webfang_core/src/infrastructure/converter/wikilinks.rs` | `resolve_alias_text`/`humanize_last_segment` (+4 unit tests) |
| `crates/webfang_core/tests/obsidian_byline_artifact_test.rs` | integración slice 2 (wiremock, hermetic) |
| `crates/webfang_core/tests/vault_redirect_test.rs` | integración slice 1: redirect E2E + conflicto exit 64 con snapshot |

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines` clean
- [x] `cargo nextest run` — tests nuevos 13/13 green, módulo orchestrator 42/42, sin regresiones en #695/#638

## Named tests proving closure
**Slice 1:** `explicit_vault_redirects_output_into_vault` (E2E wiremock: el .md cae DENTRO del vault, no existe output/), `conflict_rejects_explicit_vault_with_custom_output`, `quick_save_is_exempt_from_vault_output_conflict`, `explicit_vault_with_default_output_is_allowed`, `config_filled_vault_does_not_conflict_with_custom_output`, `vault_with_custom_output_exits_with_usage_error` (snapshot exit 64), `explicit_vault_redirects_both_roots_to_vault`, `config_filled_vault_does_not_redirect`, `explicit_vault_without_path_falls_back_to_output_dir`
**Slice 2:** `empty_byline_fragment_repaired_in_excerpt`, `parenthetical_alias_recovers_author_from_link_target`, `byline_fragment_dropped_when_author_missing`, `repair_empty_byline_completes_with_author`, `repair_empty_byline_keeps_real_by_phrases`, `test_parenthetical_alias_falls_back_to_path_segment`